### PR TITLE
STYLE: Fix typos in header (.h) comments

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogic.h
+++ b/Base/Logic/vtkSlicerApplicationLogic.h
@@ -81,7 +81,7 @@ class VTK_SLICER_BASE_LOGIC_EXPORT vtkSlicerApplicationLogic
       RequestWriteDataEvent,
       /// Event fired when a readData, writeData or readScene request
       /// has been processed.
-      /// The uid of the request is passed as callData.
+      /// The UID of the request is passed as callData.
       /// \todo Add support for "modified" request.
       RequestProcessedEvent
     };

--- a/Base/Logic/vtkSlicerBaseLogic.h
+++ b/Base/Logic/vtkSlicerBaseLogic.h
@@ -11,7 +11,6 @@
  * This is needed for loading slicer code as module.
  * Added here to isolate the changes to the main files in case
  * further mods are needed.
- * - sp 2002-04-19
  */
 
 #ifndef __vtkSlicerBaseLogic_h

--- a/Base/QTCLI/qSlicerCLIModule.h
+++ b/Base/QTCLI/qSlicerCLIModule.h
@@ -64,7 +64,7 @@ public:
   QString tempDirectory() const;
 
   /// Set module entry point. Typically "slicer:0x012345" for loadable CLI
-  /// or "/home/user/work/Slicer-Superbuild/../mycliexec" for executable CLI
+  /// or "/home/user/work/Slicer-SuperBuild/../my-cli-exec" for executable CLI
   void setEntryPoint(const QString& entryPoint);
   QString entryPoint() const;
 
@@ -93,7 +93,7 @@ public:
   void setLogo(const ModuleLogo& logo);
 
   /// Convert a ModuleLogo into a QIcon
-  /// \todo: Find a better place for this util function
+  /// \todo: Find a better place for this helper function
   static QImage moduleLogoToImage(const ModuleLogo& logo);
 
   /// Return the module description object used to store

--- a/Base/QTCore/qSlicerAbstractCoreModule.h
+++ b/Base/QTCore/qSlicerAbstractCoreModule.h
@@ -194,7 +194,7 @@ public:
   /// Constructor
   /// Warning: If there is no parent given, make sure you delete the object.
   /// The modules can typically be instantiated before the application
-  /// is initialized (module manager, iomanager...). Most of the
+  /// is initialized (module manager, IO manager...). Most of the
   /// initialization must be done in qSlicerAbstractCoreModule::setup()
   qSlicerAbstractCoreModule(QObject *parent=nullptr);
   ~qSlicerAbstractCoreModule() override;

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -618,7 +618,7 @@ protected:
 
 protected slots:
 
-  /// Process command line arguments **atfer** the application event loop is started.
+  /// Process command line arguments **after** the application event loop is started.
   /// \sa handlePreApplicationCommandLineArguments()
   /// \sa qSlicerApplication::startupCompleted()
   virtual void handleCommandLineArguments();

--- a/Base/QTCore/qSlicerCoreIOManager.h
+++ b/Base/QTCore/qSlicerCoreIOManager.h
@@ -123,7 +123,7 @@ public:
 
   /// Load a list of nodes corresponding to \a fileType. A given \a fileType corresponds
   /// to a specific reader qSlicerIO.
-  /// A map of qvariant allows to specify which \a parameters should be passed to the reader.
+  /// A map of QVariant allows to specify which \a parameters should be passed to the reader.
   /// The function return 0 if it fails.
   /// The map associated with most of the \a fileType should contains either
   /// fileName (QString or QStringList) or fileNames (QStringList).

--- a/Base/QTCore/qSlicerExtensionsManagerModel.h
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.h
@@ -569,7 +569,7 @@ private:
 
 Q_DECLARE_METATYPE(qSlicerExtensionsManagerModel::ServerAPI);
 
-// Metatype already declared in qSlicerIO.h
+// MetaType already declared in qSlicerIO.h
 //Q_DECLARE_METATYPE(qSlicerExtensionsManagerModel::ExtensionMetadataType)
 
 #endif

--- a/Base/QTCore/qSlicerFileReader.h
+++ b/Base/QTCore/qSlicerFileReader.h
@@ -63,7 +63,7 @@ public:
   /// "*.nrrd" is more specific than "*.*".
   virtual double canLoadFileConfidence(const QString& file)const;
 
-  /// Return the matching name filters -> if the fileName is "myimage.nrrd"
+  /// Return the matching name filters -> if the fileName is "my_image.nrrd"
   /// and the supported extensions are "Volumes (*.mha *.nrrd *.raw)",
   /// "Images (*.png" *.jpg")", "DICOM (*)" then it returns
   /// "Volumes (*.mha *.nrrd *.raw), DICOM (*)"

--- a/Base/QTCore/qSlicerPersistentCookieJar.h
+++ b/Base/QTCore/qSlicerPersistentCookieJar.h
@@ -32,7 +32,7 @@ class qSlicerPersistentCookieJarPrivate;
 /// qSlicerPersistentCookieJar provides a mechanism allowing to store persistently cookies
 /// when associated with an instance of QNetworkAccessManager.
 ///
-/// The cookies will be storted in a INI config file. By default, the config file will
+/// The cookies will be stored in a INI config file. By default, the config file will
 /// be located in the directory associated with the current application settings and will be
 /// named cookies.ini. This could be overwritten using qSlicerPersistentCookieJar::setFilePath
 ///

--- a/Base/QTCore/qSlicerRelativePathMapper.h
+++ b/Base/QTCore/qSlicerRelativePathMapper.h
@@ -35,7 +35,7 @@ class qSlicerRelativePathMapperPrivate;
 ///   qSlicerRelativePathMapper* makeRelative =
 ///     new qSlicerRelativePathMapper("directory", SIGNAL("directoryChanged(QString)"), directorySelector);
 ///   makeRelative->setPath("some/folder");
-///   // -> directorySelector->directory() == "applicationhome/some/folder"
+///   // -> directorySelector->directory() == "applicationHome/some/folder"
 ///   makeRelative->setPath("/some/absolute/folder");
 ///   // -> directorySelector->directory() == "/some/absolute/folder"
 ///

--- a/Base/QTCore/qSlicerScriptedFileWriter.h
+++ b/Base/QTCore/qSlicerScriptedFileWriter.h
@@ -79,7 +79,7 @@ public:
   bool write(const qSlicerIO::IOProperties& properties) override;
 
   /// Added so node writers can report back written nodes
-  /// \sa qSlicerFileWriter::writtenNodex()
+  /// \sa qSlicerFileWriter::writtenNodes()
   void addWrittenNode(const QString& writtenNode);
 
   /// Reimplemented to support python methods and q_property

