### PR TITLE
BUG: Include closing segment of closed curve when appropriate.

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
@@ -310,10 +310,12 @@ double vtkMRMLMarkupsCurveNode::GetCurveLength(vtkPoints* curvePoints, bool clos
     vtkGenericWarningMacro("Invalid startCurvePointIndex=" << startCurvePointIndex << ", using 0 instead");
     startCurvePointIndex = 0;
     }
-  vtkIdType lastCurvePointIndex = curvePoints->GetNumberOfPoints()-1;
-  if (numberOfCurvePoints >= 0 && startCurvePointIndex + numberOfCurvePoints - 1 < lastCurvePointIndex)
+  vtkIdType lastCurvePointIndex = curvePoints->GetNumberOfPoints() - 1;
+  bool addClosingSegment = closedCurve & startCurvePointIndex <= lastCurvePointIndex;
+  if (numberOfCurvePoints >= 0 && startCurvePointIndex + numberOfCurvePoints - 1 <= lastCurvePointIndex)
     {
     lastCurvePointIndex = startCurvePointIndex + numberOfCurvePoints - 1;
+    addClosingSegment = false;
     }
 
   double length = 0.0;
@@ -329,7 +331,7 @@ double vtkMRMLMarkupsCurveNode::GetCurveLength(vtkPoints* curvePoints, bool clos
     previousPoint[2] = nextPoint[2];
     }
   // Add length of closing segment
-  if (closedCurve && (numberOfCurvePoints < 0 || numberOfCurvePoints >= curvePoints->GetNumberOfPoints()))
+  if (addClosingSegment)
     {
     curvePoints->GetPoint(0, nextPoint);
     length += sqrt(vtkMath::Distance2BetweenPoints(previousPoint, nextPoint));

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
@@ -305,7 +305,9 @@ double vtkMRMLMarkupsCurveNode::GetCurveLength(vtkPoints* curvePoints, bool clos
     {
     return 0.0;
     }
-  if (startCurvePointIndex >= curvePoints->GetNumberOfPoints() + closedCurve)
+  // In case of closed curve we allow one more point beyond the curve points
+  // (corresponding to the closing segment).
+  if (startCurvePointIndex >= curvePoints->GetNumberOfPoints() + (closedCurve ? 1 : 0))
     {
     // Starts after the last segment
     return 0.0;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
@@ -305,13 +305,18 @@ double vtkMRMLMarkupsCurveNode::GetCurveLength(vtkPoints* curvePoints, bool clos
     {
     return 0.0;
     }
+  if (startCurvePointIndex >= curvePoints->GetNumberOfPoints() + closedCurve)
+    {
+    // Starts after the last segment
+    return 0.0;
+    }
   if (startCurvePointIndex < 0)
     {
     vtkGenericWarningMacro("Invalid startCurvePointIndex=" << startCurvePointIndex << ", using 0 instead");
     startCurvePointIndex = 0;
     }
   vtkIdType lastCurvePointIndex = curvePoints->GetNumberOfPoints() - 1;
-  bool addClosingSegment = closedCurve & startCurvePointIndex <= lastCurvePointIndex;
+  bool addClosingSegment = closedCurve;
   if (numberOfCurvePoints >= 0 && startCurvePointIndex + numberOfCurvePoints - 1 <= lastCurvePointIndex)
     {
     lastCurvePointIndex = startCurvePointIndex + numberOfCurvePoints - 1;


### PR DESCRIPTION
Fix a bug where the closing segment (from the last control point to the first control point) in a closed curve is not incorporated into a `vtkMRMLMarkupsCurveNode::GetCurveLength` computation in all cases that it should be.  Specifically, a computation where
```c++
    startCurvePointIndex <= lastCurvePointIndex &&
    startCurvePointIndex + numberOfCurvePoints - 1 > lastCurvePointIndex
```
should include the closing segment's length even when the requested `numberOfCurvePoints` is not strictly greater than the number of control points.
