### PR TITLE
Make text in MRML library translatable

### DIFF
--- a/Base/QTCLI/qSlicerCLIProgressBar.cxx
+++ b/Base/QTCLI/qSlicerCLIProgressBar.cxx
@@ -364,7 +364,7 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
     }
 
   // Update progress
-  d->StatusLabel->setText(node->GetStatusString());
+  d->StatusLabel->setText(QString::fromStdString(node->GetDisplayableStatusString()));
   d->NameLabel->setText(node->GetName());
 
   // Update Progress
@@ -383,7 +383,7 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
       d->ProgressBar->setValue(info->Progress * 100.);
       if (info->ElapsedTime != 0.)
         {
-        d->StatusLabel->setText(statusLabelFormat.arg(node->GetStatusString()).arg(info->ElapsedTime, 0, 'f', 1));
+        d->StatusLabel->setText(statusLabelFormat.arg(QString::fromStdString(node->GetDisplayableStatusString())).arg(info->ElapsedTime, 0, 'f', 1));
         }
       // We keep StageProgressBar maximum at 100, because if it was set to 0
       // then the progress message would not be displayed.
@@ -395,7 +395,7 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
     case vtkMRMLCommandLineModuleNode::CompletedWithErrors:
       if (info->ElapsedTime != 0.)
         {
-        d->StatusLabel->setText(statusLabelFormat.arg(node->GetStatusString()).arg(info->ElapsedTime, 0, 'f', 1));
+        d->StatusLabel->setText(statusLabelFormat.arg(QString::fromStdString(node->GetDisplayableStatusString())).arg(info->ElapsedTime, 0, 'f', 1));
         }
       d->ProgressBar->setMaximum(100);
       d->ProgressBar->setValue(100);

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -16,6 +16,7 @@ Version:   $Revision: 1.2 $
 #include "vtkMRMLCommandLineModuleNode.h"
 
 // MRML includes
+#include "vtkMRMLI18N.h"
 
 /// SlicerExecutionModel includes
 #include <ModuleDescription.h>
@@ -671,6 +672,25 @@ const char* vtkMRMLCommandLineModuleNode::GetStatusString() const
       break;
     }
   return "Unknown";
