### PR TITLE
BUG: Update VTK to fix regression preventing from loading older vtp files

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "6c02c9b3769bbb433b1451128993945198fa6bc3") # slicer-v9.2.20230607-1ff325c54
+    set(_git_tag "8e0f1f9af77a8a018d2a609cd6779c95f2bbda18") # slicer-v9.2.20230607-1ff325c54
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
This ensures that reading an empty "vtkPolyData" reports a warning instead of an error message.

List of VTK changes:

```
$ git shortlog 6c02c9b376..8e0f1f9af7 --no-merges
Jean-Christophe Fillion-Robin (1):
      [Backport MR-10295] Allow const std::vector<vtkSmartPointer<T>> in Python (part 2)

Steve Pieper (1):
      [Backport MR-9648] BUG: error for non-fatal xml issue
```