### PR TITLE
ENH: Update VTK from 9.1.20220125 to 9.2.20230607

### DIFF
--- a/Base/Logic/vtkSlicerScriptedLoadableModuleLogic.cxx
+++ b/Base/Logic/vtkSlicerScriptedLoadableModuleLogic.cxx
@@ -145,7 +145,7 @@ void vtkSlicerScriptedLoadableModuleLogic::PrintSelf(ostream& os, vtkIndent inde
 
 //  PyObject * arguments = PyTuple_New(3);
 //  PyTuple_SET_ITEM(arguments, 0, vtkPythonUtil::GetObjectFromPointer(caller));
-//  PyTuple_SET_ITEM(arguments, 1, PyInt_FromLong(event));
+//  PyTuple_SET_ITEM(arguments, 1, PyLong_FromLong(event));
 //  PyTuple_SET_ITEM(arguments, 2,
 //                   vtkPythonUtil::GetObjectFromPointer(reinterpret_cast<vtkMRMLNode*>(callData)));
 
@@ -167,7 +167,7 @@ void vtkSlicerScriptedLoadableModuleLogic::PrintSelf(ostream& os, vtkIndent inde
 
 //  PyObject * arguments = PyTuple_New(3);
 //  PyTuple_SET_ITEM(arguments, 0, vtkPythonUtil::GetObjectFromPointer(caller));
-//  PyTuple_SET_ITEM(arguments, 1, PyInt_FromLong(event));
+//  PyTuple_SET_ITEM(arguments, 1, PyLong_FromLong(event));
 //  PyTuple_SET_ITEM(arguments, 2,
 //                   vtkPythonUtil::GetObjectFromPointer(reinterpret_cast<vtkMRMLNode*>(callData)));
 

--- a/Base/QTCore/Testing/Cxx/qSlicerScriptedUtilsTest1.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerScriptedUtilsTest1.cxx
@@ -63,16 +63,16 @@ int qSlicerScriptedUtilsTest1(int, char * [] )
   PyImport_AddModule("moduleA.moduleB");
 
   PythonQtObjectPtr attrMain;
-  attrMain.setNewRef(PyInt_FromLong(1));
+  attrMain.setNewRef(PyLong_FromLong(1));
 
   PythonQtObjectPtr attrMain2;
-  attrMain2.setNewRef(PyInt_FromLong(2));
+  attrMain2.setNewRef(PyLong_FromLong(2));
 
   PythonQtObjectPtr attrA;
-  attrA.setNewRef(PyInt_FromLong(10));
+  attrA.setNewRef(PyLong_FromLong(10));
 
   PythonQtObjectPtr attrB;
-  attrB.setNewRef(PyInt_FromLong(20));
+  attrB.setNewRef(PyLong_FromLong(20));
 
   if (!setModuleAttribute(__LINE__, "moduleX", "attrX", attrA, false))
     {

--- a/Base/QTCore/qSlicerScriptedFileReader.cxx
+++ b/Base/QTCore/qSlicerScriptedFileReader.cxx
@@ -176,14 +176,14 @@ QString qSlicerScriptedFileReader::description()const
     {
     return QString();
     }
-  if (!PyString_Check(result))
+  if (!PyUnicode_Check(result))
     {
     qWarning() << d->PythonSource
                << " - In" << d->PythonClassName << "class, function 'description' "
                << "is expected to return a string !";
     return QString();
     }
-  QString fileType = QString(PyString_AsString(result));
+  QString fileType = QString(PyUnicode_AsUTF8(result));
   return fileType;
 }
 
@@ -197,14 +197,14 @@ qSlicerIO::IOFileType qSlicerScriptedFileReader::fileType()const
     {
     return IOFileType();
     }
-  if (!PyString_Check(result))
+  if (!PyUnicode_Check(result))
     {
     qWarning() << d->PythonSource
                << " - In" << d->PythonClassName << "class, function 'fileType' "
                << "is expected to return a string !";
     return IOFileType();
     }
-  return IOFileType(PyString_AsString(result));
+  return IOFileType(PyUnicode_AsUTF8(result));
 }
 
 //-----------------------------------------------------------------------------
@@ -228,14 +228,14 @@ QStringList qSlicerScriptedFileReader::extensions()const
   Py_ssize_t size = PyTuple_Size(resultAsTuple);
   for (Py_ssize_t i = 0; i < size; ++i)
     {
-    if (!PyString_Check(PyTuple_GetItem(resultAsTuple, i)))
+    if (!PyUnicode_Check(PyTuple_GetItem(resultAsTuple, i)))
       {
       qWarning() << d->PythonSource
                  << " - In" << d->PythonClassName << "class, function 'extensions' "
                  << "is expected to return a string list !";
       break;
       }
-    extensionList << PyString_AsString(PyTuple_GetItem(resultAsTuple, i));
+    extensionList << PyUnicode_AsUTF8(PyTuple_GetItem(resultAsTuple, i));
     }
   Py_DECREF(resultAsTuple);
   return extensionList;
@@ -246,7 +246,7 @@ bool qSlicerScriptedFileReader::canLoadFile(const QString& file)const
 {
   Q_D(const qSlicerScriptedFileReader);
   PyObject* arguments = PyTuple_New(1);
-  PyTuple_SET_ITEM(arguments, 0, PyString_FromString(file.toUtf8()));
+  PyTuple_SET_ITEM(arguments, 0, PyUnicode_FromString(file.toUtf8()));
   PyObject* result = d->PythonCppAPI.callMethod(d->CanLoadFileMethod, arguments);
   Py_DECREF(arguments);
   if (!result)
@@ -269,7 +269,7 @@ double qSlicerScriptedFileReader::canLoadFileConfidence(const QString& file)cons
 {
   Q_D(const qSlicerScriptedFileReader);
   PyObject* arguments = PyTuple_New(1);
-  PyTuple_SET_ITEM(arguments, 0, PyString_FromString(file.toUtf8()));
+  PyTuple_SET_ITEM(arguments, 0, PyUnicode_FromString(file.toUtf8()));
   PyObject* result = d->PythonCppAPI.callMethod(d->CanLoadFileConfidenceMethod, arguments);
   Py_DECREF(arguments);
   if (!result)

--- a/Base/QTCore/qSlicerScriptedFileWriter.cxx
+++ b/Base/QTCore/qSlicerScriptedFileWriter.cxx
@@ -176,14 +176,14 @@ QString qSlicerScriptedFileWriter::description()const
     {
     return QString();
     }
-  if (!PyString_Check(result))
+  if (!PyUnicode_Check(result))
     {
     qWarning() << d->PythonSource
                << " - In" << d->PythonClassName << "class, function 'description' "
                << "is expected to return a string !";
     return QString();
     }
-  QString fileType = QString(PyString_AsString(result));
+  QString fileType = QString(PyUnicode_AsUTF8(result));
   return fileType;
 }
 
@@ -197,14 +197,14 @@ qSlicerIO::IOFileType qSlicerScriptedFileWriter::fileType()const
     {
     return IOFileType();
     }
-  if (!PyString_Check(result))
+  if (!PyUnicode_Check(result))
     {
     qWarning() << d->PythonSource
                << " - In" << d->PythonClassName << "class, function 'fileType' "
                << "is expected to return a string !";
     return IOFileType();
     }
-  return IOFileType(PyString_AsString(result));
+  return IOFileType(PyUnicode_AsUTF8(result));
 }
 
 //-----------------------------------------------------------------------------
@@ -280,14 +280,14 @@ QStringList qSlicerScriptedFileWriter::extensions(vtkObject* object)const
   Py_ssize_t size = PyTuple_Size(resultAsTuple);
   for (Py_ssize_t i = 0; i < size; ++i)
     {
-    if (!PyString_Check(PyTuple_GetItem(resultAsTuple, i)))
+    if (!PyUnicode_Check(PyTuple_GetItem(resultAsTuple, i)))
       {
       qWarning() << d->PythonSource
                  << " - In" << d->PythonClassName << "class, function 'extensions' "
                  << "is expected to return a string list !";
       break;
       }
-    extensionList << PyString_AsString(PyTuple_GetItem(resultAsTuple, i));
+    extensionList << PyUnicode_AsUTF8(PyTuple_GetItem(resultAsTuple, i));
     }
   Py_DECREF(resultAsTuple);
   return extensionList;

--- a/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.cxx
@@ -215,8 +215,8 @@ bool qSlicerScriptedLoadableModuleWidget::setEditedNode(vtkMRMLNode* node,
   Q_D(qSlicerScriptedLoadableModuleWidget);
   PyObject* arguments = PyTuple_New(3);
   PyTuple_SET_ITEM(arguments, 0, vtkPythonUtil::GetObjectFromPointer(node));
-  PyTuple_SET_ITEM(arguments, 1, PyString_FromString(role.toUtf8()));
-  PyTuple_SET_ITEM(arguments, 2, PyString_FromString(context.toUtf8()));
+  PyTuple_SET_ITEM(arguments, 1, PyUnicode_FromString(role.toUtf8()));
+  PyTuple_SET_ITEM(arguments, 2, PyUnicode_FromString(context.toUtf8()));
   PyObject* result = d->PythonCppAPI.callMethod(d->SetEditedNodeMethod, arguments);
   Py_DECREF(arguments);
   if (!result)

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -682,7 +682,6 @@ std::string vtkMRMLAbstractViewNode::GetDirectionLabel(double direction[3], bool
   // Compute labels and angles
   std::string axisLabels[3];
   double absoluteNormalAngleDiffsRad[3] = { 0.0, 0.0, 0.0 };
-  double axisSign = positive ? 1.0 : -1.0;
   for (int axisIndex = 0; axisIndex < 3; ++axisIndex)
     {
     double axisDirection[3] = { axisIndex == 0 ? 1.0 : 0.0, axisIndex == 1 ? 1.0 : 0.0, axisIndex == 2 ? 1.0 : 0.0 };

--- a/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.cxx
@@ -178,7 +178,7 @@ void vtkMRMLScriptedDisplayableManager
 
   PyObject * arguments = PyTuple_New(3);
   PyTuple_SET_ITEM(arguments, 0, vtkPythonUtil::GetObjectFromPointer(caller));
-  PyTuple_SET_ITEM(arguments, 1, PyInt_FromLong(event));
+  PyTuple_SET_ITEM(arguments, 1, PyLong_FromLong(event));
   PyTuple_SET_ITEM(arguments, 2,
                    vtkPythonUtil::GetObjectFromPointer(reinterpret_cast<vtkMRMLNode*>(callData)));
 
@@ -201,7 +201,7 @@ void vtkMRMLScriptedDisplayableManager::ProcessMRMLNodesEvents(vtkObject *caller
 
   PyObject * arguments = PyTuple_New(3);
   PyTuple_SET_ITEM(arguments, 0, vtkPythonUtil::GetObjectFromPointer(caller));
-  PyTuple_SET_ITEM(arguments, 1, PyInt_FromLong(event));
+  PyTuple_SET_ITEM(arguments, 1, PyLong_FromLong(event));
   PyTuple_SET_ITEM(arguments, 2, vtkPythonUtil::GetObjectFromPointer(nullptr));
 
   PyObject_CallObject(method, arguments);
@@ -246,7 +246,7 @@ void vtkMRMLScriptedDisplayableManager::OnInteractorStyleEvent(int eventid)
     }
 
   PyObject * arguments = PyTuple_New(1);
-  PyTuple_SET_ITEM(arguments, 0, PyInt_FromLong(eventid));
+  PyTuple_SET_ITEM(arguments, 0, PyLong_FromLong(eventid));
 
   PyObject_CallObject(method, arguments);
   PyErr_Print();

--- a/Libs/vtkSegmentationCore/vtkPolyDataToFractionalLabelmapFilter.cxx
+++ b/Libs/vtkSegmentationCore/vtkPolyDataToFractionalLabelmapFilter.cxx
@@ -36,6 +36,7 @@
 #include <vtkTransformPolyDataFilter.h>
 #include <vtkNew.h>
 #include <vtkPolyDataNormals.h>
+#include <vtkSMPThreadLocalObject.h>
 #include <vtkTriangleFilter.h>
 #include <vtkStripper.h>
 #include <vtkImageStencil.h>
@@ -598,7 +599,12 @@ void vtkPolyDataToFractionalLabelmapFilter::FillImageStencilData(
       else
         {
         // if no polys, select polylines instead
+#if (VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 2, 20230212))
+        vtkSMPThreadLocalObject<vtkIdList> storage;
+        this->PolyDataSelector(input, slice, storage.Local(), z, spacing[2]);
+#else
         this->PolyDataSelector(input, slice, z, spacing[2]);
+#endif
         }
 
       if (!slice->GetNumberOfLines())

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedEffect.cxx
@@ -266,14 +266,14 @@ const QString qSlicerSegmentEditorScriptedEffect::helpText()const
     }
 
   // Parse result
-  if (!PyString_Check(result))
+  if (!PyUnicode_Check(result))
     {
     qWarning() << d->PythonSource << ": qSlicerSegmentEditorScriptedEffect: Function 'helpText' is expected to return a string!";
     return this->Superclass::helpText();
     }
 
-  const char* role = PyString_AsString(result);
-  return QString::fromLocal8Bit(role);
+  const char* role = PyUnicode_AsUTF8(result);
+  return QString::fromUtf8(role);
 }
 
 //-----------------------------------------------------------------------------
@@ -354,7 +354,7 @@ bool qSlicerSegmentEditorScriptedEffect::processInteractionEvents(vtkRenderWindo
   Q_D(const qSlicerSegmentEditorScriptedEffect);
   PyObject* arguments = PyTuple_New(3);
   PyTuple_SET_ITEM(arguments, 0, vtkPythonUtil::GetObjectFromPointer((vtkObject*)callerInteractor));
-  PyTuple_SET_ITEM(arguments, 1, PyInt_FromLong(eid));
+  PyTuple_SET_ITEM(arguments, 1, PyLong_FromLong(eid));
   PyTuple_SET_ITEM(arguments, 2, PythonQtConv::QVariantToPyObject(QVariant::fromValue<QObject*>((QObject*)viewWidget)));
   PyObject* result = d->PythonCppAPI.callMethod(d->ProcessInteractionEventsMethod, arguments);
   Py_DECREF(arguments);
@@ -379,7 +379,7 @@ void qSlicerSegmentEditorScriptedEffect::processViewNodeEvents(vtkMRMLAbstractVi
   Q_D(const qSlicerSegmentEditorScriptedEffect);
   PyObject* arguments = PyTuple_New(3);
   PyTuple_SET_ITEM(arguments, 0, vtkPythonUtil::GetObjectFromPointer((vtkObject*)callerViewNode));
-  PyTuple_SET_ITEM(arguments, 1, PyInt_FromLong(eid));
+  PyTuple_SET_ITEM(arguments, 1, PyLong_FromLong(eid));
   PyTuple_SET_ITEM(arguments, 2, PythonQtConv::QVariantToPyObject(QVariant::fromValue<QObject*>((QObject*)viewWidget)));
   PyObject* result = d->PythonCppAPI.callMethod(d->ProcessViewNodeEventsMethod, arguments);
   Py_DECREF(arguments);

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedLabelEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedLabelEffect.cxx
@@ -257,14 +257,14 @@ const QString qSlicerSegmentEditorScriptedLabelEffect::helpText()const
     }
 
   // Parse result
-  if (!PyString_Check(result))
+  if (!PyUnicode_Check(result))
     {
     qWarning() << d->PythonSource << ": qSlicerSegmentEditorScriptedLabelEffect: Function 'helpText' is expected to return a string!";
     return this->Superclass::helpText();
     }
 
-  const char* role = PyString_AsString(result);
-  return QString::fromLocal8Bit(role);
+  const char* role = PyUnicode_AsUTF8(result);
+  return QString::fromUtf8(role);
 }
 
 //-----------------------------------------------------------------------------
@@ -345,7 +345,7 @@ bool qSlicerSegmentEditorScriptedLabelEffect::processInteractionEvents(vtkRender
   Q_D(const qSlicerSegmentEditorScriptedLabelEffect);
   PyObject* arguments = PyTuple_New(3);
   PyTuple_SET_ITEM(arguments, 0, vtkPythonUtil::GetObjectFromPointer((vtkObject*)callerInteractor));
-  PyTuple_SET_ITEM(arguments, 1, PyInt_FromLong(eid));
+  PyTuple_SET_ITEM(arguments, 1, PyLong_FromLong(eid));
   PyTuple_SET_ITEM(arguments, 2, PythonQtConv::QVariantToPyObject(QVariant::fromValue<QObject*>((QObject*)viewWidget)));
   PyObject* result = d->PythonCppAPI.callMethod(d->ProcessInteractionEventsMethod, arguments);
   Py_DECREF(arguments);
@@ -370,7 +370,7 @@ void qSlicerSegmentEditorScriptedLabelEffect::processViewNodeEvents(vtkMRMLAbstr
   Q_D(const qSlicerSegmentEditorScriptedLabelEffect);
   PyObject* arguments = PyTuple_New(3);
   PyTuple_SET_ITEM(arguments, 0, vtkPythonUtil::GetObjectFromPointer((vtkObject*)callerViewNode));
-  PyTuple_SET_ITEM(arguments, 1, PyInt_FromLong(eid));
+  PyTuple_SET_ITEM(arguments, 1, PyLong_FromLong(eid));
   PyTuple_SET_ITEM(arguments, 2, PythonQtConv::QVariantToPyObject(QVariant::fromValue<QObject*>((QObject*)viewWidget)));
   PyObject* result = d->PythonCppAPI.callMethod(d->ProcessViewNodeEventsMethod, arguments);
   Py_DECREF(arguments);

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedPaintEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedPaintEffect.cxx
@@ -242,14 +242,14 @@ const QString qSlicerSegmentEditorScriptedPaintEffect::helpText()const
     }
 
   // Parse result
-  if (!PyString_Check(result))
+  if (!PyUnicode_Check(result))
     {
     qWarning() << d->PythonSource << ": qSlicerSegmentEditorScriptedPaintEffect: Function 'helpText' is expected to return a string!";
     return this->Superclass::helpText();
     }
 
-  const char* role = PyString_AsString(result);
-  return QString::fromLocal8Bit(role);
+  const char* role = PyUnicode_AsUTF8(result);
+  return QString::fromUtf8(role);
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.cxx
@@ -258,14 +258,14 @@ const QString qSlicerSubjectHierarchyScriptedPlugin::roleForPlugin()const
     }
 
   // Parse result
-  if (!PyString_Check(result))
+  if (!PyUnicode_Check(result))
     {
     qWarning() << d->PythonSource << ": " << Q_FUNC_INFO << ": Function 'roleForPlugin' is expected to return a string!";
     return this->Superclass::roleForPlugin();
     }
 
-  const char* role = PyString_AsString(result);
-  return QString::fromLocal8Bit(role);
+  const char* role = PyUnicode_AsUTF8(result);
+  return QString::fromUtf8(role);
 }
 
 //---------------------------------------------------------------------------
@@ -280,14 +280,14 @@ const QString qSlicerSubjectHierarchyScriptedPlugin::helpText()const
     }
 
   // Parse result
-  if (!PyString_Check(result))
+  if (!PyUnicode_Check(result))
     {
     qWarning() << d->PythonSource << ": " << Q_FUNC_INFO << ": Function 'helpText' is expected to return a string!";
     return this->Superclass::helpText();
     }
 
-  const char* role = PyString_AsString(result);
-  return QString::fromLocal8Bit(role);
+  const char* role = PyUnicode_AsUTF8(result);
+  return QString::fromUtf8(role);
 }
 
 //---------------------------------------------------------------------------