+}
+
+//----------------------------------------------------------------------------
+std::string vtkMRMLCommandLineModuleNode::GetDisplayableStatusString() const
+{
+  switch (this->Internal->Status)
+  {
+  case Idle: return vtkMRMLTr("vtkMRMLCommandLineModuleNode", "Idle");
+  case Scheduled: return vtkMRMLTr("vtkMRMLCommandLineModuleNode", "Scheduled");
+  case Running: return vtkMRMLTr("vtkMRMLCommandLineModuleNode", "Running");
+  case Cancelling: return vtkMRMLTr("vtkMRMLCommandLineModuleNode", "Cancelling");
+  case Cancelled: return vtkMRMLTr("vtkMRMLCommandLineModuleNode", "Cancelled");
+  case Completing: return vtkMRMLTr("vtkMRMLCommandLineModuleNode", "Completing");
+  case Completed: return vtkMRMLTr("vtkMRMLCommandLineModuleNode", "Completed");
+  case CompletedWithErrors: return vtkMRMLTr("vtkMRMLCommandLineModuleNode", "Completed with errors");
+  default:
+    break;
+  }
+  return vtkMRMLTr("vtkMRMLCommandLineModuleNode", "Unknown");
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
@@ -113,9 +113,13 @@ public:
   /// \sa SetStatus(), GetStatusString(), IsBusy()
   int GetStatus() const;
 
-  /// Return current status as a string for display.
-  /// \sa GetStatus(), IsBusy()
+  /// Return current status as a string. Not translated.
+  /// \sa GetStatus(), IsBusy(), GetDisplayableStatusString()
   const char* GetStatusString() const;
+
+  /// Return current status as a string for display (translated to current language).
+  /// \sa GetStatusString()
+  std::string GetDisplayableStatusString() const;
 
   //@{
   /// Start/stop continuous updating of output and error texts during execution.

--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -139,6 +139,8 @@ set(MRMLCore_SRCS
   vtkCodedEntry.cxx
   vtkEventBroker.cxx
   vtkDataFileFormatHelper.cxx
+  vtkMRMLI18N.cxx
+  vtkMRMLI18N.h
   vtkMRMLMeasurement.cxx
   vtkMRMLStaticMeasurement.cxx
   vtkMRMLLogic.cxx
@@ -221,6 +223,7 @@ set(MRMLCore_SRCS
   vtkMRMLTransformStorageNode.cxx
   vtkMRMLTransformDisplayNode.cxx
   vtkMRMLTransformableNode.cxx
+  vtkMRMLTranslator.h
   vtkMRMLUnitNode.cxx
   vtkMRMLVectorVolumeDisplayNode.cxx
   vtkMRMLViewNode.cxx

--- a/Libs/MRML/Core/Testing/CMakeLists.txt
+++ b/Libs/MRML/Core/Testing/CMakeLists.txt
@@ -31,6 +31,7 @@ create_test_sourcelist(Tests ${KIT}CxxTests.cxx
   vtkMRMLGridTransformNodeTest1.cxx
   vtkMRMLHierarchyNodeTest1.cxx
   vtkMRMLHierarchyNodeTest3.cxx
+  vtkMRMLI18NTest1.cxx
   vtkMRMLInteractionNodeTest1.cxx
   vtkMRMLLabelMapVolumeDisplayNodeTest1.cxx
   vtkMRMLLayoutNodeTest1.cxx

--- a/Libs/MRML/Core/Testing/vtkMRMLI18NTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLI18NTest1.cxx
@@ -1,0 +1,61 @@
+/*=auto=========================================================================
+
+  Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH)
+  All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Program:   3D Slicer
+
+=========================================================================auto=*/
+
+// MRML includes
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLScene.h"
+
+// VTK includes
+#include <vtkMRMLI18N.h>
+#include <vtkMRMLTranslator.h>
+
+namespace
+{
+
+  class vtkTestTranslator : public vtkMRMLTranslator
+  {
+  public:
+    static vtkTestTranslator * New();
+    vtkTypeMacro(vtkTestTranslator, vtkMRMLTranslator);
+
+    /// Translation method for testing that returns "translated-(context)(sourceText)" as translation
+    std::string Translate(const char* context, const char* sourceText, const char* disambiguation = nullptr, int n = -1) override
+      {
+      return std::string("translated-") + context + sourceText;
+      }
+
+  protected:
+    vtkTestTranslator () = default;
+    ~vtkTestTranslator () override = default;
+    vtkTestTranslator (const vtkTestTranslator &) = delete;
+    void operator=(const vtkTestTranslator &) = delete;
+  };
+
+  vtkStandardNewMacro(vtkTestTranslator );
+}
+
+int vtkMRMLI18NTest1(int, char*[])
+{
+  // Check default translation (simply sourcetext is returned)
+  CHECK_STD_STRING(vtkMRMLI18N::Translate("SomeContext", "SomeMessage"), "SomeMessage");
+
+  // Set custom translator
+  vtkNew<vtkTestTranslator> translator;
+  vtkMRMLI18N::GetInstance()->SetTranslator(translator);
+
+  // Check translation with custom translator
+  CHECK_STD_STRING(vtkMRMLI18N::Translate("SomeContext", "SomeMessage"), "translated-SomeContextSomeMessage");
+  // Use translation convenience function
+  CHECK_STD_STRING(vtkMRMLTr("SomeContext", "SomeMessage"), "translated-SomeContextSomeMessage");
+
+  return EXIT_SUCCESS;
+}

--- a/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
@@ -15,6 +15,7 @@ Version:   $Revision: 1.6 $
 // MRML include
 #include "vtkMRMLColorTableStorageNode.h"
 #include "vtkMRMLColorTableNode.h"
+#include "vtkMRMLI18N.h"
 #include "vtkMRMLScene.h"
 
 // VTK include
@@ -315,13 +316,13 @@ int vtkMRMLColorTableStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
 //----------------------------------------------------------------------------
 void vtkMRMLColorTableStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("Color Table (.ctbl)");
-  this->SupportedReadFileTypes->InsertNextValue("Text (.txt)");
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLColorTableStorageNode", "MRML Color Table") + " (.ctbl)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLColorTableStorageNode", "MRML Color Table") + " (.txt)");  //: file format name
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLColorTableStorageNode::InitializeSupportedWriteFileTypes()
 {
-  this->SupportedWriteFileTypes->InsertNextValue("Color Table (.ctbl)");
-  this->SupportedWriteFileTypes->InsertNextValue("Text (.txt)");
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLColorTableStorageNode", "MRML Color Table") + " (.ctbl)");  //: file format name
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLColorTableStorageNode", "MRML Color Table") + " (.txt)");  //: file format name
 }

--- a/Libs/MRML/Core/vtkMRMLI18N.cxx
+++ b/Libs/MRML/Core/vtkMRMLI18N.cxx
@@ -1,0 +1,149 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright(c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// MRML includes
+#include "vtkMRMLI18N.h"
+#include "vtkMRMLTranslator.h"
+
+// VTK includes
+#include <vtkObjectFactory.h>
+
+vtkCxxSetObjectMacro(vtkMRMLI18N, Translator, vtkMRMLTranslator);
+
+//----------------------------------------------------------------------------
+// The i18n manager singleton.
+// This MUST be default initialized to zero by the compiler and is
+// therefore not initialized here.  The ClassInitialize and
+// ClassFinalize methods handle this instance.
+static vtkMRMLI18N* vtkMRMLI18NInstance;
+
+//----------------------------------------------------------------------------
+// Must NOT be initialized.  Default initialization to zero is necessary.
+unsigned int vtkMRMLI18NInitialize::Count;
+
+//----------------------------------------------------------------------------
+// Implementation of vtkMRMLI18NInitialize class.
+//----------------------------------------------------------------------------
+vtkMRMLI18NInitialize::vtkMRMLI18NInitialize()
+{
+  if(++Self::Count == 1)
+    {
+    vtkMRMLI18N::classInitialize();
+    }
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLI18NInitialize::~vtkMRMLI18NInitialize()
+{
+  if(--Self::Count == 0)
+    {
+    vtkMRMLI18N::classFinalize();
+    }
+}
+
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+// Up the reference count so it behaves like New
+vtkMRMLI18N* vtkMRMLI18N::New()
+{
+  vtkMRMLI18N* ret = vtkMRMLI18N::GetInstance();
+  ret->Register(nullptr);
+  return ret;
+}
+
+//----------------------------------------------------------------------------
+// Return the single instance of the vtkMRMLI18N
+vtkMRMLI18N* vtkMRMLI18N::GetInstance()
+{
+  if(!vtkMRMLI18NInstance)
+    {
+    // Try the factory first
+    vtkMRMLI18NInstance = (vtkMRMLI18N*)vtkObjectFactory::CreateInstance("vtkMRMLI18N");
+    // if the factory did not provide one, then create it here
+    if(!vtkMRMLI18NInstance)
+      {
+      vtkMRMLI18NInstance = new vtkMRMLI18N;
+#ifdef VTK_HAS_INITIALIZE_OBJECT_BASE
+      vtkMRMLI18NInstance->InitializeObjectBase();
+#endif
+      }
+    }
+  // return the instance
+  return vtkMRMLI18NInstance;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLI18N::vtkMRMLI18N()
+{
+  this->Translator = nullptr;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLI18N::~vtkMRMLI18N()
+{
+  if (this->Translator)
+    {
+    this->Translator->Delete();
+    }
+  this->Translator = nullptr;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLI18N::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->vtkObject::PrintSelf(os, indent);
+
+  os << indent << "Translator:";
+  if (this->GetTranslator())
+    {
+    this->GetTranslator()->PrintSelf(os, indent.GetNextIndent());
+    }
+  else
+    {
+    os << " (none)" << "\n";
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLI18N::classInitialize()
+{
+  // Allocate the singleton
+  vtkMRMLI18NInstance = vtkMRMLI18N::GetInstance();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLI18N::classFinalize()
+{
+  vtkMRMLI18NInstance->Delete();
+  vtkMRMLI18NInstance = nullptr;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkMRMLI18N::Translate(const char *context, const char *sourceText, const char *disambiguation/*=nullptr*/, int n/*=-1*/)
+{
+  vtkMRMLI18N* i18n = vtkMRMLI18N::GetInstance();
+  vtkMRMLTranslator* translator = i18n ? i18n->GetTranslator() : nullptr;
+  if (translator)
+    {
+    return translator->Translate(context, sourceText, disambiguation, n);
+    }
+  else
+    {
+    return sourceText ? sourceText : "";
+    }
+}

--- a/Libs/MRML/Core/vtkMRMLI18N.h
+++ b/Libs/MRML/Core/vtkMRMLI18N.h
@@ -1,0 +1,98 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright(c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __vtkMRMLI18N_h
+#define __vtkMRMLI18N_h
+
+// MRML includes
+#include "vtkMRML.h"
+
+// VTK includes
+#include <vtkObject.h>
+
+class vtkMRMLTranslator;
+
+/// \brief Class that provide internationalization (i18n) features,
+/// such as language translation or region-specific units and date formatting.
+///
+class VTK_MRML_EXPORT vtkMRMLI18N : public vtkObject
+{
+public:
+  vtkTypeMacro(vtkMRMLI18N, vtkObject);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  ///
+  /// Return the singleton instance with no reference counting.
+  static vtkMRMLI18N* GetInstance();
+
+  ///
+  /// This is a singleton pattern New.  There will only be ONE
+  /// reference to a vtkMRMLI18N object per process.  Clients that
+  /// call this must call Delete on the object so that the reference
+  /// counting will work. The single instance will be unreferenced when
+  /// the program exits.
+  static vtkMRMLI18N* New();
+
+  /// Translate message with the current translator
+  static std::string Translate(const char *context, const char *sourceText, const char *disambiguation = nullptr, int n = -1);
+
+  /// Set translator object. This class takes ownership of the translator
+  /// and it releases it when the process quits.
+  void SetTranslator(vtkMRMLTranslator* translator);
+
+  /// Get translator object that can translate text that is displayed to the user
+  /// to the currently chosen language.
+  vtkGetObjectMacro (Translator, vtkMRMLTranslator);
+
+protected:
+  vtkMRMLI18N();
+  ~vtkMRMLI18N() override;
+  vtkMRMLI18N(const vtkMRMLI18N&);
+  void operator=(const vtkMRMLI18N&);
+
+  ///
+  /// Singleton management functions.
+  static void classInitialize();
+  static void classFinalize();
+
+  friend class vtkMRMLI18NInitialize;
+  typedef vtkMRMLI18N Self;
+
+  vtkMRMLTranslator* Translator{ nullptr };
+};
+
+/// Utility class to make sure qSlicerModuleManager is initialized before it is used.
+class VTK_MRML_EXPORT vtkMRMLI18NInitialize
+{
+public:
+  typedef vtkMRMLI18NInitialize Self;
+
+  vtkMRMLI18NInitialize();
+  ~vtkMRMLI18NInitialize();
+private:
+  static unsigned int Count;
+};
+
+/// This instance will show up in any translation unit that uses
+/// vtkMRMLI18N.  It will make sure vtkMRMLI18N is initialized
+/// before it is used.
+static vtkMRMLI18NInitialize vtkMRMLI18NInitializer;
+
+/// Translation function used in MRML classes
+#define vtkMRMLTr(context, sourceText) vtkMRMLI18N::Translate(context, sourceText)
+
+#endif

--- a/Libs/MRML/Core/vtkMRMLLinearTransformSequenceStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLinearTransformSequenceStorageNode.cxx
@@ -11,6 +11,7 @@ or http://www.slicer.org/copyright/copyright.txt for details.
 #include <algorithm>
 #include <sstream>
 
+#include "vtkMRMLI18N.h"
 #include "vtkMRMLLinearTransformSequenceStorageNode.h"
 #include "vtkMRMLMessageCollection.h"
 #include "vtkMRMLSequenceStorageNode.h"
@@ -598,19 +599,21 @@ int vtkMRMLLinearTransformSequenceStorageNode::WriteDataInternal(vtkMRMLNode *re
 //----------------------------------------------------------------------------
 void vtkMRMLLinearTransformSequenceStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("Linear transform sequence (.seq.mhd)");
-  this->SupportedReadFileTypes->InsertNextValue("Linear transform sequence (.seq.mha)");
-  this->SupportedReadFileTypes->InsertNextValue("Linear transform sequence (.mha)");
-  this->SupportedReadFileTypes->InsertNextValue("Linear transform sequence (.mhd)");
+  std::string fileType = vtkMRMLTr("vtkMRMLLinearTransformSequenceStorageNode", "Linear transform sequence");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.seq.mhd)");
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.seq.mha)");
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.mha)");
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.mhd)");
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLLinearTransformSequenceStorageNode::InitializeSupportedWriteFileTypes()
 {
-  this->SupportedWriteFileTypes->InsertNextValue("Linear transform sequence (.seq.mhd)");
-  this->SupportedWriteFileTypes->InsertNextValue("Linear transform sequence (.seq.mha)");
-  this->SupportedWriteFileTypes->InsertNextValue("Linear transform sequence (.mhd)");
-  this->SupportedWriteFileTypes->InsertNextValue("Linear transform sequence (.mha)");
+  std::string fileType = vtkMRMLTr("vtkMRMLLinearTransformSequenceStorageNode", "Linear transform sequence");  //: file format name
+  this->SupportedWriteFileTypes->InsertNextValue(fileType + " (.seq.mhd)");
+  this->SupportedWriteFileTypes->InsertNextValue(fileType + " (.seq.mha)");
+  this->SupportedWriteFileTypes->InsertNextValue(fileType + " (.mhd)");
+  this->SupportedWriteFileTypes->InsertNextValue(fileType + " (.mha)");
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLModelStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelStorageNode.cxx
@@ -15,6 +15,7 @@
 #include "vtkMRMLModelStorageNode.h"
 
 #include "vtkMRMLDisplayNode.h"
+#include "vtkMRMLI18N.h"
 #include "vtkMRMLMessageCollection.h"
 #include "vtkMRMLModelNode.h"
 #include "vtkMRMLScene.h"
@@ -742,17 +743,17 @@ int vtkMRMLModelStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
 //----------------------------------------------------------------------------
 void vtkMRMLModelStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("Poly Data (.vtk)");
-  this->SupportedReadFileTypes->InsertNextValue("XML Poly Data (.vtp)");
-  this->SupportedReadFileTypes->InsertNextValue("Unstructured Grid (.vtk)");
-  this->SupportedReadFileTypes->InsertNextValue("XML Unstructured Grid (.vtu)");
-  this->SupportedReadFileTypes->InsertNextValue("vtkXMLPolyDataReader (.g)");
-  this->SupportedReadFileTypes->InsertNextValue("BYU (.byu)");
-  this->SupportedReadFileTypes->InsertNextValue("vtkXMLPolyDataReader (.meta)");
-  this->SupportedReadFileTypes->InsertNextValue("STL (.stl)");
-  this->SupportedReadFileTypes->InsertNextValue("PLY (.ply)");
-  this->SupportedReadFileTypes->InsertNextValue("UCD (.ucd)");
-  this->SupportedReadFileTypes->InsertNextValue("Wavefront OBJ (.obj)");
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "VTK Polygon Mesh") + " (.vtk)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "VTK XML Polygon Mesh") + " (.vtp)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "VTK Unstructured Grid") + " (.vtk)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "VTK XML Unstructured Grid") + " (.vtu)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "Movie.BYU Mesh") + " (.g)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "Movie.BYU Mesh") + " (.byu)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "MetaIO Mesh") + " (.meta)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "Stereolithography Mesh") + " (.stl)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "Stanford Polygon Mesh") + " (.ply)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "AVS Unstructured Grid") + " (.ucd)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "Wavefront Mesh") + " (.obj)");  //: file format name
 }
 
 //----------------------------------------------------------------------------
@@ -761,20 +762,20 @@ void vtkMRMLModelStorageNode::InitializeSupportedWriteFileTypes()
   vtkMRMLModelNode* modelNode = this->GetAssociatedDataNode();
   if (!modelNode || modelNode->GetMeshType() == vtkMRMLModelNode::PolyDataMeshType)
     {
-    this->SupportedWriteFileTypes->InsertNextValue("Poly Data (.vtk)");
-    this->SupportedWriteFileTypes->InsertNextValue("XML Poly Data (.vtp)");
+    this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "VTK Polygon Mesh") + " (.vtk)");  //: file format name
+    this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "VTK XML Polygon Mesh") + " (.vtp)");  //: file format name
     // Look at WriteData(), .g and .meta are not being written even though
     // SupportedFileType() says they are supported
