### PR TITLE
ENH: Load DICOM files using DICOM module by default

### DIFF
--- a/Base/QTCore/qSlicerScriptedFileReader.cxx
+++ b/Base/QTCore/qSlicerScriptedFileReader.cxx
@@ -278,7 +278,7 @@ double qSlicerScriptedFileReader::canLoadFileConfidence(const QString& file)cons
     return this->Superclass::canLoadFileConfidence(file);
     }
 
-  if (PyFloat_Check(result))
+  if (!PyFloat_Check(result))
     {
     qWarning() << d->PythonSource
                << " - In" << d->PythonClassName << "class, function 'canLoadFileConfidence' "

--- a/Docs/user_guide/modules/dicom.md
+++ b/Docs/user_guide/modules/dicom.md
@@ -62,7 +62,7 @@ Since DICOM files are often located in several folders, they can cross-reference
 
 :::{note}
 
-When a folder is drag-and-dropped to the Slicer application while not the DICOM module is active, Slicer displays a popup, asking what to do - click OK ("Load directory in DICOM database"). After import is completed, go to DICOM module.
+When a folder is drag-and-dropped to the Slicer application, Slicer displays a popup, asking what to do - click OK ("Load directory in DICOM database"). After import is completed, go to DICOM module.
 
 :::
 


### PR DESCRIPTION
Drag-and-dropping a DICOM file made Slicer use ITK DICOM reader, which often did not load the data correctly.

This commit adds a new "DICOM import" reader type, which is selected by default for DICOM files. This reader imports the files into the Slicer DICOM database and switches to the DICOM module.

The workaround of interpreting all files as DICOM by default while in DICOM module has now been removed. "Add data" window is brought up when loading a file, regardless of what is the active module. The workaround surprised users when they could not load non-DICOM data while they were in DICOM module.

If a user wants to read the DICOM file using ITK reader, it is possible by changing "Description" in the "Add data" module to "Volume".

fixes #5726