### PR TITLE
COMP: Consistently define include guards to match filename

### DIFF
--- a/Base/QTCore/qSlicerIOOptions_p.h
+++ b/Base/QTCore/qSlicerIOOptions_p.h
@@ -20,8 +20,8 @@
 
 #include "qSlicerIO.h"
 
-#ifndef __qSlicerIOOptionsWidget_p_h
-#define __qSlicerIOOptionsWidget_p_h
+#ifndef qSlicerIOOptions_p_h
+#define qSlicerIOOptions_p_h
 
 //
 //  W A R N I N G

--- a/Base/QTCore/qSlicerScriptedUtils_p.h
+++ b/Base/QTCore/qSlicerScriptedUtils_p.h
@@ -18,8 +18,8 @@
 
 ==============================================================================*/
 
-#ifndef __qSlicerScriptedUtils_h
-#define __qSlicerScriptedUtils_h
+#ifndef qSlicerScriptedUtils_p_h
+#define qSlicerScriptedUtils_p_h
 
 //
 //  W A R N I N G

--- a/Base/QTGUI/qSlicerExtensionsServerWidget_p.h
+++ b/Base/QTGUI/qSlicerExtensionsServerWidget_p.h
@@ -18,8 +18,8 @@
 
 ==============================================================================*/
 
-#ifndef __qSlicerExtensionsServerWidgetPrivate_p_h
-#define __qSlicerExtensionsServerWidgetPrivate_p_h
+#ifndef qSlicerExtensionsServerWidget_p_h
+#define qSlicerExtensionsServerWidget_p_h
 
 // Qt includes
 #include <QObject>

--- a/Base/QTGUI/qSlicerSettingsUserInformationPanel.h
+++ b/Base/QTGUI/qSlicerSettingsUserInformationPanel.h
@@ -7,8 +7,8 @@
 
 =========================================================================auto=*/
 
-#ifndef __qqSlicerSettingsUserInformationPanel_h
-#define __qqSlicerSettingsUserInformationPanel_h
+#ifndef qSlicerSettingsUserInformationPanel_h
+#define qSlicerSettingsUserInformationPanel_h
 
 // Qt includes
 #include <QWidget>

--- a/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.h
@@ -20,8 +20,8 @@
 
 ==============================================================================*/
 
-#ifndef __vtkMRMLTableSQLightStorageNode_h
-#define __vtkMRMLTableSQLightStorageNode_h
+#ifndef vtkMRMLTableSQLiteStorageNode_h
+#define vtkMRMLTableSQLiteStorageNode_h
 
 #include "vtkMRMLStorageNode.h"
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.h
@@ -38,8 +38,8 @@
  * vtkMRMLAbstractWidgetRepresentation vtkMRMLAbstractWidget
 */
 
-#ifndef vtkMRMLAbstractRepresentation_h
-#define vtkMRMLAbstractRepresentation_h
+#ifndef vtkMRMLAbstractWidgetRepresentation_h
+#define vtkMRMLAbstractWidgetRepresentation_h
 
 #include "vtkMRMLDisplayableManagerExport.h"
 #include "vtkWidgetRepresentation.h"

--- a/Libs/vtkITK/vtkITKImageToImageFilterUSF.h
+++ b/Libs/vtkITK/vtkITKImageToImageFilterUSF.h
@@ -7,8 +7,8 @@
 
 ==========================================================================*/
 
-#ifndef __vtkITKImageToImageFilterUSF
-#define __vtkITKImageToImageFilterUSF
+#ifndef vtkITKImageToImageFilterUSF_h
+#define vtkITKImageToImageFilterUSF_h
 
 #include "vtkITKImageToImageFilter.h"
 #include "vtkImageAlgorithm.h"

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManagerHelper.h
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManagerHelper.h
@@ -12,8 +12,8 @@
 
  =========================================================================auto=*/
 
-#ifndef VTKMRMLANNOTATIONDISPLAYABLEMANAGERHELPER_H_
-#define VTKMRMLANNOTATIONDISPLAYABLEMANAGERHELPER_H_
+#ifndef vtkMRMLAnnotationDisplayableManagerHelper_h
+#define vtkMRMLAnnotationDisplayableManagerHelper_h
 
 // Annotations includes
 #include "vtkSlicerAnnotationsModuleMRMLDisplayableManagerExport.h"

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonElement.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonElement.h
@@ -20,8 +20,8 @@
 // Helper objects for reading/writing markups from/to JSON file
 //
 
