### PR TITLE
COMP: Update RapidJSON from 2016.08.25 (v1.1.0) to 2023.05.09 to fix warnings

### DIFF
--- a/SuperBuild/External_RapidJSON.cmake
+++ b/SuperBuild/External_RapidJSON.cmake
@@ -27,7 +27,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "v1.1.0"
+    "973dc9c06dcd3d035ebd039cfb9ea457721ec213" # 2023.05.09
     QUIET
     )
 


### PR DESCRIPTION
This fixes the following warning through the integration of fa5963a2f (Fix -Wclass-memaccess warnings/errors):

```
/path/to/Slicer/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonElement.cxx:536:64:   required from here
/path/to/Slicer-Release/RapidJSON/include/rapidjson/document.h:1952:24: warning: ‘void* memcpy(void*, const void*, size_t)’ writing to an object of type ‘rapidjson::GenericValue<rapidjson::UTF8<> >::Member’ {aka ‘struct rapidjson::GenericMember<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<> >’} with no trivial copy-assignment; use copy-assignment instead [-Wclass-memaccess]
 1952 |             std::memcpy(m, members, count * sizeof(Member));
      |             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Note that since there is no new RapidJSON tagged release since v1.1.0, this commit updates to the latest version.


List of RapidJSON changes:

```
$ git shortlog v1.1.0..973dc9c06 --no-merges
Adam Calhoon (2):
      Fix the alignment of placement new buffer for GenericValue.
      Fix the alignment of placement new buffer for GenericValue.

Adam Majer (1):
      Fix compilation with older GCC versions

Albert Hung (2):
      Eliminate missing prototypes warning
      Check for __GNUC__ definition

:...skipping...
Adam Calhoon (2):
      Fix the alignment of placement new buffer for GenericValue.
      Fix the alignment of placement new buffer for GenericValue.

Adam Majer (1):
      Fix compilation with older GCC versions

Albert Hung (2):
      Eliminate missing prototypes warning
      Check for __GNUC__ definition

Alejandro Martinez (4):
      Fixed bug on space hexadecimal encoding
      Added unittests for invalid ascii control chars
      Changed error code for invalid special ascii chars, fixed writer tests
      Added ARM-Neon support for SIMD.SkipWhitespace*

Andrew (1):
      typo on documentation dom.zh-cn.md: "己于" -> "已于"

Andrey Glebov (3):
      - replaced RAPIDJSON_NEW macro with variadic varient
      - replaced RAPIDJSON_NEW calls in fwdtest.cpp
      - replaced RAPIDJSON_NEW with C++98 compatible version

Bart Muzzin (1):
      Issue ISSUE-1028: Visual Studio natvis file.

Benjamin Lee (1):
      Handle non-throwing exception specifications that can still throw ISSUE-1280

BennyYip (1):
      fix ISSUE-749

Captain Crutches (2):
      Make RapidJSON_INCLUDE_DIR non-blank in Config.cmake
      Use SOURCE_DIR instead of CMAKE_DIR for build tree

Charles Milette (5):
      Fix ARM NEON under MSVC
      Fix build error under non-Clang compilers
      Fix signedness error
      Update comment
      Change #ifdef to #if defined

Chocobo1 (1):
      Improve readme.md

Christian Semmler (4):
      add remote ref to schemaMap_
      add test case for remote ref issue
      fix C++03 compatibility
      remove superfluous typename

Christopher Warrington (5):
      Fix Windows doc build MSBuild error MSB6001
      Guard against min/max being macros in document.h
      Guard against min/max macros in tests too
      Assert Type enum lower bound as well
      Guard against min/max being macros in reader.h

Clemens Arth (1):
      update to create config file which is independent from actual install location

Crunkle (1):
      Fix processor check when empty

David Newman (1):
      chore: correct spelling

Eric Rannaud (1):
      Make GenericMemberIterator::Iterator public again (RAPIDJSON_NOMEMBERITERATORCLASS)

Erik Froseth (2):
      Remove executable bit
      Detect C++11 features for Developer Studio

