### PR TITLE
BUG: Fix potential segfault during initialization of qMRMLSliceWidget

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -975,7 +975,7 @@ bool vtkMRMLSliceLogic::UpdateFractions(vtkImageMathematics* fraction, double op
 //----------------------------------------------------------------------------
 void vtkMRMLSliceLogic::UpdateReconstructionSlab(vtkMRMLSliceLogic* sliceLogic, vtkMRMLSliceLayerLogic* sliceLayerLogic)
 {
-  if (!sliceLogic || !sliceLayerLogic || !sliceLogic->GetSliceNode())
+  if (!sliceLogic || !sliceLayerLogic || !sliceLogic->GetSliceNode() || !sliceLayerLogic->GetSliceNode())
     {
     return;
     }


### PR DESCRIPTION
This pull request fixes a regression introduced in 530b8fcdc (ENH: Update Slicer Controller adding Thick Slab Reconstruction (#7021)) and fixes these tests:
- `qMRMLSliceWidgetTest1_vol_and_cube.mrml`
- `qMRMLVolumeThresholdWidgetTest2_vol_and_cube.mrml`

The problem was that in the context of these tests the call to `vtkMRMLSliceLayerLogic::SetSliceNode` happens after `UpdateSliceCompositeNode`

For reference the sequence of calls lead to the segfault for test `qMRMLSliceWidgetTest1_vol_and_cube` was the following:

```
#20 main(int, char**) (ac=<optimized out>, av=<optimized out>)
#19 qMRMLSliceWidgetTest1(int, char**)
#18 qMRMLSliceWidget::setMRMLSliceNode(vtkMRMLSliceNode*)
#17 qMRMLSliceControllerWidget::setMRMLSliceNode(vtkMRMLSliceNode*) (this=
#16 vtkMRMLSliceLogic::SetSliceNode(vtkMRMLSliceNode*)
#15 vtkMRMLSliceLogic::UpdateSliceCompositeNode() (this=0x56366358b080)
#14 vtkMRMLSliceLogic::UpdatePipeline() (this=0x56366358b080)
#13 vtkMRMLSliceLogic::SetSliceExtentsToSliceNode() (this=0x56366358b080)
#12 vtkMRMLSliceNode::UpdateMatrices() (this=0x563662f41e00)
#11 vtkMRMLNode::EndModify(int) (previousDisableModifiedEventState=0, this=0x563662f41e00)
#10 vtkMRMLNode::InvokePendingModifiedEvent() (this=0x563662f41e00)
#9  vtkSubjectHelper::InvokeEvent(unsigned long, void*, vtkObject*)
#8  vtkCallbackCommand::Execute(vtkObject*, unsigned long, void*)
#7  vtkEventBroker::ProcessEvent(vtkObservation*, vtkObject*, unsigned long, void*) (this=0x563662ddf450, observation=0x5636638d4170, caller=<optimized out>, eid=33, callData=0x0)
#6  vtkEventBroker::InvokeObservation(vtkObservation*, unsigned long, void*)
#5  vtkCallbackCommand::Execute(vtkObject*, unsigned long, void*)
#4  vtkMRMLAbstractLogic::MRMLNodesCallback(vtkObject*, unsigned long, void*, void*)
#3  vtkMRMLAbstractLogic::MRMLNodesCallback(vtkObject*, unsigned long, void*, void*) (callData=0x0, clientData=0x56366358b080, eid=33, caller=0x563662f41e00)
#2  vtkMRMLSliceLogic::OnMRMLNodeModified(vtkMRMLNode*)
#1  vtkMRMLSliceLogic::UpdateReconstructionSlab(vtkMRMLSliceLogic*, vtkMRM
```

References:
* https://github.com/Slicer/Slicer/pull/7021