### PR TITLE
ENH: Improve error reporting in ScriptedFileReaderWriterTest

### DIFF
--- a/Applications/SlicerApp/Testing/Python/SlicerScriptedFileReaderWriterTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerScriptedFileReaderWriterTest.py
@@ -85,9 +85,10 @@ class SlicerScriptedFileReaderWriterTestFileReader:
             # self.parent.userMessages().AddMessage(vtk.vtkCommand.WarningEvent, "This is a warning message")
 
         except Exception as e:
-            logging.error('Failed to load file: ' + str(e))
             import traceback
             traceback.print_exc()
+            errorMessage = f"Failed to read file: {str(e)}"
+            self.parent.userMessages().AddMessage(vtk.vtkCommand.ErrorEvent, errorMessage)
             return False
 
         self.parent.loadedNodes = [loadedNode.GetID()]
@@ -128,9 +129,10 @@ class SlicerScriptedFileReaderWriterTestFileWriter:
                 myfile.write(node.GetText())
 
         except Exception as e:
-            logging.error('Failed to write file: ' + str(e))
             import traceback
             traceback.print_exc()
+            errorMessage = f"Failed to write file: {str(e)}"
+            self.parent.userMessages().AddMessage(vtk.vtkCommand.ErrorEvent, errorMessage)
             return False
 
         self.parent.writtenNodes = [node.GetID()]


### PR DESCRIPTION
This is a follow-up of 8381ef3e6 (BUG: Improve error reporting in file loading)

It was created based of changes originally contributed through:
* https://github.com/Slicer/Slicer/pull/6733