### PR TITLE
Update Debian distribution names in linux.md

### DIFF
--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -35,7 +35,7 @@ part of the *superbuild*:
   - Private
 - libXt
 
-### Debian 11 Stable (Bullseye) and Testing (Bookworm) 
+### Debian 12 Bookworm (Stable) and Bullseye 11 (OldStable) 
 
 Install the development tools and the support libraries:
 


### PR DESCRIPTION
Debian 12 "bookworm" released on June 10th, 2023 is the new stable distribution.