@@ -318,7 +318,7 @@ QIcon qSlicerSubjectHierarchyScriptedPlugin::visibilityIcon(int visible)
 {
   Q_D(const qSlicerSubjectHierarchyScriptedPlugin);
   PyObject* arguments = PyTuple_New(1);
-  PyTuple_SET_ITEM(arguments, 0, PyInt_FromLong(visible));
+  PyTuple_SET_ITEM(arguments, 0, PyLong_FromLong(visible));
   PyObject* result = d->PythonCppAPI.callMethod(d->VisibilityIconMethod, arguments);
   Py_DECREF(arguments);
   if (!result)
@@ -559,13 +559,13 @@ QString qSlicerSubjectHierarchyScriptedPlugin::displayedItemName(vtkIdType itemI
     }
 
   // Parse result
-  if (!PyString_Check(result))
+  if (!PyUnicode_Check(result))
     {
     qWarning() << d->PythonSource << ": " << Q_FUNC_INFO << ": Function 'displayedItemName' is expected to return a string!";
     return this->Superclass::displayedItemName(itemID);
     }
 
-  return PyString_AsString(result);
+  return PyUnicode_AsUTF8(result);
 }
 
 //-----------------------------------------------------------------------------
@@ -583,13 +583,13 @@ QString qSlicerSubjectHierarchyScriptedPlugin::tooltip(vtkIdType itemID)const
     }
 
   // Parse result
