### PR TITLE
STYLE: Update ITK to minimize confusion related to image_from_vtk_image support

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -33,7 +33,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "c927a320a7e318556fb00306bae81efe317a12ca" # slicer-v5.3rc04-2022-09-19-62eb5ca
+    "37c5991ee57516c4eb029b4fdc9e119de0a7d794" # slicer-v5.3rc04-2022-09-19-62eb5ca
     QUIET
     )
 


### PR DESCRIPTION
These changes are specific to the ITK Python wheels and are not directly used in Slicer.

They are backported for consistency sake anticipating the integration of the python utility functions supporting ITK image <-> volume node conversion:
* https://github.com/Slicer/Slicer/pull/7094

List of ITK changes:

```
$ git shortlog c927a320a7..37c5991ee5 --no-merges
Dženan Zukić (1):
      [Backport] ENH: Better support for multi-component images in image_from_vtk_image

Jean-Christophe Fillion-Robin (1):
      [Backport] ENH: Ensure 3D multi-components conversion in image_from_vtk_image is tested
```