--- a/Base/QTCore/qSlicerUtils.h
+++ b/Base/QTCore/qSlicerUtils.h
@@ -96,7 +96,7 @@ public:
 
   /// Return the path without the intermediate directory or return \a path if there is no
   /// expected "IntDir".
-  /// \a subDirWithoutIntDir corresponds to N last compononent of the path excluding
+  /// \a subDirWithoutIntDir corresponds to N last component of the path excluding
   /// the "IntDir".
   ///
   /// <table border="1">

--- a/Base/QTGUI/qSlicerAbstractModule.h
+++ b/Base/QTGUI/qSlicerAbstractModule.h
@@ -55,7 +55,7 @@ public:
   /// as well as in the frequently used module toolbar (if any).
   virtual QIcon icon()const;
 
-  /// The logo of the module, the credits given by the grants or instution
+  /// The logo of the module, the credits given by the grants or institution
   virtual QImage logo()const;
 
   /// Returns then associated QAction of the module. It contains all the

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -240,7 +240,7 @@ signals:
   /// Startup is complete when all the modules have been
   /// initialized and the main window is shown to the user.
   ///
-  /// \note If the application is started without the mainwindow,
+  /// \note If the application is started without the mainWindow,
   /// the signal is emitted after the modules are initialized.
   ///
   /// \sa qSlicerAppMainWindow::initialWindowShown()

