### PR TITLE
ENH: Update VTK to backport OpenXR error handling improvements

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "abbbb1bc3a76e97ff2ea7428dd8bb3156efa5c36") # slicer-v9.2.20230607-1ff325c54
+    set(_git_tag "5c31352993bbcb8ef156881c9cd060d0eb4caa81") # slicer-v9.2.20230607-1ff325c54
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
List of VTK changes:

```
$ git shortlog abbbb1bc3..5c3135299 --no-merges
Jean-Christophe Fillion-Robin (2):
      [Backport MR-10450] OpenXR: Improve XrCheckOutput API fixing constness of level parameter
      [Backport MR-10450] OpenXRRemoting: Fix windows build using XrCheckOutput instead of XrCheckError

Mathieu Westphal (2):
      [Backport MR-10450] OpenXR: Generalize XrCheck* into a single method
      [Backport MR-10450] OpenXR: Downgrade action suggestions to debug output
```