-#ifndef __vtkMRMLMarkupsJsonIO_h
-#define __vtkMRMLMarkupsJsonIO_h
+#ifndef vtkMRMLMarkupsJsonElement_h
+#define vtkMRMLMarkupsJsonElement_h
 
 // Markups includes
 #include "vtkSlicerMarkupsModuleMRMLExport.h"

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManagerHelper.h
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManagerHelper.h
@@ -24,8 +24,8 @@
 ///
 
 
-#ifndef VTKMRMLMARKUPSDISPLAYABLEMANAGERHELPER_H_
-#define VTKMRMLMARKUPSDISPLAYABLEMANAGERHELPER_H_
+#ifndef vtkMRMLMarkupsDisplayableManagerHelper_h
+#define vtkMRMLMarkupsDisplayableManagerHelper_h
 
 // MarkupsModule includes
 #include "vtkSlicerMarkupsModuleMRMLDisplayableManagerExport.h"

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
@@ -38,8 +38,8 @@
  * vtkSlicerMarkupsWidgetRepresentation vtkMRMLAbstractWidget vtkPointPlacer
 */
 
-#ifndef vtkSlicerMarkupsRepresentation_h
-#define vtkSlicerMarkupsRepresentation_h
+#ifndef vtkSlicerMarkupsWidgetRepresentation_h
+#define vtkSlicerMarkupsWidgetRepresentation_h
 
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 

--- a/Modules/Loadable/Markups/Widgets/Testing/Cxx/qMRMLMarkupsMalformedWidget.h
+++ b/Modules/Loadable/Markups/Widgets/Testing/Cxx/qMRMLMarkupsMalformedWidget.h
@@ -18,8 +18,8 @@
 
 ==============================================================================*/
 
-#ifndef __qMRMLMalformedWidget_h_
-#define __qMRMLMalformedWidget_h_
+#ifndef qMRMLMarkupsMalformedWidget_h_
+#define qMRMLMarkupsMalformedWidget_h_
 
 // Markups widgets includes
 #include "qMRMLMarkupsAbstractOptionsWidget.h"

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsCurveSettingsWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsCurveSettingsWidget.h
@@ -18,8 +18,8 @@
 
 ==============================================================================*/
 
-#ifndef __qSlicerCurveSettingsWidget_h_
-#define __qSlicerCurveSettingsWidget_h_
+#ifndef qMRMLMarkupsCurveSettingsWidget_h
+#define qMRMLMarkupsCurveSettingsWidget_h
 
 // Markups widgets includes
 #include "qMRMLMarkupsAbstractOptionsWidget.h"

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsOptionsWidgetsFactory.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsOptionsWidgetsFactory.h
@@ -19,8 +19,8 @@
 
   ==============================================================================*/
 
-#ifndef __qslicermarkupsfactory_h_
-#define __qslicermarkupsfactory_h_
+#ifndef qMRMLMarkupsOptionsWidgetsFactory_h
+#define qMRMLMarkupsOptionsWidgetsFactory_h
 
 // Markups widgets includes
 #include "qMRMLMarkupsAbstractOptionsWidget.h"

--- a/Modules/Loadable/Markups/qSlicerMarkupsReader.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsReader.h
@@ -15,8 +15,8 @@
 
 ==============================================================================*/
 
-#ifndef __qSlicerMarkupsReader
-#define __qSlicerMarkupsReader
+#ifndef qSlicerMarkupsReader_h
+#define qSlicerMarkupsReader_h
 
 // Slicer includes
 #include "qSlicerFileReader.h"

--- a/Modules/Loadable/Plots/qSlicerPlotsModuleWidget.h
+++ b/Modules/Loadable/Plots/qSlicerPlotsModuleWidget.h
@@ -20,8 +20,8 @@
 
 ==============================================================================*/
 
-#ifndef __qSlicerTransformsModuleWidget_h
-#define __qSlicerTransformsModuleWidget_h
+#ifndef qSlicerPlotsModuleWidget_h
+#define qSlicerPlotsModuleWidget_h
 
 // Slicer includes
 #include "qSlicerAbstractModuleWidget.h"

--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.h
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.h
@@ -18,8 +18,8 @@
 
 ==============================================================================*/
 