-    //this->SupportedWriteFileTypes->InsertNextValue("vtkXMLPolyDataReader (.g)");
-    //this->SupportedWriteFileTypes->InsertNextValue("vtkXMLPolyDataReader (.meta)");
-    this->SupportedWriteFileTypes->InsertNextValue("STL (.stl)");
-    this->SupportedWriteFileTypes->InsertNextValue("PLY (.ply)");
-    this->SupportedWriteFileTypes->InsertNextValue("Wavefront OBJ (.obj)");
+    //this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "Movie.BYU Mesh") + " (.g)");  //: file format name
+    //this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "Movie.BYU Mesh") + " (.meta)");  //: file format name
+    this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "Stereolithography Mesh") + " (.stl)");  //: file format name
+    this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "Stanford Polygon Mesh") + " (.ply)");  //: file format name
+    this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "Wavefront Mesh") + " (.obj)");  //: file format name
     }
   if (!modelNode || modelNode->GetMeshType() == vtkMRMLModelNode::UnstructuredGridMeshType)
     {
-    this->SupportedWriteFileTypes->InsertNextValue("Unstructured Grid (.vtk)");
-    this->SupportedWriteFileTypes->InsertNextValue("XML Unstructured Grid (.vtu)");
+    this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "VTK Unstructured Grid") + " (.vtk)");  //: file format name
+    this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLModelStorageNode", "VTK XML Unstructured Grid") + " (.vtu)");  //: file format name
     }
 }
 

