### PR TITLE
DOC: Fix developer guide extensions section bash snippet syntax

### DIFF
--- a/Docs/developer_guide/extensions.md
+++ b/Docs/developer_guide/extensions.md
@@ -27,18 +27,20 @@ Similarly to the building of Slicer core, multi-configuration builds are not sup
 Assuming that the source code of your extension is located in folder `MyExtension`, an extension can be built by the following steps.
 
 :::{tip}
-For testing purpose, it is possible to force the Slicer revision associated with the extension build by setting the `Slicer_REVISION`
-environment variable before configuring the project::
+For testing purposes, it is possible to force the Slicer revision associated with the extension build by setting the `Slicer_REVISION`
+environment variable before configuring the project:
 
-  $ cd MyExtension-debug
-  $ export Slicer_REVISION=31806
-  $ cmake -DCMAKE_BUILD_TYPE:STRING=Debug -DSlicer_DIR:PATH=/path/to/Slicer-SuperBuild-Debug/Slicer-build ../MyExtension
-  [...]
-  -- SlicerConfig: Forcing Slicer_REVISION to '31806'
-  [...]
-  -- Configuring done
-  -- Generating done
-  -- Build files have been written to: /path/to/MyExtension-debug
+```bash
+$ cd MyExtension-debug
+$ export Slicer_REVISION=31806
+$ cmake -DCMAKE_BUILD_TYPE:STRING=Debug -DSlicer_DIR:PATH=/path/to/Slicer-SuperBuild-Debug/Slicer-build ../MyExtension
+[...]
+-- SlicerConfig: Forcing Slicer_REVISION to '31806'
+[...]
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /path/to/MyExtension-debug
+```
 :::
 
 ### Linux and macOS


### PR DESCRIPTION
Fix developer guide extensions section extension build tip box bash snippet syntax: enclose the bash code snippet with triple backticks. Remove the double colon at the end of the accompanying text.

Explicitly state the highlight to correspond to bash code.

Take advantage of the commit to fix a typo in the accompanying text.