-#ifndef __vtkMRMLSceneViewsModuleLogic_h
-#define __vtkMRMLSceneViewsModuleLogic_h
+#ifndef vtkSlicerSceneViewsModuleLogic_h
+#define vtkSlicerSceneViewsModuleLogic_h
 
 // SlicerLogic includes
 #include "vtkSlicerBaseLogic.h"

--- a/Modules/Loadable/Segmentations/Logic/vtkImageGrowCutSegment.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkImageGrowCutSegment.h
@@ -1,5 +1,5 @@
-#ifndef FASTGROWCUT_H
-#define FASTGROWCUT_H
+#ifndef vtkImageGrowCutSegment_h
+#define vtkImageGrowCutSegment_h
 
 #include "vtkSlicerSegmentationsModuleLogicExport.h"
 

--- a/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qSlicerSequencesModuleWidgetsAbstractPlugin.h
+++ b/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qSlicerSequencesModuleWidgetsAbstractPlugin.h
@@ -18,8 +18,8 @@
 
 ==============================================================================*/\
 
-#ifndef __qSlicerMarkupsModuleWidgetsAbstractPlugin_h
-#define __qSlicerMarkupsModuleWidgetsAbstractPlugin_h
+#ifndef qSlicerSequencesModuleWidgetsAbstractPlugin_h
+#define qSlicerSequencesModuleWidgetsAbstractPlugin_h
 
 #include <QtGlobal>
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))

--- a/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qSlicerSequencesModuleWidgetsPlugin.h
+++ b/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qSlicerSequencesModuleWidgetsPlugin.h
@@ -18,8 +18,8 @@
 
 ==============================================================================*/
 
-#ifndef __qSlicerSequenceBrowserModuleWidgetsPlugin_h
-#define __qSlicerSequenceBrowserModuleWidgetsPlugin_h
+#ifndef qSlicerSequencesModuleWidgetsPlugin_h
+#define qSlicerSequencesModuleWidgetsPlugin_h
 
 // Qt includes
 #include "vtkSlicerConfigure.h" // For Slicer_HAVE_QT5

--- a/Modules/Loadable/Tables/qSlicerTablesModuleWidget.h
+++ b/Modules/Loadable/Tables/qSlicerTablesModuleWidget.h
@@ -20,8 +20,8 @@
 
 ==============================================================================*/
 
-#ifndef __qSlicerTransformsModuleWidget_h
-#define __qSlicerTransformsModuleWidget_h
+#ifndef qSlicerTablesModuleWidget_h
+#define qSlicerTablesModuleWidget_h
 
 // Slicer includes
 #include "qSlicerAbstractModuleWidget.h"

--- a/Modules/Loadable/Tables/qSlicerTablesReader.h
+++ b/Modules/Loadable/Tables/qSlicerTablesReader.h
@@ -20,8 +20,8 @@
 
 ==============================================================================*/
 
-#ifndef __qSlicerTablesReader
-#define __qSlicerTablesReader
+#ifndef qSlicerTablesReader_h
+#define qSlicerTablesReader_h
 
 // Slicer includes
 #include "qSlicerFileReader.h"

--- a/Modules/Loadable/Texts/Widgets/DesignerPlugins/qSlicerTextsModuleWidgetsPlugin.h
+++ b/Modules/Loadable/Texts/Widgets/DesignerPlugins/qSlicerTextsModuleWidgetsPlugin.h
@@ -19,8 +19,8 @@
 ==============================================================================*/
 
 
-#ifndef __qSlicerTextModuleWidgetsPlugin_h
-#define __qSlicerTextModuleWidgetsPlugin_h
+#ifndef qSlicerTextsModuleWidgetsPlugin_h
+#define qSlicerTextsModuleWidgetsPlugin_h
 
 // Qt includes
 #include <QtUiPlugin/QDesignerCustomWidgetCollectionInterface>

--- a/Modules/Loadable/Units/Widgets/DesignerPlugins/qSlicerUnitsModuleWidgetsAbstractPlugin.h
+++ b/Modules/Loadable/Units/Widgets/DesignerPlugins/qSlicerUnitsModuleWidgetsAbstractPlugin.h
@@ -18,8 +18,8 @@
 
 ==============================================================================*/
 
