### PR TITLE
COMP: Fix python-extension-manager-ssl-requirements build specifying "[crypto]"

### DIFF
--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -53,8 +53,10 @@ if(NOT Slicer_USE_SYSTEM_${proj})
                        --hash=sha256:b4ceb5324b998ce2003bc17d519080b4ec8d5b7b70794cbd2836101406a9be31 \
                        --hash=sha256:1fee5aacc7367487b4e22484d3c7e547992ed726d14864ee33c0176ae43b0d7c
   # [/cryptography]
+  # Specifying "[crypto]" is required since PyGithub 1.58.1
+  # See https://github.com/Slicer/Slicer/issues/7112
   # [PyJWT]
-  PyJWT==2.7.0 --hash=sha256:ba2b425b15ad5ef12f200dc67dd56af4e26de2331f965c5439994dad075876e1
+  PyJWT[crypto]==2.7.0 --hash=sha256:ba2b425b15ad5ef12f200dc67dd56af4e26de2331f965c5439994dad075876e1
   # [/PyJWT]
   # [wrapt]
   # Hashes correspond to the following packages:


### PR DESCRIPTION
This commit fixes a regression introduced in 7d58308e2 (`COMP: Update python packages to latest) by explicitly specifying "[crypto]"`).

It addresses the following error reported on macOS, Linux and Windows when doing a clean build:

```
${SLICER_BUILD_DIR}/python-install/bin/PythonSlicer \
-m pip install \
  --require-hashes \
  -r ${SLICER_BUILD_DIR}/python-extension-manager-ssl-requirements-requirements.txt

[...]
Collecting pyjwt[crypto]>=2.4.0 (from PyGithub==1.59.0->-r <SLICER_BUILD_DIR>/python-extension-manager-ssl-requirements-requirements.txt (line 85))
ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    pyjwt[crypto]>=2.4.0 from https://files.pythonhosted.org/packages/2b/4f/e04a8067c7c96c364cef7ef73906504e2f40d690811c021e1a1901473a19/PyJWT-2.8.0-py3-none-any.whl (from PyGithub==1.59.0->-r /path/to/python-extension-manager-ssl-requirements-requirements.txt (line 85))
```