### PR TITLE
ENH: Make it easier to load of .vtk image files

### DIFF
--- a/Modules/Loadable/Models/qSlicerModelsReader.h
+++ b/Modules/Loadable/Models/qSlicerModelsReader.h
@@ -47,6 +47,12 @@ public:
   QStringList extensions()const override;
   qSlicerIOOptions* options()const override;
 
+  /// Returns a positive number (>0) if the reader can load this file.
+  /// It uses default confidence value except for .vtk files. For .vtk image files it returns
+  /// lower than default (0.0, because this reader cannot read images) and
+  /// for mesh files it returns higher than default (0.6).
+  double canLoadFileConfidence(const QString& file)const override;
+
   bool load(const IOProperties& properties) override;
 
 protected:


### PR DESCRIPTION
.vtk files tried to be loaded as Model node by default. Loading failed when attempted to load an image file without manually setting Description to Volume in "Add data" window.

This commit makes .vtk image file loaded as image by default, avoiding user questions such as this one: https://discourse.slicer.org/t/error-exporting-and-importing-vtk/30733/2