### PR TITLE
Fix external project download extract timestamp warnings

### DIFF
--- a/CMake/ExternalProjectDependency.cmake
+++ b/CMake/ExternalProjectDependency.cmake
@@ -92,14 +92,17 @@ endif()
 #.rst:
 # .. cmake:variable:: EP_GIT_PROTOCOL
 #
-# The value of this variable is controlled by the option ``<SUPERBUILD_TOPLEVEL_PROJECT>_USE_GIT_PROTOCOL``
-# automatically defined by including this CMake module. Setting this option allows to update the value of
-# ``EP_GIT_PROTOCOL`` variable.
+# The value of this variable is always set to ``https``.
 #
-# If enabled, the variable ``EP_GIT_PROTOCOL`` is set to ``git``. Otherwise, it is set to ``https``.
-# Since GitHub removed unauthenticated access through the git protocol
-# (see https://github.blog/2021-09-01-improving-git-protocol-security-github/ ),
-# and most projects are hosted on GitHub the option is disabled (https is used) by default.
+# Following the removal of git protocol by GitHub, the option
+# ``<SUPERBUILD_TOPLEVEL_PROJECT>_USE_GIT_PROTOCOL`` is obsolete.
+# It allowed to toggle between ``git`` and ``https``.
+# If this option is enabled, a warning is reported and the option is forced to ``OFF``.
+#
+# Similarly, if the variable ``EP_GIT_PROTOCOL`` is already set to ``git``, a warning is reported
+# and the value is forced to ``https``.
+#
+# See details at https://github.blog/2021-09-01-improving-git-protocol-security-github
 #
 # The variable ``EP_GIT_PROTOCOL`` can be used when adding external project. For example:
 #
@@ -111,10 +114,23 @@ endif()
 #     [...]
 #     )
 #
-option(${SUPERBUILD_TOPLEVEL_PROJECT}_USE_GIT_PROTOCOL "Turn off if using GitHub or behind a firewall." OFF)
-set(EP_GIT_PROTOCOL "https")
-if(${SUPERBUILD_TOPLEVEL_PROJECT}_USE_GIT_PROTOCOL)
-  set(EP_GIT_PROTOCOL "git")
+if(DEFINED ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_GIT_PROTOCOL AND ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_GIT_PROTOCOL)
+  message(WARNING "Forcing ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_GIT_PROTOCOL to OFF (Already set to ON in current scope)")
+  set(${SUPERBUILD_TOPLEVEL_PROJECT}_USE_GIT_PROTOCOL OFF CACHE BOOL "" FORCE)
+endif()
+if(DEFINED EP_GIT_PROTOCOL)
+  if("${EP_GIT_PROTOCOL}" STREQUAL "git")
+    get_property(_value_set_in_cache CACHE EP_GIT_PROTOCOL PROPERTY VALUE SET)
+    if(_value_set_in_cache)
+      message(WARNING "Forcing EP_GIT_PROTOCOL cache variable to 'https' (Already set to '${EP_GIT_PROTOCOL}' in current scope)")
+      set(EP_GIT_PROTOCOL "https" CACHE STRING "" FORCE)
+    else()
+      message(WARNING "Forcing EP_GIT_PROTOCOL variable to 'https' (Already set to '${EP_GIT_PROTOCOL}' in current scope)")
+      set(EP_GIT_PROTOCOL "https")
+    endif()
+  endif()
+else()
+  set(EP_GIT_PROTOCOL "https")
 endif()
 
 # Compute -G arg for configuring external projects with the same CMake generator:
@@ -449,16 +465,37 @@ function(_sb_get_external_project_arguments proj varname)
 
   set(_ep_arguments "")
 
