### PR TITLE
BUG: Update test_slicer_util_save to use non-deprecated method

### DIFF
--- a/Base/Python/slicer/tests/test_slicer_util_save.py
+++ b/Base/Python/slicer/tests/test_slicer_util_save.py
@@ -41,7 +41,7 @@ class SlicerUtilSaveTests(unittest.TestCase):
         tumorSeed.Update()
         segmentationNode.AddSegmentFromClosedSurfaceRepresentation(tumorSeed.GetOutput(), "Tumor", [1.0, 0.0, 0.0])
         segmentationNode.CreateBinaryLabelmapRepresentation()
-        segmentationNode.SetMasterRepresentationToBinaryLabelmap()
+        segmentationNode.SetSourceRepresentationToBinaryLabelmap()
         # Save
         filename = slicer.app.temporaryPath + '/SlicerUtilSaveTestsSegmentation.nrrd'
         self.assertTrue(slicer.util.saveNode(segmentationNode, filename))


### PR DESCRIPTION
This fix is a follow of these commits:
* 37416c2e5 (ENH: Use inclusive language for segmentation source representation)
* 5204e7a31 (ENH: Improve default description selection in Add data window)