### PR TITLE
STYLE: Consistently use `canceled` and `canceling` spelling

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CLIEventTest.py
+++ b/Applications/SlicerApp/Testing/Python/CLIEventTest.py
@@ -183,7 +183,7 @@ class CLIEventTestTest(ScriptedLoadableModuleTest):
 
     # Testing a the status event when canceling
     def test_CLIStatusEventTestCancel(self):
-        self.delayDisplay('Testing status events when cancelling the execution of a CLI')
+        self.delayDisplay('Testing status events when canceling the execution of a CLI')
 
         tempFile = qt.QTemporaryFile("CLIEventTest-outputFile-XXXXXX")
         self.assertTrue(tempFile.open())
@@ -207,8 +207,8 @@ class CLIEventTestTest(ScriptedLoadableModuleTest):
 
         expectedEvents = [
             cli.Scheduled,
-            cli.Cancelling,
-            cli.Cancelled,
+            cli.Canceling,
+            cli.Canceled,
         ]
 
         # Ignore cli.Running event (it may or may not be fired)
@@ -216,7 +216,7 @@ class CLIEventTestTest(ScriptedLoadableModuleTest):
             logic.StatusEvents.remove(cli.Running)
 
         self.assertEqual(logic.StatusEvents, expectedEvents)
-        self.delayDisplay('Testing cancelled execution Passed')
+        self.delayDisplay('Testing canceled execution Passed')
 
     def test_SubjectHierarchyReference(self):
         self.delayDisplay('Test that output node moved to referenced node location in subject hierarchy')

--- a/Base/Logic/vtkDataIOManagerLogic.cxx
+++ b/Base/Logic/vtkDataIOManagerLogic.cxx
@@ -327,8 +327,8 @@ int vtkDataIOManagerLogic::QueueRead ( vtkMRMLNode *node )
       }
     else
       {
-      //--- Mark the node's read state as cancelled.
-      dnode->GetNthStorageNode(storageNodeIndex)->SetReadStateCancelled();
+      //--- Mark the node's read state as canceled.
+      dnode->GetNthStorageNode(storageNodeIndex)->SetReadStateCanceled();
       }
     //--- Invoke an event that will trigger GUI to post
     //--- a message box telling if one hasn't been posted already
@@ -378,9 +378,9 @@ int vtkDataIOManagerLogic::QueueRead ( vtkMRMLNode *node )
   if ( retval == 0)
     {
     //--- no permission fields were completed.
-    //--- Transfer should be cancelled -- how do we do this?
-    dnode->GetNthStorageNode(storageNodeIndex)->SetReadStateCancelled();
-    vtkDebugMacro("QueueRead: cancelling data transfer.");
+    //--- Transfer should be canceled -- how do we do this?
+    dnode->GetNthStorageNode(storageNodeIndex)->SetReadStateCanceled();
+    vtkDebugMacro("QueueRead: canceling data transfer.");
     return 0;
     }
 

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -682,7 +682,7 @@ def loadNodeFromFile(filename, filetype=None, properties={}, returnNode=False):
                      If not specified then the reader with the highest confidence is used.
     :param properties: map containing additional parameters for the loading.
     :param returnNode: Deprecated. If set to true then the method returns status flag and node
-      instead of signalling error by throwing an exception.
+      instead of signaling error by throwing an exception.
     :return: loaded node (if multiple nodes are loaded then a list of nodes).
       If returnNode is True then a status flag and loaded node are returned.
     :raises RuntimeError: in case of failure

--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -1264,7 +1264,7 @@ void qSlicerMainWindow::closeEvent(QCloseEvent *event)
     }
   else
     {
-    // Request is cancelled, application will not be closed
+    // Request is canceled, application will not be closed
     event->ignore();
     d->IsClosing = false;
     }

--- a/Base/QTCLI/qSlicerCLIProgressBar.cxx
+++ b/Base/QTCLI/qSlicerCLIProgressBar.cxx
@@ -372,7 +372,7 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
   QString statusLabelFormat = tr("%1 (%2s)");
   switch (node->GetStatus())
     {
-    case vtkMRMLCommandLineModuleNode::Cancelled:
+    case vtkMRMLCommandLineModuleNode::Canceled:
       d->ProgressBar->setMaximum(0);
       break;
     case vtkMRMLCommandLineModuleNode::Scheduled:

--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
@@ -833,13 +833,13 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
   // release it when it goes out of scope
   node0.TakeReference(reinterpret_cast<vtkMRMLCommandLineModuleNode*>(clientdata));
 
-  // Check to see if this node/task has been cancelled
-  if (node0->GetStatus() == vtkMRMLCommandLineModuleNode::Cancelling ||
-      node0->GetStatus() == vtkMRMLCommandLineModuleNode::Cancelled)
+  // Check to see if this node/task has been canceled
+  if (node0->GetStatus() == vtkMRMLCommandLineModuleNode::Canceling ||
+      node0->GetStatus() == vtkMRMLCommandLineModuleNode::Canceled)
     {
     node0->SetOutputText("", false);
     node0->SetErrorText("", false);
-    node0->SetStatus(vtkMRMLCommandLineModuleNode::Cancelled, false);
+    node0->SetStatus(vtkMRMLCommandLineModuleNode::Canceled, false);
     this->GetApplicationLogic()->RequestModified( node0 );
     return;
     }
@@ -1809,7 +1809,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
       // reset the timeout value
       timeout = timeoutlimit;
 
-      // Check to see if the plugin was cancelled
+      // Check to see if the plugin was canceled
       if (node0->GetModuleDescription().GetProcessInformation()->Abort)
         {
         itksysProcess_Kill(process);
@@ -1925,9 +1925,9 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
     node0->SetErrorText(stderrbuffer, false);
 
     // check the exit state / error state of the process
-    if (node0->GetStatus() == vtkMRMLCommandLineModuleNode::Cancelling)
+    if (node0->GetStatus() == vtkMRMLCommandLineModuleNode::Canceling)
       {
-      node0->SetStatus(vtkMRMLCommandLineModuleNode::Cancelled, false);
+      node0->SetStatus(vtkMRMLCommandLineModuleNode::Canceled, false);
       this->GetApplicationLogic()->RequestModified(node0);
       }
     else
@@ -2052,9 +2052,9 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
       }
     catch (itk::ExceptionObject& exc)
       {
-      if (node0->GetStatus() == vtkMRMLCommandLineModuleNode::Cancelling)
+      if (node0->GetStatus() == vtkMRMLCommandLineModuleNode::Canceling)
         {
-        vtkInfoMacro(<< node0->GetModuleDescription().GetTitle() << " cancelled.");
+        vtkInfoMacro(<< node0->GetModuleDescription().GetTitle() << " canceled.");
         }
       else
         {
@@ -2075,9 +2075,9 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
       std::cout.rdbuf( origcoutrdbuf );
       std::cerr.rdbuf( origcerrrdbuf );
       }
-    if (node0->GetStatus() == vtkMRMLCommandLineModuleNode::Cancelling)
+    if (node0->GetStatus() == vtkMRMLCommandLineModuleNode::Canceling)
       {
-      node0->SetStatus(vtkMRMLCommandLineModuleNode::Cancelled, false);
+      node0->SetStatus(vtkMRMLCommandLineModuleNode::Canceled, false);
       this->GetApplicationLogic()->RequestModified( node0 );
       }
     // Check the return status of the module
@@ -2092,12 +2092,12 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
       }
     }
 
