### PR TITLE
ENH: Update MultiVolumeImporter to load as volume sequence by default

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -237,7 +237,7 @@ list_conditional_append(Slicer_BUILD_MultiVolumeExplorer Slicer_REMOTE_DEPENDENC
 
 Slicer_Remote_Add(MultiVolumeImporter
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/fedorov/MultiVolumeImporter.git
-  GIT_TAG c14758931e009419dd95963219e904e5b7d70bbf
+  GIT_TAG 198e6b32031f51e010ade27001acb5b79c8f189e
   OPTION_NAME Slicer_BUILD_MultiVolumeImporter
   OPTION_DEPENDS "Slicer_BUILD_QTLOADABLEMODULES;Slicer_BUILD_MULTIVOLUME_SUPPORT;Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
Time sequence of volumes can be loaded as multivolume (vtkMRMLMultiVolumeNode) or volume sequence (vtkMRMLSequenceNode). Volume sequence is a more generic representation and many more modules use it than the old multivolume representation.

This commit changes the default so that when a user loads a 4D volume from DICOM then it is loaded into a volume sequence by default.

Users can revert to the old behavior by selecting in Application settings / DICOM / Preferred multi-volume import format -> multi-volume. For loading a single image using non-default settings, enable "Advanced" option in DICOM module, click Examine, and choose the appropriate loadable (loadables are offered for both multivolme and volume sequence representation, application settings specify which is selected by default).