### PR TITLE
BUG: Skip camera undo when undo is not enabled on vtkMRMLCameraNode

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
@@ -1076,11 +1076,13 @@ void vtkMRMLCameraWidget::CameraModifyEnd(bool wasModified, bool updateClippingR
 //----------------------------------------------------------------------------
 void vtkMRMLCameraWidget::SaveStateForUndo()
 {
-  if (!this->GetCameraNode() || !this->GetCameraNode()->GetScene())
+  vtkMRMLCameraNode* cameraNode = this->GetCameraNode();
+  vtkMRMLScene* mrmlScene = cameraNode ? cameraNode->GetScene() : nullptr;
+  if (!mrmlScene || !cameraNode || !cameraNode->GetUndoEnabled())
     {
     return;
     }
-  this->GetCameraNode()->GetScene()->SaveStateForUndo();
+  mrmlScene->SaveStateForUndo();
 }
 
 //-------------------------------------------------------------------------


### PR DESCRIPTION
Undo states were being added to the stack when the camera was modified, even if undo was not enabled for the camera.