-  if (node0->GetStatus() == vtkMRMLCommandLineModuleNode::Cancelling)
+  if (node0->GetStatus() == vtkMRMLCommandLineModuleNode::Canceling)
     {
-    node0->SetStatus(vtkMRMLCommandLineModuleNode::Cancelled, false);
+    node0->SetStatus(vtkMRMLCommandLineModuleNode::Canceled, false);
     this->GetApplicationLogic()->RequestModified( node0 );
     }
-  else if (node0->GetStatus() != vtkMRMLCommandLineModuleNode::Cancelled
+  else if (node0->GetStatus() != vtkMRMLCommandLineModuleNode::Canceled
            && node0->GetStatus() != vtkMRMLCommandLineModuleNode::CompletedWithErrors)
     {
     node0->SetStatus(vtkMRMLCommandLineModuleNode::Completing, false);
@@ -2171,7 +2171,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
   // if there was a miniscene that needs loading, request it
   if (miniscene->GetNumberOfNodes() > 0)
     {
-    // don't load the mini scene if errors were found or the cli was cancelled.
+    // don't load the mini scene if errors were found or the cli was canceled.
     if (node0->GetStatus() == vtkMRMLCommandLineModuleNode::Completing)
       {
       bool displayData = this->IsCommandLineModuleNodeUpdatingDisplay(node0);
@@ -2613,9 +2613,9 @@ void vtkSlicerCLIModuleLogic
       {
       return;
       }
-    if (node->GetStatus() != vtkMRMLCommandLineModuleNode::Cancelling)
+    if (node->GetStatus() != vtkMRMLCommandLineModuleNode::Canceling)
       {
-      // request the module execution to be cancelled.
+      // request the module execution to be canceled.
       node->Cancel();
       // Wait until the module is stopped
       extraDelay = 100;

--- a/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
@@ -1081,10 +1081,10 @@ void qSlicerExtensionsManagerModelTester::testCancelExtensionScheduledForUninsta
 
   {
     QFETCH(QStringList, extensionNamesToCancelScheduledForUninstall);
-    QFETCH(int, expectedSpyExtensionCancelledScheduleForUninstallCount);
+    QFETCH(int, expectedSpyExtensionCanceledScheduleForUninstallCount);
     qSlicerExtensionsManagerModel model;
     model.setExtensionsSettingsFilePath(QSettings().fileName());
-    QSignalSpy spyExtensionCancelledScheduleForUninstall(&model, SIGNAL(extensionCancelledScheduleForUninstall(QString)));
+    QSignalSpy spyExtensionCanceledScheduleForUninstall(&model, SIGNAL(extensionCanceledScheduleForUninstall(QString)));
     model.setSlicerRequirements(slicerRevision, operatingSystem, architecture);
     model.setSlicerVersion(slicerVersion);
     model.updateModel();
@@ -1092,7 +1092,7 @@ void qSlicerExtensionsManagerModelTester::testCancelExtensionScheduledForUninsta
       {
       model.cancelExtensionScheduledForUninstall(extensionNameToCancelScheduledForUninstall);
       }
-    QCOMPARE(spyExtensionCancelledScheduleForUninstall.count(), expectedSpyExtensionCancelledScheduleForUninstallCount);
+    QCOMPARE(spyExtensionCanceledScheduleForUninstall.count(), expectedSpyExtensionCanceledScheduleForUninstallCount);
   }
 
   {
@@ -1116,7 +1116,7 @@ void qSlicerExtensionsManagerModelTester::testCancelExtensionScheduledForUninsta
   QTest::addColumn<QList<int> >("extensionIdsToInstall");
   QTest::addColumn<QStringList>("extensionNamesToScheduleForUninstall");
   QTest::addColumn<QStringList>("extensionNamesToCancelScheduledForUninstall");
-  QTest::addColumn<int>("expectedSpyExtensionCancelledScheduleForUninstallCount");
+  QTest::addColumn<int>("expectedSpyExtensionCanceledScheduleForUninstallCount");
   QTest::addColumn<QStringList>("expectedExtensionNamesScheduledForUninstall");
 
   QString slicerRevision("30987");

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -2491,7 +2491,7 @@ bool qSlicerExtensionsManagerModel::cancelExtensionScheduledForUpdate(
     }
   d->removeExtensionFromScheduledForUpdateList(extensionName);
 
-  emit this->extensionCancelledScheduleForUpdate(extensionName);
+  emit this->extensionCanceledScheduleForUpdate(extensionName);
 
   return true;
 }
@@ -2623,7 +2623,7 @@ bool qSlicerExtensionsManagerModel::cancelExtensionScheduledForUninstall(const Q
     }
   d->removeExtensionFromScheduledForUninstallList(extensionName);
   d->addExtensionSettings(extensionName);
-  emit this->extensionCancelledScheduleForUninstall(extensionName);
+  emit this->extensionCanceledScheduleForUninstall(extensionName);
 
   return true;
 }

--- a/Base/QTCore/qSlicerExtensionsManagerModel.h
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.h
@@ -534,11 +534,11 @@ signals:
 
   void extensionScheduledForUninstall(const QString& extensionName);
 
-  void extensionCancelledScheduleForUninstall(const QString& extensionName);
+  void extensionCanceledScheduleForUninstall(const QString& extensionName);
 
   void extensionScheduledForUpdate(const QString& extensionName);
 
-  void extensionCancelledScheduleForUpdate(const QString& extensionName);
+  void extensionCanceledScheduleForUpdate(const QString& extensionName);
 
   void extensionUninstalled(const QString& extensionName);
 

--- a/Base/QTGUI/qSlicerExtensionsLocalWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsLocalWidget.cxx
@@ -860,7 +860,7 @@ void qSlicerExtensionsLocalWidget::setExtensionsManagerModel(qSlicerExtensionsMa
   disconnect(this, SLOT(onExtensionUninstalled(QString)));
   disconnect(this, SLOT(onExtensionMetadataUpdated(QString)));
   disconnect(this, SLOT(onExtensionScheduledForUninstall(QString)));
-  disconnect(this, SLOT(onExtensionCancelledScheduleForUninstall(QString)));
+  disconnect(this, SLOT(onExtensionCanceledScheduleForUninstall(QString)));
   disconnect(this, SLOT(onModelExtensionEnabledChanged(QString,bool)));
   disconnect(this, SLOT(onExtensionBookmarkedChanged(QString,bool)));
   disconnect(this, SLOT(setExtensionUpdateDownloadProgress(QString,qint64,qint64)));
@@ -877,11 +877,11 @@ void qSlicerExtensionsLocalWidget::setExtensionsManagerModel(qSlicerExtensionsMa
     connect(d->ExtensionsManagerModel, SIGNAL(extensionMetadataUpdated(QString)), this, SLOT(onExtensionMetadataUpdated(QString)));
     connect(d->ExtensionsManagerModel, SIGNAL(extensionBookmarkedChanged(QString, bool)), this, SLOT(onExtensionBookmarkedChanged(QString,bool)));
     connect(d->ExtensionsManagerModel, SIGNAL(extensionScheduledForUninstall(QString)), this, SLOT(onExtensionScheduledForUninstall(QString)));
-    connect(d->ExtensionsManagerModel, SIGNAL(extensionCancelledScheduleForUninstall(QString)), this, SLOT(onExtensionCancelledScheduleForUninstall(QString)));
+    connect(d->ExtensionsManagerModel, SIGNAL(extensionCanceledScheduleForUninstall(QString)), this, SLOT(onExtensionCanceledScheduleForUninstall(QString)));
     connect(d->ExtensionsManagerModel, SIGNAL(extensionEnabledChanged(QString,bool)), this, SLOT(onModelExtensionEnabledChanged(QString,bool)));
     connect(d->ExtensionsManagerModel, SIGNAL(extensionUpdateAvailable(QString)), this, SLOT(setExtensionUpdateAvailable(QString)));
     connect(d->ExtensionsManagerModel, SIGNAL(extensionScheduledForUpdate(QString)), this, SLOT(setExtensionUpdateScheduled(QString)));
-    connect(d->ExtensionsManagerModel, SIGNAL(extensionCancelledScheduleForUpdate(QString)), this, SLOT(setExtensionUpdateCanceled(QString)));
+    connect(d->ExtensionsManagerModel, SIGNAL(extensionCanceledScheduleForUpdate(QString)), this, SLOT(setExtensionUpdateCanceled(QString)));
     connect(d->ExtensionsManagerModel, SIGNAL(updateDownloadProgress(QString,qint64,qint64)),
       this, SLOT(setExtensionUpdateDownloadProgress(QString,qint64,qint64)));
     connect(d->ExtensionsManagerModel, SIGNAL(installDownloadProgress(QString, qint64, qint64)),
@@ -1014,7 +1014,7 @@ void qSlicerExtensionsLocalWidget::onExtensionScheduledForUninstall(const QStrin
 }
 
 // -------------------------------------------------------------------------
-void qSlicerExtensionsLocalWidget::onExtensionCancelledScheduleForUninstall(const QString& extensionName)
+void qSlicerExtensionsLocalWidget::onExtensionCanceledScheduleForUninstall(const QString& extensionName)
 {
   Q_D(qSlicerExtensionsLocalWidget);
   d->updateExtensionItem(extensionName);

--- a/Base/QTGUI/qSlicerExtensionsLocalWidget.h
+++ b/Base/QTGUI/qSlicerExtensionsLocalWidget.h
@@ -81,7 +81,7 @@ protected slots:
   void onExtensionMetadataUpdated(const QString& extensionName);
   void onExtensionBookmarkedChanged(const QString& extensionName, bool bookmarked);
   void onExtensionScheduledForUninstall(const QString& extensionName);
-  void onExtensionCancelledScheduleForUninstall(const QString& extensionName);
+  void onExtensionCanceledScheduleForUninstall(const QString& extensionName);
   void setExtensionUpdateScheduled(const QString& extensionName);
   void setExtensionUpdateCanceled(const QString& extensionName);
   void setExtensionUpdateDownloadProgress(

--- a/Base/QTGUI/qSlicerExtensionsManagerDialog.cxx
+++ b/Base/QTGUI/qSlicerExtensionsManagerDialog.cxx
@@ -159,11 +159,11 @@ void qSlicerExtensionsManagerDialog::setExtensionsManagerModel(qSlicerExtensions
             this, SLOT(onModelUpdated()));
     connect(model, SIGNAL(extensionScheduledForUninstall(QString)),
             this, SLOT(onModelUpdated()));
-    connect(model, SIGNAL(extensionCancelledScheduleForUninstall(QString)),
+    connect(model, SIGNAL(extensionCanceledScheduleForUninstall(QString)),
             this, SLOT(onModelUpdated()));
     connect(model, SIGNAL(extensionScheduledForUpdate(QString)),
             this, SLOT(onModelUpdated()));
-    connect(model, SIGNAL(extensionCancelledScheduleForUpdate(QString)),
+    connect(model, SIGNAL(extensionCanceledScheduleForUpdate(QString)),
             this, SLOT(onModelUpdated()));
     connect(model, SIGNAL(extensionEnabledChanged(QString,bool)),
             this, SLOT(onModelUpdated()));

--- a/Base/QTGUI/qSlicerExtensionsManagerWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsManagerWidget.cxx
@@ -351,7 +351,7 @@ void qSlicerExtensionsManagerWidget::setExtensionsManagerModel(qSlicerExtensions
     connect(model, SIGNAL(extensionInstalled(QString)), this, SLOT(onModelUpdated()));
     connect(model, SIGNAL(extensionUninstalled(QString)), this, SLOT(onModelUpdated()));
     connect(model, SIGNAL(extensionScheduledForUpdate(QString)), this, SLOT(onModelUpdated()));
-    connect(model, SIGNAL(extensionCancelledScheduleForUpdate(QString)), this, SLOT(onModelUpdated()));
+    connect(model, SIGNAL(extensionCanceledScheduleForUpdate(QString)), this, SLOT(onModelUpdated()));
     connect(model, SIGNAL(extensionBookmarkedChanged(QString,bool)), this, SLOT(onModelUpdated()));
     connect(model, SIGNAL(extensionUpdateAvailable(QString)), this, SLOT(onModelUpdated()));
     connect(model, SIGNAL(autoUpdateSettingsChanged()), this, SLOT(updateAutoUpdateWidgetsFromModel()));

--- a/Base/QTGUI/qSlicerExtensionsServerWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsServerWidget.cxx
@@ -239,8 +239,8 @@ void qSlicerExtensionsServerWidget::setExtensionsManagerModel(qSlicerExtensionsM
     QObject::connect(model, SIGNAL(extensionScheduledForUninstall(QString)),
                      this, SLOT(onExtensionScheduledForUninstall(QString)));
 
-    QObject::connect(model, SIGNAL(extensionCancelledScheduleForUninstall(QString)),
-                     this, SLOT(onExtensionCancelledScheduleForUninstall(QString)));
+    QObject::connect(model, SIGNAL(extensionCanceledScheduleForUninstall(QString)),
+                     this, SLOT(onExtensionCanceledScheduleForUninstall(QString)));
 
     QObject::connect(model, SIGNAL(slicerRequirementsChanged(QString,QString,QString)),
                      this, SLOT(onSlicerRequirementsChanged()));
@@ -314,7 +314,7 @@ void qSlicerExtensionsServerWidget::onExtensionScheduledForUninstall(const QStri
 }
 
 // -------------------------------------------------------------------------
-void qSlicerExtensionsServerWidget::onExtensionCancelledScheduleForUninstall(const QString& extensionName)
+void qSlicerExtensionsServerWidget::onExtensionCanceledScheduleForUninstall(const QString& extensionName)
 {
   this->onExtensionInstalled(extensionName);
 }

--- a/Base/QTGUI/qSlicerExtensionsServerWidget.h
+++ b/Base/QTGUI/qSlicerExtensionsServerWidget.h
@@ -59,7 +59,7 @@ public slots:
 
   void onExtensionScheduledForUninstall(const QString& extensionName);
 
-  void onExtensionCancelledScheduleForUninstall(const QString& extensionName);
+  void onExtensionCanceledScheduleForUninstall(const QString& extensionName);
 
   void onSlicerRequirementsChanged();
 

--- a/Base/QTGUI/qSlicerIOManager.cxx
+++ b/Base/QTGUI/qSlicerIOManager.cxx
@@ -98,7 +98,7 @@ bool qSlicerIOManagerPrivate::startProgressDialog(int steps)
   this->ProgressDialog->setWindowTitle(qSlicerIOManager::tr("Loading ..."));
   if (steps == 1)
     {
-    // We only support cancelling a load action if we can have control over it
+    // We only support canceling a load action if we can have control over it
     this->ProgressDialog->setCancelButton(nullptr);
     }
   this->ProgressDialog->setWindowModality(Qt::WindowModal);

--- a/Base/QTGUI/qSlicerSettingsModulesPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsModulesPanel.cxx
@@ -321,7 +321,7 @@ void qSlicerSettingsModulesPanel::onAddModulesAdditionalPathClicked()
   QString path = QFileDialog::getExistingDirectory(
         this, tr("Select folder"),
         mostRecentPath);
-  // An empty directory means that the user cancelled the dialog.
+  // An empty directory means that the user canceled the dialog.
   if (path.isEmpty())
     {
     return;

--- a/Base/QTGUI/qSlicerSettingsStylesPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsStylesPanel.cxx
@@ -251,7 +251,7 @@ void qSlicerSettingsStylesPanel::onAddStyleAdditionalPathClicked()
   QString path = QFileDialog::getExistingDirectory(
       this, tr("Select a path containing a \"styles\" plugin directory"),
       extensionInstallPath);
-  // An empty directory means that the user cancelled the dialog.
+  // An empty directory means that the user canceled the dialog.
   if (path.isEmpty())
     {
     return;

--- a/CMake/NSIS.template.in
+++ b/CMake/NSIS.template.in
@@ -517,7 +517,7 @@ Function DownloadFile
 
     Pop $1
     StrCmp $1 "success" success
-    StrCmp $1 "Cancelled" cancel
+    StrCmp $1 "Canceled" cancel
     MessageBox MB_OK "Download failed: $1"
   cancel:
     Return

--- a/Docs/developer_guide/script_repository/gui.md
+++ b/Docs/developer_guide/script_repository/gui.md
@@ -193,7 +193,7 @@ class MyModuleFileDialog ():
   def execDialog(self):
     # Implement custom scene save operation here.
     # Return True if saving completed successfully,
-    # return False if saving was cancelled.
+    # return False if saving was canceled.
     ...
     return saved
 ```

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -550,7 +550,7 @@ void vtkMRMLCommandLineModuleNode::SetStatus(int status, bool modify)
       case vtkMRMLCommandLineModuleNode::Running:
         this->Internal->LastRunTime.Modified();
         break;
-      case vtkMRMLCommandLineModuleNode::Cancelling:
+      case vtkMRMLCommandLineModuleNode::Canceling:
         this->AbortProcess();
         break;
       default:
@@ -662,8 +662,8 @@ const char* vtkMRMLCommandLineModuleNode::GetStatusString() const
     case Idle: return "Idle";
     case Scheduled: return "Scheduled";
     case Running: return "Running";
-    case Cancelling: return "Cancelling";
-    case Cancelled: return "Cancelled";
+    case Canceling: return "Canceling";
+    case Canceled: return "Canceled";
     case Completing: return "Completing";
     case Completed: return "Completed";
     case CompletedWithErrors: return "Completed with errors";
@@ -678,7 +678,7 @@ void vtkMRMLCommandLineModuleNode::Cancel()
 {
   if (this->IsBusy())
     {
-    this->SetStatus(vtkMRMLCommandLineModuleNode::Cancelling);
+    this->SetStatus(vtkMRMLCommandLineModuleNode::Canceling);
     }
 }
 

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
@@ -82,12 +82,12 @@ public:
     Scheduled=0x01,
     /// State when the CLI is being executed.
     Running=0x02,
-    /// State when the CLI has been requested to be cancelled.
-    Cancelling=0x04,
+    /// State when the CLI has been requested to be canceled.
+    Canceling=0x04,
     /// State when the CLI is no longer being executed because
-    /// Cancelling has been requested.
+    /// Canceling has been requested.
     /// Do not set manually, use Cancel() instead.
-    Cancelled=0x08,
+    Canceled=0x08,
     /// State when the CLI has been successfully executed and is in a finishing
     /// state that loads the outputs into the scene.
     Completing=0x10,
@@ -99,7 +99,7 @@ public:
     /// State when the CLI has been executed with errors
     CompletedWithErrors= Completed | ErrorsMask,
     /// Mask used to know if the CLI is in pending mode.
-    BusyMask = Scheduled | Running | Cancelling | Completing
+    BusyMask = Scheduled | Running | Canceling | Completing
     };
 
   /// Set the status of the node (Idle, Scheduled, Running,
@@ -150,7 +150,7 @@ public:
   //@}
 
   /// Return true if the module is in a busy state: Scheduled, Running,
-  /// Cancelling, Completing.
+  /// Canceling, Completing.
   /// \sa SetStatus(), GetStatus(), BusyMask, Cancel()
   bool IsBusy()const;
 
@@ -158,7 +158,7 @@ public:
 
   /// Set a request to stop the processing of the CLI.
   /// Do nothing if the module is not "busy".
-  /// \sa IsBusy(), Cancelling, Cancelled
+  /// \sa IsBusy(), Canceling, Canceled
   void Cancel();
 
   /// This enum type controls when the CLI should be run automatically.
@@ -167,7 +167,7 @@ public:
   {
     /// Triggering a new autorun cancels the processing of the current CLI if
     /// any.
-    /// \sa SetStatus(), Cancelling
+    /// \sa SetStatus(), Canceling
     AutoRunCancelsRunningProcess = 0x01,
     /// When set, it triggers autorun requests when a parameter is modified
     /// when calling SetParameterAsXXX().

--- a/Libs/MRML/Core/vtkDataIOManager.cxx
+++ b/Libs/MRML/Core/vtkDataIOManager.cxx
@@ -386,7 +386,7 @@ void vtkDataIOManager::QueueRead ( vtkMRMLNode *node )
     //---
     //--- WJPtest
     //--- Test for space to download the file. If no space,
-    //--- then mark the node's read state as cancelled and
+    //--- then mark the node's read state as canceled and
     //--- Then,  check for InsufficientFreeBufferNotificationFlag.
     //--- If it's already set, the user has already been notified, so do nothing.
     //--- If not yet set, send an event, that will cause GUI to post
@@ -402,12 +402,12 @@ void vtkDataIOManager::QueueRead ( vtkMRMLNode *node )
       //--- No space left in cache. Don't trigger logic to download;
       //--- by invoking a RemoteReadEvent.
       //--- And trigger GUI to post a pop-up dialog to inform user.
-      //--- Mark the node cancelled.
+      //--- Mark the node canceled.
       if ( cm->GetInsufficientFreeBufferNotificationFlag() == 0 )
         {
         cm->InvokeEvent ( vtkCacheManager::InsufficientFreeBufferEvent );
         cm->SetInsufficientFreeBufferNotificationFlag(1);
-        dnode->GetNthStorageNode(storageNodeIndex)->SetReadStateCancelled();
+        dnode->GetNthStorageNode(storageNodeIndex)->SetReadStateCanceled();
         }
       }
     else

--- a/Libs/MRML/Core/vtkDataIOManager.h
+++ b/Libs/MRML/Core/vtkDataIOManager.h
@@ -77,7 +77,7 @@ class VTK_MRML_EXPORT vtkDataIOManager : public vtkObject
   void QueueWrite ( vtkMRMLNode *node );
 
   ///
-  /// Set the status of a data transfer (Idle, Scheduled, Cancelled Running,
+  /// Set the status of a data transfer (Idle, Scheduled, Canceled Running,
   /// Completed).  The "modify" parameter indicates whether the object
   /// can be modified by the call.
   void SetTransferStatus(vtkDataTransfer *transfer, int status);

--- a/Libs/MRML/Core/vtkDataTransfer.h
+++ b/Libs/MRML/Core/vtkDataTransfer.h
@@ -56,7 +56,7 @@ class VTK_MRML_EXPORT vtkDataTransfer : public vtkObject
       case vtkDataTransfer::Completed: return "Completed";
       case vtkDataTransfer::CompletedWithErrors: return "CompletedWithErrors";
       case vtkDataTransfer::TimedOut: return "TimedOut";
-      case vtkDataTransfer::Cancelled: return "Cancelled";
+      case vtkDataTransfer::Canceled: return "Canceled";
       case vtkDataTransfer::Deleted: return "Deleted";
       case vtkDataTransfer::Ready: return "Ready";
       }
@@ -85,7 +85,7 @@ class VTK_MRML_EXPORT vtkDataTransfer : public vtkObject
       Completed,
       CompletedWithErrors,
       CancelPending,
-      Cancelled,
+      Canceled,
       Ready,
       Deleted,
       TimedOut

--- a/Libs/MRML/Core/vtkMRMLCoreTestingUtilities.cxx
+++ b/Libs/MRML/Core/vtkMRMLCoreTestingUtilities.cxx
@@ -427,9 +427,9 @@ int ExerciseBasicStorageMRMLMethods(vtkMRMLStorageNode* node)
   node->SetReadStateTransferDone();
   rstate = node->GetReadStateAsString();
   std::cout << "Read state, TransfrerDone = " << rstate << std::endl;
-  node->SetReadStateCancelled();
+  node->SetReadStateCanceled();
   rstate = node->GetReadStateAsString();
-  std::cout << "Read state, Cancelled = " << rstate << std::endl;
+  std::cout << "Read state, Canceled = " << rstate << std::endl;
 
   TEST_SET_GET_INT_RANGE(node, WriteState, 0, 5);
   const char *wstate = node->GetWriteStateAsString();
@@ -449,9 +449,9 @@ int ExerciseBasicStorageMRMLMethods(vtkMRMLStorageNode* node)
   node->SetWriteStateTransferDone();
   wstate = node->GetWriteStateAsString();
   std::cout << "Write state, TransfrerDone = " << wstate << std::endl;
-  node->SetWriteStateCancelled();
+  node->SetWriteStateCanceled();
   wstate = node->GetWriteStateAsString();
-  std::cout << "Write state, Cancelled = " << wstate << std::endl;
+  std::cout << "Write state, Canceled = " << wstate << std::endl;
 
   std::string fullName = node->GetFullNameFromFileName();
   std::cout << "fullName = " << fullName.c_str() << std::endl;

--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -548,7 +548,7 @@ void vtkMRMLStorageNode::StageWriteData ( vtkMRMLNode *refNode )
 //    this->Scene->InvokeEvent (vtkMRMLScene::SaveProgressFeedbackEvent );
     }
 
-  if (this->WriteState == Cancelled || this->WriteState == SkippedNoData)
+  if (this->WriteState == Canceled || this->WriteState == SkippedNoData)
     {
     return;
     }
@@ -634,9 +634,9 @@ const char * vtkMRMLStorageNode::GetStateAsString(int state)
     {
     return "TransferDone";
     }
-  if (state == this->Cancelled)
+  if (state == this->Canceled)
     {
-    return "Cancelled";
+    return "Canceled";
     }
   if (state == this->SkippedNoData)
     {

--- a/Libs/MRML/Core/vtkMRMLStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.h
@@ -119,7 +119,7 @@ public:
   /// Scheduled: the data is remote, and is scheduled for download
   /// Transferring: data is remote, and the transfer is working to completion
   /// TransferDone: the data is on disk and ready to be read
-  /// Cancelled: the user cancelled the remote data transfer
+  /// Canceled: the user canceled the remote data transfer
   /// SkippedNoData: writing or reading was skipped due to data not present.
   ///                This is a valid state used if and only if the data node
   ///                is empty and there is nothing to be written or read.
@@ -130,7 +130,7 @@ public:
     Scheduled,
     Transferring,
     TransferDone,
-    Cancelled,
+    Canceled,
     SkippedNoData
   };
 
@@ -142,7 +142,7 @@ public:
   void SetReadStateScheduled() { this->SetReadState(this->Scheduled); };
   void SetReadStateTransferring() { this->SetReadState(this->Transferring); };
   void SetReadStateTransferDone() { this->SetReadState(this->TransferDone); };
-  void SetReadStateCancelled() { this->SetReadState(this->Cancelled); };
+  void SetReadStateCanceled() { this->SetReadState(this->Canceled); };
   void SetReadStateSkippedNoData() { this->SetReadState(this->SkippedNoData); };
   const char *GetStateAsString(int state);
   const char *GetReadStateAsString() { return this->GetStateAsString(this->ReadState); };
@@ -156,7 +156,7 @@ public:
   void SetWriteStateScheduled() { this->SetWriteState(this->Scheduled); };
   void SetWriteStateTransferring() { this->SetWriteState(this->Transferring); };
   void SetWriteStateTransferDone() { this->SetWriteState(this->TransferDone); };
-  void SetWriteStateCancelled() { this->SetWriteState(this->Cancelled); };
+  void SetWriteStateCanceled() { this->SetWriteState(this->Canceled); };
   void SetWriteStateSkippedNoData() { this->SetWriteState(this->SkippedNoData); };
   const char *GetWriteStateAsString() { return this->GetStateAsString(this->WriteState); };
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.cxx
@@ -572,7 +572,7 @@ bool vtkMRMLWindowLevelWidget::ProcessSetWindowLevelFromRegionEnd(vtkMRMLInterac
     }
   else
     {
-    // cancelled
+    // canceled
     return true;
     }
 }

--- a/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.h
@@ -144,7 +144,7 @@ protected:
 
   bool ProcessSetWindowLevelFromRegionStart(vtkMRMLInteractionEventData* eventData);
   void ProcessSetWindowLevelFromRegion(vtkMRMLInteractionEventData* eventData);
-  // If updateWindowLevel is set to false then the operation is cancelled without changing the window/level
+  // If updateWindowLevel is set to false then the operation is canceled without changing the window/level
   bool ProcessSetWindowLevelFromRegionEnd(vtkMRMLInteractionEventData* eventData, bool updateWindowLevel=true);
 
   bool ProcessResetWindowLevel(vtkMRMLInteractionEventData* eventData);

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationControlPointsNode.h
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationControlPointsNode.h
@@ -138,7 +138,7 @@ public:
   // add display node if not already present
   void CreateAnnotationPointDisplayNode();
 
-  /// flags to determine how the next fiducial added to the list is labelled
+  /// flags to determine how the next fiducial added to the list is labeled
   enum NumberingSchemes
   {
       SchemeMin = 0,

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorAutoCompleteEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorAutoCompleteEffect.py
@@ -167,7 +167,7 @@ class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEdi
             segment = segmentation.GetSegment(segmentID)
             if not segment:
                 # selected segment was deleted, cancel segmentation
-                logging.debug("Segmentation cancelled because an input segment was deleted")
+                logging.debug("Segmentation canceled because an input segment was deleted")
                 self.onCancel()
                 return
             segmentLabelmap = segment.GetRepresentation(vtkSegmentationCore.vtkSegmentationConverter.GetSegmentationBinaryLabelmapRepresentationName())

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsSettingsPanel.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsSettingsPanel.cxx
@@ -205,7 +205,7 @@ void qSlicerSegmentationsSettingsPanel::onEditDefaultTerminologyEntry()
   d->TerminologiesLogic->DeserializeTerminologyEntry(terminologyStdStr, entry);
   if (!qSlicerTerminologySelectorDialog::getTerminology(entry, this))
     {
-    // user cancelled
+    // user canceled
     return;
     }
   this->setDefaultTerminologyEntry(vtkSlicerTerminologiesModuleLogic::SerializeTerminologyEntry(entry).c_str());

--- a/Modules/Scripted/DICOMLib/DICOMBrowser.py
+++ b/Modules/Scripted/DICOMLib/DICOMBrowser.py
@@ -411,8 +411,8 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
                 slicer.app.processEvents()
                 progressDialog.setValue(progressValue)
                 slicer.app.processEvents()
-                cancelled = progressDialog.wasCanceled
-                return cancelled
+                canceled = progressDialog.wasCanceled
+                return canceled
 
             loadablesByPlugin, loadEnabled = DICOMLib.getLoadablesFromFileLists(fileLists, selectedPlugins, messages,
                                                                                 lambda progressLabel, progressValue, progressDialog=progressDialog: progressCallback(progressDialog, progressLabel, progressValue),
@@ -536,8 +536,8 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
             slicer.app.processEvents()
             progressDialog.setValue(progressValue)
             slicer.app.processEvents()
-            cancelled = progressDialog.wasCanceled
-            return cancelled
+            canceled = progressDialog.wasCanceled
+            return canceled
 
         qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
 

--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -484,7 +484,7 @@ class DICOMSender(DICOMProcess):
             try:
                 for file in self.files:
                     if not self.progressCallback(f"Sending {file} to {self.destinationUrl.toString()} using {self.protocol}"):
-                        raise UserWarning("Sending was cancelled, upload is incomplete.")
+                        raise UserWarning("Sending was canceled, upload is incomplete.")
                     import pydicom
                     dataset = pydicom.dcmread(file)
                     client.store_instances(datasets=[dataset])
@@ -496,7 +496,7 @@ class DICOMSender(DICOMProcess):
             for file in self.files:
                 self.start(file)
                 if not self.progressCallback(f"Sent {file} to {self.destinationUrl.host()}:{self.destinationUrl.port()}"):
-                    raise UserWarning("Sending was cancelled, upload is incomplete.")
+                    raise UserWarning("Sending was canceled, upload is incomplete.")
 
     def dicomSend(self, file, config=None, config_profile='Default'):
         """Send DICOM file to the specified modality."""

--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -735,8 +735,8 @@ def getLoadablesFromFileLists(fileLists, pluginClassNames=None, messages=None, p
             pluginInstances[pluginClassName] = slicer.modules.dicomPlugins[pluginClassName]()
         plugin = pluginInstances[pluginClassName]
         if progressCallback:
-            cancelled = progressCallback(pluginClassName, step * 100 / len(pluginClassNames))
-            if cancelled:
+            canceled = progressCallback(pluginClassName, step * 100 / len(pluginClassNames))
+            if canceled:
                 break
         try:
             if detailedLogging:
@@ -782,8 +782,8 @@ def loadLoadables(loadablesByPlugin, messages=None, progressCallback=None):
 
     for step, (loadable, plugin) in enumerate(selectedLoadables.items(), start=1):
         if progressCallback:
-            cancelled = progressCallback(loadable.name, step * 100 / len(selectedLoadables))
-            if cancelled:
+            canceled = progressCallback(loadable.name, step * 100 / len(selectedLoadables))
+            if canceled:
                 break
 
         try:
@@ -797,21 +797,21 @@ def loadLoadables(loadablesByPlugin, messages=None, progressCallback=None):
         if (not loadSuccess) and (messages is not None):
             messages.append(f'Could not load: {loadable.name} as a {plugin.loadType}')
 
-        cancelled = False
+        canceled = False
         try:
             # DICOM reader plugins (for example, in PETDICOM extension) may generate additional DICOM files
             # during loading. These must be added to the database.
             for derivedItem in loadable.derivedItems:
                 indexer = ctk.ctkDICOMIndexer()
                 if progressCallback:
-                    cancelled = progressCallback(f"{loadable.name} ({derivedItem})", step * 100 / len(selectedLoadables))
-                    if cancelled:
+                    canceled = progressCallback(f"{loadable.name} ({derivedItem})", step * 100 / len(selectedLoadables))
+                    if canceled:
                         break
                 indexer.addFile(slicer.dicomDatabase, derivedItem)
         except AttributeError:
             # no derived items or some other attribute error
             pass
-        if cancelled:
+        if canceled:
             break
 
     slicer.mrmlScene.RemoveObserver(sceneObserverTag)
@@ -877,7 +877,7 @@ def importFromDICOMWeb(dicomWebEndpoint, studyInstanceUID, seriesInstanceUID=Non
         clientLogger.setLevel(logging.WARNING)
 
         fileNumber = 0
-        cancelled = False
+        canceled = False
         for seriesIndex, currentSeriesInstanceUID in enumerate(seriesInstanceUIDs):
             progressDialog.labelText = f'Retrieving series {seriesIndex+1} of {len(seriesInstanceUIDs)}...'
             slicer.app.processEvents()
@@ -906,8 +906,8 @@ def importFromDICOMWeb(dicomWebEndpoint, studyInstanceUID, seriesInstanceUID=Non
                         series_instance_uid=currentSeriesInstanceUID)
 
                 slicer.app.processEvents()
-                cancelled = progressDialog.wasCanceled
-                if cancelled:
+                canceled = progressDialog.wasCanceled
+                if canceled:
                     break
 
                 outputDirectoryBase = slicer.dicomDatabase.databaseDirectory + "/DICOMweb"
@@ -925,14 +925,14 @@ def importFromDICOMWeb(dicomWebEndpoint, studyInstanceUID, seriesInstanceUID=Non
                         instance = client.retrieve_instance(studyInstanceUID, currentSeriesInstanceUID, sopInstanceUID)
                     progressDialog.setValue(int(100 * instanceIndex / numberOfInstances))
                     slicer.app.processEvents()
-                    cancelled = progressDialog.wasCanceled
-                    if cancelled:
+                    canceled = progressDialog.wasCanceled
+                    if canceled:
                         break
                     filename = outputDirectoryPath + "/" + str(fileNumber) + ".dcm"
                     instance.save_as(filename)
                     fileNumber += 1
 
-                if cancelled:
+                if canceled:
                     # cancel was requested in instance retrieve loop,
                     # stop the entire import process
                     break
@@ -954,7 +954,7 @@ def importFromDICOMWeb(dicomWebEndpoint, studyInstanceUID, seriesInstanceUID=Non
 
     if errors:
         slicer.util.errorDisplay(f"Errors occurred during DICOMweb import of {len(errors)} series.", detailedText="\n\n".join(errors))
-    elif cancelled and (len(seriesImported) < len(seriesInstanceUIDs)):
+    elif canceled and (len(seriesImported) < len(seriesInstanceUIDs)):
         slicer.util.infoDisplay(f"DICOMweb import has been interrupted after completing {len(seriesImported)} out of {len(seriesInstanceUIDs)} series.")
 
     return seriesImported

--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -836,7 +836,7 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
         self.watermarkImagePath = None
 
     def requestCancel(self):
-        logging.info("User requested cancelling of capture")
+        logging.info("User requested canceling of capture")
         self.cancelRequested = True
 
     def addLog(self, text):


### PR DESCRIPTION
These changes to make the spelling consistent compile and `ctest` on my local system.  However, _will they break folks who use 3D Slicer by accessing something by the previous spelling?_

These changes are achieved from Linux `bash` with:
```bash
cd Slicer/Slicer
egrep -Ril 'cancell(ed|ing)' * |
    tr \\n \\0 |
    xargs -r0 sed -i -r -e 's/(cancel)l(ed|ing)/\1\2/gi'
```

Also `signalling` -> `signaling` and `labelled` -> `labeled`.