### PR TITLE
STYLE: Consistently specify "#endif" include guards without a comment

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogicRequests.h
+++ b/Base/Logic/vtkSlicerApplicationLogicRequests.h
@@ -657,4 +657,4 @@ protected:
 };
 
 
-#endif // __vtkSlicerApplicationLogicRequests_h
+#endif

--- a/Base/QTCLI/qSlicerCLIModuleWidgetEventPlayer.h
+++ b/Base/QTCLI/qSlicerCLIModuleWidgetEventPlayer.h
@@ -43,4 +43,4 @@ private:
   qSlicerCLIModuleWidgetEventPlayer& operator=(const qSlicerCLIModuleWidgetEventPlayer&); // NOT implemented
 };
 
-#endif // __qSlicerCLIModuleWidgetEventPlayer_h
+#endif

--- a/CMake/vtkSlicerConfigure.h.in
+++ b/CMake/vtkSlicerConfigure.h.in
@@ -128,4 +128,4 @@
 #define Slicer_QM_OUTPUT_DIRS "@Slicer_QM_OUTPUT_DIRS@"
 #define Slicer_LANGUAGES "@Slicer_LANGUAGES@"
 
-#endif //__vtkSlicerConfigure_h
+#endif

--- a/CMake/vtkSlicerObjectFactory.h.in
+++ b/CMake/vtkSlicerObjectFactory.h.in
@@ -39,4 +39,4 @@ private:
   void operator=(const @vtk-module@ObjectFactory&) = delete;
 };
 
-#endif // __@vtk-module@ObjectFactory_h
+#endif

--- a/CMake/vtkSlicerVersionConfigure.h.in
+++ b/CMake/vtkSlicerVersionConfigure.h.in
@@ -105,4 +105,4 @@
 /// \sa Slicer_MAIN_PROJECT_REVISION
 #define Slicer_MAIN_PROJECT_COMMIT_COUNT "@Slicer_MAIN_PROJECT_COMMIT_COUNT@"
 
-#endif // __vtkSlicerVersionConfigure_h
+#endif

--- a/CMake/vtkSlicerVersionConfigureMinimal.h.in
+++ b/CMake/vtkSlicerVersionConfigureMinimal.h.in
@@ -90,4 +90,4 @@
 /// \brief Type of Slicer release: `Experimental`, `Nightly` or `Stable`.
 #define Slicer_RELEASE_TYPE "@Slicer_RELEASE_TYPE@"
 
-#endif // __vtkSlicerVersionConfigureMinimal_h
+#endif

--- a/Libs/MRML/Core/vtkITKTransformConverter.h
+++ b/Libs/MRML/Core/vtkITKTransformConverter.h
@@ -1473,4 +1473,4 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
   return nullptr;
 }
 
-#endif // __vtkITKTransformConverter_h
+#endif

--- a/Libs/MRML/Core/vtkITKTransformInverse.h
+++ b/Libs/MRML/Core/vtkITKTransformInverse.h
@@ -320,4 +320,4 @@ typedef itk::InverseDisplacementFieldTransform< double, 3 > InverseDisplacementF
 typedef itk::InverseThinPlateSplineKernelTransform< float, 3 > InverseThinPlateSplineTransformFloatType;
 typedef itk::InverseThinPlateSplineKernelTransform< double, 3 > InverseThinPlateSplineTransformDoubleType;
 
-#endif // __vtkITKTransformInverse_h
+#endif

--- a/Libs/MRML/Core/vtkMRMLNodePropertyMacros.h
+++ b/Libs/MRML/Core/vtkMRMLNodePropertyMacros.h
@@ -592,4 +592,4 @@
 
 /// @}
 
-#endif // __vtkMRMLNodePropertyMacros_h
+#endif

--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.h
@@ -375,4 +375,4 @@ protected:
   std::string SegmentListFilterOptions;
 };
 
-#endif // __vtkMRMLSegmentationNode_h
+#endif

--- a/Libs/MRML/DisplayableManager/vtkMRMLThreeDReformatDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLThreeDReformatDisplayableManager.h
@@ -63,4 +63,4 @@ private:
   vtkInternal* Internal;
 };
 
-#endif // vtkMRMLThreeDReformatDisplayableManager_h
+#endif

--- a/Libs/MRML/DisplayableManager/vtkSingleton.h
+++ b/Libs/MRML/DisplayableManager/vtkSingleton.h
@@ -142,4 +142,4 @@ VTK_SINGLETON_INITIALIZER_CXX(NAME)
 
 /// @}
 
-#endif //__vtkSingleton_h
+#endif

--- a/Libs/MRML/IDImageIO/itkMRMLIDImageIO.h
+++ b/Libs/MRML/IDImageIO/itkMRMLIDImageIO.h
@@ -140,4 +140,4 @@ private:
 
 
 } /// end namespace itk
-#endif /// itkMRMLIDImageIO_h
+#endif

--- a/Libs/MRML/Widgets/qMRMLNodeComboBoxDelegate.h
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBoxDelegate.h
@@ -74,4 +74,4 @@ private:
   Q_DISABLE_COPY(qMRMLNodeComboBoxDelegate);
 };
 
