### PR TITLE
ENH: Translation/rotation of unlocked points in a list

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -286,6 +286,8 @@ public:
 
   /// Return the number of control points that are stored in this node
   int GetNumberOfControlPoints();
+  /// Return the number of unlocked control points with defined position in this node
+  int GetNumberOfMovableControlPoints();
   /// Return the number of control points that are already placed (not being previewed or undefined).
   int GetNumberOfDefinedControlPoints(bool includePreview=false);
   /// Return the number of control points that have not been placed (not being previewed or skipped).
@@ -312,7 +314,7 @@ public:
   /// New control points are added if needed.
   /// Existing control points are updated with the new positions.
   /// Any extra existing control points are removed.
-  void SetControlPointPositionsWorld(vtkPoints* points);
+  void SetControlPointPositionsWorld(vtkPoints* points, bool setUndefinedPoints=true);
 
   /// Get a copy of all control point positions in world coordinate system
   void GetControlPointPositionsWorld(vtkPoints* points);


### PR DESCRIPTION
This commit adds a new function that allows unlocked markup points to move using the markup interaction handles. Currently, the interaction handles are disabled when any point is locked. This commit also fixes a bug where any points with an undefined position status are reset on using a markup's interaction handles. To support the new functionality, the interaction handle center of rotation is updated to ignore locked and undefined points. This commit is a product of the PW 39 2023 projects: https://projectweek.na-mic.org/PW39_2023_Montreal/Projects/TranslationRotationOfSelectPointsInAList/
and https://projectweek.na-mic.org/PW39_2023_Montreal/Projects/SlicerLiver/.