### PR TITLE
DOC: Fix miscellaneous typos in the documentation

### DIFF
--- a/Docs/developer_guide/style_guide.md
+++ b/Docs/developer_guide/style_guide.md
@@ -188,7 +188,7 @@ While developing code, enable VTK_DEBUG_LEAKS (ON by default) in your vtk build 
 ## Coordinate Systems
 
 - World space for 3D Views is in RAS (Right Anterior Superior) space. See [[Coordinate systems]].
-- All units are expressed in Millimeters (mm)
+- All units are expressed in millimeters (mm)
 
 ## String encoding: UTF-8 everywhere
 

--- a/Docs/user_guide/extensions_manager.md
+++ b/Docs/user_guide/extensions_manager.md
@@ -99,7 +99,7 @@ Extensions can be downloaded from the Extensions Catalog website and can be inst
 
 - Open Extensions manager using menu: View / Extensions manager.
 - Click the "Install from file..." button.
-- Select the the previously downloaded extension package(s). Multiple extension packages can be selected at once.
+- Select the previously downloaded extension package(s). Multiple extension packages can be selected at once.
 - Wait for the installations to complete.
 - Click "Restart" button to restart the application.
 
@@ -107,7 +107,7 @@ Extensions can be downloaded from the Extensions Catalog website and can be inst
 
 ### Extensions manager takes very long time to start
 
-When starting the extensions manager, the "Extensions manager is starting, please wait..." message is displayed immediately and normally list of extensions should show up within 10-20 seconds. If startup takes longer (several minutes) then most likely the the Slicer Extensions Catalog server is temporarily overloaded. Retry in an hour. If the problem persists after 6 hours then report it on the [Slicer forum](https://discourse.slicer.org).
+When starting the extensions manager, the "Extensions manager is starting, please wait..." message is displayed immediately and normally list of extensions should show up within 10-20 seconds. If startup takes longer (several minutes) then most likely the Slicer Extensions Catalog server is temporarily overloaded. Retry in an hour. If the problem persists after 6 hours then report it on the [Slicer forum](https://discourse.slicer.org).
 
 ### Extensions manager does not show any extensions
 

--- a/Docs/user_guide/modules/cropvolume.md
+++ b/Docs/user_guide/modules/cropvolume.md
@@ -38,7 +38,7 @@ Most frequently used for these scenarios:
 
 - **Input ROI:** The region of interest driving the cropping process. ROIs have a box-like shape in which the interior of the box is the region to preserve and the exterior is the region to exclude. This combobox widget will allow the user to select an already existing ROI or create a new one (in addition, this widget will provide additional options such as rename or edit an existing ROI).
 
-  - **Display ROI:** Turn on/off the display of the ROI representation. If this is on, a representation of the ROI will be visible in the Slice views (2D) or in the 3D view. The resulting ROI can be manipulated interactively in any of the the Slice views (2D) or the 3D view.
+  - **Display ROI:** Turn on/off the display of the ROI representation. If this is on, a representation of the ROI will be visible in the Slice views (2D) or in the 3D view. The resulting ROI can be manipulated interactively in any of the Slice views (2D) or the 3D view.
 
   - **Fit to Volume:** This will resize the ROI to fit the extent of the Input volume specified.
 

--- a/Docs/user_guide/modules/dicom.md
+++ b/Docs/user_guide/modules/dicom.md
@@ -31,7 +31,7 @@ More information about DICOM standard:
 
 To organize the data and allow faster access, Slicer keeps a local DICOM Database containing copies of (or links to) DICOM files, and basic information about content of each file. You can have multiple databases on your computer at a time, and switch between them if, for example, they include data from different research projects.  Each database is simply a directory on your local disk that has a few [SQLite](https://sqlite.org/) files and subdirectories to store image data.  Do not manually modify the contents of these directories. DICOM data can enter the database either through file import or via a DICOM network transfer. Slicer modules may also populate the DICOM database with computation results.
 
-Note that the DICOM standard does not specify how files will be organized on disk, so if you have DICOM data from a CDROM or otherwise transferred from a scanner, you cannot in general tell anything about the contents from the file or directory names. However once the data is imported to the database, it will be organized according the the DICOM standard Patient/Study/Series hierarchy.
+Note that the DICOM standard does not specify how files will be organized on disk, so if you have DICOM data from a CDROM or otherwise transferred from a scanner, you cannot in general tell anything about the contents from the file or directory names. However once the data is imported to the database, it will be organized according to the DICOM standard Patient/Study/Series hierarchy.
 
 ### DICOM plugins
 

--- a/Docs/user_guide/settings.md
+++ b/Docs/user_guide/settings.md
@@ -96,7 +96,7 @@ modules/webserver.html
 
 Settings are stored in *.ini files. If the settings file is found in application home directory (within organization name or domain subfolder) then that .ini file is used. This can be used for creating a portable application that contains all software and settings in a relocatable folder. Relative paths in settings files are resolved using the application home directory, and therefore are portable along with the application.
 
-If .ini file is not found in the the application home directory then it is searched in user profile:
+If .ini file is not found in the application home directory then it is searched in user profile:
 
 -  Windows: `%USERPROFILE%\AppData\Roaming\slicer.org\` (typically `C:\Users\<your_user_name>\AppData\Roaming\slicer.org\`)
 -  Linux: `~/.config/slicer.org/`


### PR DESCRIPTION
Fix miscellaneous typos across documentation markdown files. Specifically:
- Remove duplicate `the` article in consecutive appearances.
- Use lowercase in `millimeter`.