-#endif // __qMRMLNodeComboBoxDelegate_h
+#endif

--- a/Libs/MRML/Widgets/qMRMLNodeComboBoxMenuDelegate.h
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBoxMenuDelegate.h
@@ -63,4 +63,4 @@ private:
   Q_DISABLE_COPY(qMRMLNodeComboBoxMenuDelegate);
 };
 
-#endif // __qMRMLNodeComboBoxMenuDelegate_h
+#endif

--- a/Libs/MRML/Widgets/qMRMLWidgetsExport.h
+++ b/Libs/MRML/Widgets/qMRMLWidgetsExport.h
@@ -12,4 +12,4 @@
  #define QMRML_WIDGETS_EXPORT
 #endif
 
-#endif //__qMRMLWidgetsExport_h
+#endif

--- a/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.h
+++ b/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.h
@@ -106,4 +106,4 @@ private:
   void operator=(const vtkBinaryLabelmapToClosedSurfaceConversionRule&) = delete;
 };
 
-#endif // __vtkBinaryLabelmapToClosedSurfaceConversionRule_h
+#endif

--- a/Libs/vtkSegmentationCore/vtkClosedSurfaceToBinaryLabelmapConversionRule.h
+++ b/Libs/vtkSegmentationCore/vtkClosedSurfaceToBinaryLabelmapConversionRule.h
@@ -115,4 +115,4 @@ private:
   void operator=(const vtkClosedSurfaceToBinaryLabelmapConversionRule&) = delete;
 };
 
-#endif // __vtkClosedSurfaceToBinaryLabelmapConversionRule_h
+#endif

--- a/Libs/vtkSegmentationCore/vtkClosedSurfaceToFractionalLabelmapConversionRule.h
+++ b/Libs/vtkSegmentationCore/vtkClosedSurfaceToFractionalLabelmapConversionRule.h
@@ -90,4 +90,4 @@ private:
   void operator=(const vtkClosedSurfaceToFractionalLabelmapConversionRule&) = delete;
 };
 
-#endif // __vtkClosedSurfaceToFractionalLabelmapConversionRule_h
+#endif

--- a/Libs/vtkSegmentationCore/vtkFractionalLabelmapToClosedSurfaceConversionRule.h
+++ b/Libs/vtkSegmentationCore/vtkFractionalLabelmapToClosedSurfaceConversionRule.h
@@ -85,4 +85,4 @@ private:
   void operator=(const vtkFractionalLabelmapToClosedSurfaceConversionRule&) = delete;
 };
 
-#endif // __vtkFractionalLabelmapToClosedSurfaceConversionRule_h
+#endif

--- a/Libs/vtkSegmentationCore/vtkSegment.h
+++ b/Libs/vtkSegmentationCore/vtkSegment.h
@@ -158,4 +158,4 @@ private:
   void operator=(const vtkSegment&) = delete;
 };
 
-#endif // __vtkSegment_h
+#endif

--- a/Libs/vtkSegmentationCore/vtkSegmentation.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.h
@@ -604,4 +604,4 @@ private:
   void operator=(const vtkSegmentation&) = delete;
 };
 
-#endif // __vtkSegmentation_h
+#endif

--- a/Libs/vtkSegmentationCore/vtkSegmentationConversionParameters.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentationConversionParameters.h
@@ -105,4 +105,4 @@ private:
   void operator=(const vtkSegmentationConversionParameters&) = delete;
 };
 
-#endif // __vtkSegment_h
+#endif

--- a/Libs/vtkSegmentationCore/vtkSegmentationConversionPath.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentationConversionPath.h
@@ -147,4 +147,4 @@ inline vtkSegmentationConversionPath* vtkSegmentationConversionPaths::GetNextPat
   return static_cast<vtkSegmentationConversionPath*>(this->GetNextItemAsObject());
 }
 
-#endif // __vtkSegment_h
+#endif

--- a/Libs/vtkSegmentationCore/vtkSegmentationConverter.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentationConverter.h
@@ -191,4 +191,4 @@ private:
   void operator=(const vtkSegmentationConverter&) = delete;
 };
 
-#endif // __vtkSegmentationConverter_h
+#endif

--- a/Libs/vtkSegmentationCore/vtkSegmentationConverterRule.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentationConverterRule.h
@@ -156,4 +156,4 @@ protected:
   friend class vtkSegmentationConverter;
 };
 
-#endif // __vtkSegmentationConverterRule_h
+#endif

--- a/Libs/vtkSegmentationCore/vtkSegmentationHistory.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentationHistory.h
@@ -129,4 +129,4 @@ private:
   void operator=(const vtkSegmentationHistory&) = delete;
 };
 
-#endif // __vtkSegmentation_h
+#endif

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManagerHelper.h
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManagerHelper.h
@@ -158,4 +158,4 @@ private:
   typedef std::vector<vtkSmartPointer<vtkHandleWidget> >::iterator HandleWidgetListIt;
 };
 
