### PR TITLE
COMP: Update VTK to workaround external project output flagged as error

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "8e0f1f9af77a8a018d2a609cd6779c95f2bbda18") # slicer-v9.2.20230607-1ff325c54
+    set(_git_tag "a3ab617b0f356f566b5749ffdb9a164568dd348f") # slicer-v9.2.20230607-1ff325c54
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
This commit updates VTK to include an empty commit working around the fact CTest incorrectly flag the external project update output as an error.

It fixes a regression introduced in e3aadb552 (BUG: Update VTK to fix regression preventing from loading older vtp files)

To illustrate, it flags the following output as an error on Linux and Windows:

```
Cloning into 'VTK'...
HEAD is now at 8e0f1f9af7 [Backport MR-9648] BUG: error for non-fatal xml issue
Submodule 'VTK-m' (https://github.com/KitwareMedical/vtk-m.git) registered for path 'ThirdParty/vtkm/vtkvtkm/vtk-m'
Cloning into '/.../Slicer-0-build/VTK/ThirdParty/vtkm/vtkvtkm/vtk-m'...
[...]
```

This happens despite of having "HEAD is now" being listed in `CTEST_CUSTOM_WARNING_EXCEPTION` in `CMake/CTestCustom.cmake.in`.

List of VTK changes:

```
$ git shortlog 8e0f1f9af..a3ab617b0 --no-merges
Jean-Christophe Fillion-Robin (1):
      [Slicer] COMP: Empty commit to workaround CTest false positive
```

Suggested by @lassoan 

References:


Illustrations:

| Linux | Windows |
|--|--|
| ![image](https://github.com/Slicer/Slicer/assets/219043/ae940b77-e441-4ce9-b6e6-60814c70a023) | | ![image](https://github.com/Slicer/Slicer/assets/219043/8905bebe-ca63-44c6-9d45-304b9ef95bc9) |

