### PR TITLE
COMP: Fix deprecation warnings by explicitly calling vtkStdString::c_str()

### DIFF
--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -525,7 +525,7 @@ const char* vtkMRMLAbstractViewNode::GetAxisLabel(int labelIndex)
       << vtkMRMLAbstractViewNode::AxisLabelsCount);
     return "";
     }
-  return this->AxisLabels->GetValue(labelIndex);
+  return this->AxisLabels->GetValue(labelIndex).c_str();
 }
 
 //-----------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLModelStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelStorageNode.cxx
@@ -303,7 +303,7 @@ int vtkMRMLModelStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
       vtkStringArray* comments = reader->GetComments();
       for (int commentIndex = 0; commentIndex < comments->GetNumberOfValues(); commentIndex++)
         {
-        coordinateSystemInFileHeader = vtkMRMLModelStorageNode::GetCoordinateSystemFromFileHeader(comments->GetValue(commentIndex));
+        coordinateSystemInFileHeader = vtkMRMLModelStorageNode::GetCoordinateSystemFromFileHeader(comments->GetValue(commentIndex).c_str());
         if (coordinateSystemInFileHeader >= 0)
           {
           // found a comment that contains coordinate system information

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLCameraDisplayableManagerTest1.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLCameraDisplayableManagerTest1.cxx
@@ -624,7 +624,7 @@ int vtkMRMLCameraDisplayableManagerTest1(int argc, char* argv[])
   vtkStdString savedScene = testHelper->GetTempDirectory();
   savedScene += "/vtkMRMLCameraDisplayableManagerTest1_saved.mrml";
   scene->SetVersion("Slicer4.4.0"); // Force scene version to be the same as in the baseline scene file
-  if (!scene->Commit(savedScene))
+  if (!scene->Commit(savedScene.c_str()))
     {
     std::cerr << "Failed to save current scene into: " << savedScene << std::endl;
     return EXIT_FAILURE;
@@ -661,7 +661,7 @@ int vtkMRMLCameraDisplayableManagerTest1(int argc, char* argv[])
     }
 
   // Import baseline scene
-  scene->SetURL(baselineScene);
+  scene->SetURL(baselineScene.c_str());
   if (scene->GetURL() != baselineScene)
     {
     std::cerr << "Failed to set URL: " << baselineScene << std::endl;

--- a/Libs/MRML/Widgets/qMRMLTableModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLTableModel.cxx
@@ -304,7 +304,7 @@ void qMRMLTableModel::updateModelFromMRML()
             }
           else
             {
-            item->setText(QString(variant.ToString()));
+            item->setText(QString(variant.ToString().c_str()));
             }
           item->setData(QVariant(), UserRoleValueType);
           item->setCheckable(false);
@@ -372,7 +372,7 @@ void qMRMLTableModel::updateModelFromMRML()
       {
       if (tableRow>=0)
         {
-        rowLabel = QString(table->GetValue(tableRow, 0).ToString());
+        rowLabel = QString(table->GetValue(tableRow, 0).ToString().c_str());
         }
       else
         {
@@ -506,7 +506,7 @@ void qMRMLTableModel::updateMRMLFromModel(QStandardItem* item)
           // The value is not changed then it means it is invalid,
           // restore previous value
           this->blockSignals(true);
-          item->setText(QString(valueInTableBefore.ToString()));
+          item->setText(QString(valueInTableBefore.ToString().c_str()));
           this->blockSignals(false);
           }
         else
@@ -670,7 +670,7 @@ int qMRMLTableModel::removeSelectionFromMRML(QModelIndexList selection, bool rem
                 qCritical("qMRMLTableModel::updateMRMLFromModel failed: column %d is invalid", columnIndex);
                 continue;
                 }
-              d->MRMLTableNode->RenameColumn(columnIndex, table->GetValue(0,columnIndex).ToString());
+              d->MRMLTableNode->RenameColumn(columnIndex, table->GetValue(0, columnIndex).ToString().c_str());
             }
           d->MRMLTableNode->RemoveRow(0);
           }

--- a/Modules/Loadable/Annotations/Logic/vtkSlicerAnnotationModuleLogic.cxx
+++ b/Modules/Loadable/Annotations/Logic/vtkSlicerAnnotationModuleLogic.cxx
@@ -174,15 +174,13 @@ void vtkSlicerAnnotationModuleLogic::RegisterNodes()
       return;
       }
 