Etienne Laurin (3):
      Allow pointer tokens to have non-null-terminated strings
      fix template parameter
      add test for non-null-terminated token

Flaviu_ (1):
      Resolve conflict with Windows header about max macro

Florin Malita (1):
      Prevent int underflow when parsing exponents

Gao Mingfei (1):
      Add CMake minimum version required.

Gaspard Petit (2):
      Adding a single customization point that ensures all allocations within rapidjson can be performed with a custom memory allocator; Introduces the macros RAPIDJSON_MALLOC, RAPIDJSON_REALLOC, and RAPIDJSON_FREE.
      Added parameters to RAPIDJSON_MALLOC, RAPIDJSON_REALLOC and RAPIDJSON_FREE

Gustav (1):
      Fixes issue #1718

Haffon (2):
      GetParseOffset to GetErrorOffset
      GetParseOffset to GetErrorOffset

Harry Wong (2):
      Supress implicit fallthrough in GCC
      Onley apply to GCC 7

Hartwig (1):
      Add convenience method Key(std::basic_string<Ch> const&) to Writer

Hendrik Muhs (3):
      add a test that provokes a compile time error on windows
      don't let the GetObject macro rewrite the GetObject method, add a GetObj alias
      replace auto with concrete type

IceTrailer (1):
      Fixed parentheses in reader.h which were required to prevent the using of max macro

Ivan Kravets (1):
      Update version to 1.1.0

Ivan Le Lann (1):
      Support CMake none targets

Janusz Chorko (2):
      Removed non-compiling assignment operator. Fixed ISSUE-718
      Explicitly disable copy assignment operator

Jean-Claude Monnin (1):
      Fix warning when NDEBUG is defined [-Wunused-variable]

John (1):
      ensure the pragma is only applied to MSVC

John Stiles (24):
      Restored original IterativeParse implementation
      Test coverage up
      Attempt to suppress valgrind wcslen error
      Trivial change to re-trigger Travis CI
      Trivial change to trigger Travis CI
      Try again to suppress Valgrind
      Once again
      Remove unneeded change
      Remove unneeded change
      Quoted strings to String() or Key() are auto-sized by template
      Quoted strings to String() or Key() are auto-sized by template
      Assert that String() and Key() are given null-terminated strings
      Fix msvc x64 compilation issue
      Add unit test for Issue 889
      Remove broken templatized string length optimization
      Improve LookaheadParser
      Remove switch
      Initialize v_ to placate GCC
      Remove all switch
      Provide a Flush() API within Writer
      Fix template length optimization issue in PrettyWriter
      added test for parsing 0e100
      Update readertest.cpp
      Added test for issue ISSUE-1251

Johnny Shaw (2):
      Make schema dtor robust against exceptions
      fixes for natvis

Joshua Watt (1):
      Remove shadow typedef

Julien Courtat (1):
      faq: fix document insertion example

Jun (2):
      Replace RAPIDJSON_CLZLL with internal clzll (PR-1660)
      ci: upgrade distro to xenial and add arm64 test cases (PR-1662)

KLsz (1):
      Adding a few missing includes

KaitoHH (7):
      Add feature of locating line and column number of error
      fix stream wrapper initializer
      suppress C4512, C4702 warning
      add cursor wrapper
      add unit test for cursorstreamwrapper
      remove unnecessary code
      fix gcc & cl warning

Kent Ross (3):
      gate definition of symmetric equality operators on impl, not lib
      delete unused variable
      do not define operator!= in C++20

Konstantin Käfer (1):
      Avoid pointer arithmetic on null pointer to remove undefined behavior

Krystian Chmura (1):
      Add implicit conversion from Object and Array to Value (PR-1404)

Kyrega (8):
      Fix RawNumber for longer char types
      Added typename
      Using unsigned for WIStreamWrapper
      Do not depend on c++11 conditional
      Use rapidjson internal::SelectIf
      No default template parameter for older compilers
      No default template parameter for older compilers
      Correct WIStreamWrapper

Lars Klein (2):
      Improve surrogate handling
      Add test case for low surrogate handling

Laurent Stacul (1):
      Fix recursive operator== call in C++20 (PR-1846)

