### PR TITLE
COMP: Fix extension packaging on macOS accounting for synthetic firmlink

### DIFF
--- a/CMake/SlicerExtensionCPack.cmake
+++ b/CMake/SlicerExtensionCPack.cmake
@@ -194,6 +194,14 @@ if(APPLE)
   set(EXTENSION_SUPERBUILD_DIR ${EXTENSION_SUPERBUILD_BINARY_DIR})
   get_filename_component(Slicer_SUPERBUILD_DIR ${Slicer_DIR}/.. ABSOLUTE)
 
+  # If any, resolve synthetic firmlink  (e.g from "/D/P/A" to "/Users/svc-dashboard/D/P/A")
+  #
+  # Since the output of "otool -L" reports paths with synthetic firmlinks resolved
+  # (see GetPrerequisitesWithRPath), we are using REAL_PATH below to also resolve
+  # Slicer_SUPERBUILD_DIR and ensure that the test in "SlicerExtensionCPackBundleFixup.cmake.in"
+  # checking if "${key}_ITEM" is a library built in Slicer itself work as expected.
+  file(REAL_PATH ${Slicer_SUPERBUILD_DIR} Slicer_SUPERBUILD_DIR)
+
   #------------------------------------------------------------------------------
   # <ExtensionName>_FIXUP_BUNDLE_LIBRARY_DIRECTORIES
   #------------------------------------------------------------------------------


### PR DESCRIPTION
Since the output of `otool -L` reports paths with synthetic firmlinks resolved (see `GetPrerequisitesWithRPath`), we are using the `REAL_PATH` file command to also resolve `Slicer_SUPERBUILD_DIR` and ensure that the test in `SlicerExtensionCPackBundleFixup.cmake.in` checking if `${key}_ITEM` is a library built in Slicer itself work as expected.

To illustrate, copied below is the content of the ImageMaker extension package before/after implementing the fix.

```
$ pwd
/D/P/S-0-E-b/ImageMaker-build/_CPack_Packages/Darwin/TGZ/32140-macosx-amd64-ImageMaker-git6293f99-2017-07-03/Slicer.app/Contents
```

Before:

```
$ find .
.
./Extensions-32140
./Extensions-32140/ImageMaker
./Extensions-32140/ImageMaker/lib
./Extensions-32140/ImageMaker/lib/Slicer-5.5
./Extensions-32140/ImageMaker/lib/Slicer-5.5/cli-modules ./Extensions-32140/ImageMaker/lib/Slicer-5.5/cli-modules/ImageMaker ./Extensions-32140/ImageMaker/lib/Slicer-5.5/cli-modules/libImageMakerLib.dylib ./Extensions-32140/ImageMaker/lib/Slicer-5.5/cli-modules/ImageMaker.xml ./Extensions-32140/ImageMaker/share
./Extensions-32140/ImageMaker/share/Slicer-5.5
./Extensions-32140/ImageMaker/share/Slicer-5.5/ImageMaker.s4ext ./lib
./lib/Slicer-5.5
./lib/Slicer-5.5/libitkopenjpeg-5.3.1.dylib
./lib/Slicer-5.5/libvtkfreetype-9.2.1.dylib
./lib/Slicer-5.5/libITKznz-5.3.1.dylib
./lib/Slicer-5.5/libITKIOJPEG-5.3.1.dylib
[...]
./lib/Slicer-5.5/libvtkglew-9.2.1.dylib
./lib/Slicer-5.5/libITKDeformableMesh-5.3.1.dylib
./lib/Slicer-5.5/libITKTransformFactory-5.3.1.dylib ./lib/Slicer-5.5/libvtkFiltersHybrid-9.2.1.dylib
./lib/Slicer-5.5/libitkhdf5_cpp-shared-5.3.1.dylib
```

After:

```
$ find .
.
./Extensions-32140
./Extensions-32140/ImageMaker
./Extensions-32140/ImageMaker/lib
./Extensions-32140/ImageMaker/lib/Slicer-5.5
./Extensions-32140/ImageMaker/lib/Slicer-5.5/cli-modules ./Extensions-32140/ImageMaker/lib/Slicer-5.5/cli-modules/ImageMaker ./Extensions-32140/ImageMaker/lib/Slicer-5.5/cli-modules/libImageMakerLib.dylib ./Extensions-32140/ImageMaker/lib/Slicer-5.5/cli-modules/ImageMaker.xml ./Extensions-32140/ImageMaker/share
./Extensions-32140/ImageMaker/share/Slicer-5.5
./Extensions-32140/ImageMaker/share/Slicer-5.5/ImageMaker.s4ext
```