### PR TITLE
BUG: Fix color synchronization inaccuarcy in volume rendering module

### DIFF
--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.h
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.h
@@ -36,7 +36,6 @@ class vtkMRMLVolumePropertyNode;
 
 // VTK includes
 class vtkColorTransferFunction;
-class vtkLookupTable;
 class vtkPiecewiseFunction;
 class vtkScalarsToColors;
 class vtkVolumeProperty;
@@ -217,7 +216,7 @@ public:
   /// \sa SetThresholdToVolumeProp
   void SetWindowLevelToVolumeProp(
     double scalarRange[2], double windowLevel[2],
-    vtkLookupTable* lut, vtkVolumeProperty* node);
+    vtkScalarsToColors* lut, vtkVolumeProperty* node);
 
   /// Create an opacity transfer function for gradient opacity.
   /// It ranges from 0 to scalarRange[1] - scalarRange[0].
@@ -229,7 +228,7 @@ public:
   /// transfer function from the labelmap LUT \a colors.
   /// \sa SetWindowLevelToVolumeProp, SetThresholdToVolumeProp
   void SetLabelMapToVolumeProp(
-    vtkScalarsToColors* lut, vtkVolumeProperty* node);
+    vtkScalarsToColors* colors, vtkVolumeProperty* node);
 
   /// Update DisplayNode from VolumeNode,
   /// Can pass a VolumePropertyNode and an ROI node to be the display node.


### PR DESCRIPTION
When a color node with few color table entries (such as fMRI) was used for showing a volume, the "Synchronize with Volumes module" button in volume rendering module very inaccurately copied the color entries to the color transfer function. The problem was that only every 64th color table entry was copied. Fixed the issue by copying up to 24 color entries (evenly sampled in the lookup table) of the table into the transfer function. This number is large enough to accurately represent a color table, but not too high so that users can still edit the color transfer manually.

Also fixed synchronization of continuous color mapping. All control points of continuous color maps are copied, so these are copied in full fidelity.

Fixes the problem reported at https://discourse.slicer.org/t/the-colormap-in-volume-rendering-is-wrong-when-using-fmri-lookup-table-in-volume/30186