-#ifndef __qSlicerUnitModuleWidgetsAbstractPlugin_h
-#define __qSlicerUnitModuleWidgetsAbstractPlugin_h
+#ifndef qSlicerUnitsModuleWidgetsAbstractPlugin_h
+#define qSlicerUnitsModuleWidgetsAbstractPlugin_h
 
 #include <QtGlobal>
 #include <QtUiPlugin/QDesignerCustomWidgetInterface>

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/Logic/vtkSlicerTemplateKeyLogic.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/Logic/vtkSlicerTemplateKeyLogic.h
@@ -18,8 +18,8 @@
 
 ==============================================================================*/
 
-#ifndef __vtkSlicerTemplateKeyMarkupslogic_h_
-#define __vtkSlicerTemplateKeyMarkupslogic_h_
+#ifndef __vtkSlicerTemplateKeyLogic_h
+#define __vtkSlicerTemplateKeyLogic_h
 
 #include <vtkSlicerMarkupsLogic.h>
 

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/MRML/vtkMRMLMarkupsTestLineNode.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/MRML/vtkMRMLMarkupsTestLineNode.h
@@ -18,8 +18,8 @@
 
 ==============================================================================*/
 
-#ifndef __vtkmrmlmarkupstestlinenode_h_
-#define __vtkmrmlmarkupstestlinenode_h_
+#ifndef __vtkMRMLMarkupsTestLineNode_h
+#define __vtkMRMLMarkupsTestLineNode_h
 
 #include <vtkMRMLMarkupsLineNode.h>
 

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/VTKWidgets/vtkSlicerTestLineRepresentation2D.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/VTKWidgets/vtkSlicerTestLineRepresentation2D.h
@@ -37,8 +37,8 @@
 
 ==============================================================================*/
 
-#ifndef __vtkslicertestlinerepresentation2d_h_
-#define __vtkslicertestlinerepresentation2d_h_
+#ifndef __vtkSlicerTestLineRepresentation2D_h
+#define __vtkSlicerTestLineRepresentation2D_h
 
 #include "vtkSlicerTemplateKeyModuleVTKWidgetsExport.h"
 

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/VTKWidgets/vtkSlicerTestLineRepresentation3D.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/VTKWidgets/vtkSlicerTestLineRepresentation3D.h
@@ -18,8 +18,8 @@
 
 ==============================================================================*/
 
-#ifndef __vtkslicertestlinerepresentation3d_h_
-#define __vtkslicertestlinerepresentation3d_h_
+#ifndef __vtkSlicerTestLineRepresentation3D_h
+#define __vtkSlicerTestLineRepresentation3D_h
 
 #include "vtkSlicerTemplateKeyModuleVTKWidgetsExport.h"
 

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/VTKWidgets/vtkSlicerTestLineWidget.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/VTKWidgets/vtkSlicerTestLineWidget.h
@@ -18,8 +18,8 @@
 
 ==============================================================================*/
 
-#ifndef __vtkslicerslicingcontourwidget_h_
-#define __vtkslicerslicingcontourwidget_h_
+#ifndef __vtkSlicerTestLineWidget_h
+#define __vtkSlicerTestLineWidget_h
 
 #include "vtkSlicerTemplateKeyModuleVTKWidgetsExport.h"
 

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/Widgets/qMRMLMarkupsTestLineWidget.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/Widgets/qMRMLMarkupsTestLineWidget.h
@@ -18,8 +18,8 @@
 
 ==============================================================================*/
 
-#ifndef __qSlicerTestLineWidget_h_
-#define __qSlicerTestLineWidget_h_
+#ifndef __qMRMLMarkupsTestLineWidget_h
+#define __qMRMLMarkupsTestLineWidget_h
 
 // Markups widgets includes
 #include "qMRMLMarkupsAbstractOptionsWidget.h"


### PR DESCRIPTION
This commit updates the files to match any of these:

```
  <stem>_h   (*)
  __<stem>_h
  __<STEM>_H
```

(*) Note that this is the preferred way because of the clang -Wreserved-id-macro
    warning. See https://wiki.sei.cmu.edu/confluence/display/c/DCL37-C.+Do+not+declare+or+define+a+reserved+identifier

The following one-liner was used to identify the files:

```
for file in $(\
  fd \
    -e h \
    -E "Modules/CLI/ExtractSkeleton/SkelGraph.h" \
    -E "Modules/CLI/ExtractSkeleton/coordTypes.h" \
    -E "Modules/CLI/ExtractSkeleton/misc.h" \
); do
  filename=$(basename $file);
  guard=${filename/./_};
  cat $file | ack -i "define \_?\_?$guard" > /dev/null || echo "$file";
done
```