### PR TITLE
ENH: Skip steps in required job rather than skipping workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,27 +5,9 @@ on:
   push:
     branches:
       - "main"
-    paths-ignore:
-      - "COPYRIGHT.txt"
-      - "License.txt"
-      - "README.txt"
-      - "requirements-docs.txt"
-      - "SuperBuild.cmake"
-      - "SuperBuild/**"
-      - "**.md"
-      - "Docs/**"
   pull_request:
     branches:
       - "*"
-    paths-ignore:
-      - "COPYRIGHT.txt"
-      - "License.txt"
-      - "README.txt"
-      - "requirements-docs.txt"
-      - "SuperBuild.cmake"
-      - "SuperBuild/**"
-      - "**.md"
-      - "Docs/**"
   # Allows running this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -35,12 +17,30 @@ jobs:
     name: Build Slicer
     runs-on: ubuntu-latest
     steps:
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        id: changes
+        with:
+          filters: |
+            paths-to-include:
+              - ".github/actions/slicer-build/**"
+              - "Applications/**"
+              - "Base/**"
+              - "CMake/**"
+              - "Extensions/**"
+              - "Libs/**"
+              - "Modules/**"
+              - "Resources/**"
+              - "Testing/**"
+              - "CMakeLists.txt"
+
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: 'Build Slicer'
+        if: steps.changes.outputs.paths-to-include == 'true'
         uses: ./.github/actions/slicer-build
 
       - name: 'Upload Slicer package'
+        if: steps.changes.outputs.paths-to-include == 'true'
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: slicer-package


### PR DESCRIPTION
This allows for a job such as "Build Slicer" to report successful even if the changed files are in the list of ones to ignore. A skipped job will report its status as "Success". See the following link for more details:

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks

From https://github.com/Slicer/Slicer/pull/7053#issuecomment-1613335912

> - Had a change to a .cxx file and also DOC and github workflow changes - https://github.com/Slicer/Slicer/actions/runs/5413682866/jobs/9839616035?pr=7053
> - Only DOC and github workflow changes - https://github.com/Slicer/Slicer/actions/runs/5413703493/jobs/9839670031?pr=7053