### PR TITLE
COMP: Update python packages to latest

### DIFF
--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -41,35 +41,31 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pydicom]
-  pydicom==2.3.1 --hash=sha256:b00bacdabc1f8a18b61a08bb6cd0f41c419446531638c895a708c22a35d69cfe
+  pydicom==2.4.1 --hash=sha256:301cbf8bf2cca95643ccf678f5b0cfecfd15974cd27e199f0856c44694852c0e
   # [/pydicom]
   # [six]
   six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
   # [/six]
   # [Pillow]
   # Hashes correspond to the following packages:
-  #  - Pillow-9.4.0-1-cp39-cp39-macosx_10_10_x86_64.whl
-  #  - Pillow-9.4.0-2-cp39-cp39-macosx_10_10_x86_64.whl
-  #  - Pillow-9.4.0-cp39-cp39-macosx_10_10_x86_64.whl
-  #  - Pillow-9.4.0-cp39-cp39-macosx_11_0_arm64.whl
-  #  - Pillow-9.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - Pillow-9.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - Pillow-9.4.0-cp39-cp39-manylinux_2_28_aarch64.whl
-  #  - Pillow-9.4.0-cp39-cp39-manylinux_2_28_x86_64.whl
-  #  - Pillow-9.4.0-cp39-cp39-musllinux_1_1_aarch64.whl
-  #  - Pillow-9.4.0-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - Pillow-9.4.0-cp39-cp39-win_amd64.whl
-  Pillow==9.4.0 --hash=sha256:b8c2f6eb0df979ee99433d8b3f6d193d9590f735cf12274c108bd954e30ca858 \
-                --hash=sha256:9e5f94742033898bfe84c93c831a6f552bb629448d4072dd312306bab3bd96f1 \
-                --hash=sha256:0f3269304c1a7ce82f1759c12ce731ef9b6e95b6df829dccd9fe42912cc48569 \
-                --hash=sha256:cb362e3b0976dc994857391b776ddaa8c13c28a16f80ac6522c23d5257156bed \
-                --hash=sha256:a2e0f87144fcbbe54297cae708c5e7f9da21a4646523456b00cc956bd4c65815 \
-                --hash=sha256:0884ba7b515163a1a05440a138adeb722b8a6ae2c2b33aea93ea3118dd3a899e \
-                --hash=sha256:53dcb50fbdc3fb2c55431a9b30caeb2f7027fcd2aeb501459464f0214200a503 \
-                --hash=sha256:e8c5cf126889a4de385c02a2c3d3aba4b00f70234bfddae82a5eaa3ee6d5e3e6 \
-                --hash=sha256:6c6b1389ed66cdd174d040105123a5a1bc91d0aa7059c7261d20e583b6d8cbd2 \
-                --hash=sha256:0dd4c681b82214b36273c18ca7ee87065a50e013112eea7d78c7a1b89a739153 \
-                --hash=sha256:54614444887e0d3043557d9dbc697dbb16cfb5a35d672b7a0fcc1ed0cf1c600b
+  #  - Pillow-10.0.0-cp39-cp39-macosx_10_10_x86_64.whl
+  #  - Pillow-10.0.0-cp39-cp39-macosx_11_0_arm64.whl
+  #  - Pillow-10.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - Pillow-10.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - Pillow-10.0.0-cp39-cp39-manylinux_2_28_aarch64.whl
+  #  - Pillow-10.0.0-cp39-cp39-manylinux_2_28_x86_64.whl
+  #  - Pillow-10.0.0-cp39-cp39-musllinux_1_1_aarch64.whl
+  #  - Pillow-10.0.0-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - Pillow-10.0.0-cp39-cp39-win_amd64.whl
+  Pillow==10.0.0 --hash=sha256:9211e7ad69d7c9401cfc0e23d49b69ca65ddd898976d660a2fa5904e3d7a9baa \
+                 --hash=sha256:faaf07ea35355b01a35cb442dd950d8f1bb5b040a7787791a535de13db15ed90 \
+                 --hash=sha256:c9f72a021fbb792ce98306ffb0c348b3c9cb967dce0f12a49aa4c3d3fdefa967 \
+                 --hash=sha256:9f7c16705f44e0504a3a2a14197c1f0b32a95731d251777dcb060aa83022cb2d \
+                 --hash=sha256:76edb0a1fa2b4745fb0c99fb9fb98f8b180a1bbceb8be49b087e0b21867e77d3 \
+                 --hash=sha256:368ab3dfb5f49e312231b6f27b8820c823652b7cd29cfbd34090565a015e99ba \
+                 --hash=sha256:608bfdee0d57cf297d32bcbb3c728dc1da0907519d1784962c5f0c68bb93e5a3 \
+                 --hash=sha256:5c6e3df6bdd396749bafd45314871b3d0af81ff935b2d188385e970052091017 \
+                 --hash=sha256:7be600823e4c8631b74e4a0d38384c73f680e6105a7d3c6824fcf226c178c7e6
   # [/Pillow]
   # [retrying]
   retrying==1.3.4 --hash=sha256:8cc4d43cb8e1125e0ff3344e9de678fefd85db3b750b81b2240dc0183af37b35

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -32,8 +32,29 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
+  # [cryptography]
+  # Hashes correspond to the following packages:
+  #  - cryptography-41.0.1-cp37-abi3-macosx_10_12_universal2.whl
+  #  - cryptography-41.0.1-cp37-abi3-macosx_10_12_x86_64.whl
+  #  - cryptography-41.0.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - cryptography-41.0.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - cryptography-41.0.1-cp37-abi3-manylinux_2_28_aarch64.whl
+  #  - cryptography-41.0.1-cp37-abi3-manylinux_2_28_x86_64.whl
+  #  - cryptography-41.0.1-cp37-abi3-musllinux_1_1_aarch64.whl
+  #  - cryptography-41.0.1-cp37-abi3-musllinux_1_1_x86_64.whl
+  #  - cryptography-41.0.1-cp37-abi3-win_amd64.whl
+  cryptography==41.0.1 --hash=sha256:f73bff05db2a3e5974a6fd248af2566134d8981fd7ab012e5dd4ddb1d9a70699 \
+                       --hash=sha256:1a5472d40c8f8e91ff7a3d8ac6dfa363d8e3138b961529c996f3e2df0c7a411a \
+                       --hash=sha256:7fa01527046ca5facdf973eef2535a27fec4cb651e4daec4d043ef63f6ecd4ca \
+                       --hash=sha256:b46e37db3cc267b4dea1f56da7346c9727e1209aa98487179ee8ebed09d21e43 \
+                       --hash=sha256:d198820aba55660b4d74f7b5fd1f17db3aa5eb3e6893b0a41b75e84e4f9e0e4b \
+                       --hash=sha256:948224d76c4b6457349d47c0c98657557f429b4e93057cf5a2f71d603e2fc3a3 \
+                       --hash=sha256:059e348f9a3c1950937e1b5d7ba1f8e968508ab181e75fc32b879452f08356db \
+                       --hash=sha256:b4ceb5324b998ce2003bc17d519080b4ec8d5b7b70794cbd2836101406a9be31 \
+                       --hash=sha256:1fee5aacc7367487b4e22484d3c7e547992ed726d14864ee33c0176ae43b0d7c
+  # [/cryptography]
   # [PyJWT]