--- a/Libs/MRML/Core/vtkMRMLProceduralColorStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLProceduralColorStorageNode.cxx
@@ -13,6 +13,7 @@ Version:   $Revision: 1.6 $
 =========================================================================auto=*/
 
 // MRML include
+#include "vtkMRMLI18N.h"
 #include "vtkMRMLProceduralColorStorageNode.h"
 #include "vtkMRMLProceduralColorNode.h"
 #include "vtkMRMLScene.h"
@@ -217,13 +218,13 @@ int vtkMRMLProceduralColorStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
 //----------------------------------------------------------------------------
 void vtkMRMLProceduralColorStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("Color Function (.cxml)");
-  this->SupportedReadFileTypes->InsertNextValue("Text (.txt)");
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLProceduralColorStorageNode", "MRML Color Function") + " (.cxml)");   //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLProceduralColorStorageNode", "MRML Color Function") + " (.txt)");  //: file format name
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLProceduralColorStorageNode::InitializeSupportedWriteFileTypes()
 {
-  this->SupportedWriteFileTypes->InsertNextValue("Color Function (.cxml)");
-  this->SupportedWriteFileTypes->InsertNextValue("Text (.txt)");
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLProceduralColorStorageNode", "MRML Color Function") + " (.cxml)");  //: file format name
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLProceduralColorStorageNode", "MRML Color Function") + " (.txt)");  //: file format name
 }

