### PR TITLE
STYLE: Update CTK

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "491614f129e09e30682cbb7322ced540eba71ec0"
+    "9856b3fcf2ec896a92062118246463f4810287c5"
     QUIET
     )
 


### PR DESCRIPTION
This update does not integrate any functional changes.

See https://github.com/commontk/CTK/compare/491614f12...9856b3fcf

Note that within the span of this update, commit commontk/CTK@9856b3fcf [^1] reverts the effect of commit commontk/CTK@7bb0d9fdb [2].

[^1]: commontk/CTK@9856b3fcf (`BUG: Fix ctkDICOMIndexer reverting back to functor signal/slot`)
[^2]: commontk/CTK@7bb0d9fdb (`COMP: Fix Qt4/C++98 ctkDICOMIndexerPrivate build using literal signal/slot`)

List of CTK changes:

```
$ git shortlog 491614f12..9856b3fcf --no-merges
Jean-Christophe Fillion-Robin (50):
      COMP: Update ctkCompilerDetections_p.h to include CTK_OVERRIDE
      COMP: Fix Qt4/C++98 build updating Widget & DICOM libraries to use CTK_OVERRIDE
      COMP: Fix Qt4/C++98 build using '> >' instead of '>>' in nested templates
      COMP: Update ctkWrapPythonQt script to consider CTK_NULLPTR
      COMP: Fix Qt4/C++98 build using CTK_NULLPTR instead of nullptr
      COMP: Fix Qt4/C++98 ctkDICOMBrowser build error using ctk::isDirEmpty
      COMP: Fix Qt4/C++98 build using explicit trivial destructor implementation
      COMP: Fix Qt4 ctkDICOMQuery build error simplifying setting of Q_PROPERTY
      COMP: Fix Qt4/C++98 build of DICOMCore using Q_FOREACH
      COMP: Fix Qt4/C++98 ctkDICOMIndexerPrivate build using literal signal/slot
      COMP: Fix Qt4/C++98 ctkDICOMTableView build error due to missing QJsonObject
      COMP: Fix Qt4 ctkDICOMTableView build error using setResizeMode
      COMP: Fix Qt4 ctkDICOMBrowser build error using QStringLiteral
      COMP: Fix Qt4/C++98 ctkDICOMBrowser and ctkDICOMTableView
      COMP: Update ITK to support building against C++98
      COMP: Update ctkVTKMagnifyViewTest1 to support building against VTK >= 8.90
      COMP: Update ctkVTKOpenGLNativeWidget to fix build against VTK 8
      COMP: Update ctkVTKChartView to fix build against VTK 8
      COMP: Update external projects to consistently display revision_tag
      COMP: Update (qImageToVTK|qImageTo)VTKImageData to fix build against VTK8/Qt4
      COMP: Update ctkVTKSurfaceMaterialPropertyWidget to fix build against VTK8/Qt4
      COMP: Display name and value of CTK library options during configuration
      COMP: Update ctkDICOMQueryRetrieveWidget to fix build against Qt4/C++98
      COMP: Fix Qt4/C++98 ctkDICOMBrowser build error due to protected signal
      COMP: Fix Qt4/C++98 build for ctkDICOM(ThumbnailGenerator|ObjectListWidget)
      COMP: Update ctkVTKAbstractViewTest1 to fix build against VTK 8
      COMP: Fix Qt4/C++98 ctkPythonConsole build by explicitly comparing with QChar
      COMP: Fix Qt4/C++98 build updating ctkPythonConsole to use CTK_OVERRIDE
      DOC: Update README adding sections like Overview, Getting Started and Topics
      DOC: Mention Qt 4/C++98/Python 2.7/VTK 8/ITK v4.13.3 are unsupported
      ENH: Update CircleCI removing support for building Qt4
      COMP: Require CMake >= 3.0 for project building against CTK
      COMP: Remove obsolete CMake code related to CMake < 3.0
      STYLE: Fix indent following removal of obsolete CMake code
      COMP: Remove obsolete CTK copy of CMakePackageConfigHelpers
      COMP: Remove support for setting CTK_QT_VERSION to "4"
      COMP: Update C++ source files removing code specific to Qt 4
      COMP: Update CMake files removing support for Qt 4.x
      DOC: Update obsolete references from doc.trolltech.com to doc.qt.io
      DOC: Remove obsolete references to Q_EXPORT_PLUGIN2 specific to Qt4
      ENH: Update Log4Qt external project GitHub fork to support Qt5
      BUG: Re-enable support for "org.commontk.log4qt" plugin with Qt5
      DOC: Add comment documenting why the "eventbus" plugin is disabled with Qt5
      ENH: Re-enable support for building ctkQtTesting example app with Qt5
      DOC: Fix typos
      STYLE: Remove obsolete CTK_NULLPTR macro not needed with C++ >= 11
      STYLE: Remove obsolete CTK_OVERRIDE macro not needed with C++ >= 11
      STYLE: Remove use of obsolete HAVE_QT5 macro
      STYLE: Simplify ctkWrapPythonQt script removing use of obsolete CTK_NULLPTR
      BUG: Fix ctkDICOMIndexer reverting back to functor signal/slot
```