### PR TITLE
ENH: Add extension model API for downloading and installing an extension

### DIFF
--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -1714,7 +1714,7 @@ bool qSlicerExtensionsManagerModel::downloadAndInstallExtensionByName(const QStr
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerExtensionsManagerModel::installExtensionFromServer(const QString& extensionName, bool confirm, bool restart)
+void qSlicerExtensionsManagerModel::installExtensionFromServer(const QString& extensionName, bool restart)
 {
   Q_D(qSlicerExtensionsManagerModel);
 
@@ -1732,10 +1732,10 @@ void qSlicerExtensionsManagerModel::installExtensionFromServer(const QString& ex
     installationConfirmed = true;
     qDebug() << "Installing the extension(s) without asking for confirmation (testing mode is enabled)";
     }
-  else if (!confirm)
+  else if (!this->interactive())
     {
     installationConfirmed = true;
-    qDebug() << "Installing the extension(s) without asking for confirmation";
+    qDebug() << "Installing the extension(s) without asking for confirmation (interactive mode is disabled)";
     }
   else
     {
@@ -1755,19 +1755,11 @@ void qSlicerExtensionsManagerModel::installExtensionFromServer(const QString& ex
     }
 
   // Install extension and its dependencies
-  bool wasInteractive = this->interactive();
-  if (isTestingEnabled || !confirm)
-    {
-    // Prevent extensions manager model from displaying popups during installation
-    this->setInteractive(false);
-    }
   if (!this->downloadAndInstallExtensionByName(extensionName, /* installDependencies= */ true, /* waitForCompletion= */ true))
     {
     d->critical(tr("Failed to install %1 extension").arg(extensionName));
-    this->setInteractive(wasInteractive);
     return;
     }
-  this->setInteractive(wasInteractive);
 
   if (!restart)
     {
@@ -1781,10 +1773,10 @@ void qSlicerExtensionsManagerModel::installExtensionFromServer(const QString& ex
     restartConfirmed = false;
     qDebug() << "Skipping application restart (testing mode is enabled)";
     }
-  else if (!confirm)
+  else if (!this->interactive())
     {
     restartConfirmed = true;
-    qDebug() << "Restarting the application without asking for confirmation";
+    qDebug() << "Restarting the application without asking for confirmation (interactive mode is disabled)";
     }
   else
     {

--- a/Base/QTCore/qSlicerExtensionsManagerModel.h
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.h
@@ -391,20 +391,20 @@ public slots:
   /// and its dependencies without any confirmation dialogs. In this case,
   /// the application is not automatically restarted.
   ///
-  /// If testing mode is not already enabled, you can set the \a confirm
-  /// parameter to false to skip the confirmation dialogs during installation.
+  /// If you wish to skip the confirmation dialogs during installation
+  /// without enabling testing mode, you can call setInteractive(false) on
+  /// the extensions manager model before invoking this function.
   ///
-  /// Similarly, by setting the \a restart parameter to false, you can prevent
-  /// the application from automatically restarting after the installation is
-  /// completed.
+  /// To prevent the application from automatically restarting after the
+  /// installation is completed, set the \a restart parameter to false.
   ///
   /// \param extensionName The name of the extension to be installed.
-  /// \param confirm Set to false to skip confirmation dialogs (default: true).
   /// \param restart Set to false to prevent automatic application restart (default: true).
   ///
+  /// \sa setInteractive
   /// \sa isExtensionInstalled, installExtension, updateExtensionsMetadataFromServer, downloadAndInstallExtensionByName
-  /// \sa qSlicerCoreApplication::restart
-  void installExtensionFromServer(const QString& extensionName, bool confirm = true, bool restart = true);
+  /// \sa qSlicerCoreApplication::testAttribute, qSlicerCoreApplication::AA_EnableTesting, qSlicerCoreApplication::restart
+  void installExtensionFromServer(const QString& extensionName, bool restart = true);
 
   /// \brief Schedule \a extensionName of uninstall
   /// Tell the application to uninstall \a extensionName when it will restart

--- a/Base/QTCore/qSlicerExtensionsManagerModel.h
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.h
@@ -380,6 +380,32 @@ public slots:
   /// \sa installExtension, scheduleExtensionForUninstall, uninstallScheduledExtensions
   bool downloadAndInstallExtensionByName(const QString& extensionName, bool installDependencies = true, bool waitForCompletion = false);
 
+  /// \brief Download and install an extension from the extensions server.
+  ///
+  /// This function allows the user to download and install an extension
+  /// along with its dependencies from the extensions server. By default,
+  /// it will prompt the user to confirm the installation and restart of
+  /// the application after installation.
+  ///
+  /// When the testing mode is enabled, the function installs the extension
+  /// and its dependencies without any confirmation dialogs. In this case,
+  /// the application is not automatically restarted.
+  ///
+  /// If testing mode is not already enabled, you can set the \a confirm
+  /// parameter to false to skip the confirmation dialogs during installation.
+  ///
+  /// Similarly, by setting the \a restart parameter to false, you can prevent
+  /// the application from automatically restarting after the installation is
+  /// completed.
+  ///
+  /// \param extensionName The name of the extension to be installed.
+  /// \param confirm Set to false to skip confirmation dialogs (default: true).
+  /// \param restart Set to false to prevent automatic application restart (default: true).
+  ///
+  /// \sa isExtensionInstalled, installExtension, updateExtensionsMetadataFromServer, downloadAndInstallExtensionByName
+  /// \sa qSlicerCoreApplication::restart
+  void installExtensionFromServer(const QString& extensionName, bool confirm = true, bool restart = true);
+
   /// \brief Schedule \a extensionName of uninstall
   /// Tell the application to uninstall \a extensionName when it will restart
   /// An extension scheduled for uninstall can be effectively uninstalled by calling


### PR DESCRIPTION
By default, the extension and its dependencies are installed and the application restarted also after asking the user to confirm each.

If testing mode is enabled, the extension and its dependencies are installed without asking for confirmation. In this the application is not restarted.