### PR TITLE
COMP: Update CTK to ensure only used Qt components are expected (part 2)

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "c0c8e41db1318ffab37ffd42aac48bdb72cd8014"
+    "dc0d7eb5591e03f8da38085d285b580d59112791"
     QUIET
     )
 


### PR DESCRIPTION
This commit is a following up of the previous commit introduced through this pull request:
*https://github.com/Slicer/Slicer/pull/7129

It ensures that CTK QtTesting library is also properly linked.

Before (both https://github.com/Slicer/Slicer/pull/7129 and this pull request):

```
-- Configuring CTK with Qt 5.15.2 (using modules: Core, Xml, XmlPatterns, Concurrent, Sql, Test, Multimedia, Widgets, OpenGL, UiTools)
```

After:

```
-- Configuring CTK with Qt 5.15.2 (using modules: Core, Xml, XmlPatterns, Sql, Multimedia, Widgets, OpenGL, UiTools, Designer)
```

```diff
Core
Xml
XmlPatterns
- Concurrent
Sql
- Test
Multimedia
Widgets
OpenGL
UiTools
+ Designer
```

List of CTK changes:

```
$ git shortlog c0c8e41d..dc0d7eb5 --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Fix CTK QtTesting library build
```