--- a/Base/QTGUI/qSlicerExportNodeDialog_p.h
+++ b/Base/QTGUI/qSlicerExportNodeDialog_p.h
@@ -119,7 +119,7 @@ public:
 
   /* Set the nodes being exported and fill out the dialog widgets with a reasonable initial state.
   Two lists of node pointers must be given, one based on recursively including the storable node child items of the selected node in the
-  subject hierarchy tree, and one based on nonrecursively doing so.
+  subject hierarchy tree, and one based on non-recursively doing so.
   selectedNode is the single storable node that was selected in the subject hierarchy to trigger this export, if there is one;
   can be null if there isn't. nodeIdToSubjectHierarchyPath is a mapping from node IDs to lists of subject hierarchy item names, where
   each list starts from the parent of the aforementioned node ID and goes up the hierarchy until it reaches selectedNodeID;

--- a/Base/QTGUI/qSlicerFileDialog.h
+++ b/Base/QTGUI/qSlicerFileDialog.h
@@ -65,12 +65,12 @@ public:
   };
   virtual qSlicerFileDialog::IOAction action()const = 0;
   /// run the dialog to select the file/files/directory
-  /// Properties available with IOPorperties: fileMode, multipleFiles, fileType.
+  /// Properties available with IOProperties: fileMode, multipleFiles, fileType.
   Q_INVOKABLE virtual bool exec(const qSlicerIO::IOProperties& ioProperties =
                     qSlicerIO::IOProperties()) = 0;
 
   /// TBD: move in qSlicerCoreIOManager or qSlicerIOManager ?
-  /// Return the namefilters of all the readers in IOManager corresponding to
+  /// Return the nameFilters of all the readers in IOManager corresponding to
   /// fileType
   Q_INVOKABLE static QStringList nameFilters(qSlicerIO::IOFileType fileType =
                                  QString("NoFile"));

--- a/Base/QTGUI/qSlicerScriptedFileDialog.h
+++ b/Base/QTGUI/qSlicerScriptedFileDialog.h
@@ -65,7 +65,7 @@ public:
   /// Return the dragEnterEvent when dragEnterEvent() is being called.
   /// \sa dragEnterEvent()
   Q_INVOKABLE const QMimeData* mimeData()const;
-  /// Return the dropEvent when dropEvent() is bebing called.
+  /// Return the dropEvent when dropEvent() is being called.
   /// \sa dropEvent()
   Q_INVOKABLE QDropEvent* dropEvent()const;
 

--- a/Libs/MRML/Core/vtkCacheManager.h
+++ b/Libs/MRML/Core/vtkCacheManager.h
@@ -63,22 +63,22 @@ class VTK_MRML_EXPORT vtkCacheManager : public vtkObject
 
   ///
   /// Before a file or directory is deleted,
-  /// Marks any nodes that hold the uri as
+  /// Marks any nodes that hold the URI as
   /// a reference as modified since read.
   void MarkNodesBeforeDeletingDataFromCache (const char *);
 
   ///
-  /// Checks to see if a uri appears to point to remote location
+  /// Checks to see if a URI appears to point to remote location
   /// and returns true if so. Looks for a '://' and if present,
   /// checks to see if the prefix is 'file'. If not 'file' but the
   /// thing:/// pattern exists, then returns true.
   virtual int IsRemoteReference ( const char *uri );
   ///
-  /// Looks for a 'file://' in the uri and if present, returns true.
+  /// Looks for a 'file://' in the URI and if present, returns true.
   virtual int IsLocalReference ( const char *uri );
 
   ///
-  /// Checks to see if a uri is a file on disk and returns
+  /// Checks to see if a URI is a file on disk and returns
   /// true if so. Strips off a file:/// prefix if present, and
   /// expects an absolute path.
   virtual int LocalFileExists ( const char *uri );
@@ -90,7 +90,7 @@ class VTK_MRML_EXPORT vtkCacheManager : public vtkObject
   const char* FindCachedFile ( const char * target, const char *dirname );
 
   ///
-  /// Checks to see if the The uri provided exists on disk.
+  /// Checks to see if the The URI provided exists on disk.
   /// If not, it appends the Remote Cache Directory path
   /// and checks again, in case no path was provided.
   /// If neither exists, returns 0. If one exists, returns 1.

--- a/Libs/MRML/Core/vtkDataFileFormatHelper.h
+++ b/Libs/MRML/Core/vtkDataFileFormatHelper.h
@@ -32,7 +32,7 @@ class VTK_MRML_EXPORT vtkDataFileFormatHelper : public vtkObject
    const char* fileformat);
 
   ///
-  /// Get the itkimageio supported file formats.
+  /// Get the itkImageIO supported file formats.
   //vtkGetObjectMacro ( ITKSupportedWriteFileFormats, vtkStringArray);
   virtual vtkStringArray* GetITKSupportedWriteFileFormats();
   virtual vtkStringArray* GetITKSupportedReadFileFormats()

--- a/Libs/MRML/Core/vtkEventBroker.h
+++ b/Libs/MRML/Core/vtkEventBroker.h
@@ -149,7 +149,7 @@ public:
   vtkGetMacro (EventNestingLevel, int);
 
   ///
-  /// File to write event logs to when EventLoging is turned on
+  /// File to write event logs to when EventLogging is turned on
   vtkSetStringMacro (LogFileName);
   vtkGetStringMacro (LogFileName);
 

--- a/Libs/MRML/Core/vtkITKTransformInverse.h
+++ b/Libs/MRML/Core/vtkITKTransformInverse.h
@@ -15,7 +15,7 @@
 
 /// \brief Simplified inverse ITK transforms
 ///
-/// These are simple implementatations of ITK inverse transforms that
+/// These are simple implementations of ITK inverse transforms that
 /// cannot actually compute any transformations, but only store all transform
 /// parameters. This is used for reading/writing transformToParent
 /// (resampling transform), even if only if its inverse (transformFromParent)

--- a/Libs/MRML/Core/vtkMRMLColorNode.h
+++ b/Libs/MRML/Core/vtkMRMLColorNode.h
@@ -33,7 +33,7 @@ class vtkScalarsToColors;
 /// a user. More than one model or label volume or editor can access the prebuilt
 /// nodes. This is used as a superclass for table based, procedural based, and
 /// implicit function based color nodes.
-/// All the color names are initialised to \a NoName ("(none)") when the table
+/// All the color names are initialized to \a NoName ("(none)") when the table
 /// is created, using the max index of the colors expected to fill the table
 /// to set the size of the names array. If the node is being read in from a
 /// file, not all of the colors might be present from 0-max, so the color
@@ -41,7 +41,7 @@ class vtkScalarsToColors;
 /// But if the color node is being built up from colors without names, there
 /// is a method to init the names from the color RGBA values so that
 /// something would be there rather than the default \a NoName which is used
-/// to determine that it's a unnamed and probably uninitialised color.
+/// to determine that it's a unnamed and probably uninitialized color.
 ///
 /// Subclasses must reimplement GetColor() and GetNumberOfColors().
 class VTK_MRML_EXPORT vtkMRMLColorNode : public vtkMRMLStorableNode
@@ -177,7 +177,7 @@ public:
   vtkSetStringMacro(NoName);
 
   ///
-  /// Get/Set for the flag on names array having been initialised
+  /// Get/Set for the flag on names array having been initialized
   vtkGetMacro(NamesInitialised, int);
   vtkSetMacro(NamesInitialised, int);
   vtkBooleanMacro(NamesInitialised, int);
@@ -202,7 +202,7 @@ public:
 
   /// Helper function for copying lookup tables
   /// It handles special types of lookup tables and fixes
-  /// error in vtkLoookupTable copy.
+  /// error in vtkLookupTable copy.
   virtual vtkLookupTable* CreateLookupTableCopy();
 
 protected:

--- a/Libs/MRML/Core/vtkMRMLDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLDisplayNode.h
@@ -593,7 +593,7 @@ public:
   /// If empty, display in all views
   /// \sa ViewNodeIDs, GetNthViewNodeID(), AddViewNodeID()
   inline std::vector< std::string > GetViewNodeIDs()const;
-  /// True if the view node id is present in the viewnodeid list
+  /// True if the view node id is present in the viewNodeID list
   /// false if not found
   /// \sa ViewNodeIDs, IsDisplayableInView(), AddViewNodeID()
   bool IsViewNodeIDPresent(const char* viewNodeID)const;

--- a/Libs/MRML/Core/vtkMRMLProceduralColorNode.h
+++ b/Libs/MRML/Core/vtkMRMLProceduralColorNode.h
@@ -95,7 +95,7 @@ public:
   vtkLookupTable * GetLookupTable() override;
 
   /// Reimplemented vtkMRMLColorNode::GetScalarsToColors() to return the
-  /// transfer function instead of the empty lookuptable
+  /// transfer function instead of the empty lookup table
   /// \sa ColorTransferFunction, GetColorTransferFunction()
   vtkScalarsToColors* GetScalarsToColors() override;
 

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
@@ -205,7 +205,7 @@ protected:
   void CalculateAutoLevels();
 
   /// Return the image data with scalar type, it can be in the middle of the
-  /// pipeline, it's typically the input of the threshold/windowlevel filters
+  /// pipeline, it's typically the input of the Threshold/WindowLevel filters
   vtkImageData* GetScalarImageData();
   virtual vtkAlgorithmOutput* GetScalarImageDataConnection();
 

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -548,9 +548,9 @@ public:
   ///
   /// Returns nullptr on failure
   vtkURIHandler *FindURIHandler(const char *URI);
-  /// Returns a URIhandler of a specific type if its name is known.
+  /// Returns a URIHandler of a specific type if its name is known.
   vtkURIHandler *FindURIHandlerByName (const char *name);
-  /// Add a uri handler to the collection.
+  /// Add a URI handler to the collection.
   void AddURIHandler(vtkURIHandler *handler);
 
   /// The state of the scene reflects what the scene is doing.

--- a/Libs/MRML/Core/vtkMRMLSequenceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSequenceNode.h
@@ -152,7 +152,7 @@ public:
   /// requests a more specific storage node class.
   vtkMRMLStorageNode* CreateDefaultStorageNode() override;
 
-  /// Returns the most specific storage node possible (such as stvtkMRMLVolumeSequenceStorageNode
+  /// Returns the most specific storage node possible (such as vtkMRMLVolumeSequenceStorageNode
   /// if sequence contains volumes with the same type and geometry, or vtkMRMLLinearTransformSequenceStorageNode
   /// if sequence contains a list of linear transforms) and generic vtkMRMLSequenceStorageNode otherwise.
   std::string GetDefaultStorageNodeClassName(const char* filename = nullptr) override;

--- a/Libs/MRML/Core/vtkMRMLSequenceStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLSequenceStorageNode.h
@@ -44,8 +44,8 @@ public:
   /// Return true if the reference node can be read in
   bool CanReadInReferenceNode(vtkMRMLNode *refNode) override;
 
-  // filename: fCal_Test_Validation_3NWires_fCal2.0-ProbeToTracker-Seq.seq.mha
-  // itemname: ProbeToTracker
+  // fileName: fCal_Test_Validation_3NWires_fCal2.0-ProbeToTracker-Seq.seq.mha
+  // itemName: ProbeToTracker
   // return: fCal_Test_Validation_3NWires_fCal2.0
   static std::string GetSequenceBaseName(const std::string& fileNameName, const std::string& itemName);
 

--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -108,17 +108,17 @@ class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
   /// If empty, display in all views
   /// \sa ThreeDViewIDs, GetNthThreeDViewID(), AddThreeDViewID()
   inline std::vector< std::string > GetThreeDViewIDs()const;
-  /// True if the view node id is present in the ThreeDViewid list
+  /// True if the view node id is present in the ThreeDViewID list
   /// false if not found
   /// \sa ThreeDViewIDs, IsDisplayableInView(), AddThreeDViewID()
   bool IsThreeDViewIDPresent(const char* ThreeDViewID)const;
-  /// Returns true if the ThreeDViewID is present in the ThreeDViewId list
-  /// or there is no ThreeDViewId in the list (meaning all the views display the
+  /// Returns true if the ThreeDViewID is present in the ThreeDViewID list
+  /// or there is no ThreeDViewID in the list (meaning all the views display the
   /// node)
   /// \sa ThreeDViewIDs, IsThreeDViewIDPresent(), AddThreeDViewID()
   bool IsDisplayableInThreeDView(const char* viewNodeID)const;
 
-  /// The ImpplicitePlane widget mode
+  /// The ImplicitPlane widget mode
   /// this lock the normal of the plane to the camera's one
   vtkGetMacro(WidgetNormalLockedToCamera, int);
   vtkSetMacro(WidgetNormalLockedToCamera, int);
@@ -440,7 +440,7 @@ public:
   /// axes of the provided reference coordinate system
   /// so that no oblique resampling
   /// occurs when rendering (helps to see original acquisition data
-  /// and for obluique volumes with few slices).
+  /// and for oblique volumes with few slices).
   /// If sliceNormalAxisIndex is >=0 then slice plane normal will
   /// be aligned with that axis.
   void RotateToAxes(vtkMatrix4x4 *referenceToRAS, int sliceNormalAxisIndex=-1);

--- a/Libs/MRML/Core/vtkMRMLStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.h
@@ -162,7 +162,7 @@ public:
 
   ///
   /// Get the file's absolute path from the file name and the mrml scene root
-  /// dir. GetFullnameFromFileName calls GetFullNameFromNthFileName with -1.
+  /// dir. GetFullNameFromFileName calls GetFullNameFromNthFileName with -1.
   std::string GetFullNameFromFileName();
   std::string GetFullNameFromNthFileName(int n);
 
@@ -233,7 +233,7 @@ public:
   void ResetURIList();
 
   ///
-  /// Return how many uri names this storage node holds in it's list
+  /// Return how many URI names this storage node holds in it's list
   int GetNumberOfURIs()
   {
     return (int)this->URIList.size();
@@ -260,7 +260,7 @@ public:
   /// Set the nth file in FileNameList, checks that it is already defined
   void ResetNthFileName(int n, const char *fileName);
   ///
-  /// Set the nth uri in URIList, checks that it is already defined
+  /// Set the nth URI in URIList, checks that it is already defined
   void ResetNthURI(int n, const char *uri);
 
   ///

--- a/Libs/MRML/Core/vtkMRMLStreamingVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLStreamingVolumeNode.h
@@ -89,7 +89,7 @@ public:
   virtual bool DecodeFrame();
 
   /// Returns true if the current frame is a keyframe
-  /// Keyframes are not interpolated and don't require any additional frames in order to be decoded to an uncompressed image
+  /// KeyFrames are not interpolated and don't require any additional frames in order to be decoded to an uncompressed image
   virtual bool IsKeyFrame();
 
   /// Callback that is called if the current frame is modified

--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyLegacyNode.h
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyLegacyNode.h
@@ -132,7 +132,7 @@ protected:
   char* OwnerPluginName{nullptr};
 
   /// List of UIDs of this subject hierarchy node
-  /// UIDs can be DICOM UIDs, Girder urls, etc.
+  /// UIDs can be DICOM UIDs, Girder URLs, etc.
   std::map<std::string, std::string> UIDs;
 
 protected:

--- a/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.h
@@ -28,7 +28,7 @@
 /// \brief MRML node for handling Table node storage
 ///
 /// vtkMRMLTableSQLiteStorageNode allows reading/writing of table node from
-/// SQLight database.
+/// SQLite database.
 ///
 ///
 
@@ -49,11 +49,11 @@ public:
   /// Return true if the node can be read in
   bool CanReadInReferenceNode(vtkMRMLNode *refNode) override;
 
-  /// SQLight Database password
+  /// SQLite Database password
   vtkSetStringMacro(Password);
   vtkGetStringMacro(Password);
 
-  /// SQLight Database table name
+  /// SQLite Database table name
   vtkSetStringMacro(TableName);
   vtkGetStringMacro(TableName);
 

--- a/Libs/MRML/Core/vtkMRMLTransformableNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformableNode.h
@@ -68,7 +68,7 @@ public:
                                   unsigned long /*event*/,
                                   void * /*callData*/ ) override;
 
