### PR TITLE
ENH: Remove fixed size buttons in view controller for better restyling

### DIFF
--- a/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx
@@ -113,7 +113,6 @@ void qMRMLPlotViewControllerWidgetPrivate::init()
   this->FitToWindowToolButton = new QToolButton(q);
   this->FitToWindowToolButton->setAutoRaise(true);
   this->FitToWindowToolButton->setDefaultAction(this->actionFit_to_window);
-  this->FitToWindowToolButton->setIconSize(QSize(12, 12));
   this->BarLayout->insertWidget(2, this->FitToWindowToolButton);
 }
 

--- a/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx
@@ -113,7 +113,7 @@ void qMRMLPlotViewControllerWidgetPrivate::init()
   this->FitToWindowToolButton = new QToolButton(q);
   this->FitToWindowToolButton->setAutoRaise(true);
   this->FitToWindowToolButton->setDefaultAction(this->actionFit_to_window);
-  this->FitToWindowToolButton->setFixedSize(15, 15);
+  this->FitToWindowToolButton->setIconSize(QSize(12, 12));
   this->BarLayout->insertWidget(2, this->FitToWindowToolButton);
 }
 

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -117,11 +117,8 @@ qMRMLSliceControllerWidgetPrivate::~qMRMLSliceControllerWidgetPrivate() = defaul
 //---------------------------------------------------------------------------
 void qMRMLSliceControllerWidgetPrivate::setColor(QColor barColor)
 {
-  //this->SliceOffsetSlider->spinBox()->setAutoFillBackground(true);
   this->Superclass::setColor(barColor);
-  QPalette spinBoxPalette( this->SliceOffsetSlider->spinBox()->palette());
-  spinBoxPalette.setColor(QPalette::Base, barColor.lighter(130));
-  this->SliceOffsetSlider->spinBox()->setPalette(spinBoxPalette);
+  this->SliceOffsetSlider->spinBox()->setStyleSheet("background-color: transparent");
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -390,7 +390,6 @@ void qMRMLSliceControllerWidgetPrivate::init()
   //this->FitToWindowToolButton->setIcon(fitToWindowIcon);
   this->FitToWindowToolButton->setAutoRaise(true);
   this->FitToWindowToolButton->setDefaultAction(this->actionFit_to_window);
-  this->FitToWindowToolButton->setIconSize(QSize(12, 12));
   this->BarLayout->insertWidget(2, this->FitToWindowToolButton);
 
   this->SliderSpacer = new ctkDynamicSpacer(q);

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -390,7 +390,7 @@ void qMRMLSliceControllerWidgetPrivate::init()
   //this->FitToWindowToolButton->setIcon(fitToWindowIcon);
   this->FitToWindowToolButton->setAutoRaise(true);
   this->FitToWindowToolButton->setDefaultAction(this->actionFit_to_window);
-  this->FitToWindowToolButton->setFixedSize(15, 15);
+  this->FitToWindowToolButton->setIconSize(QSize(12, 12));
   this->BarLayout->insertWidget(2, this->FitToWindowToolButton);
 
   this->SliderSpacer = new ctkDynamicSpacer(q);

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -273,7 +273,6 @@ void qMRMLThreeDViewControllerWidgetPrivate::init()
   this->CenterToolButton = new QToolButton(q);
   this->CenterToolButton->setAutoRaise(true);
   this->CenterToolButton->setDefaultAction(this->actionCenter);
-  this->CenterToolButton->setIconSize(QSize(12, 12));
   this->CenterToolButton->setObjectName("CenterButton_Header");
   this->BarLayout->insertWidget(2, this->CenterToolButton);
 

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -273,7 +273,7 @@ void qMRMLThreeDViewControllerWidgetPrivate::init()
   this->CenterToolButton = new QToolButton(q);
   this->CenterToolButton->setAutoRaise(true);
   this->CenterToolButton->setDefaultAction(this->actionCenter);
-  this->CenterToolButton->setFixedSize(15, 15);
+  this->CenterToolButton->setIconSize(QSize(12, 12));
   this->CenterToolButton->setObjectName("CenterButton_Header");
   this->BarLayout->insertWidget(2, this->CenterToolButton);
 

--- a/Libs/MRML/Widgets/qMRMLViewControllerBar.cxx
+++ b/Libs/MRML/Widgets/qMRMLViewControllerBar.cxx
@@ -103,7 +103,6 @@ void qMRMLViewControllerBarPrivate::init()
   this->PinButton->setObjectName("PinButton");
   this->PinButton->setCheckable(true);
   this->PinButton->setAutoRaise(true);
-  this->PinButton->setIconSize(QSize(12, 12));
   QIcon pushPinIcon;
   pushPinIcon.addFile(":/Icons/PushPinIn.png", QSize(), QIcon::Normal, QIcon::On);
   pushPinIcon.addFile(":/Icons/PushPinOut.png", QSize(), QIcon::Normal, QIcon::Off);
@@ -130,7 +129,6 @@ void qMRMLViewControllerBarPrivate::init()
   this->MaximizeViewButton->setObjectName("MaximizeViewButton");
   this->MaximizeViewButton->setToolTip(tr("Maximize/restore view"));
   this->MaximizeViewButton->setAutoRaise(true);
-  this->MaximizeViewButton->setIconSize(QSize(12, 12));
   this->MaximizeViewButton->setIcon(this->ViewMaximizeIcon);
   this->BarLayout->addWidget(this->MaximizeViewButton);
   QObject::connect(this->MaximizeViewButton, SIGNAL(clicked()), q, SLOT(maximizeView()));

--- a/Libs/MRML/Widgets/qMRMLViewControllerBar.cxx
+++ b/Libs/MRML/Widgets/qMRMLViewControllerBar.cxx
@@ -121,7 +121,6 @@ void qMRMLViewControllerBarPrivate::init()
 #else
   this->ViewLabel->setMinimumWidth(this->ViewLabel->fontMetrics().width("XX"));
 #endif
-  this->ViewLabel->setAutoFillBackground(true);
   this->BarLayout->addWidget(this->ViewLabel);
 
   this->ViewMaximizeIcon = QIcon(":Icons/ViewMaximize.png");

--- a/Libs/MRML/Widgets/qMRMLViewControllerBar.cxx
+++ b/Libs/MRML/Widgets/qMRMLViewControllerBar.cxx
@@ -103,7 +103,7 @@ void qMRMLViewControllerBarPrivate::init()
   this->PinButton->setObjectName("PinButton");
   this->PinButton->setCheckable(true);
   this->PinButton->setAutoRaise(true);
-  this->PinButton->setFixedSize(15, 15);
+  this->PinButton->setIconSize(QSize(12, 12));
   QIcon pushPinIcon;
   pushPinIcon.addFile(":/Icons/PushPinIn.png", QSize(), QIcon::Normal, QIcon::On);
   pushPinIcon.addFile(":/Icons/PushPinOut.png", QSize(), QIcon::Normal, QIcon::Off);
@@ -130,7 +130,7 @@ void qMRMLViewControllerBarPrivate::init()
   this->MaximizeViewButton->setObjectName("MaximizeViewButton");
   this->MaximizeViewButton->setToolTip(tr("Maximize/restore view"));
   this->MaximizeViewButton->setAutoRaise(true);
-  this->MaximizeViewButton->setFixedSize(15, 15);
+  this->MaximizeViewButton->setIconSize(QSize(12, 12));
   this->MaximizeViewButton->setIcon(this->ViewMaximizeIcon);
   this->BarLayout->addWidget(this->MaximizeViewButton);
   QObject::connect(this->MaximizeViewButton, SIGNAL(clicked()), q, SLOT(maximizeView()));


### PR DESCRIPTION
If restyling ToolButtons as a whole through QSS with a fixed vertical size set, but a variable width allowed, the fixed size specification in qMRMLViewControllerBar was still forcing these buttons to be 15px wide.

| `main` | This PR |
|--------|----------|
|![image](https://github.com/Slicer/Slicer/assets/15837524/37f1351e-a30d-4c19-a063-52df2a026466)|![image](https://github.com/Slicer/Slicer/assets/15837524/a113dd03-010a-4bb2-83ff-81f32ed4454a)|

Now these buttons are sized based on their contents which in this case is their icon. This results in a slightly different spacing and sizing as previously the FixedSize call was actually cutting off part of the ToolButton's normal margin/padding. However I think the end result is near identical and functionally acts the same. This change ultimately allows for better ways of restyling QToolButtons through QSS.

---------------------------------------
I could also issue a separate change to allow these QToolButton's in the slice view controller to be their default size based on their normal 24px icons (remove any fixed size or iconSize specifications for these QToolButtons). This will result in the buttons being the same size as those in the Slice controller floating pop-up widget which I think is more consistent and the larger size buttons make the accessibility better to avoid mis-clicks and speeds up the time it takes to click successfully. It would look like the following:

| `main` | Default size for 24px icon |
|--------|----------|
![image](https://github.com/Slicer/Slicer/assets/15837524/cd5ae01d-a8c6-4136-b9fc-ad7e0e0cd7d1)|![image](https://github.com/Slicer/Slicer/assets/15837524/db7f8720-ebab-4996-b1c9-45593bc6a451)|