-  PyJWT==2.6.0 --hash=sha256:d83c3d892a77bbb74d3e1a2cfa90afaadb60945205d1095d9221f04466f64c14
+  PyJWT==2.7.0 --hash=sha256:ba2b425b15ad5ef12f200dc67dd56af4e26de2331f965c5439994dad075876e1
   # [/PyJWT]
   # [wrapt]
   # Hashes correspond to the following packages:
@@ -55,7 +76,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
                 --hash=sha256:64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640
   # [/wrapt]
   # [Deprecated]
-  Deprecated==1.2.13 --hash=sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d
+  Deprecated==1.2.14 --hash=sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c
   # [/Deprecated]
   # [pycparser]
   pycparser==2.21 --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9
@@ -95,7 +116,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
                 --hash=sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93
   # [/PyNaCl]
   # [PyGithub]
-  PyGithub==1.58.0 --hash=sha256:b7bac601492a2b6c876ef326e4ffa3c1923e32707e415da76bfb8307ee8ffb7e
+  PyGithub==1.59.0 --hash=sha256:126bdbae72087d8d038b113aab6b059b4553cb59348e3024bb1a1cae406ace9e
   # [/PyGithub]
   ]===])
 

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -29,21 +29,20 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  # [nose]
-  nose==1.3.7 --hash=sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac  # needed for NumPy unit tests
-  # [/nose]
   # [numpy]
   # Hashes correspond to the following packages:
-  #  - numpy-1.24.2-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - numpy-1.24.2-cp39-cp39-macosx_11_0_arm64.whl
-  #  - numpy-1.24.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - numpy-1.24.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - numpy-1.24.2-cp39-cp39-win_amd64.whl
-  numpy==1.24.2 --hash=sha256:4199e7cfc307a778f72d293372736223e39ec9ac096ff0a2e64853b866a8e18a \
-                --hash=sha256:adbdce121896fd3a17a77ab0b0b5eedf05a9834a18699db6829a64e1dfccca7f \
-                --hash=sha256:889b2cc88b837d86eda1b17008ebeb679d82875022200c6e8e4ce6cf549b7acb \
-                --hash=sha256:f64bb98ac59b3ea3bf74b02f13836eb2e24e48e0ab0145bbda646295769bd780 \
-                --hash=sha256:a77d3e1163a7770164404607b7ba3967fb49b24782a6ef85d9b5f54126cc39e5
+  #  - numpy-1.25.1-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - numpy-1.25.1-cp39-cp39-macosx_11_0_arm64.whl
+  #  - numpy-1.25.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - numpy-1.25.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - numpy-1.25.1-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - numpy-1.25.1-cp39-cp39-win_amd64.whl
+  numpy==1.25.1 --hash=sha256:3d7abcdd85aea3e6cdddb59af2350c7ab1ed764397f8eec97a038ad244d2d105 \
+                --hash=sha256:1a180429394f81c7933634ae49b37b472d343cccb5bb0c4a575ac8bbc433722f \
+                --hash=sha256:d412c1697c3853c6fc3cb9751b4915859c7afe6a277c2bf00acf287d56c4e625 \
+                --hash=sha256:20e1266411120a4f16fad8efa8e0454d21d00b8c7cee5b5ccad7565d95eb42dd \
+                --hash=sha256:f76aebc3358ade9eacf9bc2bb8ae589863a4f911611694103af05346637df1b7 \
+                --hash=sha256:1d5d3c68e443c90b38fdf8ef40e60e2538a27548b39b12b73132456847f4b631
   # [/numpy]
   ]===])
 

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pip]
-  pip==23.0.1 --hash=sha256:236bcb61156d76c4b8a05821b988c7b8c35bf0da28a4b614e8d6ab5212c25c6f
+  pip==23.1.2 --hash=sha256:3ef6ac33239e4027d9a5598a381b9d30880a1477e50039db2eac6e8a8f6d1b18
   # [/pip]
   ]===])
 

--- a/SuperBuild/External_python-pythonqt-requirements.cmake
+++ b/SuperBuild/External_python-pythonqt-requirements.cmake
@@ -32,10 +32,10 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [packaging]
-  packaging==23.0 --hash=sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2
+  packaging==23.1 --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61
   # [/packaging]
   # [pyparsing]
-  pyparsing==3.0.9 --hash=sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc
+  pyparsing==3.1.0 --hash=sha256:d554a96d1a7d3ddaf7183104485bc19fd80543ad6ac5bdb6426719d766fb06c1
   # [/pyparsing]
   # [six]
   six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -27,37 +27,37 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [certifi]
-  certifi==2022.12.7 --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
+  certifi==2023.5.7 --hash=sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716
   # [/certifi]
   # [idna]
   idna==3.4 --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
   # [/idna]
   # [charset-normalizer]
   # Hashes correspond to the following packages:
