### PR TITLE
BUG: Fix home shortcut not working when python console visible

### DIFF
--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -308,6 +308,16 @@ void qSlicerApplicationPrivate::init()
       << "slicer.mrmlScene"
       << "qt.QPushButton";
     q->pythonConsole()->completer()->setAutocompletePreferenceList(autocompletePreferenceList);
+    foreach(QAction* action, q->pythonConsole()->actions())
+      {
+      if (action->shortcut() == QKeySequence("Ctrl+H"))
+        {
+        // Remove action as "Ctrl+H" is reserved for going to the "Home" module
+        q->pythonConsole()->removeAction(action);
+        action->setParent(nullptr);
+        break;
+        }
+      }
     }
 #endif
 


### PR DESCRIPTION
This closes #7154.

This removes the "Ctrl+H" shortcut defined for the ctkConsole so that it does not conflict with the "Ctrl+H" shortcut to go to the Slicer "Home" module.

Currently when the python console is visible "Ctrl+H" does not work for either of the defined slots and the following error is reported: [Qt] QAction::event: Ambiguous shortcut overload: Ctrl+H