-  if (!PyString_Check(result))
+  if (!PyUnicode_Check(result))
     {
     qWarning() << d->PythonSource << ": " << Q_FUNC_INFO << ": Function 'tooltip' is expected to return a string!";
     return this->Superclass::tooltip(itemID);
     }
 
-  return PyString_AsString(result);
+  return PyUnicode_AsUTF8(result);
 }
 
 //-----------------------------------------------------------------------------
@@ -598,7 +598,7 @@ void qSlicerSubjectHierarchyScriptedPlugin::setDisplayVisibility(vtkIdType itemI
   Q_D(const qSlicerSubjectHierarchyScriptedPlugin);
   PyObject* arguments = PyTuple_New(2);
   PyTuple_SET_ITEM(arguments, 0, PyLong_FromLongLong(itemID));
-  PyTuple_SET_ITEM(arguments, 1, PyInt_FromLong(visible));
+  PyTuple_SET_ITEM(arguments, 1, PyLong_FromLong(visible));
   PyObject* result = d->PythonCppAPI.callMethod(d->SetDisplayVisibilityMethod, arguments);
   Py_DECREF(arguments);
   if (!result)
@@ -623,11 +623,11 @@ int qSlicerSubjectHierarchyScriptedPlugin::getDisplayVisibility(vtkIdType itemID
     }
 
   // Parse result
-  if (!PyInt_Check(result))
+  if (!PyLong_Check(result))
     {
     qWarning() << d->PythonSource << ": " << Q_FUNC_INFO << ": Function 'getDisplayVisibility' is expected to return an integer!";
     return this->Superclass::getDisplayVisibility(itemID);
     }
 
-  return (int)PyInt_AsLong(result);
+  return (int)PyLong_AsLong(result);
 }

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,8 +139,8 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "9bde2b3fa9887a801e3eec686ce591072986977f") # slicer-v9.1.20220125-efbe2afc2
-    set(vtk_egg_info_version "9.1.20220125")
+    set(_git_tag "6c02c9b3769bbb433b1451128993945198fa6bc3") # slicer-v9.2.20230607-1ff325c54
+    set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")
   endif()


