### PR TITLE
Empty folder SH visibility

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/CMakeLists.txt
@@ -49,6 +49,8 @@ set(${KIT}_SRCS
   qSlicerSubjectHierarchyVisibilityPlugin.h
   qSlicerSubjectHierarchyExportPlugin.cxx
   qSlicerSubjectHierarchyExportPlugin.h
+  qSlicerSubjectHierarchyExpandToDepthPlugin.cxx
+  qSlicerSubjectHierarchyExpandToDepthPlugin.h
   )
 if(Slicer_USE_PYTHONQT)
   list(APPEND ${KIT}_SRCS
@@ -74,6 +76,7 @@ set(${KIT}_MOC_SRCS
   qMRMLSubjectHierarchyModel.h
   qMRMLSortFilterSubjectHierarchyProxyModel.h
   qSlicerSubjectHierarchyExportPlugin.h
+  qSlicerSubjectHierarchyExpandToDepthPlugin.h
   )
 if(Slicer_USE_PYTHONQT)
   list(APPEND ${KIT}_MOC_SRCS

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSortFilterSubjectHierarchyProxyModel.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSortFilterSubjectHierarchyProxyModel.cxx
@@ -1001,10 +1001,19 @@ qMRMLSortFilterSubjectHierarchyProxyModel::AcceptType qMRMLSortFilterSubjectHier
       }
     }
 
-  // Hide hierarchy item if none of its children are accepted and the corresponding filter is turned on
-  if (!d->ShowEmptyHierarchyItems && (!dataNode || dataNode->IsA("vtkMRMLFolderDisplayNode")))
+  if (!dataNode || dataNode->IsA("vtkMRMLFolderDisplayNode"))
     {
-    onlyAcceptIfAnyChildIsAccepted = true;
+    if (d->ShowEmptyHierarchyItems)
+      {
+      // Reset this flag if item is a hierarchy item and it should be shown even if empty.
+      // (The flag may have been set before if node type filter was set, which did not include the folder display node)
+      onlyAcceptIfAnyChildIsAccepted = false;
+      }
+    else
+      {
+      // Hide hierarchy item if none of its children are accepted and the corresponding filter is turned on
+      onlyAcceptIfAnyChildIsAccepted = true;
+      }
     }
 
   // If the visibility of an item depends on whether any of its children are shown, then evaluate that condition

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -2633,6 +2633,9 @@ void qMRMLSubjectHierarchyTreeView::onCustomContextMenu(const QPoint& point)
       }
     }
 
+  // Save tree view for the plugins to access if needed
+  qSlicerSubjectHierarchyPluginHandler::instance()->setCurrentTreeView(this);
+
   // Get subject hierarchy item at mouse click position
   vtkIdType itemID = this->sortFilterProxyModel()->subjectHierarchyItemFromIndex(index);
   // Populate context menu for the current item

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -125,7 +125,6 @@ public:
   QAction* SelectPluginAction;
   QMenu* SelectPluginSubMenu;
   QActionGroup* SelectPluginActionGroup;
-  QAction* ExpandToDepthAction;
   QMenu* SceneMenu;
   QMenu* VisibilityMenu;
   QStringList PluginAllowlist;
