### PR TITLE
BUG: Ensure DICOMUtils.loadLoadables do not return temporary nodes

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -907,6 +907,12 @@ def loadLoadables(loadablesByPlugin, messages=None, progressCallback=None):
 
     slicer.mrmlScene.RemoveObserver(sceneObserverTag)
 
+    # Filter out temporary node(s)
+    loadedNodeIDs = [
+        loadedNodeID for loadedNodeID in loadedNodeIDs
+        if slicer.mrmlScene.GetNodeByID(loadedNodeID) is not None
+    ]
+
     return loadedNodeIDs
 
 

--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -864,7 +864,13 @@ def loadLoadables(loadablesByPlugin, messages=None, progressCallback=None):
         if not isinstance(node, slicer.vtkMRMLStorageNode) and not isinstance(node, slicer.vtkMRMLDisplayNode):
             loadedNodeIDs.append(node.GetID())
 
+    @vtk.calldata_type(vtk.VTK_OBJECT)
+    def onNodeRemoved(caller, event, calldata):
+        node = calldata
+        loadedNodeIDs.remove(node.GetID())
+
     sceneObserverTag = slicer.mrmlScene.AddObserver(slicer.vtkMRMLScene.NodeAddedEvent, onNodeAdded)
+    sceneObserverTag2 = slicer.mrmlScene.AddObserver(slicer.vtkMRMLScene.NodeRemovedEvent, onNodeRemoved)
 
     for step, (loadable, plugin) in enumerate(selectedLoadables.items(), start=1):
         if progressCallback:
@@ -906,12 +912,7 @@ def loadLoadables(loadablesByPlugin, messages=None, progressCallback=None):
             break
 
     slicer.mrmlScene.RemoveObserver(sceneObserverTag)
-
-    # Filter out temporary node(s)
-    loadedNodeIDs = [
-        loadedNodeID for loadedNodeID in loadedNodeIDs
-        if slicer.mrmlScene.GetNodeByID(loadedNodeID) is not None
-    ]
+    slicer.mrmlScene.RemoveObserver(sceneObserverTag2)
 
     return loadedNodeIDs
 


### PR DESCRIPTION
Since loader may add temporary nodes to the scene while loading a file, this function makes sure these are not included in the list of returned node IDs.

Example of such loaded is `UltrasoundImage3dReaderFileReader` adding a temporary node to construct the volume sequence.

See https://github.com/SlicerHeart/SlicerHeart/blob/52eeb23576c7eda14dbe3e602667f4c5b68c4475/UltrasoundImage3dReader/UltrasoundImage3dReader.py#L172-L173