### PR TITLE
BUG: Fix CPACK_NSIS_INSTALL_SUBDIRECTORY being overwritten

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -354,7 +354,9 @@ endif()
 # -------------------------------------------------------------------------
 if(CPACK_GENERATOR STREQUAL "NSIS")
 
-  set(Slicer_CPACK_NSIS_INSTALL_SUBDIRECTORY "")
+  if(NOT DEFINED Slicer_CPACK_NSIS_INSTALL_SUBDIRECTORY)
+    set(Slicer_CPACK_NSIS_INSTALL_SUBDIRECTORY "")
+  endif()
   slicer_cpack_set("CPACK_NSIS_INSTALL_SUBDIRECTORY")
 
   set(_nsis_install_root "${Slicer_CPACK_NSIS_INSTALL_ROOT}")

--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -354,6 +354,9 @@ endif()
 # -------------------------------------------------------------------------
 if(CPACK_GENERATOR STREQUAL "NSIS")
 
+  # Conditionally set the variable so that a different value
+  # can be passed to the inner build (usually done by a custom
+  # application).
   if(NOT DEFINED Slicer_CPACK_NSIS_INSTALL_SUBDIRECTORY)
     set(Slicer_CPACK_NSIS_INSTALL_SUBDIRECTORY "")
   endif()


### PR DESCRIPTION
Introduced by https://github.com/Slicer/Slicer/commit/43dd44e85c210fc09375997bd435da61adbe136b

I was using this along with `mark_as_superbuild(Slicer_CPACK_NSIS_INSTALL_SUBDIRECTORY "${Slicer_ORGANIZATION_NAME}")` in the CMakeLists.txt of my Slicer custom app to change the default system level install location from "C:/Program Files/{ApplicationName}" to "C:/Program Files/{OrganizationName}/{ApplicationName}