@@ -185,7 +184,6 @@ qMRMLSubjectHierarchyTreeViewPrivate::qMRMLSubjectHierarchyTreeViewPrivate(qMRML
   , SelectPluginAction(nullptr)
   , SelectPluginSubMenu(nullptr)
   , SelectPluginActionGroup(nullptr)
-  , ExpandToDepthAction(nullptr)
   , SceneMenu(nullptr)
   , VisibilityMenu(nullptr)
   , SubjectHierarchyNode(nullptr)
@@ -368,30 +366,6 @@ void qMRMLSubjectHierarchyTreeViewPrivate::setupActions()
   nodeMenuActions.append(this->HideAction);
   nodeMenuActions.append(this->ShowAction);
   nodeMenuActions.append(this->ToggleVisibilityAction);
-
-  // Set up expand to level action and its menu
-  this->ExpandToDepthAction = new QAction(qMRMLSubjectHierarchyTreeView::tr("Expand tree to level..."), this->SceneMenu);
-  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->ExpandToDepthAction,
-    qSlicerSubjectHierarchyAbstractPlugin::SectionFolder, 10);
-  sceneMenuActions.append(this->ExpandToDepthAction);
-
-  QMenu* expandToDepthSubMenu = new QMenu();
-  this->ExpandToDepthAction->setMenu(expandToDepthSubMenu);
-  QAction* expandToDepth_1 = new QAction("1",q);
-  QObject::connect(expandToDepth_1, SIGNAL(triggered()), q, SLOT(expandToDepthFromContextMenu()));
-  expandToDepthSubMenu->addAction(expandToDepth_1);
-  this->ExpandToDepthAction->setMenu(expandToDepthSubMenu);
-  QAction* expandToDepth_2 = new QAction("2",q);
-  QObject::connect(expandToDepth_2, SIGNAL(triggered()), q, SLOT(expandToDepthFromContextMenu()));
-  expandToDepthSubMenu->addAction(expandToDepth_2);
-  this->ExpandToDepthAction->setMenu(expandToDepthSubMenu);
-  QAction* expandToDepth_3 = new QAction("3",q);
-  QObject::connect(expandToDepth_3, SIGNAL(triggered()), q, SLOT(expandToDepthFromContextMenu()));
-  expandToDepthSubMenu->addAction(expandToDepth_3);
-  this->ExpandToDepthAction->setMenu(expandToDepthSubMenu);
-  QAction* expandToDepth_4 = new QAction("4",q);
-  QObject::connect(expandToDepth_4, SIGNAL(triggered()), q, SLOT(expandToDepthFromContextMenu()));
-  expandToDepthSubMenu->addAction(expandToDepth_4);
 
   // Perform tasks needed for all plugins
   foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, this->enabledPlugins())
@@ -2115,20 +2089,6 @@ void qMRMLSubjectHierarchyTreeView::toggleVisibilityOfSelectedItems()
 {
   Q_D(qMRMLSubjectHierarchyTreeView);
   d->setVisibilityOfSelectedItems(qMRMLSubjectHierarchyTreeViewPrivate::ToggleVisibility);
-}
-
-//--------------------------------------------------------------------------
-void qMRMLSubjectHierarchyTreeView::expandToDepthFromContextMenu()
-{
-  QAction* senderAction = qobject_cast<QAction*>(this->sender());
-  if (!senderAction)
-    {
-    qCritical() << Q_FUNC_INFO << ": Unable to get sender action";
-    return;
-    }
-
-  int depth = senderAction->text().toInt();
-  this->expandToDepth(depth);
 }
 
 //--------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
@@ -323,9 +323,6 @@ protected slots:
   /// Updates subject hierarchy item expanded property when item is collapsed
   virtual void onItemCollapsed(const QModelIndex &collapsedItemIndex);
 