-  #  - charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_universal2.whl
-  #  - charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - charset_normalizer-3.1.0-cp39-cp39-macosx_11_0_arm64.whl
-  #  - charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_aarch64.whl
-  #  - charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - charset_normalizer-3.1.0-cp39-cp39-win_amd64.whl
-  #  - charset_normalizer-3.1.0-py3-none-any.whl
-  charset-normalizer==3.1.0 --hash=sha256:38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e \
-                            --hash=sha256:6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31 \
-                            --hash=sha256:8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f \
-                            --hash=sha256:3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e \
-                            --hash=sha256:21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706 \
-                            --hash=sha256:ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0 \
-                            --hash=sha256:53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f \
-                            --hash=sha256:830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b \
-                            --hash=sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d
+  #  - charset_normalizer-3.2.0-cp39-cp39-macosx_10_9_universal2.whl
+  #  - charset_normalizer-3.2.0-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - charset_normalizer-3.2.0-cp39-cp39-macosx_11_0_arm64.whl
+  #  - charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_aarch64.whl
+  #  - charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - charset_normalizer-3.2.0-cp39-cp39-win_amd64.whl
+  #  - charset_normalizer-3.2.0-py3-none-any.whl
+  charset-normalizer==3.2.0 --hash=sha256:855eafa5d5a2034b4621c74925d89c5efef61418570e5ef9b37717d9c796419c \
+                            --hash=sha256:203f0c8871d5a7987be20c72442488a0b8cfd0f43b7973771640fc593f56321f \
+                            --hash=sha256:e857a2232ba53ae940d3456f7533ce6ca98b81917d47adc3c7fd55dad8fab858 \
+                            --hash=sha256:5e86d77b090dbddbe78867a0275cb4df08ea195e660f1f7f13435a4649e954e5 \
+                            --hash=sha256:8700f06d0ce6f128de3ccdbc1acaea1ee264d2caa9ca05daaf492fde7c2a7200 \
+                            --hash=sha256:c1c76a1743432b4b60ab3358c937a3fe1341c828ae6194108a94c69028247f22 \
+                            --hash=sha256:1249cbbf3d3b04902ff081ffbb33ce3377fa6e4c7356f759f3cd076cc138d020 \
+                            --hash=sha256:7095f6fbfaa55defb6b733cfeb14efaae7a29f0b59d8cf213be4e7ca0b857b80 \
+                            --hash=sha256:8e098148dd37b4ce3baca71fb394c81dc5d9c7728c95df695d2dca218edf40e6
   # [/charset-normalizer]
   # [urllib3]
-  urllib3==1.26.14 --hash=sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1
+  urllib3==2.0.3 --hash=sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1
   # [/urllib3]
   # [requests]
-  requests==2.28.2 --hash=sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa
+  requests==2.31.0 --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f
   # [/requests]
   ]===])
 

--- a/SuperBuild/External_python-scipy.cmake
+++ b/SuperBuild/External_python-scipy.cmake
@@ -31,16 +31,18 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [scipy]
   # Hashes correspond to the following packages:
-  #  - scipy-1.10.1-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - scipy-1.10.1-cp39-cp39-macosx_12_0_arm64.whl
-  #  - scipy-1.10.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - scipy-1.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - scipy-1.10.1-cp39-cp39-win_amd64.whl
-  scipy==1.10.1 --hash=sha256:cd9f1027ff30d90618914a64ca9b1a77a431159df0e2a195d8a9e8a04c78abf9 \
-                --hash=sha256:79c8e5a6c6ffaf3a2262ef1be1e108a035cf4f05c14df56057b64acc5bebffb6 \
-                --hash=sha256:51af417a000d2dbe1ec6c372dfe688e041a7084da4fdd350aeb139bd3fb55353 \
-                --hash=sha256:1b4735d6c28aad3cdcf52117e0e91d6b39acd4272f3f5cd9907c24ee931ad601 \
-                --hash=sha256:7ff7f37b1bf4417baca958d254e8e2875d0cc23aaadbe65b3d5b3077b0eb23ea
+  #  - scipy-1.11.1-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - scipy-1.11.1-cp39-cp39-macosx_12_0_arm64.whl
+  #  - scipy-1.11.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - scipy-1.11.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - scipy-1.11.1-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - scipy-1.11.1-cp39-cp39-win_amd64.whl
+  scipy==1.11.1 --hash=sha256:39154437654260a52871dfde852adf1b93b1d1bc5dc0ffa70068f16ec0be2624 \
+                --hash=sha256:b588311875c58d1acd4ef17c983b9f1ab5391755a47c3d70b6bd503a45bfaf71 \
+                --hash=sha256:d51565560565a0307ed06fa0ec4c6f21ff094947d4844d6068ed04400c72d0c3 \
+                --hash=sha256:b41a0f322b4eb51b078cb3441e950ad661ede490c3aca66edef66f4b37ab1877 \
+                --hash=sha256:396fae3f8c12ad14c5f3eb40499fd06a6fef8393a6baa352a652ecd51e74e029 \
+                --hash=sha256:be8c962a821957fdde8c4044efdab7a140c13294997a407eaee777acf63cbf0c
   # [/scipy]
   ]===])
 

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -26,7 +26,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [setuptools]
-  setuptools==67.5.1 --hash=sha256:1c39d42bda4cb89f7fdcad52b6762e3c309ec8f8715b27c684176b7d71283242
+  setuptools==68.0.0 --hash=sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f
   # [/setuptools]
   ]===])
 