--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -26,6 +26,7 @@
 #include "vtkOrientedImageDataResample.h"
 
 // MRML includes
+#include "vtkMRMLI18N.h"
 #include "vtkMRMLMessageCollection.h"
 #include <vtkMRMLScalarVolumeNode.h>
 #include <vtkMRMLScene.h>
@@ -142,14 +143,15 @@ void vtkMRMLSegmentationStorageNode::Copy(vtkMRMLNode *anode)
 //----------------------------------------------------------------------------
 void vtkMRMLSegmentationStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("Segmentation (.seg.nrrd)");
-  this->SupportedReadFileTypes->InsertNextValue("Segmentation (.seg.nhdr)");
-  this->SupportedReadFileTypes->InsertNextValue("Segmentation (.seg.vtm)");
-  this->SupportedReadFileTypes->InsertNextValue("Segmentation (.nrrd)");
-  this->SupportedReadFileTypes->InsertNextValue("Segmentation (.vtm)");
-  this->SupportedReadFileTypes->InsertNextValue("Segmentation (.nii.gz)");
-  this->SupportedReadFileTypes->InsertNextValue("Segmentation (.hdr)");
-  this->SupportedReadFileTypes->InsertNextValue("Segmentation (.nii)");
+  std::string fileType = vtkMRMLTr("vtkMRMLSegmentationStorageNode", "Segmentation");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.seg.nrrd)");
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.seg.nhdr)");
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.seg.vtm)");
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.nrrd)");
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.vtm)");
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.nii.gz)");
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.hdr)");
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.nii)");
 }
 
 //----------------------------------------------------------------------------
@@ -171,17 +173,18 @@ void vtkMRMLSegmentationStorageNode::InitializeSupportedWriteFileTypes()
       masterIsPolyData = true;
       }
     }
+  std::string fileType = vtkMRMLTr("vtkMRMLSegmentationStorageNode", "Segmentation");  //: file format name
   if (masterIsImage)
     {
-    this->SupportedWriteFileTypes->InsertNextValue("Segmentation (.seg.nrrd)");
-    this->SupportedWriteFileTypes->InsertNextValue("Segmentation (.seg.nhdr)");
-    this->SupportedWriteFileTypes->InsertNextValue("Segmentation (.nrrd)");
-    this->SupportedWriteFileTypes->InsertNextValue("Segmentation (.nhdr)");
+    this->SupportedWriteFileTypes->InsertNextValue(fileType + " (.seg.nrrd)");
+    this->SupportedWriteFileTypes->InsertNextValue(fileType + " (.seg.nhdr)");
+    this->SupportedWriteFileTypes->InsertNextValue(fileType + " (.nrrd)");
+    this->SupportedWriteFileTypes->InsertNextValue(fileType + " (.nhdr)");
     }
   if (masterIsPolyData)
     {
-    this->SupportedWriteFileTypes->InsertNextValue("Segmentation (.seg.vtm)");
-    this->SupportedWriteFileTypes->InsertNextValue("Segmentation (.vtm)");
+    this->SupportedWriteFileTypes->InsertNextValue(fileType + " (.seg.vtm)");
+    this->SupportedWriteFileTypes->InsertNextValue(fileType + " (.vtm)");
     }
 }
 