-  /// Expand tree to depth specified by the clicked context menu action
-  virtual void expandToDepthFromContextMenu();
-
   /// Update root item to restore view
   /// (e.g. after tree was updated in the model from the subject hierarchy)
   virtual void updateRootItem();

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyExpandToDepthPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyExpandToDepthPlugin.cxx
@@ -1,0 +1,156 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) EBATINCA, S.L., Las Palmas de Gran Canaria, Spain.
+  All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, EBATINCA, S.L.
+
+==============================================================================*/
+
+// SubjectHierarchy MRML includes
+#include "vtkMRMLSubjectHierarchyNode.h"
+
+// SubjectHierarchy Widgets includes
+#include "qMRMLSubjectHierarchyTreeView.h"
+#include "qSlicerSubjectHierarchyPluginHandler.h"
+#include "qSlicerSubjectHierarchyExpandToDepthPlugin.h"
+#include "qSlicerSubjectHierarchyFolderPlugin.h"
+
+// Qt includes
+#include <QAction>
+#include <QDebug>
+#include <QMenu>
+
+//-----------------------------------------------------------------------------
+/// \ingroup Slicer_QtModules_SubjectHierarchy_Widgets
+class qSlicerSubjectHierarchyExpandToDepthPluginPrivate: public QObject
+{
+  Q_DECLARE_PUBLIC(qSlicerSubjectHierarchyExpandToDepthPlugin);
+protected:
+  qSlicerSubjectHierarchyExpandToDepthPlugin* const q_ptr;
+public:
+  qSlicerSubjectHierarchyExpandToDepthPluginPrivate(qSlicerSubjectHierarchyExpandToDepthPlugin& object);
+  ~qSlicerSubjectHierarchyExpandToDepthPluginPrivate() override;
+  void init();
+public:
+  QAction* ExpandToDepthAction;
+};
+
+//-----------------------------------------------------------------------------
+// qSlicerSubjectHierarchyExpandToDepthPluginPrivate methods
+
+//-----------------------------------------------------------------------------
+qSlicerSubjectHierarchyExpandToDepthPluginPrivate::qSlicerSubjectHierarchyExpandToDepthPluginPrivate(qSlicerSubjectHierarchyExpandToDepthPlugin& object)
+: q_ptr(&object)
+, ExpandToDepthAction(nullptr)
+{
+}
+
+//------------------------------------------------------------------------------
+void qSlicerSubjectHierarchyExpandToDepthPluginPrivate::init()
+{
+  Q_Q(qSlicerSubjectHierarchyExpandToDepthPlugin);
+
+  // Set up expand to level action and its menu
+  this->ExpandToDepthAction = new QAction(qMRMLSubjectHierarchyTreeView::tr("Expand tree to level..."), q);
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->ExpandToDepthAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionFolder, 10);
+  //sceneMenuActions.append(this->ExpandToDepthAction);
+
+  QMenu* expandToDepthSubMenu = new QMenu();
+  this->ExpandToDepthAction->setMenu(expandToDepthSubMenu);
+  QAction* expandToDepth_1 = new QAction("1",q);
+  QObject::connect(expandToDepth_1, SIGNAL(triggered()), q, SLOT(expandToDepthFromContextMenu()));
+  expandToDepthSubMenu->addAction(expandToDepth_1);
+  this->ExpandToDepthAction->setMenu(expandToDepthSubMenu);
+  QAction* expandToDepth_2 = new QAction("2",q);
+  QObject::connect(expandToDepth_2, SIGNAL(triggered()), q, SLOT(expandToDepthFromContextMenu()));
+  expandToDepthSubMenu->addAction(expandToDepth_2);
+  this->ExpandToDepthAction->setMenu(expandToDepthSubMenu);
+  QAction* expandToDepth_3 = new QAction("3",q);
+  QObject::connect(expandToDepth_3, SIGNAL(triggered()), q, SLOT(expandToDepthFromContextMenu()));
+  expandToDepthSubMenu->addAction(expandToDepth_3);
+  this->ExpandToDepthAction->setMenu(expandToDepthSubMenu);
+  QAction* expandToDepth_4 = new QAction("4",q);
+  QObject::connect(expandToDepth_4, SIGNAL(triggered()), q, SLOT(expandToDepthFromContextMenu()));
+  expandToDepthSubMenu->addAction(expandToDepth_4);
+}
+
+//-----------------------------------------------------------------------------
+qSlicerSubjectHierarchyExpandToDepthPluginPrivate::~qSlicerSubjectHierarchyExpandToDepthPluginPrivate() = default;
+
+//-----------------------------------------------------------------------------
+// qSlicerSubjectHierarchyExpandToDepthPlugin methods
+
+//-----------------------------------------------------------------------------
+qSlicerSubjectHierarchyExpandToDepthPlugin::qSlicerSubjectHierarchyExpandToDepthPlugin(QObject* parent)
+ : Superclass(parent)
+ , d_ptr( new qSlicerSubjectHierarchyExpandToDepthPluginPrivate(*this) )
+{
+  this->m_Name = QString("ExpandToDepth");
+
+  Q_D(qSlicerSubjectHierarchyExpandToDepthPlugin);
+  d->init();
+}
+
+//-----------------------------------------------------------------------------
+qSlicerSubjectHierarchyExpandToDepthPlugin::~qSlicerSubjectHierarchyExpandToDepthPlugin() = default;
+
+//-----------------------------------------------------------------------------
+QList<QAction*> qSlicerSubjectHierarchyExpandToDepthPlugin::sceneContextMenuActions()const
+{
+  Q_D(const qSlicerSubjectHierarchyExpandToDepthPlugin);
+
+  QList<QAction*> actions;
+  actions << d->ExpandToDepthAction;
+  return actions;
+}
+
+//---------------------------------------------------------------------------
+void qSlicerSubjectHierarchyExpandToDepthPlugin::showContextMenuActionsForItem(vtkIdType itemID)
+{
+  vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();
+  if (!shNode)
+    {
+    qCritical() << Q_FUNC_INFO << ": Failed to access subject hierarchy node";
+    return;
+    }
+
+  Q_D(qSlicerSubjectHierarchyExpandToDepthPlugin);
+
+  // Scene
+  if (itemID == shNode->GetSceneItemID())
+    {
+    d->ExpandToDepthAction->setVisible(true);
+    }
+}
+
+//--------------------------------------------------------------------------
+void qSlicerSubjectHierarchyExpandToDepthPlugin::expandToDepthFromContextMenu()
+{
+  QAction* senderAction = qobject_cast<QAction*>(this->sender());
+  if (!senderAction)
+    {
+    qCritical() << Q_FUNC_INFO << ": Unable to get sender action";
+    return;
+    }
+
+  int depth = senderAction->text().toInt();
+
+  qMRMLSubjectHierarchyTreeView* currentTreeView = qSlicerSubjectHierarchyPluginHandler::instance()->currentTreeView();
+  if (currentTreeView)
+    {
+    currentTreeView->expandToDepth(depth);
+    }
+}

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyExpandToDepthPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyExpandToDepthPlugin.h
@@ -1,0 +1,64 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) EBATINCA, S.L., Las Palmas de Gran Canaria, Spain.
+  All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, EBATINCA, S.L.
+
+==============================================================================*/
+
+#ifndef __qSlicerSubjectHierarchyExpandToDepthPlugin_h
+#define __qSlicerSubjectHierarchyExpandToDepthPlugin_h
+
+// SubjectHierarchy Plugins includes
+#include "qSlicerSubjectHierarchyAbstractPlugin.h"
+
+#include "qSlicerSubjectHierarchyModuleWidgetsExport.h"
+
+class qSlicerSubjectHierarchyExpandToDepthPluginPrivate;
+
+/// \ingroup Slicer_QtModules_SubjectHierarchy_Widgets
+class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qSlicerSubjectHierarchyExpandToDepthPlugin : public qSlicerSubjectHierarchyAbstractPlugin
+{
+public:
+  Q_OBJECT
+
+public:
+  typedef qSlicerSubjectHierarchyAbstractPlugin Superclass;
+  qSlicerSubjectHierarchyExpandToDepthPlugin(QObject* parent = nullptr);
+  ~qSlicerSubjectHierarchyExpandToDepthPlugin() override;
+
+public:
+  /// Get scene context menu item actions to add to tree view
+  /// Separate method is needed for the scene, as its actions are set to the
+  /// tree by a different method \sa itemContextMenuActions
+  QList<QAction*> sceneContextMenuActions()const override;
+
+  /// Show context menu actions valid for a given subject hierarchy item.
+  /// \param itemID Subject Hierarchy item to show the context menu items for
+  void showContextMenuActionsForItem(vtkIdType itemID) override;
+
+public slots:
+  /// Expand tree to depth specified by the clicked context menu action
+  virtual void expandToDepthFromContextMenu();
+
+protected:
+  QScopedPointer<qSlicerSubjectHierarchyExpandToDepthPluginPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerSubjectHierarchyExpandToDepthPlugin);
+  Q_DISABLE_COPY(qSlicerSubjectHierarchyExpandToDepthPlugin);
+};
+
+#endif

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.h
@@ -31,6 +31,7 @@
 // CTK includes
 #include <ctkVTKObject.h>
 
