### PR TITLE
BUG: Fix "Build Slicer" CI workflow in the context of push event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     name: Build Slicer
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changes
         with:
@@ -32,8 +34,6 @@ jobs:
               - "Resources/**"
               - "Testing/**"
               - "CMakeLists.txt"
-
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: 'Build Slicer'
         if: steps.changes.outputs.paths-to-include == 'true'


### PR DESCRIPTION
This commit is a follow-up of 2d6d136e94 (ENH: Skip steps in required job rather than skipping workflow) that should ensure the "dorny/paths-filter" action works in the context of push event.

See https://github.com/dorny/paths-filter/issues/88#issuecomment-847003742