-    vtkStdString nameString = vtkStdString(name);
-
     vtkMRMLAnnotationSnapshotNode * newSnapshotNode =
         vtkMRMLAnnotationSnapshotNode::New();
     newSnapshotNode->SetScene(this->GetMRMLScene());
-    if (strcmp(nameString, ""))
+    if (std::string(name) != "")
       {
       // a name was specified
-      newSnapshotNode->SetName(nameString.c_str());
+      newSnapshotNode->SetName(name);
       }
     else
       {
@@ -232,12 +230,10 @@ void vtkSlicerAnnotationModuleLogic::RegisterNodes()
       return;
       }
 
-    vtkStdString nameString = vtkStdString(name);
-
-    if (strcmp(nameString, ""))
+    if (std::string(name) != "")
       {
       // a name was specified
-      snapshotNode->SetName(nameString.c_str());
+      snapshotNode->SetName(name);
       }
     else
       {

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationNode.cxx
@@ -248,7 +248,7 @@ void vtkMRMLAnnotationNode::PrintAnnotationInfo(ostream& os, vtkIndent indent, i
     os << endl;
     for (int i = 0 ; i < this->GetNumberOfTexts() ; i++)
       {
-      os << indent << "  " << i <<": " <<  (TextList->GetValue(i) ? TextList->GetValue(i) : "(none)") << endl;
+      os << indent << "  " << i <<": " <<  (TextList->GetValue(i).empty() ? "(none)" : TextList->GetValue(i).c_str()) << endl;
     }
     }
 

--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
@@ -116,14 +116,12 @@ void vtkSlicerSceneViewsModuleLogic::CreateSceneView(const char* name, const cha
     return;
     }
 
-  vtkStdString nameString = vtkStdString(name);
-
   vtkNew<vtkMRMLSceneViewNode> newSceneViewNode;
   newSceneViewNode->SetScene(this->GetMRMLScene());
-  if (strcmp(nameString,""))
+  if (std::string(name) != "")
     {
     // a name was specified
-    newSceneViewNode->SetName(nameString.c_str());
+    newSceneViewNode->SetName(name);
     }
   else
     {
@@ -175,11 +173,10 @@ void vtkSlicerSceneViewsModuleLogic::
     return;
     }
 
-  vtkStdString nameString = vtkStdString(name);
-  if (strcmp(nameString,""))
+  if (std::string(name) != "")
     {
     // a name was specified
-    viewNode->SetName(nameString.c_str());
+    viewNode->SetName(name);
     }
   else
     {

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
@@ -1521,7 +1521,7 @@ std::string vtkMRMLSegmentationsDisplayableManager2D::GetDataProbeInfoStringForP
     std::string segmentsInfoStr;
     for (int segmentIdIndex = 0; segmentIdIndex < segmentIDs->GetNumberOfValues(); ++segmentIdIndex)
       {
-      const char* segmentId = segmentIDs->GetValue(segmentIdIndex);
+      const char* segmentId = segmentIDs->GetValue(segmentIdIndex).c_str();
       vtkSegment* segment = segmentationNode->GetSegmentation()->GetSegment(segmentId);
       if (segment)
         {

--- a/Modules/Loadable/Tables/Logic/vtkSlicerTablesLogic.cxx
+++ b/Modules/Loadable/Tables/Logic/vtkSlicerTablesLogic.cxx
@@ -104,7 +104,7 @@ vtkMRMLTableNode* vtkSlicerTablesLogic
       // Storage node
       vtkNew<vtkMRMLTableSQLiteStorageNode> tableStorageNode;
       tableStorageNode->SetFileName(fileName);
-      tableStorageNode->SetTableName(table);
+      tableStorageNode->SetTableName(table.c_str());
       this->GetMRMLScene()->AddNode(tableStorageNode.GetPointer());
 
       // Storable node

--- a/Modules/Loadable/Tables/Testing/Cxx/vtkSlicerTablesLogicAddFileTest.cxx
+++ b/Modules/Loadable/Tables/Testing/Cxx/vtkSlicerTablesLogicAddFileTest.cxx
@@ -124,7 +124,7 @@ int testAddFile(const char * filePath)
 
   // Verify that files that contain backslsh are read correctly
   vtkStringArray* stringArray = vtkStringArray::SafeDownCast(table->GetColumnByName("TestString"));
-  CHECK_STRING(stringArray->GetValue(4), "some\\escape\\characters\\n\\t");
+  CHECK_STRING(stringArray->GetValue(4).c_str(), "some\\escape\\characters\\n\\t");
 
   std::cout << "Test passed." << std::endl;
   return EXIT_SUCCESS;

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -492,7 +492,7 @@ void vtkSlicerVolumesLogic::InitializeStorageNode(
       for (int n = 0; n < numURIs; n++)
         {
         thisURI = fileList->GetValue(n);
-        storageNode->AddURI(thisURI);
+        storageNode->AddURI(thisURI.c_str());
         }
       }
     }
@@ -509,7 +509,7 @@ void vtkSlicerVolumesLogic::InitializeStorageNode(
         {
         thisFileName = fileList->GetValue(n);
         //vtkDebugMacro("\tfile " << n << " =  " << thisFileName);
-        storageNode->AddFileName(thisFileName);
+        storageNode->AddFileName(thisFileName.c_str());
         }
       }
     }

--- a/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest2.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest2.cxx
@@ -123,7 +123,7 @@ int main( int argc, char * argv[] )
 
   vtkSmartPointer<vtkMRMLVectorVolumeNode> vectorVolume =
     vtkMRMLVectorVolumeNode::SafeDownCast(
-      logic->AddArchetypeVolume(fileNameList->GetValue(0), "rgbVolume", 0, fileNameList));
+      logic->AddArchetypeVolume(fileNameList->GetValue(0).c_str(), "rgbVolume", 0, fileNameList));
 
   if (!vectorVolume ||
       !isImageDataValid(vectorVolume->GetImageDataConnection()))

--- a/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMLoadable.cxx
+++ b/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMLoadable.cxx
@@ -163,7 +163,7 @@ void qSlicerDICOMLoadable::copyFromVtkLoadable(vtkSlicerDICOMLoadable* vtkLoadab
     {
     for (int fileIndex = 0; fileIndex < filesArray->GetNumberOfValues(); ++fileIndex)
       {
-      d->Files.append(QString(filesArray->GetValue(fileIndex)));
+      d->Files.append(QString(filesArray->GetValue(fileIndex).c_str()));
       }
     }
 
@@ -172,7 +172,7 @@ void qSlicerDICOMLoadable::copyFromVtkLoadable(vtkSlicerDICOMLoadable* vtkLoadab
     {
     for (int fileIndex = 0; fileIndex < referencedInstanceUIDsArray->GetNumberOfValues(); ++fileIndex)
       {
-      d->ReferencedInstanceUIDs.append(QString(referencedInstanceUIDsArray->GetValue(fileIndex)));
+      d->ReferencedInstanceUIDs.append(QString(referencedInstanceUIDsArray->GetValue(fileIndex).c_str()));
       }
     }
 }

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -202,7 +202,7 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG 800a0fb33332e0ebc6924dafa4d03ae19178a7c7
+  GIT_TAG 87e5df9ac609a2d7a21991f7cba37c5b51482d7e
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_vtkAddon Slicer_REMOTE_DEPENDENCIES vtkAddon)
@@ -337,7 +337,7 @@ list_conditional_append(Slicer_BUILD_LandmarkRegistration Slicer_REMOTE_DEPENDEN
 
 Slicer_Remote_Add(SurfaceToolbox
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/SlicerSurfaceToolbox"
-  GIT_TAG 25999cefa2554b5fa4698b847716f75837070e33
+  GIT_TAG f8b734436581ca0954d0303b16c6c17b69efdff3
   OPTION_NAME Slicer_BUILD_SurfaceToolbox
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
This commit fixes warnings like the following:

```
/path/to/Slicer/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest2.cxx:126:88: warning: ‘vtkStdString::operator const char*()’ is deprecated: Call `.c_str()` explicitly [-Wdeprecated-declarations]
  126 |       logic->AddArchetypeVolume(fileNameList->GetValue(0), "rgbVolume", 0, fileNameList));
      |                                                                                        ^
```

List of vtkAddon changes:

```
$ git shortlog 800a0fb33..87e5df9ac --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Fix deprecation warnings by explicitly calling vtkStdString::c_str()
```

This pull request is a follow-up of:
* https://github.com/Slicer/Slicer/pull/7010