### PR TITLE
BUG: Fix SlicerOrientationSelectorTestTest to account for widget rename

### DIFF
--- a/Applications/SlicerApp/Testing/Python/SlicerOrientationSelectorTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerOrientationSelectorTest.py
@@ -113,9 +113,9 @@ class SlicerOrientationSelectorTestTest(ScriptedLoadableModuleTest):
         sliceNodeSelector = slicer.util.findChildren(widget, "SliceNodeSelector")[0]
         sliceNodeSelector.setCurrentNodeID("vtkMRMLSliceNodeRed")
 
-        # Set LR value using Reformat module
-        lrslider = slicer.util.findChildren(widget, "LRSlider")[0]
-        lrslider.value = 1
+        # Set RotateZ slider value using Reformat module
+        rotateZSlider = slicer.util.findChildren(widget, "RotateZSlider")[0]
+        rotateZSlider.value = 1
 
         # Get reference to the Red slice controller
         lm = slicer.app.layoutManager()


### PR DESCRIPTION
This commit is a follow-up of e75785816 (ENH: Add flip and rotate buttons to Reformat module (#7078)) accounting for the slide widget rename introduced in:
* https://github.com/Slicer/Slicer/pull/7078