### PR TITLE
BUG: Update CTK to fix initial sizing of modules using ctkFlowLayout

### DIFF
--- a/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.cxx
+++ b/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.cxx
@@ -2,9 +2,6 @@
 #include <QDebug>
 #include <QMessageBox>
 
-// CTK includes
-#include <ctkFlowLayout.h>
-
 // VTK includes
 #include <vtkNew.h>
 #include <vtkMatrix4x4.h>

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "9856b3fcf2ec896a92062118246463f4810287c5"
+    "1feb4981c4aa113237b2696800c63f61932cae21"
     QUIET
     )
 


### PR DESCRIPTION
This fixes a regression introduced in commontk/CTK@e66324212 (COMP: Fix deprecated warning related to QWidget::getContentsMargins()).

Since functions `QWidget::contentsRect()` and `QWidget::contentsMargins()` are not equivalent, the logic associated with `ctkFlowLayout::minimumSize()` and `ctkFlowLayout::sizeHint()` was incorrect.

For future reference, modules using `ctkFlowLayout` are the following:

* CLIs (`Base/QTCLI/qSlicerCLIModuleUIHelper.cxx`)
* Loadable:
  - Segmentations (`qSlicerSegmentationsIOOptionsWidget.cxx`)
  - Volumes (`qSlicerVolumesIOOptionsWidget.cxx`)
  - Data (`qSlicerSceneIOOptionsWidget.cxx`)
* Scripted
  - SampleData (`SampleData.py`)

Additionally, it updates `CropVolumeModuleWidget` removing unused `ctkFlowLayout` include. Following 4cacc07bd (`ENH: Improved Crop Volume module`), including `ctkFlowLayout.h` became unnecessary.