### PR TITLE
ENH: Update CTK to fix warnings and misc issues

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "cd194fff1360e2da114b6b55ce963f089c6f46f2"
+    "5d241ecc539dcee182a78b03ecf78514a7fba58c"
     QUIET
     )
 


### PR DESCRIPTION
Highlighted fixes:

* Ensure ctk::copyDirRecursively skips hidden file by default. See commontk/CTK@97cc44525
* Fix regression in ctkDateRangeWidget. See commontk/CTK@ac4c0d755
* Remove obsolete error message in ctkDateRangeWidget::displayTime. See commontk/CTK@a17882bbd

List of CTK changes:

```
$ Jean-Christophe Fillion-Robin (60):
      COMP: Fix -Wint-in-bool-context in ctkWorkflow
      COMP: Fix -Wcatch-value warnings in DICOM libraries, tests and apps
      COMP: Fix -Wunused-* warnings
      COMP: Fix -Wreorder warning in ctkExampleHostControlWidget
      COMP: Fix -Wcomment in ctkDICOMApplicationTest1
      COMP: Fix CMake warning CMP0115 in org.commontk.plugingenerator.core
      COMP: Fix QFlags deprecation warnings related to ctkPlugin::Start/StopOptions
      COMP: Fix -Wunused-function warnings in ctkErrorLogModelTestHelper
      COMP: Fix -Wdeprecated-declarations warnings
      BUG: Ensure prefix is set in ctkCmdLineModuleObjectTreeWalker::prefixedProperty
      COMP: Fix -Wdeprecated-declarations related to qSort()
      COMP: Fix -Wdeprecated-declarations using Qt::MiddleButton instead of Qt::MidButton
      COMP: Update QtSOAP to fix QString::null deprecation warnings
      BUG: Fix ctkCoreSettingsTest
      BUG: Ensure ctk::copyDirRecursively skips hidden file by default
      ENH: Add "commit-message" GitHub Actions workflow
      ENH: Introduce ctk::isDirEmpty to support Qt < 5.9 missing QDir::isEmpty
      ENH: Add ctk::(removeOne|takeFirst) to support deprecation of QLinkedList
      BUG: Fix regression in ctkDateRangeWidget
      BUG: Remove obsolete error message in ctkDateRangeWidget::displayTime
      COMP: Fix QDateTime deprecation warnings in ctkDateRangeWidgetTest1
      STYLE: Simplify handling of Qt4 & Qt5 API differences in ctkDateRangeWidget
      COMP: Fix -Wimplicit-fallthrough warnings in PluginFramework
      COMP: Fix -Wdeprecated-declarations related to QWeakPointer
      COMP: Fix -Wcatch-value in ctkPlugin
      STYLE: Consistently catch exceptions by reference
      COMP: Fix -Wsign-promo in Widgets & DICOMWidgets
      COMP: Fix -Wunused-function in ctkCoordinatesWidgetValueProxyTest
      COMP: Fix -Wdeprecated-declarations in ctkPluginAbstractTracked using std::list
      COMP: Fix -Wdeprecated-declarations in ctkPluginAbstractTracked
      COMP: Fix -Wtype-limits in ctkDICOMItem::Decode
      COMP: Fix -Woverloaded-virtual in ctkVTKSurfaceMaterialPropertyWidget
      COMP: Fix -Wdeprecated-declarations in ctkPluginAbstractTracked
      COMP: Fix -Wdeprecated-declarations in ctkTransferFunctionView
      COMP: Fix deprecated warning related to QWidget::getContentsMargins()
      COMP: Fix -Wdeprecated-declarations related to QProcess::start()
      COMP: Fix -Wdeprecated-declarations related to QProcess::pid()
      STYLE: Consistently name the PluginFramework performance test
      BUG: Ensure PluginFramework tests do not run in concurrently
      COMP: Fix deprecated use of QSet<T>::toList() in ctkWorkflowButtonBoxWidget
      COMP: Fix -Wdeprecated-declarations in ctkSoapConnectionRunnable
      COMP: Remove deprecated use of QSqlError::number() in ctkPluginStorageSQL
      COMP: Fix -Wdeprecated-declarations in ctkCommandLineModuleExplorerMain
      COMP: Fix deprecated use of QSet<T>::toList() in ctkPluginStorageSQL
      COMP: Fix deprecated use of QFileDialog::DirectoryOnly in ctkDICOMBrowser
      COMP: Fix deprecated use of QList::swap() in ctkDICOMTableView
      COMP: Fix -Wdeprecated-declarations in ctkDICOMBrowserTester
      COMP: Fix deprecated use of QFileDialog::DirectoryOnly in ctkFileDialogTest1
      COMP: Fix QFlags deprecation warnings
      COMP: Update QtSOAP to fix deprecation warnings
      COMP: Fix deprecated use of QLabel::pixmap() in org.commontk.dah plugin
      COMP: Update QtTesting to fix deprecation warnings
      COMP: Fix QWheelEvent deprecated warning in ctkVTKRenderViewEventPlayer
      COMP: Fix build of plugin tests
      COMP: Fix unused function warning related to ctkFileCompleter::nameFilters()
      COMP: Fix deprecated use of QDesktopWidget::primaryScreen() in ctkSettings
      COMP: Fix deprecated use of QDesktopWidget in ctkTreeComboBox
      COMP: Fix unused variable warning in ctkVTKAbstractViewTest1
      COMP: Fix QFlags deprectation warning in ctkQtResourcesTreeModel
      COMP: Fix -Wint-in-bool-context warning in ctkErrorLogModelTerminalOutputTest1
```