### PR DESCRIPTION

Update `vtkPolyDataToFractionalLabelmapFilter` to account for vtkPolyDataToImageStencil::PolyDataSelector() API update introduced in kitware/VTK@3b0b72a74 (Make vtkPolyDatToImageStencil thread-safe)

List of Slicer specific changes:

```
$ git shortlog 1ff325c54a..6c02c9b376 --no-merges
Jean-Christophe Fillion-Robin (13):
      [Slicer] COMP: Remove custom FindOpenGL to ensure OpenGL_GL_PREFERENCE is considered
      [Slicer] BUG: Update vtkPythonUtil to disable relative import causing crash for Slicer modules
      [Slicer] COMP: Remove FindTBB and expect VTK to be configured with TBB_DIR
      [SlicerSMTK] COMP: Add support for specifying vtk-m library install components
      [SlicerSMTK] vtkm: Use github.com/KitwareMedical/vtk-m: Update diy install rules, support TBB_DIR
      [Backport MR-9892] ENH: Re-introduce support for custom logic handling VR complex gesture
      [Backport MR-9892] ENH: Generalize handling of complex gesture events in VR
      [Backport MR-9892] DOC: Update VR docstrings to consistently mention "complex gesture"
      [Backport MR-9892] ENH: Generalize VR binding definition related to complex gesture events
      [Backport MR-9892] STYLE: Add missing lines in vtkVRRenderWindowInteractor
      [SlicerVirtualReality] ENH: Re-introduce OpenVR API for retrieving last OpenVR pose
      [SlicerVirtualReality] BUG: Ensure a valid OpenVR pose is returned
      [Backport MR-10295] Allow const std::vector<vtkSmartPointer<T>> in Python

```

### Update notes

Following kitware/VTK@4d0f17c62 (vtkModuleWrapPython: make .pyi file building optional) These two commits are not needed anymore:

* COMP: Fix packaging removing install rules associated with non-existent pyi files
* COMP: Fix Windows build removing vtkpythonmodules_pyi from the default target

Since MR-8123 was abandoned and superseded by MR-9097. These commits are not needed anymore:

* [Backport MR-8123] vtk_module_build: Ensure external modules build directory are not overwritten
* [Backport MR-8123] vtk_module_build: Update CMake function fixing use of quotes and indentation
* [Backport MR-8123] Do not generate files in source tree when building module externally

These two commits were squashed together:
* vtkm: Update diy install rules, support TBB_DIR
* COMP: Update vtk-m submodule url to use github.com/KitwareMedical/vtk-m

These two commits were squashed together:
* STYLE: Remove CMake message debug statements from vtkvtkm/CMakeLists.txt
* COMP: Add support for specifying vtk-m library install components