### PR TITLE
DOC: Update build instructions that newer CMake can be used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.16.3...3.19.7 FATAL_ERROR)
 
+if("${CMAKE_VERSION}" VERSION_EQUAL "3.21.0")
+  message(FATAL_ERROR "CMake version is ${CMAKE_VERSION} and using CMake==3.21.0 is not supported.\nSee https://gitlab.kitware.com/cmake/cmake/-/issues/22476")
+endif()
+
 if("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.25.0" AND "${CMAKE_VERSION}" VERSION_LESS_EQUAL "3.25.2")
   message(FATAL_ERROR "CMake version is ${CMAKE_VERSION} and using CMake >=3.25.0,<=3.25.2 is not supported.\nSee https://gitlab.kitware.com/cmake/cmake/-/issues/24567")
 endif()

--- a/Docs/developer_guide/build_instructions/windows.md
+++ b/Docs/developer_guide/build_instructions/windows.md
@@ -8,7 +8,10 @@ Slicer relies on a number of large third-party libraries (such VTK, ITK, DCMTK),
 
 ## Install prerequisites
 
-- [CMake](https://www.cmake.org/cmake/resources/software.html) version that meets at least the minimum required CMake 3.21.1 <= version [< 3.25.0](https://gitlab.kitware.com/cmake/cmake/-/issues/24180) (or 3.16.3 <= version < 3.20.4)
+- [CMake](https://www.cmake.org/cmake/resources/software.html) version >= 3.16.3.
+  - Avoid versions with known Slicer build issues:
+    - 3.21.0 (CMake issue [22476](https://gitlab.kitware.com/cmake/cmake/-/issues/22476))
+    - 3.25.0 to 3.25.2 (CMake issues [24180](https://gitlab.kitware.com/cmake/cmake/-/issues/24180), [24567](https://gitlab.kitware.com/cmake/cmake/-/issues/24567))
 - [Git](https://git-scm.com/download/win) >= 1.7.10
   - Note: CMake must be able to find `git.exe` and `patch.exe`. If git is installed in the default location then they may be found there, but if they are not found then either add the folder that contains them to `PATH` environment variable; or set `GIT_EXECUTABLE` and `Patch_EXECUTABLE` as environment variables or as CMake variables at configure time.
 - [Visual Studio](https://visualstudio.microsoft.com/downloads/): any edition can be used (including the free Community edition), when configuring the installer:


### PR DESCRIPTION
The issue with CMake 3.25.0 was resolved in CMake 3.25.1 (https://github.com/Kitware/CMake/commit/80fc564dd7cbebc374a18fb57c71472dac5de6c1).

The build instructions were saying that CMake <3.25.0 had to be used, but I have built recent Slicer successfully using CMake 3.26.4. Therefore I'm updating the instructions to make note that specifically 3.25.0 is one of a few versions to avoid.