Lele Gaifax (5):
      Fix FileWriteStream doc
      Wrap all WriteXxx() calls within EndValue(), to ensure a flush after root-level scalar value
      Add simple test for issue ISSUE-1336
      Extend the test on issue ISSUE-1336 to cover all basic types
      Add test case on kParseNumbersAsStringsFlag being able to load big ints

Leo Mehr (2):
      Tutorial: fix typos in examples and broken links
      undo changes to links and some minor changes to make the readme more easily readable

Leonard Chan (1):
      Avoid ptrdiff between pointers to different allocations

Leonid Terenin (2):
      fix shadowed variable
      fix shadowed variable, take 2

Liang ZOU (1):
      add missing header "ios"

Luka Rahne (1):
      Allow user to define custom RAPIDJSON_NOEXCEPT_ASSERT macro

Léonard Gérard (1):
      Correct complexity claim

M.Tayel (2):
      enable cross compiling by adding option to remove -march/-cpu
      Fixed typo in CMake file

Malcolm Tyrrell (2):
      Fix vs2017 compile error C2105: '--' needs l-value
      Sanitize the code in schema.h

Marian Klymov (1):
      Autodetect RAPIDJSON_HAS_CXX11_NOEXCEPT and RAPIDJSON_HAS_CXX11_TYPETRAITS for Visual Studio

Martin Lindhe (1):
      fix some typos

Matteo Settenvini (1):
      Add a target to RapidJSONConfig.cmake.in (PR-1350)

Matthew Early (1):
      typo

Matthis Thorade (4):
      ignore DS_Store files
      Delete .DS_Store
      Delete .DS_Store
      Delete .DS_Store

MaxXSoft (1):
      doc/tutorial.zh-cn: fixed some typos

MaximeBF (4):
      Support long and unsined long as int and unsigned on Microsft platforms
      Add unittest for long as int in MSC platforms
      Fix unsigned long as unsigned unit test
      Change long/ulong as int/uint on MSC unit tests to be more inline with other templated functions unit tests

Mikhail Boldyrev (1):
      fixed Uint case in docs

Milo Yip (69):
      Defer thread creation in parsebypart example
      Add preconditions in writer and string functions
      Refactor regex
      Fix ISSUE-741
      Remove lambda expression in (pretty)writertest
      Add StringBuffer::GetLength()
      Fix schema.zh-cn.md
      Another try for fixing schema.md
      Revert "Another try for fixing schema.md"
      Remove unncessary std::move()
      Update dom.zh-cn.md
      Add Value::Value(float) and static_cast for suppressing clang warning
      Fix failing to resolve $ref in allOf causes crash in SchemaValidator::StartObject()
      Change SchemaValidator::GetNullHandler() from singleton to instance.
      Restore missing deallocation of GenericSchemaValidator::nullHandler_
      Change Schema::GetTypeless() from singleton to instance
      Fixed a bug for SchemaDocument move constructor
      Fix nullHandler allocation bug
      Remove empty NumberStream::~NumberStream()
      Refactor GenericValue deep-clone constructor
      Move GenericValue deep-clone constructor into the class declaration.
      Update sax.md
      Update sax.zh-cn.md
      Update Doxyfile.zh-cn.in
      Fix ISSUE-831 RAPIDJSON_HAS_CXX11_RANGE_FOR is error defined
      Fix output character type in writers
      Remove non-ASCII character
      Try fixing Error compilation Ubuntu 14.04 ISSUE-834
      Fix ISSUE-899
      Update schema.zh-cn.md
      Fix ISSUE-905 unable to set writeFlags for PrettyWriter
      Fix ISSUE-910 incorrect casting
      Fix ISSUE-947 -Weffc++ warning
      Remove -Weverything
      Fix ISSUE-949 about -Werror=conversion
      Update tutorial.zh-cn.md
      Fix patternProperties & additionalProperties lead to ASSERT
      Fix ISSUE-1017 allOf keyword fail with Writer handler
      Change from miloyip/rapidjson to Tencent/rapidjson
      Update appveyor badge and link
      Fix ISSUE-1071 gitbook link
      Update gitbook zh-cn link
      Partially fix ISSUE-1077
      Fix schema.md TOC
      Add anchors to Schema.md
      Add archiver example
      Try to fix travis build
      Another try to fix travis build
      Fix -Werror=effc++
      Fix invalid type in Pointer
      Fix Compile error because of -Werror=effc++ is on
      Fix false alarm from clang-tidy
      Add transcoding/validation to Writer::RawValue()
      Fix API constness
      Revert "Fix API constness"
      Fix Windows build
      Update rapidjson.h
      Update sortkeys.cpp
      Fix gcc compilation error in sortkeys
      Adding swap() for GenericMember
      Workaround of sortkeys example
      Update doxygen download URL
      Change all GenericMemberIterator from struct to class
      Disable copy constructor in GenericMember
      Provide default implementations for move constructor/assignment in GenericMember
      Update biginteger.h (PR-1652)
      PrettyWriter constructor uninitialized member (PR-1654)
      Fix Pointer::Append() crash for custom allocator on Windows
      Revert "Fix the alignment of placement new buffer for GenericValue."

