### PR TITLE
BUG: Fix splash screen loading text hidden

### DIFF
--- a/Base/QTApp/qSlicerApplicationHelper.txx
+++ b/Base/QTApp/qSlicerApplicationHelper.txx
@@ -121,7 +121,7 @@ int qSlicerApplicationHelper::postInitializeApplication(
       pixmap.setDevicePixelRatio(guiApp->devicePixelRatio());
       }
 
-    splashScreen.reset(new QSplashScreen(pixmap));
+    splashScreen.reset(new QSplashScreen(pixmap, Qt::WindowStaysOnTopHint));
     splashMessage(splashScreen, "Initializing...");
     splashScreen->show();
     }


### PR DESCRIPTION
The CTKAppLauncher creates an initial splash screen with the Qt::WindowStaysOnTopHint flag that closes with a specified delay time to close. The Slicer application initializes a second splash screen at startup that did not have the Qt::WindowStaysOnTopHint resulting in the CTKAppLauncher splash screen displaying on top of it and obscuring the loading text.

CTKAppLauncher code that specifies that launcher's SplashScreen with `Qt::WindowStaysOnTopHint`.
https://github.com/commontk/AppLauncher/blob/8109ffb2f1ae3038bb5a955bff1a5f07dd1400d2/Base/ctkAppLauncher.cpp#L743-L744

Now with this change the Slicer splash screen becomes shown on top of the CTKAppLauncher splash screen therefore showing the loading text as soon as it is available. Previously you would only see the loading text if the CTKAppLauncher close delay time had expired resulting in that splash screen closing.