### PR TITLE
ENH: Allow setting custom editor for .py files

### DIFF
--- a/Base/QTGUI/Resources/UI/qSlicerSettingsPythonPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsPythonPanel.ui
@@ -6,14 +6,46 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>487</width>
-    <height>379</height>
+    <width>370</width>
+    <height>220</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Python</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="GeneralGroupBox">
+     <property name="title">
+      <string>General</string>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+     <layout class="QFormLayout" name="formLayout_2">
+      <property name="fieldGrowthPolicy">
+       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="EditorLabel">
+        <property name="text">
+         <string>Editor for .py files:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="ctkPathLineEdit" name="EditorPathLineEdit">
+        <property name="toolTip">
+         <string>Select an executable for editing .py files. If left empty then the default program associated with .py files will be launched.</string>
+        </property>
+        <property name="settingKey">
+         <string>PythonEditor</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item>
     <widget class="QGroupBox" name="ShellDisplayGroupBox">
      <property name="title">
@@ -74,6 +106,19 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -86,6 +131,11 @@
    <class>ctkFontButton</class>
    <extends>QPushButton</extends>
    <header>ctkFontButton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkPathLineEdit</class>
+   <extends>QWidget</extends>
+   <header>ctkPathLineEdit.h</header>
   </customwidget>
   <customwidget>
    <class>ctkSettingsPanel</class>

--- a/Base/QTGUI/qSlicerSettingsGeneralPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsGeneralPanel.cxx
@@ -133,8 +133,7 @@ void qSlicerSettingsGeneralPanelPrivate::init()
     context.evalScript(QString("slicerrcfilename = getSlicerRCFileName()\n"));
     QVariant slicerrcFileNameVar = context.getVariable("slicerrcfilename");
     this->SlicerRCFileValueLabel->setText(slicerrcFileNameVar.toString());
-    QIcon openFileIcon = QApplication::style()->standardIcon(QStyle::SP_DialogOpenButton);
-    this->SlicerRCFileOpenButton->setIcon(openFileIcon);
+    this->SlicerRCFileOpenButton->setIcon(QIcon(":Icons/Go.png"));
     QObject::connect(this->SlicerRCFileOpenButton, SIGNAL(clicked()), q, SLOT(openSlicerRCFile()));
     }
   else
@@ -249,7 +248,22 @@ void qSlicerSettingsGeneralPanel::openSlicerRCFile()
       outputFile.close();
       }
     }
-  QDesktopServices::openUrl(QUrl("file:///" + slicerRcFileName, QUrl::TolerantMode));
+
+  QString editor = qSlicerApplication::application()->userSettings()->value("Python/Editor").toString();
+  if (editor.isEmpty())
+    {
+    QDesktopServices::openUrl(QUrl("file:///" + slicerRcFileName, QUrl::TolerantMode));
+    }
+  else
+    {
+    QProcess process;
+    // Use startup environment to avoid Python environment issues with text editors implemented in Python
+    process.setProcessEnvironment(qSlicerApplication::application()->startupEnvironment());
+    process.setProgram(editor);
+    process.setArguments(QStringList() << slicerRcFileName);
+    process.startDetached();
+    }
+
 }
 
 // --------------------------------------------------------------------------

--- a/Base/QTGUI/qSlicerSettingsPythonPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsPythonPanel.cxx
@@ -94,6 +94,10 @@ void qSlicerSettingsPythonPanelPrivate::init()
   // Register settings with their corresponding widgets
   //
 
+  q->registerProperty("Python/Editor", this->EditorPathLineEdit,
+    /*no tr*/"currentPath", SIGNAL(currentPathChanged(QString)),
+    qSlicerSettingsPythonPanel::tr("Python editor."));
+
   q->registerProperty("Python/DockableWindow", this->DockableWindowCheckBox,
     /*no tr*/"checked", SIGNAL(toggled(bool)),
     qSlicerSettingsPythonPanel::tr("Display Python console in a window that can be placed inside the main window."),
@@ -160,4 +164,15 @@ void qSlicerSettingsPythonPanel::setConsoleLogLevel(const QString& text)
     }
   // default to first item if conversion fails
   d->ConsoleLogLevelComboBox->setCurrentIndex(selectedIndex);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsPythonPanel::applySettings()
+{
+  Q_D(qSlicerSettingsPythonPanel);
+  if (!d->EditorPathLineEdit->currentPath().isEmpty())
+    {
+    d->EditorPathLineEdit->addCurrentPathToHistory();
+    }
+  Superclass::applySettings();
 }

--- a/Base/QTGUI/qSlicerSettingsPythonPanel.h
+++ b/Base/QTGUI/qSlicerSettingsPythonPanel.h
@@ -52,6 +52,7 @@ public:
 
 public slots:
   void setConsoleLogLevel(const QString& levelStr);
+  void applySettings() override;
 
 protected slots:
   void onFontChanged(const QFont& font);

--- a/Docs/developer_guide/python_faq.md
+++ b/Docs/developer_guide/python_faq.md
@@ -296,6 +296,16 @@ In most places, unix-type separators can be used instead of backslash. This is c
 
 See more information in Python documentation: https://docs.python.org/3/tutorial/introduction.html?#strings
 
+## How to modify a Python scripted module
+
+If `Developer mode` is enabled in application settings then `Reload and Test` section is displayed at the top of user interface of Python scripted modules. This section contains buttons for convenient editing of the module source code (`.py` file) and user interface (`.ui` file). Clicking the `Edit` button opens the module source code in the program associated with `.py` files, as defined in operating system settings. This behavior can be overridden by specifying a text editor (such as VS Code, Sublime Text, ...) in application settings: `Editor for .py files` in `Python` section.
+
+On Windows, VS Code text editor is installed by default at:
+
+```txt
+C:/Users/YourUserName/AppData/Local/Programs/Microsoft VS Code/Code.exe
+```
+
 ## How to include Python modules in an extension
 
 Sometimes a Python scripted module grows big and it becomes inconvenient to have all the source code in a single .py file. Since all the .py files in a folder that is listed among "additional module paths" are expected to be Slicer modules, these additional files cannot be simply placed in the same folder as in the Slicer module. Instead, all additional .py files can be put in a subfolder, as a regular Python module.

--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -461,7 +461,6 @@ class ScreenCaptureWidget(ScriptedLoadableModuleWidget):
 
     def openURL(self, URL):
         qt.QDesktopServices().openUrl(qt.QUrl(URL))
-        QDesktopServices
 
     def onShowCreatedOutputFile(self):
         if not self.createdOutputFile:


### PR DESCRIPTION
When "Developer mode" is enabled in Application Settings, "Edit" button opens the module .py file in the default program associated with .py files.
This is most commonly an editor, but some users associate .py files with a Python launcher (such as "c:/windows/py.exe"). In these cases, the module .py file is attempted to be launched instead of edited.

This commit adds a new "Editor for .py files" option Application settings / Python. If a text editor is specified there then that program will be launched to edit .py files.
If user holds down Shift key while clicking on "Edit" button then an editor is not launched but instead the full path is copied to the clipboard to allow the user to open it in an editor manually.

Also changed icon of opening of .sliccerrc.py file (file open button usually opens a file selector dialog, replaced by "Go" button = arrow to the right).
