### PR TITLE
COMP: Call cmake minimum required prior to top-level project

### DIFF
--- a/CMake/SlicerLinkerAsNeededFlagCheck/CMakeLists.txt
+++ b/CMake/SlicerLinkerAsNeededFlagCheck/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 project(SlicerLinkerAsNeededFlagCheck)
 add_library(A SHARED A.cxx)
 add_library(B SHARED B.cxx)


### PR DESCRIPTION
Call cmake minimum required prior to top-level project.

Fixes:
```
CMake Warning (dev) at
Slicer/CMake/SlicerLinkerAsNeededFlagCheck/CMakeLists.txt:1 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Visible, for example, in:
https://github.com/jhlegarreta/SlicerDMRI/actions/runs/5685861171/job/15411625384#step:6:39