### PR TITLE
BUG: Fix behavior after invisible segment confirmation popup

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorDrawEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorDrawEffect.py
@@ -63,13 +63,19 @@ class SegmentEditorDrawEffect(AbstractScriptedSegmentEditorLabelEffect):
         anyModifierKeyPressed = callerInteractor.GetShiftKey() or callerInteractor.GetControlKey() or callerInteractor.GetAltKey()
 
         if eventId == vtk.vtkCommand.LeftButtonPressEvent and not anyModifierKeyPressed:
+
             # Make sure the user wants to do the operation, even if the segment is not visible
             confirmedEditingAllowed = self.scriptedEffect.confirmCurrentSegmentVisible()
             if confirmedEditingAllowed == self.scriptedEffect.NotConfirmed or confirmedEditingAllowed == self.scriptedEffect.ConfirmedWithDialog:
-                # If user had to move the mouse to click on the popup, so we cannot continue with painting
-                # from the current mouse position. User will need to click again.
-                # The dialog is not displayed again for the same segment.
+                # ConfirmedWithDialog cancels the operation because the user had to move the mouse to click on the popup,
+                # which would interfere with the drawn shape. The dialog is not displayed again for the same segment.
+
+                # The event has to be aborted, because otherwise there would be a LeftButtonPressEvent without a matching
+                # LeftButtonReleaseEvent (as the popup window received the release button event).
+                abortEvent = True
+
                 return abortEvent
+
             pipeline.actionState = "drawing"
             self.scriptedEffect.cursorOff(viewWidget)
             xy = callerInteractor.GetEventPosition()

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorIslandsEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorIslandsEffect.py
@@ -262,7 +262,15 @@ about each operation, hover the mouse over the option and wait for the tooltip t
             return abortEvent
 
         # Make sure the user wants to do the operation, even if the segment is not visible
-        if not self.scriptedEffect.confirmCurrentSegmentVisible():
+        confirmedEditingAllowed = self.scriptedEffect.confirmCurrentSegmentVisible()
+        if confirmedEditingAllowed == self.scriptedEffect.NotConfirmed or confirmedEditingAllowed == self.scriptedEffect.ConfirmedWithDialog:
+            # ConfirmedWithDialog cancels the operation because without seeing the segment, the island may have looked different
+            # than what the user remembered/expected. The dialog is not displayed again for the same segment.
+
+            # The event has to be aborted, because otherwise there would be a LeftButtonPressEvent without a matching
+            # LeftButtonReleaseEvent (as the popup window received the release button event).
+            abortEvent = True
+
             return abortEvent
 
         abortEvent = True

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorLevelTracingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorLevelTracingEffect.py
@@ -73,8 +73,14 @@ follows the same intensity value back to the starting point within the current s
         anyModifierKeyPressed = callerInteractor.GetShiftKey() or callerInteractor.GetControlKey() or callerInteractor.GetAltKey()
 
         if eventId == vtk.vtkCommand.LeftButtonPressEvent and not anyModifierKeyPressed:
+            abortEvent = True
+
             # Make sure the user wants to do the operation, even if the segment is not visible
             if not self.scriptedEffect.confirmCurrentSegmentVisible():
+                self.sliceRotatedErrorLabel.text = ""
+                pipeline.actor.VisibilityOff()
+                self.lastXY = None
+                pipeline.sliceWidget.sliceView().scheduleRender()
                 return abortEvent
 
             self.scriptedEffect.saveStateForUndo()
@@ -86,7 +92,7 @@ follows the same intensity value back to the starting point within the current s
             pipeline.appendPolyMask(modifierLabelmap)
             # TODO: it would be nice to reduce extent
             self.scriptedEffect.modifySelectedSegmentByLabelmap(modifierLabelmap, slicer.qSlicerSegmentEditorAbstractEffect.ModificationModeAdd)
-            abortEvent = True
+
         elif eventId == vtk.vtkCommand.MouseMoveEvent:
             if pipeline.actionState == '':
                 xy = callerInteractor.GetEventPosition()

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
@@ -1233,7 +1233,13 @@ bool qSlicerSegmentEditorPaintEffect::processInteractionEvents(
       // If user had to move the mouse to click on the popup, so we cannot continue with painting
       // from the current mouse position. User will need to click again.
       // The dialog is not displayed again for the same segment.
-      return false;
+
+      // The event has to be aborted, because otherwise there would be a LeftButtonPressEvent without a matching
+      // LeftButtonReleaseEvent (as the popup window got the release button event) and so the view would be stuck
+      // in view rotation mode.
+      abortEvent = true;
+
+      return abortEvent;
       }
     d->IsPainting = true;
     if (!this->integerParameter("BrushPixelMode"))

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScissorsEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScissorsEffect.cxx
@@ -1472,7 +1472,13 @@ bool qSlicerSegmentEditorScissorsEffect::processInteractionEvents(
       // If user had to move the mouse to click on the popup, so we cannot continue with painting
       // from the current mouse position. User will need to click again.
       // The dialog is not displayed again for the same segment.
-      return false;
+
+      // The event has to be aborted, because otherwise there would be a LeftButtonPressEvent without a matching
+      // LeftButtonReleaseEvent (as the popup window got the release button event) and so the view would be stuck
+      // in view rotation mode.
+      abortEvent = true;
+
+      return abortEvent;
       }
 
     pipeline->IsDragging = true;

--- a/Utilities/Templates/Modules/ScriptedSegmentEditorEffect/SegmentEditorTemplateKeyLib/SegmentEditorEffect.py
+++ b/Utilities/Templates/Modules/ScriptedSegmentEditorEffect/SegmentEditorTemplateKeyLib/SegmentEditorEffect.py
@@ -76,6 +76,10 @@ To segment a single object, create a segment and paint inside and create another
 
     def onApply(self):
 
+        # Make sure the user wants to do the operation, even if the segment is not visible
+        if not self.scriptedEffect.confirmCurrentSegmentVisible():
+            return
+
         # Get list of visible segment IDs, as the effect ignores hidden segments.
         segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
         visibleSegmentIds = vtk.vtkStringArray()


### PR DESCRIPTION
When the user starts a segment editing operation on an invisible segment a popup is displayed to confirm that it is intentional (usually not). This popup left some effects in inconsistent state (3D view rotation is initiated, some feedback actors were not cleaned up). This commit avoids these inconsistent states.

fixes #6748