### PR TITLE
DOC: Fix typo in `Transforms.dox`

### DIFF
--- a/Modules/Loadable/Transforms/Documentation/Transforms.dox
+++ b/Modules/Loadable/Transforms/Documentation/Transforms.dox
@@ -2,7 +2,7 @@
 \defgroup Slicer_QtModules_Transforms Transforms
 \ingroup Slicer_QtModules
 This module is used for creating, editing, and displaying transformations.
-Transformation nodes are used in Slicer to define spacial relationships between different nodes (such as volumes, models, markups, ROI's, or other transform nodes) or between the nodes and the global RAS space.
+Transformation nodes are used in Slicer to define spatial relationships between different nodes (such as volumes, models, markups, ROIs, or other transform nodes) or between the nodes and the global RAS space.
 You can establish these relations by moving nodes from the Transformable list to the Transformed list or by dragging the nodes under the Transformation nodes in the Data module.
 
 */


### PR DESCRIPTION
s/spacial/spatial/

Edit: it could also be 'special' but in context seemed like the former