Minmin Gong (3):
      Specifies the endian of msvc ARM64 configuration.
      Update the code to adapt the new gtest.
      Update appveyor rule to support VS2017.

N. Kolotov (1):
      Fixed -Wshadow warning.

Nikolay (1):
      Three-way comparison for CLang 10 fix (PR-1679)

Oliver Hahm (2):
      fix return values
      common notation of empty if/else case

Patrick Cheng (3):
      added assertion to help suppress clang warnings
      Reserve() is sometimes called when stackTop_ is null. The assert is invalid.
      When length is 0, the code does nothing, so skip it completely.

Pave Pimenov (1):
      fix https://github.com/Tencent/rapidjson/issues/1778 (part 1)

Peter Kasting (4):
      Avoid exit-time destructors.
      Avoid exit-time destructors.
      Include conceptual change from PR 2001.
      Try to fix MSVC build.

Philipp A Hartmann (4):
      Fix -Wclass-memaccess warnings/errors
      Fix -Wsign-conversion warnings/errors
      Suppress -Wformat-overflow warning/error
      Add RAPIDJSON_NOEXCEPT_ASSERT

Philipp A. Hartmann (11):
      RAPIDJSON_STATIC_ASSERT: use C++11 static_assert, if available
      GenericValue::CopyFrom: add option to force copying of strings
      Fixup ISSUE-964 by forwarding copyConstStrings recursively
      ParseResult: improve bool conversion and add operator!=
      Travis: Switch to Ubuntu 14.04 (Trusty)
      unittest.h: change RAPIDJSON_ASSERT to allow usage in expressions
      Improved handling of NULL strings
      travis-doxygen.sh: upgrade to Doxygen 1.8.13
      GenericStringRef: move assert out of expression
      Avoid inheritance from std::iterator
      Update test/unittest/pointertest.cpp

PhoebeHui (1):
      Add vcpkg installation instructions

Renny Koshy (1):
      - Fixed a build issue by initializing "index" in the header file

Rolf Eike Beer (3):
      CMake: avoid neeless variable expansion
      CMake: do not pass -march=native or -mcpu=native when crosscompiling
      CMake: automatically handle C++11 settings if possible

Romain Geissler (1):
      Ignore GCC 8 warnings.

Romain Geissler @ Amadeus (1):
      Avoid warnings when using -std=c++20 and clang 10: use three way comparision for iterators when possible. (PR-1667)

Romain Moret (1):
      Rename a few internal preprocessor macros to avoid potential naming conflicts

Ross Younger (1):
      Use C++17 fallthrough tag instead of disabling warning

Ruslan Bilovol (1):
      CMake: remove hardcoded CMAKECONFIG_INSTALL_DIR path

Ryan Morris (1):
      Added macro RAPIDJSON_ALLOCATOR_DEFAULT_CHUNK_CAPACITY to allow default chunk capacity to be lowered for embedded devices with < 64k stack sizes

Saurabh Charde (1):
      Improve documentation

Sergey Fedorov (1):
      CMakeLists: fix optflags for ppc