-  # Automatically propagate CMake options
-  foreach(_cmake_option IN ITEMS
-    CMAKE_EXPORT_COMPILE_COMMANDS
-    CMAKE_JOB_POOL_COMPILE
-    CMAKE_JOB_POOL_LINK
-    CMAKE_JOB_POOLS
+  # Option CMAKE_FIND_USE_PACKAGE_REGISTRY was introduced in CMake 3.16
+  if(NOT CMAKE_VERSION VERSION_LESS "3.16")
+    if(NOT DEFINED CMAKE_FIND_USE_PACKAGE_REGISTRY)
+      set(CMAKE_FIND_USE_PACKAGE_REGISTRY OFF)
+    endif()
+  else()
+    if(NOT DEFINED CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY)
+      set(CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY ON)
+    endif()
+  endif()
+
+  # Set list of CMake options to propagate
+  set(_options
+    CMAKE_EXPORT_COMPILE_COMMANDS:BOOL
+    CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY:BOOL
+    CMAKE_JOB_POOL_COMPILE:STRING
+    CMAKE_JOB_POOL_LINK:STRING
+    CMAKE_JOB_POOLS:STRING
     )
+  if(NOT CMAKE_VERSION VERSION_LESS "3.16")
+    list(APPEND _options
+      CMAKE_FIND_USE_PACKAGE_REGISTRY:BOOL
+      )
+  endif()
+
+  # Automatically propagate CMake options
+  foreach(_cmake_option_and_type IN LISTS _options)
+    _sb_extract_varname_and_vartype(${_cmake_option_and_type} _cmake_option _cmake_option_type)
     if(DEFINED ${_cmake_option})
       list(APPEND _ep_arguments CMAKE_CACHE_ARGS
-        -D${_cmake_option}:BOOL=${${_cmake_option}}
+        -D${_cmake_option}:${_cmake_option_type}=${${_cmake_option}}
         )
     endif()
   endforeach()
@@ -487,6 +524,10 @@ function(_sb_get_external_project_arguments proj varname)
         USES_TERMINAL_${step} 1
         )
     endforeach()
+  endif()
+  if(CMAKE_VERSION VERSION_EQUAL "3.24" OR CMAKE_VERSION VERSION_GREATER "3.24")
+    # See https://cmake.org/cmake/help/latest/policy/CMP0135.html
+    list(APPEND _ep_arguments DOWNLOAD_EXTRACT_TIMESTAMP 1)
   endif()
   set(${varname} ${_ep_arguments} PARENT_SCOPE)
 endfunction()
@@ -760,6 +801,11 @@ macro(ExternalProject_Include_Dependencies project_name)
     #message("[${project_name}] Setting _sb_SB_VAR with default value '${_sb_SB_VAR}'")
   endif()
 
+  # Try to detect if superbuild variable was improperly passed
+  if("${_sb_SB_VAR}" STREQUAL "_SUPERBUILD")
+    message(FATAL_ERROR "SUPERBUILD_VAR value is incorrectly set to '_SUPERBUILD'")
+  endif()
+
   # Set local variables
   set(_sb_DEPENDS ${${_sb_DEPENDS_VAR}})
   set(_sb_USE_SYSTEM ${${_sb_USE_SYSTEM_VAR}})
@@ -1019,13 +1065,16 @@ endfunction()
 #
 #  ExternalProject_SetIfNotDefined(<var> <defaultvalue> [OBFUSCATE] [QUIET])
 #
-# The default value is set with:
-#  (1) if set, the value environment variable <var>.
-#  (2) if set, the value of local variable variable <var>.
-#  (3) if none of the above, the value passed as a parameter.
+# If *NOT* already defined, the variable <var> is set with:
+#  (1) the value of the environment variable <var>, if defined.
+#  (2) the value of the local variable variable <var>, if defined.
+#  (3) if none of the above is defined, the <defaultvalue> passed as a parameter.
 #
-# Setting the optional parameter 'OBFUSCATE' will display 'OBFUSCATED' instead of the real value.
-# Setting the optional parameter 'QUIET' will not display any message.
+# Passing the optional parameter 'OBFUSCATE' will display 'OBFUSCATED' instead of the real value.
+# Passing the optional parameter 'QUIET' will not display any message.
+#
+# For convenience, the value of the cache variable named <var> will
+# be displayed if it was set and if QUIET has not been passed.
 macro(ExternalProject_SetIfNotDefined var defaultvalue)
   set(_obfuscate FALSE)
   set(_quiet FALSE)
@@ -1056,6 +1105,14 @@ macro(ExternalProject_SetIfNotDefined var defaultvalue)
       message(STATUS "Setting '${var}' variable with default value '${_value}'")
     endif()
     set(${var} "${defaultvalue}")
