### PR TITLE
COMP: Update CTK to ensure only used Qt components are expected

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "ee5508d6eeec882eb39358346c1823b6c0bbe825"
+    "c0c8e41db1318ffab37ffd42aac48bdb72cd8014"
     QUIET
     )
 


### PR DESCRIPTION
This pull request supersedes:
* https://github.com/Slicer/Slicer/pull/6165

It ensures CTK only requires the Qt components it uses.

## List of CTK changes

```
$ git shortlog ee5508d6..c0c8e41db --no-merges
Jean-Christophe Fillion-Robin (4):
      COMP: Update ctk_list_to_string to use CMake join implentation if available
      ENH: Display Qt version and Qt components used to configure CTK
      ENH: Simplify setting of CTK_QT5_COMPONENTS ensuring all CTK variables are set
      ENH: Improve setting of CTK_QT5_COMPONENTS based on actual requirements
```


## Slicer configuration

_Output based of Slicer/Slicer@77f1e2d06c after manually checking out commontk/CTK#1132 and re-configuring CTK_

Before:

```
-- Configuring CTK with Qt 5.15.2 (using modules: Core, Xml, XmlPatterns, Concurrent, Sql, Test, Multimedia, Widgets, OpenGL, UiTools)
```

After:

```
-- Configuring CTK with Qt 5.15.2 (using modules: Core, Xml, Sql, Multimedia, Widgets, OpenGL, UiTools, Designer)
```

```diff
Core
Xml
- XmlPatterns
- Concurrent
Sql
- Test
Multimedia
Widgets
OpenGL
UiTools
+ Designer
```

## References

Related pull requests:
* https://github.com/commontk/CTK/pull/1130
* https://github.com/commontk/CTK/pull/1131
* https://github.com/commontk/CTK/pull/1133
* https://github.com/commontk/CTK/pull/1132

Related documentation:
* https://github.com/commontk/CTK/wiki/Maintenance#updates-of-required-qt-components