### PR TITLE
BUG: Fix rendering of SaveDataDialog checkboxes in Dark Mode

### DIFF
--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -120,6 +120,14 @@ qSlicerSaveDataDialogPrivate::qSlicerSaveDataDialogPrivate(QWidget* parentWidget
 
   this->FileWidget->setItemDelegateForColumn(
     FileNameColumn, new qSlicerFileNameItemDelegate(this));
+  this->FileWidget->setStyleSheet(QStringLiteral(
+    "QAbstractItemView::indicator:unchecked {\n"
+    "   background-color: palette(alternate-base);\n"
+    "}\n"
+    "QCheckBox::indicator:unchecked {\n"
+    "   background-color: palette(alternate-base);\n"
+    "};"
+  ));
   this->FileWidget->verticalHeader()->setVisible(false);
 
   // Checkable headers.


### PR DESCRIPTION
Set a stylesheet that sets the unchecked background to alternate base for QCheckBox in options column and QAbstractItemView in filename column.

fixes #5185


References:
* https://doc.qt.io/qt-5/stylesheet-reference.html#paletterole
* https://doc.qt.io/qt-5/stylesheet-reference.html#list-of-stylable-widgets