Sergey Kovalevich (1):
      Added const for Reader methods

Sfinktah Bungholio (1):
      Fix for winmindef.h defining min/max macros

Silas S. Brown (1):
      Remove unnecessary wording from BSD license not needed for MIT license (fixes ISSUE-528)

Stephen Kelly (1):
      Use rvalue refs with clang-cl

Steve Hanson (44):
      code and tests
      remove debug std::cout, handle empty error object in example
      remove C++ 11 enum syntax
      remove C++ 11 std::string to_string() syntax
      revert perftest
      Revert "revert perftest"
      correct workaround for issue 1805
      restore coverage
      work around issue 1089
      fix crash where simple type with sub-schema has a bad value
      code and tests
      fix bracket
      fix compile errors
      fix platform-dependent compiler error with >>
      handle internal refs properly
      remove comma
      correct #defines in uri.h
      satisfy all compilers
      satisfy all compilers 2
      satisfy all compilers 3
      fix coverage
      remove copyright & debug statements
      make std::string optional
      remove compiler warning
      remove temp debug statements
      fix coverage, unit test allocators and equality
      fix Uri.Match optional arg
      fix coverage again
      equiv fix for issue 1899
      Uri Parse improvements
      fix the warning
      initial
      corrections
      add dump of unexpected schema errors in schematest.cpp
      correct address.json so tests pass
      remove unnecessary templating from schema tests
      fix build break
      tidy up after merge from master
      attempt to fix SEH
      small corrections for schema.h
      code & tests for openapi 2.0 & 3.0 suppprt
      review comment updates
      fix ISSUE-2101
      Suppress uritest

StilesCrisis (23):
      Improved reporting
      Token-by-token pull parsing
      Fix Dev Studio bool-conversion warning
      Improve performance
      Improve coverage and performance
      Added unit test for pull parsing
      Add LIKELY and UNLIKELY hints
      Add example SimplePullHandler code
      Clean up example code
      SimplePullReader C++98 support
      More C++98 fixes
      Put in unit tests to catch parser failure
      Fix parsing of NaN/Inf
      Unit test
      Added assertion
      Add matching fix for PrettyWriter
      Unit test
      Fix null handler construction
      Add IterativeParse docs
      Tiny fix
      Specialize StrLen for char/wchar_t
      Add lookahead parser example
      Fix GCC warning

SuperSodaSea (3):
      修复拼写错误
      Translate doc/internals.md Part 1
      Translate doc/internals.md Part 2

Tall??di Mih??ly (2):
      Move constructor support for Writer
      Move constructor support for PrettyWriter

Tallódi Mihály (1):
      Tests for Writer, PrettyWriter move constructors

Tana0910 (1):
      fix a typo in error.h: literial -> literal

Ted Lyngmo (2):
      Fix -Werror=effc++ errors with GNU 6.3.1
      Fix -Werror=effc++ errors with GNU 6.3.1

Tim Gates (2):
      Fix simple typo: drived -> derived (PR-1646)
      docs: fix simple typo, perecent -> percent

Tim Miller (1):
      Updated google test to latest commit

Tom Briden (2):
      valuetest: fix potential write of terminating nul past the end of the destination
      encdedstreamtest: fix use-after-free compile error with gcc-12

Tomasz Noczynski (Linux) (2):
      If storage class is not specified as first in declaration then Intel C++ Compiler 2017 generates message: message 82: storage class is not first
      To avoid Intel C++ Compiler 1879 warnings: warning 1879: unimplemented pragma ignored: #pragma intrinsic(_BitScanReverse64) warning 1879: unimplemented pragma ignored: #pragma intrinsic(_umul128)

VeekXT (1):
      doc: fix a typo

Veselin Georgiev (1):
      Fix SIGBUS due to unaligned access

Wu Zhao (1):
      support IBM PowerPC / ppc64 / ppc64le and XL compiler

Xuanyi Zhou (5):
      fix schema test compile error
      suppress enum bitwise operation warnings on msvc
      add body to private copy constructor & copy assignment
      add return statement & comment
      also initialize class member

