### PR TITLE
COMP: Fix sphinx build warning in Python FAQ related to unknown "txt" lexer

### DIFF
--- a/Docs/developer_guide/python_faq.md
+++ b/Docs/developer_guide/python_faq.md
@@ -303,7 +303,7 @@ If `Developer mode` is enabled in the application settings then the `Reload and 
 :::{tip}
 On Windows, VS Code text editor is installed by default at:
 
-```txt
+```
 C:/Users/YourUserName/AppData/Local/Programs/Microsoft VS Code/Code.exe
 ```
 :::


### PR DESCRIPTION
Fix the following warning introduced in 44a5f634d (ENH: Allow setting custom editor for .py files (#7074)):

```
/path/to/Slicer/Docs/developer_guide/python_faq.md:306:
WARNING: Pygments lexer name 'txt' is not known
```