### PR TITLE
Fix "Model",  "plane markups" and "segmentation closed surface" slice intersections display

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
@@ -58,7 +58,7 @@
 #include <vtkWeakPointer.h>
 
 // VTK includes: customization
-#include <vtkCompositeDataGeometryFilter.h>
+#include <vtkGeometryFilter.h>
 #include <vtkPlaneCutter.h>
 #include <vtkSampleImplicitFunctionFilter.h>
 
@@ -84,7 +84,7 @@ public:
     vtkSmartPointer<vtkTransformFilter> ModelWarper;
     vtkSmartPointer<vtkPlane> Plane;
     vtkSmartPointer<vtkPlaneCutter> Cutter;
-    vtkSmartPointer<vtkCompositeDataGeometryFilter> GeometryFilter; // appends multiple cut pieces into a single polydata
+    vtkSmartPointer<vtkGeometryFilter> GeometryFilter;
     vtkSmartPointer<vtkSampleImplicitFunctionFilter> SliceDistance;
     vtkSmartPointer<vtkProp> Actor;
     };
@@ -311,7 +311,7 @@ void vtkMRMLModelSliceDisplayableManager::vtkInternal
   Pipeline* pipeline = new Pipeline();
   pipeline->Actor = actor.GetPointer();
   pipeline->Cutter = vtkSmartPointer<vtkPlaneCutter>::New();
-  pipeline->GeometryFilter = vtkSmartPointer<vtkCompositeDataGeometryFilter>::New();
+  pipeline->GeometryFilter = vtkSmartPointer<vtkGeometryFilter>::New();
   pipeline->SliceDistance = vtkSmartPointer<vtkSampleImplicitFunctionFilter>::New();
   pipeline->TransformToSlice = vtkSmartPointer<vtkTransform>::New();
   pipeline->NodeToWorld = vtkSmartPointer<vtkGeneralTransform>::New();

--- a/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
+++ b/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
@@ -25,7 +25,6 @@
 #include "vtkOrientedImageData.h"
 
 // VTK includes
-#include <vtkCompositeDataGeometryFilter.h>
 #include <vtkCompositeDataIterator.h>
 #include <vtkDecimatePro.h>
 #include <vtkDiscreteFlyingEdges3D.h>

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.cxx
@@ -24,10 +24,10 @@
 #include <vtkAppendPolyData.h>
 #include <vtkCellLocator.h>
 #include <vtkClipPolyData.h>
-#include <vtkCompositeDataGeometryFilter.h>
 #include <vtkDiscretizableColorTransferFunction.h>
 #include <vtkDoubleArray.h>
 #include <vtkFeatureEdges.h>
+#include <vtkGeometryFilter.h>
 #include <vtkGlyph2D.h>
 #include <vtkLine.h>
 #include <vtkMath.h>
@@ -65,7 +65,7 @@ vtkSlicerPlaneRepresentation2D::vtkSlicerPlaneRepresentation2D()
   this->PlaneCutter->SetInputConnection(this->PlaneFilter->GetOutputPort());
   this->PlaneCutter->SetPlane(this->SlicePlane);
 
-  this->PlaneCompositeFilter->SetInputConnection(this->PlaneCutter->GetOutputPort());
+  this->PlaneGeometryFilter->SetInputConnection(this->PlaneCutter->GetOutputPort());
 
   this->PlaneClipperSlicePlane->SetInputConnection(this->PlaneFilter->GetOutputPort());
   this->PlaneClipperSlicePlane->SetClipFunction(this->SlicePlane);
@@ -93,7 +93,7 @@ vtkSlicerPlaneRepresentation2D::vtkSlicerPlaneRepresentation2D()
   this->PlaneAppend->AddInputConnection(this->PlaneClipperStartFadeFar->GetOutputPort(0));
   this->PlaneAppend->AddInputConnection(this->PlaneClipperEndFadeFar->GetOutputPort(0));
   this->PlaneAppend->AddInputConnection(this->PlaneClipperEndFadeFar->GetOutputPort(1));
-  this->PlaneAppend->AddInputConnection(this->PlaneCompositeFilter->GetOutputPort());
+  this->PlaneAppend->AddInputConnection(this->PlaneGeometryFilter->GetOutputPort());
 
   this->PlaneSliceDistance->SetImplicitFunction(this->SlicePlane);
   this->PlaneSliceDistance->SetInputConnection(this->PlaneAppend->GetOutputPort());
@@ -111,7 +111,7 @@ vtkSlicerPlaneRepresentation2D::vtkSlicerPlaneRepresentation2D()
   this->PlaneOutlineFilter->SetInputConnection(this->PlaneFilter->GetOutputPort());
 
   this->PlanePickingAppend->AddInputConnection(this->PlaneOutlineFilter->GetOutputPort());
-  this->PlanePickingAppend->AddInputConnection(this->PlaneCompositeFilter->GetOutputPort());
+  this->PlanePickingAppend->AddInputConnection(this->PlaneGeometryFilter->GetOutputPort());
 
   this->PlaneOutlineWorldToSliceTransformer->SetTransform(this->WorldToSliceTransform);
   this->PlaneOutlineWorldToSliceTransformer->SetInputConnection(this->PlaneOutlineFilter->GetOutputPort());

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.h
@@ -39,9 +39,9 @@
 
 class vtkAppendPolyData;
 class vtkClipPolyData;
-class vtkCompositeDataGeometryFilter;
 class vtkDiscretizableColorTransferFunction;
 class vtkFeatureEdges;
+class vtkGeometryFilter;
 class vtkMRMLInteractionEventData;
 class vtkPlaneCutter;
 class vtkPlaneSource;
@@ -105,7 +105,7 @@ protected:
   vtkNew<vtkClipPolyData> PlaneClipperStartFadeFar;
   vtkNew<vtkClipPolyData> PlaneClipperEndFadeFar;
 
-  vtkNew<vtkCompositeDataGeometryFilter> PlaneCompositeFilter;
+  vtkNew<vtkGeometryFilter> PlaneGeometryFilter;
   vtkNew<vtkAppendPolyData> PlaneAppend;
   vtkNew<vtkTransformPolyDataFilter> PlaneWorldToSliceTransformer;
   vtkNew<vtkPolyDataMapper2D> PlaneFillMapper;

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
@@ -42,7 +42,7 @@
 #include <vtkActor2D.h>
 #include <vtkCallbackCommand.h>
 #include <vtkCellArray.h>
-#include <vtkCompositeDataGeometryFilter.h>
+#include <vtkGeometryFilter.h>
 #include <vtkPlaneCutter.h>
 #include <vtkCleanPolyData.h>
 #include <vtkContourTriangulator.h>
@@ -154,7 +154,7 @@ public:
       this->Cutter->SetPlane(this->Plane);
       this->Cutter->BuildTreeOff(); // the cutter crashes for complex geometries if build tree is enabled
       vtkSmartPointer<vtkTransformPolyDataFilter> polyDataOutlineTransformer = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
-      vtkNew<vtkCompositeDataGeometryFilter> geometryFilter; // merge multi-piece output of vtkPlaneCutter
+      vtkNew<vtkGeometryFilter> geometryFilter;
       geometryFilter->SetInputConnection(this->Cutter->GetOutputPort());
       polyDataOutlineTransformer->SetInputConnection(geometryFilter->GetOutputPort());
       polyDataOutlineTransformer->SetTransform(this->WorldToSliceTransform);


### PR DESCRIPTION
With the current VTK a `vtkCompositeDataGeometryFilter` cannot be used with a `vtkPolyData` so we use a `vtkGeometryFilter` instead.

Fixes:
* #7101