### PR TITLE
COMP: Update qRestAPI external project to use the correct GitHub organization

### DIFF
--- a/SuperBuild/External_qRestAPI.cmake
+++ b/SuperBuild/External_qRestAPI.cmake
@@ -27,7 +27,7 @@ if(NOT DEFINED qRestAPI_DIR)
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/MITK/qRestAPI.git"
+    "${EP_GIT_PROTOCOL}://github.com/commontk/qRestAPI.git"
     QUIET
     )
 


### PR DESCRIPTION
This commit is a follow-up of ea25fa65a (COMP: Replace deprecated Qt Script usage)

Follow-up of:
* https://github.com/Slicer/Slicer/pull/6710