+class qMRMLSubjectHierarchyTreeView;
 class qSlicerSubjectHierarchyFolderPluginPrivate;
 
 class vtkMRMLDisplayNode;
@@ -149,6 +150,10 @@ public:
   /// node, then create a display node associated to that. Otherwise create display node for folder item
   vtkMRMLDisplayNode* createDisplayNodeForItem(vtkIdType itemID);
 
+  /// Add tree view to the list of view from which empty folders have been created.
+  /// This function is called from the DICOM plugin, which can create patient and study items (which are special folders).
+  void emptyFolderCreatedFromTreeView(qMRMLSubjectHierarchyTreeView* treeView);
+
 protected slots:
   /// Create folder node under the scene
   void createFolderUnderScene();
@@ -158,6 +163,9 @@ protected slots:
 
   /// Toggle apply color to branch
   void onApplyColorToBranchToggled(bool);
+
+  /// Toggle empty folder visibility (\sa showEmptyHierarchyItems) in the sort filter proxy model of the current tree view.
+  void onShowEmptyFoldersToggled(bool);
 
 protected:
   /// Retrieve model display node for given item. If the folder item has an associated model display
@@ -169,6 +177,10 @@ protected:
   bool isApplyColorToBranchEnabledForItem(vtkIdType itemID)const;
   /// Determine if apply color to branch option is enabled to a given item or not
   void setApplyColorToBranchEnabledForItem(vtkIdType itemID, bool enabled);