+  endif()
+  get_property(_is_set CACHE ${var} PROPERTY VALUE SET)
+  if(_is_set AND NOT _quiet)
+    set(_value "${${var}}")
+    if(_obfuscate)
+      set(_value "OBFUSCATED")
+    endif()
+    message(STATUS "Cache variable '${var}' set to '${_value}'")
   endif()
 endmacro()
 

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "dc0d7eb5591e03f8da38085d285b580d59112791"
+    "5657c58a72c2db3e9fcc04f88211859eccd21067"
     QUIET
     )
 

--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -16,11 +16,19 @@ if(NOT SWIG_DIR AND NOT Slicer_USE_SYSTEM_${proj})
   set(SWIG_DOWNLOAD_SOURCE_HASH "05e7da70ce6d9a733b96c0bcfa3c1b82765bd859f48c74759bbf4bb1467acb1809caa310cba5e2b3280cd704fca249eaa0624821dffae1d2a75097c7f55d14ed")
   set(SWIG_DOWNLOAD_WIN_HASH "b8f105f9b9db6acc1f6e3741990915b533cd1bc206eb9645fd6836457fd30789b7229d2e3219d8e35f2390605ade0fbca493ae162ec3b4bc4e428b57155db03d")
 
+  set(EXTERNAL_PROJECT_OPTIONAL_ARGS)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_ARGS
+      DOWNLOAD_EXTRACT_TIMESTAMP 1
+      )
+  endif()
+
   if(WIN32)
     set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/swigwin-${SWIG_TARGET_VERSION})
 
     # swig.exe available as pre-built binary on Windows:
     ExternalProject_Add(Swig
+      ${EXTERNAL_PROJECT_OPTIONAL_ARGS}
       URL https://github.com/Slicer/SlicerBinaryDependencies/releases/download/swig/swigwin-${SWIG_TARGET_VERSION}.zip
       URL_HASH SHA512=${SWIG_DOWNLOAD_WIN_HASH}
       SOURCE_DIR "${EP_BINARY_DIR}"
@@ -86,6 +94,7 @@ ExternalProject_Execute(${proj} \"configure\" sh ${EP_SOURCE_DIR}/configure
 ")
 
     ExternalProject_add(Swig
+      ${EXTERNAL_PROJECT_OPTIONAL_ARGS}
       URL https://github.com/Slicer/SlicerBinaryDependencies/releases/download/swig/swig-${SWIG_TARGET_VERSION}.tar.gz
       URL_HASH SHA512=${SWIG_DOWNLOAD_SOURCE_HASH}
       DOWNLOAD_DIR ${CMAKE_BINARY_DIR}

--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -54,7 +54,15 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
   set(_download_3.9.10_url "https://www.python.org/ftp/python/3.9.10/Python-3.9.10.tgz")
   set(_download_3.9.10_md5 "1440acb71471e2394befdb30b1a958d1")
 
+  set(EXTERNAL_PROJECT_OPTIONAL_ARGS)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_ARGS
+      DOWNLOAD_EXTRACT_TIMESTAMP 1
+      )
+  endif()
+
   ExternalProject_Add(python-source
+    ${EXTERNAL_PROJECT_OPTIONAL_ARGS}
     URL ${_download_${Slicer_REQUIRED_PYTHON_VERSION}_url}
     URL_MD5 ${_download_${Slicer_REQUIRED_PYTHON_VERSION}_md5}
     DOWNLOAD_DIR ${CMAKE_BINARY_DIR}


### PR DESCRIPTION
This fixes `DOWNLOAD_EXTRACT_TIMESTAMP` warnings related to `CMP0135`[^1] introduced in CMake >= 3.24.

[^1]: https://cmake.org/cmake/help/latest/policy/CMP0135.html

### Summary

* Updates `ExternalProjectDependency` CMake module based on the latest version provided by https://github.com/commontk/artichoke
* Updates `CTK` so that its bundled version of `ExternalProjectDependency` is also the most recent
* Updates `Swig` and `python` external projects to explicitly set `DOWNLOAD_EXTRACT_TIMESTAMP` to `1` if using  CMake >= 3.24. This is needed because these projects are directly using `ExternalProject_Add` (without relying on `ExternalProject_Include_Dependencies`)

### DOWNLOAD_EXTRACT_TIMESTAMP warning

This will avoid warnings like the following:

```
CMake Warning (dev) at /path/to/cmake-3.26.4-linux-x86_64/share/cmake-3.26/Modules/ExternalProject.cmake:3091 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
```