--- a/Libs/MRML/Core/vtkMRMLSequenceStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSequenceStorageNode.cxx
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "vtkMRMLSequenceStorageNode.h"
 
+#include "vtkMRMLI18N.h"
 #include "vtkMRMLMessageCollection.h"
 #include "vtkMRMLSequenceNode.h"
 #include "vtkMRMLScene.h"
@@ -204,15 +205,15 @@ int vtkMRMLSequenceStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
 //----------------------------------------------------------------------------
 void vtkMRMLSequenceStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("Sequence Bundle (.seq.mrb)");
-  this->SupportedReadFileTypes->InsertNextValue("Medical Reality Bundle (.mrb)");
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLSequenceStorageNode", "MRML Sequence Bundle") + " (.seq.mrb)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLSequenceStorageNode", "MRML Sequence Bundle") + " (.mrb)");  //: file format name
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLSequenceStorageNode::InitializeSupportedWriteFileTypes()
 {
-  this->SupportedWriteFileTypes->InsertNextValue("Sequence Bundle (.seq.mrb)");
-  this->SupportedWriteFileTypes->InsertNextValue("Medical Reality Bundle (.mrb)");
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLSequenceStorageNode", "MRML Sequence Bundle") + " (.seq.mrb)");  //: file format name
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLSequenceStorageNode", "MRML Sequence Bundle") + " (.mrb)");  //: file format name
 }
 
 //----------------------------------------------------------------------------
@@ -220,8 +221,6 @@ const char* vtkMRMLSequenceStorageNode::GetDefaultWriteFileExtension()
 {
   return "seq.mrb";
 }
-
-
 
 //----------------------------------------------------------------------------
 std::string vtkMRMLSequenceStorageNode::GetSequenceBaseName(const std::string& fileNameName, const std::string& itemName)

--- a/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.cxx
@@ -21,6 +21,7 @@
 ==============================================================================*/
 
 // MRML includes
+#include "vtkMRMLI18N.h"
 #include "vtkMRMLTableSQLiteStorageNode.h"
 #include "vtkMRMLTableNode.h"
 #include "vtkMRMLScene.h"