Yolan Romailler (1):
      Removing always true if condition

Yu Chen Hou (1):
      FIx typo in documentation

Yuri Khan (10):
      Add failing test for the case when a remote schema is violated (PR-1064)
      internal::Schema: Keep pointer for future use
      Keep schema URI in GenericSchemaDocument and internal::Schema
      Report schema violation details (PR-619)
      Extend schema validation tests to compare error object
      Document schema violation format
      Update schemavalidator example to demonstrate GetError()
      refactor Schema: Keep ErrorHandler reference in Context
      Move schema violation docs into Schema chapter
      Flatten allOf keyword violations

Yuval Hager (1):
      silence clang-7 self-assign-overloaded warning

Zhihao Yuan (2):
      Treat signed-unsigned conversions as errors.
      Fix a non-type template parameter type mismatch

Zoltan Kovago (1):
      fix compilation on windows with clang

abolz (25):
      Add tests for issues with string-to-double conversions (ISSUE-849, ISSUE-1249, ISSUE-1251, ISSUE-1253, ISSUE-1256, ISSUE-1259)
      Add assertions to check preconditions of functions and unsigned integer arithmetic
      Replace unsigned with signed integer arithmetic in strtod
      Trim all zeros from input
      Properly test for overflow
      Return 0 if binary exponent is too small
      Some more tests
      Return infinity if binary exponent is too large
      Add more tests (which need to be fixed)
      Fix bogus gcc warning
      Fix implicit signed/unsigned conversion and a small glitch in the error computation
      Fix implicit signed/unsigned conversion and a small glitch in the error computation - part 2
      Use std::numeric_limits instead of macros
      Fix another signed/unsigned warning
      Use C macros with the correct header instead of std::numeric_limits and static_cast
      [Debug]
      [Debug - Initialize variable]
      Limit exponents
      Workaround incorrect rounding in MSVC
      Fix offset computation in BigInteger::operator<<
      [Debug - clean up]
      Add a test for BigInteger::operator<<
      Add more tests
      Disable failing test for now
      Run all the new tests in full-precision mode only

agate-pris (3):
      Allow the macro RAPIDJSON_DEFAULT_ALLOCATOR to be used in any namespace
      Allow the macro RAPIDJSON_DEFAULT_STACK_ALLOCATOR to be used in any namespace
      Allow access to the template parameter StackAllocator in the GenericDocument

ardb-uk (2):
      Resolve issue 1948
      Add files via upload

bluehero (7):
      use _mm_cmpistri
      modify
      add unittest
      modify unittest
      modify
      modify
      modify

bogaotory (2):
      in relation to solving issue ISSUE-784, this commit enables the schema to recognise the "default" property, and avoids a missing property error when a default is given in the schema
      again, in relation to solving issue ISSUE-784, use `SizeType`-typed variable to indicate a none-zero length string has been given in the schema as default value for the json property; added an unittest `Object_Required_PassWithDefault`

clach04 (1):
      Fix issue ISSUE-1104 Solaris compilation errors fread()/fwrite()

eisaev (1):
      Update allocators.h

escherstair (6):
      fix _BitScanReverse() usage for CE6
      fallback to the naive version for CE6
      fix naive version implementation
      add unit test for clzll()
      fix naive implementation for clzll()
      fix unit test

fredgan (1):
      fix some misspellings

h46incon (1):
      Add MemberCapacity() and MemberReserve() interface for object type.

ioannis-e (1):
      Update Visual Studio Visualizer (PR-1665)

jack_perisich (1):
      Fix small errors in dtoa output for certain doubles

jedwards (1):
      use softintrin on arm64ec

jiapeng.wen (1):
      fix tutorial error

jwillcox-telework (2):
      Update allocators.h
      Update dtoa.h

kyb (1):
      Fixed ISSUE-985 : Unittest failed with MinGWx64. And few small improvement were done while looking for mistakes.

luz.paz (1):
      Misc. typos

maficccc@gmail.com (1):
      Fix warnings Dereference of null pointer

mdamle (1):
      Closes ISSUE-1643 (PR-1644)

