### PR TITLE
ENH: Update VTK to support distribution of OpenXRRemoting in extension

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "4341e4825259e17d2acd0e30d2b6f138da10360f") # slicer-v9.2.20230607-1ff325c54
+    set(_git_tag "abbbb1bc3a76e97ff2ea7428dd8bb3156efa5c36") # slicer-v9.2.20230607-1ff325c54
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
List of VTK changes:

```
$ git shortlog 4341e48252..abbbb1bc3a --no-merges
Jean-Christophe Fillion-Robin (1):
      [Backport MR-10449] OpenXRRemoting: Streamline integration as plugin
```