### PR TITLE
ENH: Restrict workflow permissions to "read" for the content scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
   # Allows running this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
   build-slicer:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,6 +3,10 @@
 # https://github.com/codespell-project/codespell
 name: codespell
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   codespell:
     name: Check for spelling errors

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check-commit-message:
     name: Check Commit Message

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/update-slicer-certificate-bundle.yml
+++ b/.github/workflows/update-slicer-certificate-bundle.yml
@@ -6,6 +6,9 @@ on:
     - cron: "30 11 * * 2"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-slicer-certificate-bundle:
     name: Update Slicer.crt certificate bundle


### PR DESCRIPTION
This pull request follows up https://github.com/Slicer/Slicer/pull/7197 and is expected to address the `Token-Permissions` warning[^1] reported on our scorecard (as of https://github.com/Slicer/Slicer/commit/9ceb5d25e634ce7bf6438e4c907959e497e9c1b3).

[^1]: https://github.com/ossf/scorecard/blob/v4.12.0/docs/checks.md#token-permissions

### Workflow

#### `update-slicer-certificate-bundle.yml` / `create-pull-request`

Since the token `secrets.SLICERBOT_GITHUB_TOKEN` is explicitly set for that step, restricting the permissions to "reaD" for the content scope should not be a problem.

#### `ci.yml` / `upload-artifact`

As discussed in the following issue, it is unclear which permission need to be specified:
* https://github.com/actions/upload-artifact/issues/197

Looking through the documentation[^2] and reviewing the code[^3][^4] was not helpful either, outcome of this pull-request should help draw a conclusion.

[^2]: https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28
[^3]: https://github.com/actions/upload-artifact/blob/main/src/upload-artifact.ts
[^4]: See https://github.com/actions/toolkit/blob/3d652d3133965f63309e4b2e1c8852cdbdcb3833/packages/artifact/src/internal/client.ts  where permission is described for all methods except the upload.


### Warning

<img width=50% src="https://github.com/Slicer/Slicer/assets/219043/d1c6837c-cb92-4c6f-b9a0-548db2c55187"/>

### References
* https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
* https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28
* https://securityscorecards.dev/viewer/?uri=github.com/Slicer/Slicer