### PR TITLE
ENH: Update VTK backporting RenderingVR and RenderingOpenXR fixes

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "5c31352993bbcb8ef156881c9cd060d0eb4caa81") # slicer-v9.2.20230607-1ff325c54
+    set(_git_tag "b261e0c1b8b679a6af4bcdbbe01ea134750fd472") # slicer-v9.2.20230607-1ff325c54
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
List of changes:

```
$ git shortlog 5c313529..b261e0c1 --no-merges
Alexy Pellegrini (1):
      [Backport] Prevent widgets and floor from being clipped using interactive crop in VR

Jean-Christophe Fillion-Robin (1):
      [Backport MR-10452] OpenXR: Consistently name manifest install sub-directory

Mathieu Westphal (1):
      [Backport] VR: Fix ground movement

Thomas Galland (1):
      [Backport] Update obsolete VR documentation

Tom Birdsong (1):
      [Backport] DOC: Add `OpenVR`, `OpenXR`, and `OpenXRRemoting` README
```