### PR TITLE
ENH: Add a setting for the overwrite mode masking option of the segment editor

### DIFF
--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -2452,6 +2452,56 @@ void vtkSlicerSegmentationsModuleLogic::SetDefaultSurfaceSmoothingEnabled(bool e
 }
 
 //-----------------------------------------------------------------------------
+vtkMRMLSegmentEditorNode* vtkSlicerSegmentationsModuleLogic::GetDefaultSegmentEditorNode()
+{
+  vtkMRMLScene* scene = this->GetMRMLScene();
+  if (!scene)
+    {
+    return nullptr;
+    }
+  vtkSmartPointer<vtkMRMLSegmentEditorNode> defaultNode = vtkMRMLSegmentEditorNode::SafeDownCast(scene->GetDefaultNodeByClass("vtkMRMLSegmentEditorNode"));
+  if (defaultNode)
+    {
+    return defaultNode;
+    }
+  defaultNode.TakeReference(vtkMRMLSegmentEditorNode::SafeDownCast(scene->CreateNodeByClass("vtkMRMLSegmentEditorNode")));
+  if (!defaultNode)
+    {
+    return nullptr;
+    }
+  scene->AddDefaultNode(defaultNode);
+  return defaultNode;
+}
+
+//-----------------------------------------------------------------------------
+int vtkSlicerSegmentationsModuleLogic::GetDefaultOverwriteMode()
+{
+  vtkMRMLSegmentEditorNode* defaultSegmentEditorNode = this->GetDefaultSegmentEditorNode();
+  if (!defaultSegmentEditorNode)
+    {
+    return -1;
+    }
+  return defaultSegmentEditorNode->GetOverwriteMode();
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerSegmentationsModuleLogic::SetDefaultOverwriteMode(int mode)
+{
+  if (mode >= vtkMRMLSegmentEditorNode::Overwrite_Last || mode < 0)
+    {
+    vtkErrorMacro("vtkSlicerSegmentationsModuleLogic::SetOverwriteMode failed: invalid value for mode parameter");
+    return;
+    }
+  vtkMRMLSegmentEditorNode* defaultSegmentEditorNode = this->GetDefaultSegmentEditorNode();
+  if (!defaultSegmentEditorNode)
+    {
+    vtkErrorMacro("vtkSlicerSegmentationsModuleLogic::SetOverwriteMode failed: could not create default segment editor node");
+    return;
+    }
+  defaultSegmentEditorNode->SetOverwriteMode(mode);
+}
+
+//-----------------------------------------------------------------------------
 std::string vtkSlicerSegmentationsModuleLogic::GetSafeFileName(std::string originalName)
 {
   // Remove characters from node name that cannot be used in file names

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
@@ -40,6 +40,7 @@ class vtkDataObject;
 class vtkGeneralTransform;
 
 class vtkMRMLSegmentationStorageNode;
+class vtkMRMLSegmentEditorNode;
 class vtkMRMLScalarVolumeNode;
 class vtkMRMLLabelMapVolumeNode;
 class vtkMRMLVolumeNode;
@@ -381,6 +382,13 @@ public:
   /// Get/Set default closed surface smoothing enabled flag for new segmentation nodes.
   bool GetDefaultSurfaceSmoothingEnabled();
   void SetDefaultSurfaceSmoothingEnabled(bool enabled);
+
+  /// Get node that is used for initializing each new Segment Editor node.
+  vtkMRMLSegmentEditorNode* GetDefaultSegmentEditorNode();
+
+  /// Get/Set default segmentation overwrite mode for masking options.
+  int GetDefaultOverwriteMode();
+  void SetDefaultOverwriteMode(int mode);
 
   enum SegmentStatus
   {

--- a/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsSettingsPanel.ui
+++ b/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsSettingsPanel.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>292</width>
-    <height>113</height>
+    <width>416</width>
+    <height>162</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,7 +37,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -90,19 +90,29 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>Edit hidden segments: </string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="4" column="1">
     <widget class="ctkComboBox" name="AllowEditingHiddenSegmentComboBox">
      <property name="toolTip">
       <string>This option controls what the application should do if the user edits a segment that is currently not visible. It is meant to prevent unintentional changes to hidden segments.</string>
      </property>
     </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Default overwrite mode:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="ctkComboBox" name="DefaultOverwriteModeComboBox"/>
    </item>
   </layout>
  </widget>

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsSettingsPanel.h
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsSettingsPanel.h
@@ -61,6 +61,8 @@ protected slots:
   void onEditDefaultTerminologyEntry();
   void setDefaultTerminologyEntry(QString);
   void updateDefaultSegmentationNodeFromWidget();
+  void setDefaultOverwriteMode(QString);
+  void updateDefaultOverwriteModeFromWidget();
 
 signals:
   void defaultTerminologyEntryChanged(QString terminologyStr);


### PR DESCRIPTION
Hi @lassoan ,

Following this [feature request](https://discourse.slicer.org/t/consider-a-non-destructive-default-in-segment-editor-masking-options/30631/4), can you check this PR ?

It adds a combobox in settings for Segmentations, fills it with possible values, and fails to save/restore the chosen option.

When an option is selected, the Segment editor does use it by default. Once Slicer is closed, the chosen preferred option is not restored on restart.

Thank you for any input to get it working.