-  /// TransformModifiedEvent is send when the parent transform is modidied
+  /// TransformModifiedEvent is send when the parent transform is modified
   enum
     {
       TransformModifiedEvent = 15000

--- a/Libs/MRML/Core/vtkURIHandler.h
+++ b/Libs/MRML/Core/vtkURIHandler.h
@@ -90,7 +90,7 @@ public:
   void operator=(const vtkURIHandler&);
 
   ///
-  /// local file, it gets passed to C functions in libcurl
+  /// local file, it gets passed to C functions in the CURL library
   //std::ofstream* LocalFile;
   FILE *LocalFile;
   char *Prefix;

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractDisplayableManager.h
@@ -207,7 +207,7 @@ protected:
   /// Remove MRML observers
   virtual void RemoveMRMLObservers();
 
-  /// Specify if UodateFromMRML() should be called
+  /// Specify if UpdateFromMRML() should be called
   /// \sa UpdateFromMRML()
   void SetUpdateFromMRMLRequested(bool requested);
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.h
@@ -155,7 +155,7 @@ protected:
 
   bool SetVolumeWindowLevel(double window, double level, bool isAutoWindowLevel);
 
-  /// Rubberband is centered around the click position
+  /// RubberBand is centered around the click position
   vtkGetMacro(CenteredRubberBand, bool);
   vtkSetMacro(CenteredRubberBand, bool);
   vtkBooleanMacro(CenteredRubberBand, bool);

--- a/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.h
@@ -130,7 +130,7 @@ public:
   vtkGetObjectMacro (XYToIJKTransform, vtkGeneralTransform);
 
   ///
-  /// Get/set interpolation mode used in image reslicer (when interpolation is enabled).
+  /// Get/set interpolation mode used in image reslice (when interpolation is enabled).
   /// By default it uses VTK_RESLICE_LINEAR and can be set to VTK_RESLICE_CUBIC for higher quality interpolation.
   vtkGetMacro(InterpolationMode, int);
   vtkSetMacro(InterpolationMode, int);

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -48,7 +48,7 @@ struct BlendPipeline;
 ///
 /// This class manages the logic associated with display of slice windows
 /// (but not the GUI).  Features of the class include:
-///  -- a back-to-front list of MrmlVolumes to be displayed
+///  -- a back-to-front list of MRML volumes to be displayed
 ///  -- a compositing mode for each volume layer (opacity, outline, glyph, checkerboard, etc)
 ///  -- each layer is required to provide an RGBA image in the space defined by the vtkMRMLSliceNode
 ///
@@ -178,12 +178,12 @@ public:
   /// Internally used by UpdatePipeline
   void UpdateImageData();
 
-  /// Reimplemented to avoir calling ProcessMRMLSceneEvents when we are added the
+  /// Reimplemented to avoid calling ProcessMRMLSceneEvents when we are adding the
   /// MRMLModelNode into the scene
   virtual bool EnterMRMLCallback()const;
 
   ///
-  /// Manage and synchronise the SliceNode
+  /// Manage and synchronize the SliceNode
   void UpdateSliceNode();
 
   ///
@@ -191,7 +191,7 @@ public:
   void UpdateSliceNodeFromLayout();
 
   ///
-  /// Manage and synchronise the SliceCompositeNode
+  /// Manage and synchronize the SliceCompositeNode
   void UpdateSliceCompositeNode();
 
   ///
@@ -372,7 +372,7 @@ public:
   /// \sa SLICE_MODEL_NODE_NAME_SUFFIX
   static bool IsSliceModelNode(vtkMRMLNode *mrmlNode);
   /// Return true if the display node is a volume slice node display node
-  /// by checking the attribute SliceLogic.IsSliceModelDiplayNode
+  /// by checking the attribute SliceLogic.IsSliceModelDisplayNode
   /// Returns false if the attribute is not present, true if the attribute
   /// is present and not equal to zero
   static bool IsSliceModelDisplayNode(vtkMRMLDisplayNode *mrmlDisplayNode);

--- a/Libs/MRML/Widgets/qMRMLCheckableNodeComboBox.h
+++ b/Libs/MRML/Widgets/qMRMLCheckableNodeComboBox.h
@@ -60,7 +60,7 @@ public:
   /// If empty, return true.
   Q_INVOKABLE bool noneChecked()const;
 
-  /// Return the checkstate of the node.
+  /// Return the CheckState of the node.
   /// If \a node is invalid (null or not in the scene),
   /// Qt::Unchecked is returned.
   Q_INVOKABLE Qt::CheckState checkState(vtkMRMLNode* node)const;

--- a/Libs/MRML/Widgets/qMRMLCoordinatesWidget.h
+++ b/Libs/MRML/Widgets/qMRMLCoordinatesWidget.h
@@ -51,7 +51,7 @@ class qMRMLCoordinatesWidgetPrivate;
 /// it listens to the changes made upon the selection node to extract the
 /// unit properties related to its quantity and update accordingly.
 //
-/// To allow even more customisation, one can set which properties of the
+/// To allow even more customization, one can set which properties of the
 /// widget are updated by units and which aren't.
 ///
 /// \sa qMRMLSliderWidget, qMRMLSpinBox

--- a/Libs/MRML/Widgets/qMRMLLayoutWidget.h
+++ b/Libs/MRML/Widgets/qMRMLLayoutWidget.h
@@ -59,7 +59,7 @@ public slots:
   /// Set the MRML \a scene to the layout manager
   void setMRMLScene(vtkMRMLScene* scene);
 
-  /// Propagate to the layoutmanager
+  /// Propagate to the layoutManager
   void setLayout(int);
 
 protected:

--- a/Libs/MRML/Widgets/qMRMLPlotView.h
+++ b/Libs/MRML/Widgets/qMRMLPlotView.h
@@ -40,7 +40,7 @@ class vtkStringArray;
 ///
 /// qMRMLPlotView supports only 2D plots.
 /// For extending this class to 3DPlots it is needed to expand the mother class
-/// cktVTKChartView to use also vtkChartXYZ (currently exploiting only vtkChartXY).
+/// ctkVTKChartView to use also vtkChartXYZ (currently exploiting only vtkChartXY).
 
 class QMRML_WIDGETS_EXPORT qMRMLPlotView : public ctkVTKChartView
 {
@@ -89,7 +89,7 @@ signals:
   void mrmlSceneChanged(vtkMRMLScene*);
 
   /// Signal emitted when a data point or more has been selected. Returns
-  /// the MRMLPlotSeriesNodes IDs and the correspective arrays with
+  /// the MRMLPlotSeriesNodes IDs and the corresponding arrays with
   /// the data points ids (vtkIdTypeArray).
   void dataSelected(vtkStringArray* mrmlPlotSeriesIDs, vtkCollection* selectionCol);
 

--- a/Libs/MRML/Widgets/qMRMLPlotWidget.h
+++ b/Libs/MRML/Widgets/qMRMLPlotWidget.h
@@ -34,7 +34,7 @@ class qMRMLPlotWidgetPrivate;
 class vtkMRMLPlotViewNode;
 class vtkMRMLScene;
 
-/// \brief qMRMLPlotWidget is the toplevel Plotting widget that can be
+/// \brief qMRMLPlotWidget is the top-level Plotting widget that can be
 /// packed in a layout.
 ///
 /// qMRMLPlotWidget provides plotting capabilities with a display

--- a/Libs/MRML/Widgets/qMRMLSceneModel.h
+++ b/Libs/MRML/Widgets/qMRMLSceneModel.h
@@ -318,7 +318,7 @@ protected:
   /// nodeFlags
   virtual void updateNodeFromItemData(vtkMRMLNode* node, QStandardItem* item);
 
-  /// Update the items associated with the node and uid.
+  /// Update the items associated with the node and UID.
   void updateNodeItems(vtkMRMLNode* node, const QString& uid);
 
   static void onMRMLSceneEvent(vtkObject* vtk_obj, unsigned long event,

--- a/Libs/MRML/Widgets/qMRMLScreenShotDialog.h
+++ b/Libs/MRML/Widgets/qMRMLScreenShotDialog.h
@@ -67,7 +67,7 @@ public:
   QString description()const;
 
   /// Setting the data prevent the dialog from automatically taking a screenshot
-  /// each time the widgettype or scaleFactor is changed.
+  /// each time the widgetType or scaleFactor is changed.
   void setData(const QVariant& newData);
   QVariant data()const;
 

--- a/Libs/MRML/Widgets/qMRMLSliderWidget.h
+++ b/Libs/MRML/Widgets/qMRMLSliderWidget.h
@@ -48,7 +48,7 @@ class qMRMLSliderWidgetPrivate;
 /// it listens to the changes made upon the selection node to extract the
 /// unit properties related to its quantity and update accordingly.
 ///
-/// To allow even more customisation, one can set which properties of the
+/// To allow even more customization, one can set which properties of the
 /// widget are updated by units and which aren't.
 ///
 /// \sa qMRMLCoordinatesWidget, qMRMLSpinBox

--- a/Libs/MRML/Widgets/qMRMLSpinBox.h
+++ b/Libs/MRML/Widgets/qMRMLSpinBox.h
@@ -48,7 +48,7 @@ class qMRMLSpinBoxPrivate;
 /// it listens to the changes made upon the selection node to extract the
 /// unit properties related to its quantity and update accordingly.
 ///
-/// To allow even more customisation, one can set which properties of the
+/// To allow even more customization, one can set which properties of the
 /// spinbox are updated by units and which aren't.
 ///
 /// \sa qMRMLSliderWidget, qMRMLCoordinatesWidget

--- a/Libs/MRML/Widgets/qMRMLTableWidget.h
+++ b/Libs/MRML/Widgets/qMRMLTableWidget.h
@@ -37,7 +37,7 @@ class qMRMLTableWidgetPrivate;
 class vtkMRMLTableViewNode;
 class vtkMRMLScene;
 
-/// \brief qMRMLTableWidget is the toplevel table widget that can be
+/// \brief qMRMLTableWidget is the top-level table widget that can be
 /// packed in a layout.
 ///
 /// qMRMLTableWidget provides tabling capabilities with a display

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.h
@@ -75,7 +75,7 @@ public slots:
 
   void setThreeDView(qMRMLThreeDView* threeDView);
 
-  /// Link/Unlink the view controls and the cameras across all viewes
+  /// Link/Unlink the view controls and the cameras across all views
   void setViewLink(bool linked);
 
   void setOrthographicModeEnabled(bool enabled);

--- a/Libs/RemoteIO/vtkHTTPHandler.h
+++ b/Libs/RemoteIO/vtkHTTPHandler.h
@@ -21,8 +21,8 @@ public:
   vtkTypeMacro(vtkHTTPHandler, vtkURIHandler);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  /// This methods returns 1 if the handler matches the uri's required
-  /// protocol and returns 0 if it's not appropriate for the uri.
+  /// This methods returns 1 if the handler matches the URI's required
+  /// protocol and returns 0 if it's not appropriate for the URI.
   int CanHandleURI ( const char *uri ) override;
 
   /// Some web servers don't handle 'keep alive' socket transactions

--- a/Libs/vtkITK/itkConstrainedValueMultiplicationImageFilter.h
+++ b/Libs/vtkITK/itkConstrainedValueMultiplicationImageFilter.h
@@ -26,7 +26,7 @@ namespace itk
 /** \class ConstrainedValueMultiplicationImageFilter
  * \brief Implements pixel-wise the computation of constrained value addition.
  *
- * This filter is parametrized over the types of the two
+ * This filter is parameterized over the types of the two
  * input images and the type of the output image.
  *
  * Numeric conversions (castings) are done by the C++ defaults.

--- a/Libs/vtkTeem/vtkImageLabelCombine.h
+++ b/Libs/vtkTeem/vtkImageLabelCombine.h
@@ -24,7 +24,7 @@
 
 /// \brief Add, subtract, multiply, divide, invert, sin, cos, exp, log.
 ///
-/// vtkImageLabelCombine implements basic mathematic operations SetOperation is
+/// vtkImageLabelCombine implements basic mathematical operations. SetOperation is
 /// used to select the filters behavior.  The filter can take two or one
 /// input.
 class VTK_Teem_EXPORT vtkImageLabelCombine : public vtkThreadedImageAlgorithm

--- a/Modules/CLI/ExtractSkeleton/tilg_iso_3D.h
+++ b/Modules/CLI/ExtractSkeleton/tilg_iso_3D.h
@@ -22,12 +22,12 @@ int Env_Code_3_img(int loc[3], unsigned char *img, int dim[3]);
 
 int Tilg_Test_3(int c, int d, int type);
 
-/* Calculation of Tilg-criterion, c is the Neighor-code of */
+/* Calculation of Tilg-criterion, c is the Neighbor-code of */
 /* 3x3x3-Region, including the center                      */
 // returns 0 if cannot be 'tilged'
 // if type == 1 -> sheet preserving tilg
 // if type == 0 -> full tilg
-// d = for parrel tilg -> 0,1,2,3,4,5   N,S,E,W,T,D
+// d = for parallel tilg -> 0,1,2,3,4,5   N,S,E,W,T,D
 
 void tilg_iso_3D(int dx, int dy, int dz, unsigned char *data, unsigned char *res, int type);
 

--- a/Modules/CLI/RobustStatisticsSegmenter/SFLSRobustStatSegmentor3DLabelMap_single.h
+++ b/Modules/CLI/RobustStatisticsSegmenter/SFLSRobustStatSegmentor3DLabelMap_single.h
@@ -6,7 +6,6 @@
 #include <list>
 #include <vector>
 
-// #include "boost/shared_ptr.hpp"
 
 template <typename TPixel>
 class CSFLSRobustStatSegmentor3DLabelMap : public CSFLSSegmentor3D<TPixel>
@@ -17,7 +16,6 @@ public:
   typedef CSFLSSegmentor3D<TPixel> SuperClassType;
 
   typedef CSFLSRobustStatSegmentor3DLabelMap<TPixel> Self;
-  // typedef boost::shared_ptr< Self > Pointer;
 
   typedef typename SuperClassType::NodeType   NodeType;
   typedef typename SuperClassType::CSFLSLayer CSFLSLayer;
@@ -82,7 +80,7 @@ protected:
 
   const static long m_numberOfFeature = 3;
   /* Store the robust stat as the feature at each point
-     0: Meadian
+     0: median
      1: interquartile range (IRQ)
      2. median absolute deviation (MAD)
   */

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationDisplayNode.h
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationDisplayNode.h
@@ -160,7 +160,7 @@ class  VTK_SLICER_ANNOTATIONS_MODULE_MRML_EXPORT vtkMRMLAnnotationDisplayNode : 
   /// Off by default
   /// Not all subclasses have projection behavior
   /// Please refer to subclasses for more information
-  /// \sa SliceIntersectionVisibilty, ProjectedColor
+  /// \sa SliceIntersectionVisibility, ProjectedColor
   vtkSetMacro(SliceProjection, int);
   vtkGetMacro(SliceProjection, int);
 

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationFiducialNode.h
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationFiducialNode.h
@@ -15,7 +15,7 @@ class vtkMRMLStorageNode;
 /// that MRML will manage/read/write. Each control point has accompanying data.
 /// Visualization parameters for these nodes are controlled by the
 /// vtkMRMLAnnotationPointDisplayNode class.
-/// \deprecated Use vtkMRMLMarkupsFiduicalNode
+/// \deprecated Use vtkMRMLMarkupsFiducialNode
 /// \ingroup Slicer_QtModules_Annotation
 class  VTK_SLICER_ANNOTATIONS_MODULE_MRML_EXPORT vtkMRMLAnnotationFiducialNode : public vtkMRMLAnnotationControlPointsNode
 {

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLineDisplayNode.h
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLineDisplayNode.h
@@ -88,7 +88,7 @@ class  VTK_SLICER_ANNOTATIONS_MODULE_MRML_EXPORT vtkMRMLAnnotationLineDisplayNod
   /// Set line color unchanged when parallel to slice plane
   inline void SliceProjectionColoredWhenParallelOff();
 
-  /// Set line thicker when on top of the plane, thiner when under
+  /// Set line thicker when on top of the plane, thinner when under
   inline void SliceProjectionThickerOnTopOn();
 
   /// Set line thickness uniform
@@ -106,7 +106,7 @@ class  VTK_SLICER_ANNOTATIONS_MODULE_MRML_EXPORT vtkMRMLAnnotationLineDisplayNod
   /// ProjectionColoredWhenParallel : Set projected line
   /// colored when parallel to slice plane
   /// ProjectionThickerOnTop : Set projected line thicker
-  /// on top of the plane, thiner when under
+  /// on top of the plane, thinner when under
   /// Projection Off, Dashed, ColoredWhenParallel,
   /// ThickerOnTop and UseRulerColor by default
   /// \enum ProjectionFlag

--- a/Modules/Loadable/Colors/MRML/vtkMRMLColorLegendDisplayNode.h
+++ b/Modules/Loadable/Colors/MRML/vtkMRMLColorLegendDisplayNode.h
@@ -58,7 +58,7 @@ public:
 
   //@{
   /// Get/Set color legend orientation
-  /// Possible values: vtkMRMLColorLegendDisplayNode::Horizontal, vtkMRMLColorLegendDisplayNode::Vectical
+  /// Possible values: vtkMRMLColorLegendDisplayNode::Horizontal, vtkMRMLColorLegendDisplayNode::Vertical
   vtkGetMacro(Orientation, OrientationType);
   vtkSetMacro(Orientation, OrientationType);
   //@}

--- a/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.h
+++ b/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.h
@@ -56,7 +56,7 @@ class vtkMRMLCropVolumeParametersNode;
 /// of the volume can be changed.
 ///
 /// Limitations:
-/// * Region of interes (ROI) node cannot be under non-linear transform
+/// * Region of interest (ROI) node cannot be under non-linear transform
 /// * Cropped output volume node cannot be under non-linear transform
 /// * If interpolation is disabled: input volume node cannot be under non-linear transform
 ///   and ROI node must be aligned with the input volume

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -238,7 +238,7 @@ public:
   /// If projectWarp option is enabled then FitSurfaceProjectWarp method is used
   /// otherwise FitSurfaceDiskWarp is used. FitSurfaceProjectWarp produces accurate results
   /// for all quasi-planar curves (while FitSurfaceDiskWarp may significantly overestimate surface area for
-  /// planar convex curves). FitSurfaceDiskWarp is kept for compatison only and may be removed in the future.
+  /// planar convex curves). FitSurfaceDiskWarp is kept for comparison only and may be removed in the future.
   /// \param curveNode points to fit the surface to
   /// \param surface if not nullptr then the generated surface is saved into that
   static double GetClosedCurveSurfaceArea(vtkMRMLMarkupsClosedCurveNode* curveNode, vtkPolyData* surface = nullptr, bool projectWarp = true);
@@ -279,7 +279,7 @@ public:
   void RegisterJsonStorageNodeForMarkupsType(std::string markupsType, std::string storageNodeClassName);
   vtkMRMLMarkupsJsonStorageNode* AddNewJsonStorageNodeForMarkupsType(std::string markupsType);
 
-  /// Registers a markup and its corresponding widget to be handled by the Markups module.
+  /// Register a markup and its corresponding widget to be handled by the Markups module.
   /// For a markup to be handled by this module (processed by the displayable
   /// manager, UI and subject hierarchy) it needs to be registered using this method.
   /// The method also registers the markupsNode class in the scene.
@@ -289,26 +289,26 @@ public:
                            vtkSlicerMarkupsWidget* markupsWidget,
                            bool createPushButton=true);
 
-  /// Unregisters a markup and its corresponding widget. This will trigger the
+  /// Unregister a markup and its corresponding widget. This will trigger the
   /// vtkSlicerMarkupsLogic::MarkupUnregistered event.
   /// \param markupsNode MRMLMarkups node to be unregistered.
   void UnregisterMarkupsNode(vtkMRMLMarkupsNode*  markupsNode);
 
   /// Returns true if the provided class name is a known markups class
-  /// (it has ben registered in the logic using RegisterMarkupsNode).
+  /// (it has been registered in the logic using RegisterMarkupsNode).
   bool IsMarkupsNodeRegistered(const char* nodeType) const;
 
   /// This returns an instance to a corresponding vtkSlicerMarkupsWidget associated
   /// to the indicated markups name.
   /// \param markupsType registered class to retrieve the associated widget.
-  /// \return pointer to associated vtkSLicerMarkupsWidget or nullptr if the MRML node
+  /// \return pointer to associated vtkSlicerMarkupsWidget or nullptr if the MRML node
   /// class is not registered.
   vtkSlicerMarkupsWidget* GetWidgetByMarkupsType(const char* markupsType) const;
 
   /// This returns an instance to a corresponding vtkMRMLMarkupsNode associated
   /// to the indicated markups name.
   /// \param markupsType registered class to retrieve the associated widget.
-  /// \return pointer to associated vtkSLicerMarkupsWidget or nullptr if the MRML node
+  /// \return pointer to associated vtkSlicerMarkupsWidget or nullptr if the MRML node
   /// class is not registered.
   vtkMRMLMarkupsNode* GetNodeByMarkupsType(const char* markupsType) const;
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
@@ -310,7 +310,7 @@ public:
   /// is visible or not in 2D viewers on slices on which it is normally
   /// not visible.
   /// Off by default
-  /// \sa SliceIntersectionVisibilty, SliceProjectionColor
+  /// \sa SliceIntersectionVisibility, SliceProjectionColor
   vtkSetMacro(SliceProjection, bool);
   vtkGetMacro(SliceProjection, bool);
   vtkBooleanMacro(SliceProjection, bool);

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -550,7 +550,7 @@ public:
   /// determine if it is locked. If the locked flag is set to false on the node
   /// as a whole, all control point are locked but keep this value for when the
   /// list as a whole is turned unlocked.
-  /// \sa vtMRMLMarkupsNode::SetLocked
+  /// \sa vtkMRMLMarkupsNode::SetLocked
   void SetNthControlPointLocked(int n, bool flag);
 
   /// Get the Visibility flag on the Nth control point,
@@ -602,7 +602,7 @@ public:
   /// %d will resolve to the highest not yet used list index integer.
   /// Character strings will otherwise pass through
   /// Defaults to %N-%d which will yield control point names of Name-0, Name-1, Name-2.
-  /// If format string is changed then LabelFormatModifedEvent event is invoked.
+  /// If format string is changed then LabelFormatModifiedEvent event is invoked.
   std::string GetControlPointLabelFormat();
   void SetControlPointLabelFormat(std::string format);
   ///@}
@@ -623,7 +623,7 @@ public:
   bool GetModifiedSinceRead() override;
 
   /// Reset the id of the Nth control point according to the local policy
-  /// Called after an already initialised markup has been added to the
+  /// Called after an already initialized markup has been added to the
   /// scene. Returns false if n out of bounds, true on success.
   bool ResetNthControlPointID(int n);
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
@@ -12,7 +12,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-  This file was centerally developed by Kyle Sunderland, PerkLab, Queen's University
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
   and was supported through CANARIE's Research Software Program, Cancer
   Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkFastSelectVisiblePoints.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkFastSelectVisiblePoints.h
@@ -12,7 +12,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-  This file was centerally developed by Kyle Sunderland, PerkLab, Queen's University
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
   and was supported through CANARIE's Research Software Program, Cancer
   Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
@@ -109,7 +109,7 @@ public:
   /// Get the nth control point.
   virtual vtkMRMLMarkupsNode::ControlPoint *GetNthControlPoint(int n);
 
-  /// Set/Get the vtkMRMLMarkipsNode connected with this representation
+  /// Set/Get the vtkMRMLMarkupsNode connected with this representation
   virtual void SetMarkupsDisplayNode(vtkMRMLMarkupsDisplayNode *markupsDisplayNode);
   virtual vtkMRMLMarkupsDisplayNode* GetMarkupsDisplayNode();
   virtual vtkMRMLMarkupsNode* GetMarkupsNode();

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsOptionsWidgetsFactory.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsOptionsWidgetsFactory.h
@@ -49,16 +49,16 @@ public:
   Q_INVOKABLE static qMRMLMarkupsOptionsWidgetsFactory* instance();
 
 public:
-  /// Registers an additional options widget.
+  /// Register an additional options widget.
   /// This factory object takes ownership of the widget (even if it fails to register it
   /// due to for example a widget already existing for that markup type), therefore the
   /// caller must NOT delete the widget.
   Q_INVOKABLE bool registerOptionsWidget(qMRMLMarkupsAbstractOptionsWidget* widget);
 
-  /// Unregisters an additional options widget.
+  /// Unregister an additional options widget.
   Q_INVOKABLE bool unregisterOptionsWidget(const QString& className);
 
-  /// Unregisters an additional options widget.
+  /// Unregister an additional options widget.
   Q_INVOKABLE bool unregisterOptionsWidget(qMRMLMarkupsAbstractOptionsWidget* widget);
 
   /// Unregister all widgets

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
@@ -42,7 +42,7 @@ class qSlicerAbstractModuleWidget;
 class vtkMRMLAbstractViewNode;
 
 /// \ingroup Slicer_QtModules_SubjectHierarchy_Widgets
-///    In Widgets, not Plugins because the paths and libs need to be exported to extensions
+///    In Widgets, not Plugins because the paths and library paths need to be exported to extensions
 /// \brief Abstract plugin for handling Subject Hierarchy items
 ///
 /// This class provides an interface and some default implementations for the common operations on

--- a/Modules/Loadable/Tables/Widgets/qSlicerTableColumnPropertiesWidget.h
+++ b/Modules/Loadable/Tables/Widgets/qSlicerTableColumnPropertiesWidget.h
@@ -77,7 +77,7 @@ public slots:
   void setColumnNameVisible(bool);
 
   /// If enabled then column type change is not performed immediately but user
-  /// must to confirmit  by pressing "Convert" button.
+  /// must to confirm it by pressing "Convert" button.
   void setConfirmTypeChange(bool);
 
 protected slots:

--- a/Modules/Loadable/Units/Widgets/qMRMLSettingsUnitWidget.h
+++ b/Modules/Loadable/Units/Widgets/qMRMLSettingsUnitWidget.h
@@ -50,7 +50,7 @@ public:
   qMRMLSettingsUnitWidget(QWidget *parent=nullptr);
   ~qMRMLSettingsUnitWidget() override;
 
-  /// Set the units logic scene for the preset comboxes
+  /// Set the units logic scene for the preset comboboxes
   virtual void setUnitsLogic(vtkSlicerUnitsLogic* logic);
 
   qMRMLNodeComboBox* unitComboBox();

--- a/Modules/Loadable/Units/Widgets/qMRMLUnitWidget.h
+++ b/Modules/Loadable/Units/Widgets/qMRMLUnitWidget.h
@@ -140,7 +140,7 @@ public:
   /// \sa editableProperties
   UnitProperties editableProperties() const;
 
-  /// Set the units logic scene for the preset comboxes
+  /// Set the units logic scene for the preset comboboxes
   void setMRMLScene(vtkMRMLScene* unitsLogicScene) override;
 
   Q_INVOKABLE vtkMRMLNode* currentNode() const;

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerPresetComboBox.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerPresetComboBox.h
@@ -34,7 +34,7 @@ class Q_SLICER_MODULE_VOLUMERENDERING_WIDGETS_EXPORT qSlicerPresetComboBox
   : public qMRMLNodeComboBox
 {
   Q_OBJECT
-  /// Show icons in the comobox and popup window.
+  /// Show icons in the combobox and popup window.
   Q_PROPERTY(bool showIcons READ showIcons WRITE setShowIcons)
   /// Show label in the popup window.
   Q_PROPERTY(bool showLabelsInPopup READ showLabelsInPopup WRITE setShowLabelsInPopup)


### PR DESCRIPTION
Changes identified running "SimpleITKSpellChecking" with the following arguments where `slicer_additional_dictionary` is set using a custom dictionary[^1]

[^1]: https://gist.github.com/jcfr/670d1d432e1c30947f0fc6be71ac4ef4



```
# See https://gist.github.com/jcfr/670d1d432e1c30947f0fc6be71ac4ef4
slicer_additional_dictionary=/path/to/slicer_additional_dictionary.txt

codespell \
  --brief --miss \
  -I ${slicer_additional_dictionary} \
  --prefix "ctk" \
  --prefix "ctkITK" \
  --prefix "ctkVTK" \
  --prefix "itk" \
  --prefix "itksys" \
  --prefix "mrml" \
  --prefix "MRML" \
  --prefix "pq" \
  --prefix "qMRML" \
  --prefix "qSlicer" \
  --prefix "Q" \
  --prefix "slicer" \
  --prefix "vtkAddon" \
  --prefix "vtkITK" \
  --prefix "vtkMRML" \
  --prefix "vtkSlicer" \
  --prefix "vtksys" \
  --suffix ".h"
```

Note that "SimpleITKSpellChecking" based of the following pull request was used:
* https://github.com/SimpleITK/SimpleITKSpellChecking/pull/26