### PR TITLE
ENH: Add DICOM direct load reader

### DIFF
--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleE_WithFileWriter_WithoutWidget.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleE_WithFileWriter_WithoutWidget.py
@@ -1,3 +1,4 @@
+from slicer.i18n import tr as _
 from slicer.ScriptedLoadableModule import *
 
 SOMEVAR = 'E'
@@ -26,7 +27,7 @@ class ModuleE_WithFileWriter_WithoutWidgetFileWriter:
         self.parent = parent
 
     def description(self):
-        return 'My writer file type'
+        return _('My writer file type')
 
     def fileType(self):
         return 'MyWriterFileType'

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleF_WithFileReader_WithoutWidget.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleF_WithFileReader_WithoutWidget.py
@@ -1,3 +1,4 @@
+from slicer.i18n import tr as _
 from slicer.ScriptedLoadableModule import *
 
 SOMEVAR = 'F'
@@ -26,7 +27,7 @@ class ModuleF_WithFileReader_WithoutWidgetFileReader:
         self.parent = parent
 
     def description(self):
-        return 'My reader file type'
+        return _('My reader file type')
 
     def fileType(self):
         return 'MyReaderFileType'

--- a/Applications/SlicerApp/Testing/Python/SlicerScriptedFileReaderWriterTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerScriptedFileReaderWriterTest.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 import slicer
+from slicer.i18n import tr as _
 from slicer.ScriptedLoadableModule import *
 
 
@@ -34,7 +35,7 @@ class SlicerScriptedFileReaderWriterTestFileReader:
         self.parent = parent
 
     def description(self):
-        return 'My file type'
+        return _('My file type')
 
     def fileType(self):
         return 'MyFileType'
@@ -101,7 +102,7 @@ class SlicerScriptedFileReaderWriterTestFileWriter:
         self.parent = parent
 
     def description(self):
-        return 'My file type'
+        return _('My file type')
 
     def fileType(self):
         return 'MyFileType'

--- a/Modules/Scripted/CMakeLists.txt
+++ b/Modules/Scripted/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 if(Slicer_BUILD_DICOM_SUPPORT)
   list(APPEND modules
     DICOM
+    DICOMDirectReader
     DICOMLib
     DICOMPlugins
     DICOMPatcher

--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -898,7 +898,7 @@ class DICOMFileReader:
         self.parent = parent
 
     def description(self):
-        return 'DICOM import'
+        return _('DICOM import')
 
     def fileType(self):
         return 'DICOMFileImport'

--- a/Modules/Scripted/DICOMDirectReader/CMakeLists.txt
+++ b/Modules/Scripted/DICOMDirectReader/CMakeLists.txt
@@ -1,0 +1,18 @@
+#-----------------------------------------------------------------------------
+set(MODULE_NAME DICOMDirectReader)
+
+#-----------------------------------------------------------------------------
+set(MODULE_PYTHON_SCRIPTS
+  ${MODULE_NAME}.py
+  )
+
+set(MODULE_PYTHON_RESOURCES
+  )
+
+#-----------------------------------------------------------------------------
+slicerMacroBuildScriptedModule(
+  NAME ${MODULE_NAME}
+  SCRIPTS ${MODULE_PYTHON_SCRIPTS}
+  RESOURCES ${MODULE_PYTHON_RESOURCES}
+  WITH_GENERIC_TESTS
+  )

--- a/Modules/Scripted/DICOMDirectReader/DICOMDirectReader.py
+++ b/Modules/Scripted/DICOMDirectReader/DICOMDirectReader.py
@@ -30,7 +30,7 @@ class DICOMDirectReaderFileReader:
         self.parent = parent
 
     def description(self):
-        return 'DICOM direct load'
+        return _('DICOM direct load')
 
     def fileType(self):
         return 'DICOMDirectLoad'

--- a/Modules/Scripted/DICOMDirectReader/DICOMDirectReader.py
+++ b/Modules/Scripted/DICOMDirectReader/DICOMDirectReader.py
@@ -1,0 +1,68 @@
+import os
+import slicer
+from slicer.i18n import tr as _
+from slicer.i18n import translate
+from slicer.ScriptedLoadableModule import ScriptedLoadableModule
+
+
+class DICOMDirectReader(ScriptedLoadableModule):
+    """A module for loading Revvity Living Image files."""
+
+    def __init__(self, parent):
+        """Initialize this class."""
+        ScriptedLoadableModule.__init__(self, parent)
+        self.parent.title = _("DICOMDirectReader")
+        self.parent.categories = ["", translate("qSlicerAbstractCoreModule", "Informatics")]  # top level module
+        parent.dependencies = ["DICOM"]
+        parent.contributors = [""]
+        parent.helpText = _("This module allows direct loading of DICOM files without importing into the DICOM database.")
+        parent.acknowledgementText = _("This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community.")
+        # don't show this module - it is only for registering a reader
+        parent.hidden = True
+        self.parent = parent
+
+
+class DICOMDirectReaderFileReader:
+    """This reader claims DICOM files with higher-than default confidence and loads them directly into the scene.
+    """
+
+    def __init__(self, parent):
+        self.parent = parent
+
+    def description(self):
+        return 'DICOM direct load'
+
+    def fileType(self):
+        return 'DICOMDirectLoad'
+
+    def extensions(self):
+        return ['DICOM (*.dcm)', 'DICOM (*)']
+
+    def canLoadFileConfidence(self, filePath):
+        import pydicom
+        if pydicom.misc.is_dicom(filePath):
+            # This is a DICOM file, so we return higher confidence than the default 0.5
+            # to import DICOM files directly into the scene.
+            confidence = 0.6
+            if slicer.util.selectedModule() == "DICOM":
+                return confidence - 0.05  # rank "DICOM direct load" below "DICOM import"
+            return confidence + 0.05  # rank "DICOM direct load" above "DICOM import"
+        else:
+            return 0.0
+
+    def load(self, properties):
+        filePath = properties['fileName']
+        dicomFilesDirectory = os.path.dirname(os.path.abspath(filePath))
+
+        loadedNodeIDs = []
+
+        from DICOMLib import DICOMUtils
+        with DICOMUtils.TemporaryDICOMDatabase() as db:
+            DICOMUtils.importDicom(dicomFilesDirectory, db)
+            patientUIDs = db.patients()
+            for patientUID in patientUIDs:
+                loadedNodeIDs.extend(DICOMUtils.loadPatientByUID(patientUID))
+
+        self.parent.loadedNodes = loadedNodeIDs
+
+        return bool(self.parent.loadedNodes)

--- a/Modules/Scripted/ImportItkSnapLabel/ImportItkSnapLabel.py
+++ b/Modules/Scripted/ImportItkSnapLabel/ImportItkSnapLabel.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import slicer
+from slicer.i18n import tr as _
 from slicer.ScriptedLoadableModule import *
 
 
@@ -32,7 +33,7 @@ class ImportItkSnapLabelFileReader:
         self.parent = parent
 
     def description(self):
-        return 'ITK-Snap Label Description'
+        return _('ITK-Snap Label Description')
 
     def fileType(self):
         return 'ItkSnapLabel'


### PR DESCRIPTION
This is used for directly loading DICOM files into the scene without adding to the DICOM database. The DICOM module however is still used in the logic for loading. Currently there is the "DICOM import" reader option from the Add Data dialog which will import it into the DICOM database, but will not load it into the scene.

Based on https://slicer.readthedocs.io/en/latest/developer_guide/script_repository.html#load-dicom-files-into-the-scene-from-a-folder