miloyip (2):
      doc: fix incorrect template parameters in EncodedOutputStream example
      add traverse as pointer example

myd7349 (1):
      Fix typo in doc

niukuo (1):
      fix wrong length in remote schema

oviradoi (1):
      Fix creating the nuget package with Raggles' fork of CoApp

piotr-kaminski-intel (2):
      Removing Klocwork issues from schema.h
      Init variable in the constructor

piratf (2):
      fix CMake policy CMP0048 warning ISSUE-1154
      add contributing section in readme.md, introduced the basic cooperation process.

quyan (1):
      fix typo

seky (2):
      added example for sorting keys
      removed std::string and receiving const Value in printIt

sergey kachanovskiy (1):
      Fixes ISSUE-1198

shadeware (1):
      fix typos in doc code

sjaques (1):
      Fix uninitilized member Reader::state_

supperpiccle (1):
      Use passed in allocator.

xiaoPierre (1):
      Bug when switching to std regex

xpahos (1):
      Allow escaped apostrophe in values (PR-1639)

ylavic (37):
      Missing "internal" namespace for StrLen
      Use passed in allocator for internal regex parser.
      Fix a memory leak for invalid std::regex in Schema.
      GenericRegex: don't throw/abort on syntax error (unclosed parenthesis).
      Unit test for invalid GenericRegex (unclosed parenthesis).
      Optimize FileReadStream and BasicIStreamWrapper.
      Possibly std::ios::binary helps with streams on Windows
      Base buffered BasicIStreamWrapper on the original (better performing) FileReadStream algorithm.
      Fix FileReadStream::Peek4().
      Add less than operator to Pointer.
      Unit test for Pointer::operator<().
      Rework Pointer::operator<() loop.
      Speed up Pointer::operator<().
      Allow to (std::)Swap two pointers.
      Pointer tests now need <algorithm> (for std::swap), but no tabs.
      Use the allocator of the Schema for its Pointer.
      Add missing curly brackets in STDREGEX's CreatePattern().
      Fix compilation of sortkeys.cpp with MSVC 2013 (hopefully).
      RAPIDJSON_NOEXCEPT_ASSERT() should never throw.
      Provide RAPIDJSON_HAS_CXX11 and use it for RAPIDJSON_HAS_CXX11_RVALUE_REFS and RAPIDJSON_HAS_CXX11_NOEXCEPT.
      RAPIDJSON_NOEXCEPT_ASSERT should assert regardless of RAPIDJSON_HAS_CXX11_NOEXCEPT.
      Safer GenericValue& operator=(GenericValue& rhs).
      Test assignment from inner Value.
      Provide StdAllocator, STL compatible, for use with STL types.
      Tests for StdAllocator.
      Make StdAllocator C++17-20 compatible.
      Make StdAllocator C++17-20 compatible.
      Handle C++17 (and C++11 with MSVC) in CI.
      Don't define StdAllocator<void> from C++17.
      Tests for C++17 with VS 2019.
      Fix would-crash tests if the default allocator used were kNeedFree.
      Add rvalue copy and assignment to MemoryPoolAllocator and StdAllocator.
      Tests for Allocators copy by rvalue reference.
      Try some tests with -D_GLIBCXX_DEBUG and coverage with -O0.
      Set RAPIDJSON_USE_MEMBERSMAP to use a (std::multi)map for object members.
      Tests for Members in std::multimap.
      Turn some Tests to RAPIDJSON_USE_MEMBERSMAP in CI.

zhao xin (6):
      Update .travis.yml
      Update .travis.yml
      Update travis-doxygen.sh
      Update travis-doxygen.sh
      Update travis-doxygen.sh
      Update travis-doxygen.sh

Étienne Dupuis (3):
      Initialized regex with schema allocator.
      Solves ISSUE-1108. The default copy constructor of GenericPointer will use the allocator of the copied object. The extra copy constructor that takes an allocator as a parameter is distinct if someone really wants to create a copy with a null allocator.
      Added relevant unit tests for issue ISSUE-1108 suggested improvement.

仓鼠 (1):
      Doc: Fix some typos. (PR-1675)
```