-#endif /* VTKMRMLANNOTATIONDISPLAYABLEMANAGERHELPER_H_ */
+#endif

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManagerHelper.h
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManagerHelper.h
@@ -111,4 +111,4 @@ private:
   vtkMRMLMarkupsDisplayableManager* DisplayableManager;
 };
 
-#endif /* VTKMRMLMARKUPSDISPLAYABLEMANAGERHELPER_H_ */
+#endif

--- a/Modules/Loadable/Markups/Widgets/Testing/Cxx/qMRMLMarkupsMalformedWidget.h
+++ b/Modules/Loadable/Markups/Widgets/Testing/Cxx/qMRMLMarkupsMalformedWidget.h
@@ -53,4 +53,4 @@ public:
   { return new qMRMLMarkupsMalformedWidget(); }
 };
 
-#endif // __qMRMLMalformedWidget_h_
+#endif

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsAbstractOptionsWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsAbstractOptionsWidget.h
@@ -91,4 +91,4 @@ private:
   Q_DISABLE_COPY(qMRMLMarkupsAbstractOptionsWidget);
 };
 
-#endif // __qMRMLMarkupsAbstractOptionsWidget_h_
+#endif

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsAngleMeasurementsWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsAngleMeasurementsWidget.h
@@ -78,4 +78,4 @@ private:
   Q_DISABLE_COPY(qMRMLMarkupsAngleMeasurementsWidget);
 };
 
-#endif // __qMRMLMarkupsAngleMeasurementsWidget_h_
+#endif

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsCurveSettingsWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsCurveSettingsWidget.h
@@ -76,4 +76,4 @@ private:
   Q_DISABLE_COPY(qMRMLMarkupsCurveSettingsWidget);
 };
 
-#endif // __qSlicerCurveSettingsWidget_h_
+#endif

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsOptionsWidgetsFactory.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsOptionsWidgetsFactory.h
@@ -96,4 +96,4 @@ private:
   static qMRMLMarkupsOptionsWidgetsFactory* Instance;
 };
 
-#endif // __qslicermarkupsfactory_h_
+#endif

--- a/Modules/Loadable/Segmentations/Logic/FibHeap.h
+++ b/Modules/Loadable/Segmentations/Logic/FibHeap.h
@@ -259,6 +259,6 @@ private:
 
 };
 
-#endif /* FIBHEAP_H */
+#endif
 
 #endif //__VTK_WRAP__

--- a/Modules/Loadable/Segmentations/MRML/vtkMRMLSegmentEditorNode.h
+++ b/Modules/Loadable/Segmentations/MRML/vtkMRMLSegmentEditorNode.h
@@ -230,4 +230,4 @@ protected:
   double SourceVolumeIntensityMaskRange[2];
 };
 
-#endif // __vtkMRMLSegmentEditorNode_h
+#endif

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/Logic/vtkSlicerTemplateKeyLogic.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/Logic/vtkSlicerTemplateKeyLogic.h
@@ -44,4 +44,4 @@ private:
   void operator=(const vtkSlicerTemplateKeyLogic&) = delete;
 };
 
-#endif // __vtkSlicerTemplateKeyMarkupslogic_h_
+#endif

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/MRML/vtkMRMLMarkupsTestLineNode.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/MRML/vtkMRMLMarkupsTestLineNode.h
@@ -71,4 +71,4 @@ private:
   vtkPolyData *TargetOrgan = nullptr;
 };
 
-#endif //vtkmrmlmarkupstestlinenode_h_
+#endif

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/VTKWidgets/vtkSlicerTestLineRepresentation2D.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/VTKWidgets/vtkSlicerTestLineRepresentation2D.h
@@ -94,4 +94,4 @@ private:
   void operator=(const vtkSlicerTestLineRepresentation2D&) = delete;
 };
 
-#endif // __vtkslicertestlinerepresentation3d_h_
+#endif

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/VTKWidgets/vtkSlicerTestLineRepresentation3D.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/VTKWidgets/vtkSlicerTestLineRepresentation3D.h
@@ -84,4 +84,4 @@ private:
   void operator=(const vtkSlicerTestLineRepresentation3D&) = delete;
 };
 
-#endif // __vtkslicertestlinerepresentation3d_h_
+#endif

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/VTKWidgets/vtkSlicerTestLineWidget.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/VTKWidgets/vtkSlicerTestLineWidget.h
@@ -48,4 +48,4 @@ private:
   void operator=(const vtkSlicerTestLineWidget) = delete;
 };
 
-#endif // __vtkslicerslicingcontourwidget_h_
+#endif

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/Widgets/qMRMLMarkupsTestLineWidget.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/Widgets/qMRMLMarkupsTestLineWidget.h
@@ -69,4 +69,4 @@ private:
   Q_DISABLE_COPY(qMRMLMarkupsTestLineWidget);
 };
 
-#endif // __qSlicerTestLineWidget_h_
+#endif


### PR DESCRIPTION
Comments were specified only for ~40 files and some of them were incorrect (e.g see `vtkSegmentationConversionParameters.h`), this commit removes the remaining ones.