--- a/SuperBuild/External_python-wheel.cmake
+++ b/SuperBuild/External_python-wheel.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [wheel]
-  wheel==0.38.4 --hash=sha256:b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8
+  wheel==0.40.0 --hash=sha256:d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247
   # [/wheel]
   ]===])
 


### PR DESCRIPTION
Python packages were last updated on March 7th 2023 (https://github.com/Slicer/Slicer/commit/090d3c7d6457387dee5949e468a6a2a903e0e18b). This PR updates python packages to their latest versions. This type of update is something I usually do on about a quarterly cadence (every 3 months). I am a little later this time as it has been about 3.5 months

Note that SimpleITK isn't being updated here as we build it from source rather than using the provided whl on pypi.

```
PS C:\Users\butlej30383\AppData\Local\slicer.org\Slicer 5.3.0-2023-06-21\bin> ./PythonSlicer.exe "C:\Slicer\Utilities\Scripts\python_package_updater.py"
Searching external projects in C:\Slicer\SuperBuild
Validate external projects

[notice] A new release of pip is available: 23.0.1 -> 23.1.2
[notice] To update, run: python-real.exe -m pip install --upgrade pip
Package            Version         Latest   Type
------------------ --------------- -------- -----
certifi            2022.12.7       2023.5.7 wheel
charset-normalizer 3.1.0           3.2.0    wheel
Deprecated         1.2.13          1.2.14   wheel
numpy              1.24.2          1.25.1   wheel
packaging          23.0            23.1     wheel
Pillow             9.4.0           10.0.0   wheel
pip                23.0.1          23.1.2   wheel
pydicom            2.3.1           2.4.1    wheel
PyGithub           1.58.0          1.59.0   wheel
PyJWT              2.6.0           2.7.0    wheel
pyparsing          3.0.9           3.1.0    wheel
requests           2.28.2          2.31.0   wheel
scipy              1.10.1          1.11.1   wheel
setuptools         67.5.1          68.0.0   wheel
SimpleITK          2.2.0rc2.dev368 2.2.1    wheel
urllib3            1.26.14         2.0.3    wheel
wheel              0.38.4          0.40.0   wheel

  certifi==2023.5.7 --hash=sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716
  # Hashes correspond to the following packages:
  #  - charset_normalizer-3.2.0-cp39-cp39-macosx_10_9_universal2.whl
  #  - charset_normalizer-3.2.0-cp39-cp39-macosx_10_9_x86_64.whl
  #  - charset_normalizer-3.2.0-cp39-cp39-macosx_11_0_arm64.whl
  #  - charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_aarch64.whl
  #  - charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - charset_normalizer-3.2.0-cp39-cp39-win_amd64.whl
  #  - charset_normalizer-3.2.0-py3-none-any.whl
  charset-normalizer==3.2.0 --hash=sha256:855eafa5d5a2034b4621c74925d89c5efef61418570e5ef9b37717d9c796419c \
                            --hash=sha256:203f0c8871d5a7987be20c72442488a0b8cfd0f43b7973771640fc593f56321f \
                            --hash=sha256:e857a2232ba53ae940d3456f7533ce6ca98b81917d47adc3c7fd55dad8fab858 \
                            --hash=sha256:5e86d77b090dbddbe78867a0275cb4df08ea195e660f1f7f13435a4649e954e5 \
                            --hash=sha256:8700f06d0ce6f128de3ccdbc1acaea1ee264d2caa9ca05daaf492fde7c2a7200 \
                            --hash=sha256:c1c76a1743432b4b60ab3358c937a3fe1341c828ae6194108a94c69028247f22 \
                            --hash=sha256:1249cbbf3d3b04902ff081ffbb33ce3377fa6e4c7356f759f3cd076cc138d020 \
                            --hash=sha256:7095f6fbfaa55defb6b733cfeb14efaae7a29f0b59d8cf213be4e7ca0b857b80 \
                            --hash=sha256:8e098148dd37b4ce3baca71fb394c81dc5d9c7728c95df695d2dca218edf40e6
  Deprecated==1.2.14 --hash=sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c
  # Hashes correspond to the following packages:
  #  - numpy-1.25.1-cp39-cp39-macosx_10_9_x86_64.whl
  #  - numpy-1.25.1-cp39-cp39-macosx_11_0_arm64.whl
  #  - numpy-1.25.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - numpy-1.25.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - numpy-1.25.1-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - numpy-1.25.1-cp39-cp39-win_amd64.whl
  numpy==1.25.1 --hash=sha256:3d7abcdd85aea3e6cdddb59af2350c7ab1ed764397f8eec97a038ad244d2d105 \
                --hash=sha256:1a180429394f81c7933634ae49b37b472d343cccb5bb0c4a575ac8bbc433722f \
                --hash=sha256:d412c1697c3853c6fc3cb9751b4915859c7afe6a277c2bf00acf287d56c4e625 \
                --hash=sha256:20e1266411120a4f16fad8efa8e0454d21d00b8c7cee5b5ccad7565d95eb42dd \
                --hash=sha256:f76aebc3358ade9eacf9bc2bb8ae589863a4f911611694103af05346637df1b7 \
                --hash=sha256:1d5d3c68e443c90b38fdf8ef40e60e2538a27548b39b12b73132456847f4b631
  packaging==23.1 --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61
  # Hashes correspond to the following packages:
  #  - Pillow-10.0.0-cp39-cp39-macosx_10_10_x86_64.whl
  #  - Pillow-10.0.0-cp39-cp39-macosx_11_0_arm64.whl
  #  - Pillow-10.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - Pillow-10.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - Pillow-10.0.0-cp39-cp39-manylinux_2_28_aarch64.whl
  #  - Pillow-10.0.0-cp39-cp39-manylinux_2_28_x86_64.whl
  #  - Pillow-10.0.0-cp39-cp39-musllinux_1_1_aarch64.whl
  #  - Pillow-10.0.0-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - Pillow-10.0.0-cp39-cp39-win_amd64.whl
  Pillow==10.0.0 --hash=sha256:9211e7ad69d7c9401cfc0e23d49b69ca65ddd898976d660a2fa5904e3d7a9baa \
                 --hash=sha256:faaf07ea35355b01a35cb442dd950d8f1bb5b040a7787791a535de13db15ed90 \
                 --hash=sha256:c9f72a021fbb792ce98306ffb0c348b3c9cb967dce0f12a49aa4c3d3fdefa967 \
                 --hash=sha256:9f7c16705f44e0504a3a2a14197c1f0b32a95731d251777dcb060aa83022cb2d \
                 --hash=sha256:76edb0a1fa2b4745fb0c99fb9fb98f8b180a1bbceb8be49b087e0b21867e77d3 \
                 --hash=sha256:368ab3dfb5f49e312231b6f27b8820c823652b7cd29cfbd34090565a015e99ba \
                 --hash=sha256:608bfdee0d57cf297d32bcbb3c728dc1da0907519d1784962c5f0c68bb93e5a3 \
                 --hash=sha256:5c6e3df6bdd396749bafd45314871b3d0af81ff935b2d188385e970052091017 \
                 --hash=sha256:7be600823e4c8631b74e4a0d38384c73f680e6105a7d3c6824fcf226c178c7e6
  pip==23.1.2 --hash=sha256:3ef6ac33239e4027d9a5598a381b9d30880a1477e50039db2eac6e8a8f6d1b18
  pydicom==2.4.1 --hash=sha256:301cbf8bf2cca95643ccf678f5b0cfecfd15974cd27e199f0856c44694852c0e
  PyGithub==1.59.0 --hash=sha256:126bdbae72087d8d038b113aab6b059b4553cb59348e3024bb1a1cae406ace9e
  PyJWT==2.7.0 --hash=sha256:ba2b425b15ad5ef12f200dc67dd56af4e26de2331f965c5439994dad075876e1
  pyparsing==3.1.0 --hash=sha256:d554a96d1a7d3ddaf7183104485bc19fd80543ad6ac5bdb6426719d766fb06c1
  requests==2.31.0 --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f
  # Hashes correspond to the following packages:
  #  - scipy-1.11.1-cp39-cp39-macosx_10_9_x86_64.whl
  #  - scipy-1.11.1-cp39-cp39-macosx_12_0_arm64.whl
  #  - scipy-1.11.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - scipy-1.11.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - scipy-1.11.1-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - scipy-1.11.1-cp39-cp39-win_amd64.whl
  scipy==1.11.1 --hash=sha256:39154437654260a52871dfde852adf1b93b1d1bc5dc0ffa70068f16ec0be2624 \
                --hash=sha256:b588311875c58d1acd4ef17c983b9f1ab5391755a47c3d70b6bd503a45bfaf71 \
                --hash=sha256:d51565560565a0307ed06fa0ec4c6f21ff094947d4844d6068ed04400c72d0c3 \
                --hash=sha256:b41a0f322b4eb51b078cb3441e950ad661ede490c3aca66edef66f4b37ab1877 \
                --hash=sha256:396fae3f8c12ad14c5f3eb40499fd06a6fef8393a6baa352a652ecd51e74e029 \
                --hash=sha256:be8c962a821957fdde8c4044efdab7a140c13294997a407eaee777acf63cbf0c
  setuptools==68.0.0 --hash=sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f
  # Hashes correspond to the following packages:
  #  - SimpleITK-2.2.1-cp39-cp39-macosx_10_9_x86_64.whl
  #  - SimpleITK-2.2.1-cp39-cp39-macosx_11_0_arm64.whl
  #  - SimpleITK-2.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - SimpleITK-2.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - SimpleITK-2.2.1-cp39-cp39-win_amd64.whl
  SimpleITK==2.2.1 --hash=sha256:e032bb2e54b96ce426187f07ce5dd9733077b18005399f6fbbcd4765b386299f \
                   --hash=sha256:3ffec97db30f923788f4e19b5a6e708d68afcce8f89cb54d7c976bd099b9a580 \
                   --hash=sha256:d6f58cdf90dbd0b84be68e0b46545c92f28c650d86e9f24acb91ad1c27416357 \
                   --hash=sha256:9b90dfd94cba0b068bacddaf2550d96df2683df830b9ee71cd9440e64c701196 \
                   --hash=sha256:7e20bbc467a8fff15978fee34a97c851ec3d0caed2d01929f600a13a0ff2f955
  urllib3==2.0.3 --hash=sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1
  wheel==0.40.0 --hash=sha256:d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247
```

- numpy 1.25.0 removed support for Nose.
- As of PyGithub 1.58.1, it now requires the cryptography dependency

Changes to note with the numpy version update from 1.24 to 1.25 are the following:
- https://numpy.org/doc/stable/release/1.25.0-notes.html#deprecations
- https://numpy.org/doc/stable/release/1.25.0-notes.html#expired-deprecations

Changes to note with the scipy version update from 1.10 to 1.11 are the following:
- https://scipy.github.io/devdocs/release/1.11.0-notes.html#deprecated-features
- https://scipy.github.io/devdocs/release/1.11.0-notes.html#expired-deprecations

Since `scipy` is not directly used in Slicer core, we may have to update extensions to account for changes.

Additionally re https://github.com/Slicer/Slicer/pull/6590#issuecomment-1282762511, on macOS, some of the dependent libraries shipped with scipy have changed
```
Directory: scipy-1.10.1-cp39-cp39-macosx_10_9_x86_64\scipy\.dylibs
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         3/6/2023  8:54 PM         313744 libgcc_s.1.dylib
-a----         3/6/2023  8:54 PM        1588608 libgfortran.3.dylib
-a----         3/6/2023  8:54 PM       66118352 libopenblas.0.dylib
-a----         3/6/2023  8:54 PM         301952 libquadmath.0.dylib

Directory: scipy-1.11.1-cp39-cp39-macosx_10_9_x86_64\scipy\.dylibs
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         6/28/2023  10:42 PM         126416 libgcc_s.1.1.dylib
-a----         6/28/2023  10:42 PM        6786304 libgfortran.5.dylib
-a----         6/28/2023  10:42 PM       66689840 libopenblas.0.dylib
-a----         6/28/2023  10:42 PM         352704 libquadmath.0.dylib
```


## Testing Results:
Windows
- [X] Build ✔️  
- [X] Tests ✔️ 