### PR TITLE
BUG: support color DICOM data series

### DIFF
--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -380,7 +380,10 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
         if grayscale:
             reader = vtkITK.vtkITKArchetypeImageSeriesScalarReader()
         else:
-            reader = vtkITK.vtkITKArchetypeImageSeriesVectorReaderFile()
+            if len(files) > 1:
+                reader = vtkITK.vtkITKArchetypeImageSeriesVectorReaderSeries()
+            else:
+                reader = vtkITK.vtkITKArchetypeImageSeriesVectorReaderFile()
         reader.SetArchetype(files[0])
         for f in files:
             reader.AddFileName(f)


### PR DESCRIPTION
Without this change the vtkITK code complained that a series of color dicom data could not be loaded.

It appears that when the check for grayscale was added it was only tested on single instance files, not on series in multiple files.

This change invokes the correct reader based on whether it's a single file or not.