@@ -302,17 +303,19 @@ int vtkMRMLTableSQLiteStorageNode::DropTable(char *tableName, vtkSQLiteDatabase*
 //----------------------------------------------------------------------------
 void vtkMRMLTableSQLiteStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("SQLight database (.db)");
-  this->SupportedReadFileTypes->InsertNextValue("SQLight database (.db3)");
-  this->SupportedReadFileTypes->InsertNextValue("SQLight database (.sqlite)");
-  this->SupportedReadFileTypes->InsertNextValue("SQLight database (.sqlite3)");
+  std::string dbStr = vtkMRMLTr("vtkMRMLTableSQLiteStorageNode", "SQLight database");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(dbStr + " (.db)");
+  this->SupportedReadFileTypes->InsertNextValue(dbStr + " (.db3)");
+  this->SupportedReadFileTypes->InsertNextValue(dbStr + " (.sqlite)");
+  this->SupportedReadFileTypes->InsertNextValue(dbStr + " (.sqlite3)");
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLTableSQLiteStorageNode::InitializeSupportedWriteFileTypes()
 {
-  this->SupportedWriteFileTypes->InsertNextValue("SQLight database (.db)");
-  this->SupportedWriteFileTypes->InsertNextValue("SQLight database (.db3)");
-  this->SupportedWriteFileTypes->InsertNextValue("SQLight database (.sqlite)");
-  this->SupportedWriteFileTypes->InsertNextValue("SQLight database (.sqlite3)");
+  std::string dbStr = vtkMRMLTr("vtkMRMLTableSQLiteStorageNode", "SQLight database");  //: file format name
+  this->SupportedWriteFileTypes->InsertNextValue(dbStr + " (.db)");
+  this->SupportedWriteFileTypes->InsertNextValue(dbStr + " (.db3)");
+  this->SupportedWriteFileTypes->InsertNextValue(dbStr + " (.sqlite)");
+  this->SupportedWriteFileTypes->InsertNextValue(dbStr + " (.sqlite3)");
 }

--- a/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx
@@ -21,6 +21,7 @@
 ==============================================================================*/
 
 // MRML includes
+#include "vtkMRMLI18N.h"
 #include "vtkMRMLMessageCollection.h"
 #include "vtkMRMLTableStorageNode.h"
 #include "vtkMRMLTableNode.h"
@@ -224,17 +225,17 @@ int vtkMRMLTableStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
 //----------------------------------------------------------------------------
 void vtkMRMLTableStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("Tab-separated values (.tsv)");
-  this->SupportedReadFileTypes->InsertNextValue("Comma-separated values (.csv)");
-  this->SupportedReadFileTypes->InsertNextValue("Text (.txt)");
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLTableStorageNode", "Tab-separated values") + " (.tsv)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLTableStorageNode", "Comma-separated values") + " (.csv)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLTableStorageNode", "Tab-separated values") + " (.txt)");  //: file format name
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLTableStorageNode::InitializeSupportedWriteFileTypes()
 {
-  this->SupportedWriteFileTypes->InsertNextValue("Tab-separated values (.tsv)");
-  this->SupportedWriteFileTypes->InsertNextValue("Comma-separated values (.csv)");
-  this->SupportedWriteFileTypes->InsertNextValue("Text (.txt)");
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLTableStorageNode", "Tab-separated values") + " (.tsv)");  //: file format name
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLTableStorageNode", "Comma-separated values") + " (.csv)");  //: file format name
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLTableStorageNode", "Tab-separated values") + " (.txt)");  //: file format name
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLTextStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTextStorageNode.cxx
@@ -27,6 +27,7 @@
 #include "vtkMRMLTextStorageNode.h"
 
 // MRML includes
+#include "vtkMRMLI18N.h"
 #include "vtkMRMLScene.h"
 
 // VTK includes
@@ -149,17 +150,17 @@ int vtkMRMLTextStorageNode::WriteDataInternal(vtkMRMLNode * refNode)
 //----------------------------------------------------------------------------
 void vtkMRMLTextStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("Text file (.txt)");
-  this->SupportedReadFileTypes->InsertNextValue("XML document (.xml)");
-  this->SupportedReadFileTypes->InsertNextValue("JSON document (.json)");
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLTextStorageNode", "Text file") + " (.txt)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLTextStorageNode", "XML document") + " (.xml)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLTextStorageNode", "JSON document") + " (.json)");  //: file format name
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLTextStorageNode::InitializeSupportedWriteFileTypes()
 {
-  this->SupportedWriteFileTypes->InsertNextValue("Text file (.txt)");
-  this->SupportedWriteFileTypes->InsertNextValue("XML document (.xml)");
-  this->SupportedWriteFileTypes->InsertNextValue("JSON document (.json)");
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLTextStorageNode", "Text file") + " (.txt)");  //: file format name
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLTextStorageNode", "XML document") + " (.xml)");  //: file format name
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLTextStorageNode", "JSON document") + " (.json)");  //: file format name
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLTranslator.h
+++ b/Libs/MRML/Core/vtkMRMLTranslator.h
@@ -1,0 +1,49 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright(c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __vtkMRMLTranslator_h
+#define __vtkMRMLTranslator_h
+
+// MRML includes
+#include "vtkMRML.h"
+
+// VTK includes
+#include <vtkObject.h>
+
+// STD includes
+#include <string>
+
+/// \brief Base class for localization of messages that may be displayed to users.
+///
+/// This base class keeps messages unchanged. Sub-classes must implement actual translation.
+class VTK_MRML_EXPORT vtkMRMLTranslator : public vtkObject
+{
+public:
+  vtkTypeMacro(vtkMRMLTranslator, vtkObject);
+
+  /// Default translation function that returns the sourceText without any change.
+  /// This method must be overridden in derived classes.
+  virtual std::string Translate(const char *context, const char *sourceText, const char *disambiguation = nullptr, int n = -1) = 0;
+
+protected:
+  vtkMRMLTranslator() = default;
+  ~vtkMRMLTranslator() override = default;
+  vtkMRMLTranslator(const vtkMRMLTranslator&) = delete;
+  void operator=(const vtkMRMLTranslator&) = delete;
+};
+
+#endif

--- a/Libs/MRML/Core/vtkMRMLVolumeSequenceStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeSequenceStorageNode.cxx
@@ -11,6 +11,7 @@ or http://www.slicer.org/copyright/copyright.txt for details.
 
 #include <vtkAddonMathUtilities.h>
 
+#include "vtkMRMLI18N.h"
 #include "vtkMRMLMessageCollection.h"
 #include "vtkMRMLVolumeSequenceStorageNode.h"
 
@@ -587,19 +588,21 @@ int vtkMRMLVolumeSequenceStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
 //----------------------------------------------------------------------------
 void vtkMRMLVolumeSequenceStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("Volume sequence (.seq.nrrd)");
-  this->SupportedReadFileTypes->InsertNextValue("Volume sequence (.seq.nhdr)");
-  this->SupportedReadFileTypes->InsertNextValue("Volume sequence (.nrrd)");
-  this->SupportedReadFileTypes->InsertNextValue("Volume sequence (.nhdr)");
+  std::string fileType = vtkMRMLTr("vtkMRMLVolumeSequenceStorageNode", "Volume Sequence");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.seq.nrrd)");
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.seq.nhdr)");
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.nrrd)");
+  this->SupportedReadFileTypes->InsertNextValue(fileType + " (.nhdr)");
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLVolumeSequenceStorageNode::InitializeSupportedWriteFileTypes()
 {
-  this->SupportedWriteFileTypes->InsertNextValue("Volume sequence (.seq.nrrd)");
-  this->SupportedWriteFileTypes->InsertNextValue("Volume sequence (.seq.nhdr)");
-  this->SupportedWriteFileTypes->InsertNextValue("Volume sequence (.nrrd)");
-  this->SupportedWriteFileTypes->InsertNextValue("Volume sequence (.nhdr)");
+  std::string fileType = vtkMRMLTr("vtkMRMLVolumeSequenceStorageNode", "Volume Sequence");  //: file format name
+  this->SupportedWriteFileTypes->InsertNextValue(fileType + " (.seq.nrrd)");
+  this->SupportedWriteFileTypes->InsertNextValue(fileType + " (.seq.nhdr)");
+  this->SupportedWriteFileTypes->InsertNextValue(fileType + " (.nrrd)");
+  this->SupportedWriteFileTypes->InsertNextValue(fileType + " (.nhdr)");
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -18,6 +18,7 @@
 #include "vtkMRMLMarkupsFiducialStorageNode.h"
 #include "vtkMRMLMarkupsNode.h"
 
+#include "vtkMRMLI18N.h"
 #include "vtkMRMLScene.h"
 #include "vtkMRMLMessageCollection.h"
 #include "vtkSlicerVersionConfigureMinimal.h"
@@ -784,14 +785,14 @@ int vtkMRMLMarkupsFiducialStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
 //----------------------------------------------------------------------------
 void vtkMRMLMarkupsFiducialStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("Markups Fiducial CSV (.fcsv)");
-  this->SupportedReadFileTypes->InsertNextValue("Annotation Fiducial CSV (.acsv)");
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLMarkupsFiducialStorageNode", "Markups Fiducial CSV") + " (.fcsv)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLMarkupsFiducialStorageNode", "Annotation Fiducial CSV") + " (.acsv)");  //: file format name
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLMarkupsFiducialStorageNode::InitializeSupportedWriteFileTypes()
 {
-  this->SupportedWriteFileTypes->InsertNextValue("Markups Fiducial CSV (.fcsv)");
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLMarkupsFiducialStorageNode", "Markups Fiducial CSV") + " (.fcsv)");  //: file format name
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
@@ -25,6 +25,7 @@
 #include "vtkMRMLStaticMeasurement.h"
 #include "vtkMRMLUnitNode.h"
 
+#include "vtkMRMLI18N.h"
 #include "vtkMRMLScene.h"
 
 #include "vtkDoubleArray.h"
@@ -341,15 +342,15 @@ int vtkMRMLMarkupsJsonStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
 //----------------------------------------------------------------------------
 void vtkMRMLMarkupsJsonStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("Markups JSON (.mrk.json)");
-  this->SupportedReadFileTypes->InsertNextValue("Markups JSON (.json)");
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLMarkupsJsonStorageNode", "Markups JSON") + " (.mrk.json)");  //: file format name
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLMarkupsJsonStorageNode", "Markups JSON") + " (.json)");  //: file format name
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLMarkupsJsonStorageNode::InitializeSupportedWriteFileTypes()
 {
-  this->SupportedWriteFileTypes->InsertNextValue("Markups JSON (.mrk.json)");
-  this->SupportedWriteFileTypes->InsertNextValue("Markups JSON (.json)");
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLMarkupsJsonStorageNode", "Markups JSON") + " (.mrk.json)");  //: file format name
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLMarkupsJsonStorageNode", "Markups JSON") + " (.json)");  //: file format name
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyStorageNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyStorageNode.cxx
@@ -23,6 +23,7 @@
 #include "vtkMRMLShaderPropertyStorageNode.h"
 
 // MRML includes
+#include "vtkMRMLI18N.h"
 #include "vtkMRMLScene.h"
 
 // VTK includes
@@ -485,12 +486,11 @@ int vtkMRMLShaderPropertyStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
 //----------------------------------------------------------------------------
 void vtkMRMLShaderPropertyStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("Shader Property (.sp)");
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLShaderPropertyStorageNode", "MRML Shader Property") + " (.sp)");  //: file format name
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLShaderPropertyStorageNode::InitializeSupportedWriteFileTypes()
 {
-  this->SupportedWriteFileTypes->InsertNextValue("Shader Property (.sp)");
-  this->SupportedWriteFileTypes->InsertNextValue("Shader Property (.*)");
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLShaderPropertyStorageNode", "MRML Shader Property") + " (.sp)");  //: file format name
 }

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyStorageNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyStorageNode.cxx
@@ -14,6 +14,7 @@ Version:   $Revision: 1.2 $
 
 #include "vtkMRMLVolumePropertyNode.h"
 #include "vtkMRMLVolumePropertyStorageNode.h"
+#include "vtkMRMLI18N.h"
 #include "vtkMRMLScene.h"
 
 #include <vtkColorTransferFunction.h>
@@ -215,13 +216,12 @@ int vtkMRMLVolumePropertyStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
 //----------------------------------------------------------------------------
 void vtkMRMLVolumePropertyStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("VolumeProperty (.vp)");
+  this->SupportedReadFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLVolumePropertyStorageNode", "MRML Volume Property") + " (.vp)");  //: file format name
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLVolumePropertyStorageNode::InitializeSupportedWriteFileTypes()
 {
-  this->SupportedWriteFileTypes->InsertNextValue("VolumeProperty (.vp)");
-  this->SupportedWriteFileTypes->InsertNextValue("Text (.txt)");
-  this->SupportedWriteFileTypes->InsertNextValue("VolumeProperty (.*)");
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLVolumePropertyStorageNode", "MRML Volume Property") + " (.vp)");  //: file format name
+  this->SupportedWriteFileTypes->InsertNextValue(vtkMRMLTr("vtkMRMLVolumePropertyStorageNode", "MRML Volume Property") + " (.txt)");  //: file format name
 }


### PR DESCRIPTION
Allows using Qt translation infrastructure in MRML to translate text, without directly depending on Qt.

Fixes https://github.com/Slicer/Slicer/issues/6647
