### PR TITLE
ENH: Check file extension file readers before inspecting content

### DIFF
--- a/Applications/SlicerApp/Testing/Python/SlicerScriptedFileReaderWriterTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerScriptedFileReaderWriterTest.py
@@ -47,6 +47,10 @@ class SlicerScriptedFileReaderWriterTestFileReader:
         if not slicer.app.testingEnabled():
             return False
 
+        # Check first if loadable based on file extension
+        if not self.parent.supportedNameFilters(filePath):
+            return False
+
         firstLine = ''
         with open(filePath) as f:
             firstLine = f.readline()

--- a/Base/QTCore/qSlicerFileReader.h
+++ b/Base/QTCore/qSlicerFileReader.h
@@ -43,7 +43,7 @@ public:
   /// Return  a list of the supported extensions. Please read
   /// QFileDialog::nameFilters for the allowed formats
   /// Example: "Image (*.jpg *.png *.tiff)", "Model (*.vtk)"
-  virtual QStringList extensions()const;
+  Q_INVOKABLE virtual QStringList extensions()const;
 
   /// Returns true if the reader can load this file.
   /// Default implementation is a simple and fast, it just checks
@@ -51,7 +51,7 @@ public:
   /// This method is kept for backward compatibility, readers should override
   /// canLoadFileConfidence method instead of this method to indicate if they can
   /// read a file.
-  virtual bool canLoadFile(const QString& file)const;
+  Q_INVOKABLE virtual bool canLoadFile(const QString& file)const;
 
   /// Returns a positive number (>0) if the reader can load this file.
   /// The higher the returned value is the more confident the reader it is
@@ -61,7 +61,7 @@ public:
   /// The additional confidence for longer matched file extensions allow prioritization of
   /// more specific readers. For example, "*.seg.nrrd" is more specific than "*.nrrd";
   /// "*.nrrd" is more specific than "*.*".
-  virtual double canLoadFileConfidence(const QString& file)const;
+  Q_INVOKABLE virtual double canLoadFileConfidence(const QString& file)const;
 
   /// Return the matching name filters -> if the fileName is "my_image.nrrd"
   /// and the supported extensions are "Volumes (*.mha *.nrrd *.raw)",
@@ -70,20 +70,20 @@ public:
   /// \param longestExtensionMatchPtr If non-zero then the method returns
   /// the length of the longest matched extension length in this argument.
   /// It can be used to determine how specifically extension matched.
-  QStringList supportedNameFilters(const QString& fileName, int* longestExtensionMatchPtr = nullptr)const;
+  Q_INVOKABLE QStringList supportedNameFilters(const QString& fileName, int* longestExtensionMatchPtr = nullptr)const;
 
   /// Properties available: fileMode, multipleFiles, fileType.
-  virtual bool load(const IOProperties& properties);
+  Q_INVOKABLE virtual bool load(const IOProperties& properties);
 
   /// Return the list of generated nodes from loading the file(s) in load().
   /// Empty list if load() failed
   /// \sa setLoadedNodes(), load()
-  virtual QStringList loadedNodes()const;
+  Q_INVOKABLE virtual QStringList loadedNodes()const;
 
   /// Implements the file list examination for the corresponding method in the core
   /// IO manager.
   /// \sa qSlicerCoreIOManager
-  virtual bool examineFileInfoList(QFileInfoList &fileInfoList, QFileInfo &archetypeFileInfo, qSlicerIO::IOProperties &ioProperties)const;
+  Q_INVOKABLE virtual bool examineFileInfoList(QFileInfoList &fileInfoList, QFileInfo &archetypeFileInfo, qSlicerIO::IOProperties &ioProperties)const;
 
 protected:
   /// Must be called in load() on success with the list of nodes added into the

--- a/Modules/Scripted/ImportItkSnapLabel/ImportItkSnapLabel.py
+++ b/Modules/Scripted/ImportItkSnapLabel/ImportItkSnapLabel.py
@@ -41,6 +41,10 @@ class ImportItkSnapLabelFileReader:
         return ['ITK-Snap label description file (*.label)', 'ITK-Snap label description file (*.txt)']
 
     def canLoadFile(self, filePath):
+        # Check first if loadable based on file extension
+        if not self.parent.supportedNameFilters(filePath):
+            return False
+
         try:
             colors = ImportItkSnapLabelFileReader.parseLabelFile(filePath)
             if not colors:


### PR DESCRIPTION
In scripted file readers, file extension was not checked when determining if a file can be loaded. This can result in unnecessary checks when inspecting any file before loading.

see https://github.com/PerkLab/SlicerSandbox/issues/18