### PR TITLE
ENH: Add loadable warning in case of loading failure

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMBrowser.py
+++ b/Modules/Scripted/DICOMLib/DICOMBrowser.py
@@ -150,7 +150,7 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
 
         self.dicomVisualBrowser.visible = self.useExpertimentalVisualDICOMBrowser
         self.dicomBrowser.visible = not self.useExpertimentalVisualDICOMBrowser
-        self.loadableTableFrame.visible = not self.useExpertimentalVisualDICOMBrowser
+        self.loadableTableFrame.visible = (not self.useExpertimentalVisualDICOMBrowser) and self.advancedView
         self.actionButtonsFrame.visible = not self.useExpertimentalVisualDICOMBrowser
         if self.useExpertimentalVisualDICOMBrowser and self.dicomVisualBrowser.patientsTabWidget().count == 0:
             self.dicomVisualBrowser.onShowPatients()

--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -846,6 +846,7 @@ def getLoadablesFromFileLists(fileLists, pluginClassNames=None, messages=None, p
 def loadLoadables(loadablesByPlugin, messages=None, progressCallback=None):
     """Load each DICOM loadable item.
     Returns loaded node IDs.
+    `loadSuccess` attribute of each loadable is set to True if the load was successful, to False if loading failed.
     """
 
     # Find a plugin for each loadable that will load it
@@ -873,15 +874,20 @@ def loadLoadables(loadablesByPlugin, messages=None, progressCallback=None):
                 break
 
         try:
-            loadSuccess = plugin.load(loadable)
+            loadedNode = plugin.load(loadable)
         except:
-            loadSuccess = False
+            loadedNode = None
             import traceback
             logging.error("DICOM plugin failed to load '"
                           + loadable.name + "' as a '" + plugin.loadType + "'.\n"
                           + traceback.format_exc())
-        if (not loadSuccess) and (messages is not None):
+
+        # Save loading result into message list
+        if (not loadedNode) and (messages is not None):
             messages.append(f"Could not load: {loadable.name} as a {plugin.loadType}")
+
+        # Save loading result into the loadable
+        loadable.loadSuccess = bool(loadedNode)
 
         cancelled = False
         try:


### PR DESCRIPTION
The loadable warning flag can be used to manage loading failure if not empty