### PR TITLE
[5.4] COMP: Fix extension packaging on macOS accounting for synthetic firmlink

### DIFF
--- a/CMake/SlicerExtensionCPack.cmake
+++ b/CMake/SlicerExtensionCPack.cmake
@@ -194,6 +194,14 @@ if(APPLE)
   set(EXTENSION_SUPERBUILD_DIR ${EXTENSION_SUPERBUILD_BINARY_DIR})
   get_filename_component(Slicer_SUPERBUILD_DIR ${Slicer_DIR}/.. ABSOLUTE)
 
+  # If any, resolve synthetic firmlink  (e.g from "/D/P/A" to "/Users/svc-dashboard/D/P/A")
+  #
+  # Since the output of "otool -L" reports paths with synthetic firmlinks resolved
+  # (see GetPrerequisitesWithRPath), we are using REAL_PATH below to also resolve
+  # Slicer_SUPERBUILD_DIR and ensure that the test in "SlicerExtensionCPackBundleFixup.cmake.in"
+  # checking if "${key}_ITEM" is a library built in Slicer itself work as expected.
+  file(REAL_PATH ${Slicer_SUPERBUILD_DIR} Slicer_SUPERBUILD_DIR)
+
   #------------------------------------------------------------------------------
   # <ExtensionName>_FIXUP_BUNDLE_LIBRARY_DIRECTORIES
   #------------------------------------------------------------------------------


### PR DESCRIPTION
Backport of 858c19515f5e4eb69145f0b8c38aa8525b56521f originally introduced through:
* https://github.com/Slicer/Slicer/pull/7181