+
+  /// Update show empty folders context menu item visibility and checked state.
+  /// The update needs to happen in more than one place, which is handled by this method.
+  void updateShowEmptyFoldersAction();
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyFolderPluginPrivate> d_ptr;

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
@@ -486,7 +486,7 @@ void qSlicerSubjectHierarchyPluginHandler::setCurrentItem(vtkIdType itemID)
 }
 
 //-----------------------------------------------------------------------------
-vtkIdType qSlicerSubjectHierarchyPluginHandler::currentItem()
+vtkIdType qSlicerSubjectHierarchyPluginHandler::currentItem()const
 {
   if (this->m_CurrentItems.size() != 1)
     {
@@ -502,13 +502,13 @@ void qSlicerSubjectHierarchyPluginHandler::setCurrentItems(QList<vtkIdType> item
 }
 
 //-----------------------------------------------------------------------------
-QList<vtkIdType> qSlicerSubjectHierarchyPluginHandler::currentItems()
+QList<vtkIdType> qSlicerSubjectHierarchyPluginHandler::currentItems()const
 {
   return this->m_CurrentItems;
 }
 
 //------------------------------------------------------------------------------
-void qSlicerSubjectHierarchyPluginHandler::currentItems(vtkIdList* selectedItems)
+void qSlicerSubjectHierarchyPluginHandler::currentItems(vtkIdList* selectedItems)const
 {
   if (!selectedItems)
     {
@@ -520,6 +520,18 @@ void qSlicerSubjectHierarchyPluginHandler::currentItems(vtkIdList* selectedItems
     {
     selectedItems->InsertNextId(item);
     }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSubjectHierarchyPluginHandler::setCurrentTreeView(qMRMLSubjectHierarchyTreeView* treeView)
+{
+  this->m_CurrentTreeView = treeView;
+}
+
+//-----------------------------------------------------------------------------
+qMRMLSubjectHierarchyTreeView* qSlicerSubjectHierarchyPluginHandler::currentTreeView()const
+{
+  return this->m_CurrentTreeView;
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.h
@@ -42,6 +42,7 @@
 
 class vtkMRMLScene;
 class vtkCallbackCommand;
+class qMRMLSubjectHierarchyTreeView;
 class qSlicerSubjectHierarchyPluginLogic;
 class qSlicerSubjectHierarchyAbstractPlugin;
 class qSlicerSubjectHierarchyDefaultPlugin;
@@ -106,7 +107,7 @@ public:
   /// IMPORTANT NOTE: This function is solely used for plugin-provided context menus. This is NOT to be used for getting the
   ///                 selected item of individual widgets (tree views, comboboxes).
   /// \return Current item if only one is selected, otherwise INVALID_ITEM_ID
-  Q_INVOKABLE vtkIdType currentItem();
+  Q_INVOKABLE vtkIdType currentItem()const;
 
   /// Set current subject hierarchy items in case of multi-selection
   /// IMPORTANT NOTE: This function will not change the selection in individual widgets (tree views, comboboxes). This is
@@ -116,8 +117,14 @@ public:
   /// Get current subject hierarchy items in case of multi-selection
   /// IMPORTANT NOTE: This function is solely used for plugin-provided context menus. This is NOT to be used for getting the
   ///                 selected items of individual widgets (tree views, comboboxes).
-  Q_INVOKABLE QList<vtkIdType> currentItems();
-  Q_INVOKABLE void currentItems(vtkIdList* selectedItems);
+  Q_INVOKABLE QList<vtkIdType> currentItems()const;
+  Q_INVOKABLE void currentItems(vtkIdList* selectedItems)const;
+
+  /// Set current tree view. The tree view where context menu was requested sets this.
+  /// It allows accessing the tree view the user is using.
+  Q_INVOKABLE void setCurrentTreeView(qMRMLSubjectHierarchyTreeView* treeView);
+  /// Get current tree view.
+  Q_INVOKABLE qMRMLSubjectHierarchyTreeView* currentTreeView()const;
 
   Q_INVOKABLE bool autoDeleteSubjectHierarchyChildren()const;
   Q_INVOKABLE void setAutoDeleteSubjectHierarchyChildren(bool flag);
@@ -216,6 +223,9 @@ protected:
   /// Current subject hierarchy item(s)
   /// (selected items in the tree view e.g. for context menu request)
   QList<vtkIdType> m_CurrentItems;
+
+  /// Most recently right-clicked subject hierarchy tree view
+  qMRMLSubjectHierarchyTreeView* m_CurrentTreeView{nullptr};
 
   /// MRML scene (to get new subject hierarchy node if the stored one is deleted)
   vtkWeakPointer<vtkMRMLScene> m_MRMLScene;

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
@@ -37,6 +37,7 @@
 #include "qSlicerSubjectHierarchyViewContextMenuPlugin.h"
 #include "qSlicerSubjectHierarchyVisibilityPlugin.h"
 #include "qSlicerSubjectHierarchyExportPlugin.h"
+#include "qSlicerSubjectHierarchyExpandToDepthPlugin.h"
 
 // MRML includes
 #include "vtkMRMLAbstractViewNode.h"
@@ -149,6 +150,8 @@ void qSlicerSubjectHierarchyPluginLogic::registerCorePlugins()
     new qSlicerSubjectHierarchyVisibilityPlugin());
   qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(
     new qSlicerSubjectHierarchyExportPlugin());
+  qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(
+    new qSlicerSubjectHierarchyExpandToDepthPlugin());
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
- The SH tree view saves the "current tree view" pointer in the SH plugin handler
- When the user creates a new folder, the folder plugin enables showing empty folders in the sort filter proxy model of the current tree view, and stores the tree view pointer in a list
- Right-clicking on scene or any item, the folder plugin shows a new "Show empty folders" action if the user has created a new folder from that tree view (i.e. the current tree view is in the list)
- The DICOM plugin (providing the Subject and Study hierarchy items) behaves the same way as the Folder plugin
- New plugin created for the Expand to depth feature (used to be a core SH tree view feature)