### PR TITLE
DOC: Add security policy document

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,3 +29,16 @@ In general older releases are not updated.
 
 > [!NOTE]
 > There is no restriction on use, but Slicer is NOT approved for clinical use and the distributed application is intended for research use. Permissions and compliance with applicable rules are the responsibility of the user. For details on the license see [here](https://slicer.readthedocs.io/en/latest/user_guide/about.html#license).
+
+## Scope
+
+Reports may pertain to various aspects of the Slicer ecosystem, including:
+
+- Slicer applications, modules and extensions
+- Websites associated with Slicer
+
+> [!NOTE]
+> It's important to acknowledge that our impact on extension developers may be limited, and consequently, we disclaim responsibility for their actions. However, we are committed to forwarding reports to the best of our abilities.
+
+> [!IMPORTANT]
+> While we may not be able to offer legally binding commitments, we will do our best in addressing any reported security concerns.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,11 +18,14 @@ We prefer all communications to be in English.
 
 You can access the most up-to-date Slicer packages through the official [Slicer download](https://download.slicer.org/) website.
 
+This table summarizes our general policy for updates to our binary distributions.
+
 | Version | Support Status     | Update frequency                          |
 | ------- | ------------------ | ----------------------------------------- |
 | Preview | :white_check_mark: | Continual integration of features & fixes |
 | Stable  | :white_check_mark: | Essential security fixes                  |
 
+In general older releases are not updated.
 
 > [!NOTE]
 > There is no restriction on use, but Slicer is NOT approved for clinical use and the distributed application is intended for research use. Permissions and compliance with applicable rules are the responsibility of the user. For details on the license see [here](https://slicer.readthedocs.io/en/latest/user_guide/about.html#license).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security
+
+If you believe you have found a security vulnerability in Slicer, please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, send email to [slicer+security@discoursemail.com](mailto:slicer+security@discoursemail.com).
+
+You should receive a response within 24 hours.
+
+## Preferred Languages
+
+We prefer all communications to be in English.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,3 +13,16 @@ You should receive a response within 24 hours.
 ## Preferred Languages
 
 We prefer all communications to be in English.
+
+## Supported Versions
+
+You can access the most up-to-date Slicer packages through the official [Slicer download](https://download.slicer.org/) website.
+
+| Version | Support Status     | Update frequency                          |
+| ------- | ------------------ | ----------------------------------------- |
+| Preview | :white_check_mark: | Continual integration of features & fixes |
+| Stable  | :white_check_mark: | Essential security fixes                  |
+
+
+> [!NOTE]
+> There is no restriction on use, but Slicer is NOT approved for clinical use and the distributed application is intended for research use. Permissions and compliance with applicable rules are the responsibility of the user. For details on the license see [here](https://slicer.readthedocs.io/en/latest/user_guide/about.html#license).


### PR DESCRIPTION
This pull request follows up https://github.com/Slicer/Slicer/pull/7197 and is expected to address the `Security Policy` warning[^1] reported on our scorecard (as of https://github.com/Slicer/Slicer/commit/9ceb5d25e634ce7bf6438e4c907959e497e9c1b3).

Language was adapted from https://github.com/microsoft/vscode/blob/main/SECURITY.md

### Warning

<img width=50% src="https://github.com/Slicer/Slicer/assets/219043/d1c6837c-cb92-4c6f-b9a0-548db2c55187"/>

[^1]: https://github.com/ossf/scorecard/blob/v4.12.0/docs/checks.md#security-policy

### Reporting Procedure

In this pull request, it assumes we create a private discourse category called `Security` associated with the email `slicer+security@discoursemail.com`

Alternatively, as illustrated below, we could also enable the built-in `private vulnerability reporting`[^2] feature available in GitHub.

[^2]: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability

| | |
|--|--|
| ![image](https://github.com/Slicer/Slicer/assets/219043/2b2f52df-fb65-4bc3-a1d0-5ddbde415a2a) | ![image](https://github.com/Slicer/Slicer/assets/219043/2f4a8bbe-a34f-4e15-90ac-1e2c670ec7bf) |

### References

* https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository
* https://securityscorecards.dev/viewer/?uri=github.com/Slicer/Slicer
