### PR TITLE
Support 3D rendering of segmentation using Surface Nets

### DIFF
--- a/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.h
+++ b/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.h
@@ -56,6 +56,10 @@ public:
   /// Joint smoothing converts all segments in shared labelmap together, reducing smoothing artifacts.
   static const std::string GetJointSmoothingParameterName() { return "Joint smoothing"; };
 
+  // Conversion methods
+  static const std::string CONVERSION_METHOD_FLYING_EDGES;
+  static const std::string CONVERSION_METHOD_SURFACE_NETS;
+
 public:
   static vtkBinaryLabelmapToClosedSurfaceConversionRule* New();
   vtkTypeMacro(vtkBinaryLabelmapToClosedSurfaceConversionRule, vtkSegmentationConverterRule);

--- a/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.h
+++ b/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.h
@@ -43,6 +43,12 @@ public:
   static const std::string GetDecimationFactorParameterName() { return "Decimation factor"; };
   /// Conversion parameter: smoothing factor
   static const std::string GetSmoothingFactorParameterName() { return "Smoothing factor"; };
+  /// Conversion parameter: Conversion method (flying edges or surface nets)
+  static const std::string GetConversionMethodParameterName() { return "Conversion method"; };
+  /// Conversion parameter: SurfaceNets smoothing
+  /// If SurfaceNets smoothing is enabled, the smoothing available within the SurfaceNets
+  /// filter and based of vtkConstrainedSmoothingFilter is used.
+  static const std::string GetSurfaceNetInternalSmoothingParameterName() { return "SurfaceNets smoothing"; };
   /// Conversion parameter: compute surface normals
   static const std::string GetComputeSurfaceNormalsParameterName() { return "Compute surface normals"; };
   /// Conversion parameter: joint smoothing

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationShow3DButton.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationShow3DButton.cxx
@@ -44,7 +44,15 @@ public:
   /// if it is enabled.
   bool setSurfaceSmoothingFactor(double smoothingFactor);
 
+  /// Updates the method used to generate the surface representation
+  bool setConversionMethod(int conversionMethod);
+
+  /// This property holds whether smoothing internal to surface nets filter is used
+  bool setInternalSmoothing(int internalSmoothing);
+
   QAction* SurfaceSmoothingEnabledAction{ nullptr };
+  QAction* SurfaceNetsEnableAction{ nullptr };
+  QAction* SurfaceNetsSmoothingEnableAction{ nullptr };
   ctkSliderWidget* SurfaceSmoothingSlider{ nullptr };
   bool Locked{ false };
   vtkWeakPointer<vtkMRMLSegmentationNode> SegmentationNode;
@@ -79,8 +87,27 @@ void qMRMLSegmentationShow3DButtonPrivate::init()
   QObject::connect(this->SurfaceSmoothingEnabledAction, SIGNAL(toggled(bool)), q, SLOT(onEnableSurfaceSmoothingToggled(bool)));
 
   QMenu* surfaceSmoothingFactorMenu = new QMenu(qMRMLSegmentationShow3DButton::tr("Smoothing factor"), show3DButtonMenu);
-  surfaceSmoothingFactorMenu->setObjectName("slicerSpacingManualMode");
-  surfaceSmoothingFactorMenu->setIcon(QIcon(":/Icon/SlicerManualSliceSpacing.png"));
+  surfaceSmoothingFactorMenu->setObjectName("surfaceSmoothingFactorMenu");
+
+  // Add menu for experimental features
+  QMenu* experimentalMenu = new QMenu(qMRMLSegmentationShow3DButton::tr("Experimental"), show3DButtonMenu);
+  experimentalMenu->setObjectName("show3DExperimentalMenu");
+
+  // Toggle for using surface nets instead of Flying Edges
+  this->SurfaceNetsEnableAction = new QAction(qMRMLSegmentationShow3DButton::tr("Use Surface Nets (fast)"), experimentalMenu);
+  this->SurfaceNetsEnableAction->setToolTip(
+    qMRMLSegmentationShow3DButton::tr("Create closed surface using surface nets. By default, flying edges is used. Surface nets are more performant."));
+  this->SurfaceNetsEnableAction->setCheckable(true);
+  experimentalMenu->addAction(this->SurfaceNetsEnableAction);
+  QObject::connect(this->SurfaceNetsEnableAction, SIGNAL(toggled(bool)), q, SLOT(onEnableSurfaceNetsToggled(bool)));
+
+  // Toggle for using surface nets internal smoothing algorithm instead of vtkWindowedSincPolyDataFilter
+  this->SurfaceNetsSmoothingEnableAction = new QAction(qMRMLSegmentationShow3DButton::tr("Use Surface Nets Smoothing (faster)"), experimentalMenu);
+  this->SurfaceNetsSmoothingEnableAction->setToolTip(
+    qMRMLSegmentationShow3DButton::tr("Use surface nets internal smoothing (more performant). vtkWindowedSincPolyDataFilter is used by default."));
+  this->SurfaceNetsSmoothingEnableAction->setCheckable(true);
+  experimentalMenu->addAction(this->SurfaceNetsSmoothingEnableAction);
+  QObject::connect(this->SurfaceNetsSmoothingEnableAction, SIGNAL(toggled(bool)), q, SLOT(onEnableSurfaceNetsSmoothingToggled(bool)));
 
   this->SurfaceSmoothingSlider = new ctkSliderWidget(surfaceSmoothingFactorMenu);
   this->SurfaceSmoothingSlider->setToolTip(
@@ -96,10 +123,10 @@ void qMRMLSegmentationShow3DButtonPrivate::init()
   smoothingFactorAction->setCheckable(true);
   smoothingFactorAction->setDefaultWidget(this->SurfaceSmoothingSlider);
   surfaceSmoothingFactorMenu->addAction(smoothingFactorAction);
+
   show3DButtonMenu->addMenu(surfaceSmoothingFactorMenu);
-
+  show3DButtonMenu->addMenu(experimentalMenu);
   q->setMenu(show3DButtonMenu);
-
   q->setEnabled(false);
 }
 
@@ -129,6 +156,61 @@ bool qMRMLSegmentationShow3DButtonPrivate::setSurfaceSmoothingFactor(double smoo
     }
   return true;
 }
+
+//-----------------------------------------------------------------------------
+bool qMRMLSegmentationShow3DButtonPrivate::setConversionMethod(int conversionMethod)
+{
+  if (!this->SegmentationNode || !this->SegmentationNode->GetSegmentation())
+    {
+    return false;
+    }
+
+  MRMLNodeModifyBlocker blocker(this->SegmentationNode);
+
+  this->SegmentationNode->GetSegmentation()->SetConversionParameter(
+    vtkBinaryLabelmapToClosedSurfaceConversionRule::GetConversionMethodParameterName(),
+    QVariant(conversionMethod).toString().toUtf8().constData());
+
+  bool closedSurfacePresent = this->SegmentationNode->GetSegmentation()->ContainsRepresentation(
+    vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName());
+  if (closedSurfacePresent)
+    {
+    QApplication::setOverrideCursor(QCursor(Qt::BusyCursor));
+    this->SegmentationNode->GetSegmentation()->CreateRepresentation(
+      vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName(), true);
+    this->SegmentationNode->Modified();
+    QApplication::restoreOverrideCursor();
+    }
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLSegmentationShow3DButtonPrivate::setInternalSmoothing(int internalSmoothing)
+{
+  if (!this->SegmentationNode || !this->SegmentationNode->GetSegmentation())
+    {
+    return false;
+    }
+
+  MRMLNodeModifyBlocker blocker(this->SegmentationNode);
+
+  this->SegmentationNode->GetSegmentation()->SetConversionParameter(
+    vtkBinaryLabelmapToClosedSurfaceConversionRule::GetSurfaceNetInternalSmoothingParameterName(),
+    QVariant(internalSmoothing).toString().toUtf8().constData());
+
+  bool closedSurfacePresent = this->SegmentationNode->GetSegmentation()->ContainsRepresentation(
+    vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName());
+  if (closedSurfacePresent)
+    {
+    QApplication::setOverrideCursor(QCursor(Qt::BusyCursor));
+    this->SegmentationNode->GetSegmentation()->CreateRepresentation(
+      vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName(), true);
+    this->SegmentationNode->Modified();
+    QApplication::restoreOverrideCursor();
+    }
+  return true;
+}
+
 
 //-----------------------------------------------------------------------------
 vtkMRMLSegmentationNode* qMRMLSegmentationShow3DButton::segmentationNode() const
@@ -184,6 +266,7 @@ void qMRMLSegmentationShow3DButton::updateWidgetFromMRML()
     this->setEnabled(false);
     }
 
+  // Smoothing factor
   double surfaceSmoothingFactor = 0.5;
   if (d->SegmentationNode && d->SegmentationNode->GetSegmentation())
     {
@@ -198,6 +281,29 @@ void qMRMLSegmentationShow3DButton::updateWidgetFromMRML()
   d->SurfaceSmoothingSlider->setValue(surfaceSmoothingFactor);
   d->SurfaceSmoothingSlider->setEnabled(surfaceSmoothingFactor >= 0.0);
   d->SurfaceSmoothingSlider->blockSignals(wasBlocked);
+
+  // Conversion method
+  int conversionMethod = 0;
+  if (d->SegmentationNode && d->SegmentationNode->GetSegmentation())
+    {
+    conversionMethod = QString(d->SegmentationNode->GetSegmentation()->GetConversionParameter(
+      vtkBinaryLabelmapToClosedSurfaceConversionRule::GetConversionMethodParameterName()).c_str()).toInt();
+    }
+  wasBlocked = d->SurfaceNetsEnableAction->blockSignals(true);
+  d->SurfaceNetsEnableAction->setChecked(conversionMethod == 1);
+  d->SurfaceNetsEnableAction->blockSignals(wasBlocked);
+
+  // SurfaceNets smoothing
+  int surfaceNetinternalSmoothing = 0;
+  if (d->SegmentationNode && d->SegmentationNode->GetSegmentation())
+    {
+    surfaceNetinternalSmoothing = QString(d->SegmentationNode->GetSegmentation()->GetConversionParameter(
+      vtkBinaryLabelmapToClosedSurfaceConversionRule::GetSurfaceNetInternalSmoothingParameterName()).c_str()).toInt();
+    }
+  wasBlocked = d->SurfaceNetsSmoothingEnableAction->blockSignals(true);
+  d->SurfaceNetsSmoothingEnableAction->setChecked(surfaceNetinternalSmoothing == 1);
+  d->SurfaceNetsSmoothingEnableAction->setEnabled(surfaceSmoothingFactor >= 0.0 && conversionMethod == 1);
+  d->SurfaceNetsSmoothingEnableAction->blockSignals(wasBlocked);
 }
 
 //-----------------------------------------------------------------------------
@@ -290,6 +396,64 @@ void qMRMLSegmentationShow3DButton::onEnableSurfaceSmoothingToggled(bool smoothi
   if (newSmoothingFactor != originalSmoothingFactor)
     {
     d->setSurfaceSmoothingFactor(newSmoothingFactor);
+    this->updateWidgetFromMRML();
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationShow3DButton::onEnableSurfaceNetsToggled(bool surfaceNetsEnabled)
+{
+  Q_D(qMRMLSegmentationShow3DButton);
+  if (!d->SegmentationNode || !d->SegmentationNode->GetSegmentation())
+    {
+    qCritical() << Q_FUNC_INFO << ": No segmentation selected in onEnableSurfaceNetsToggled";
+    return;
+    }
+
+  // Get current conversion method
+  // 0 = flying edges
+  // 1 = Surface nets
+  int originalMethod = QString(d->SegmentationNode->GetSegmentation()->GetConversionParameter(
+    vtkBinaryLabelmapToClosedSurfaceConversionRule::GetConversionMethodParameterName()).c_str()).toInt();
+  int newMethod = 0;
+  if (surfaceNetsEnabled)
+    {
+    newMethod = 1;
+    }
+
+  // Set conversion method
+  if (newMethod != originalMethod)
+    {
+    d->setConversionMethod(newMethod);
+    this->updateWidgetFromMRML();
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationShow3DButton::onEnableSurfaceNetsSmoothingToggled(bool surfaceNetsSmoothingEnabled)
+{
+  Q_D(qMRMLSegmentationShow3DButton);
+  if (!d->SegmentationNode || !d->SegmentationNode->GetSegmentation())
+    {
+    qCritical() << Q_FUNC_INFO << ": No segmentation selected in onEnableSurfaceNetsSmoothingToggled";
+    return;
+    }
+
+  // Get current conversion method
+  // 0 = use vtkWindowedSincPolyDataFilter for smoothing
+  // 1 = Use surface nets internal smoothing
+  int originalMethod = QString(d->SegmentationNode->GetSegmentation()->GetConversionParameter(
+    vtkBinaryLabelmapToClosedSurfaceConversionRule::GetSurfaceNetInternalSmoothingParameterName()).c_str()).toInt();
+  int newMethod = 0;
+  if (surfaceNetsSmoothingEnabled)
+    {
+    newMethod = 1;
+    }
+
+  // Set conversion method
+  if (newMethod != originalMethod)
+    {
+    d->setInternalSmoothing(newMethod);
     this->updateWidgetFromMRML();
     }
 }

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationShow3DButton.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationShow3DButton.h
@@ -53,6 +53,8 @@ public slots:
 protected slots:
   void onToggled(bool toggled=true);
   void onEnableSurfaceSmoothingToggled(bool smoothingEnabled);
+  void onEnableSurfaceNetsToggled(bool surfaceNetsEnabled);
+  void onEnableSurfaceNetsSmoothingToggled(bool surfaceNetsSmoothingEnabled);
   void onSurfaceSmoothingFactorChanged(double newSmoothingFactor);
   void updateWidgetFromMRML();
 


### PR DESCRIPTION
Provides users with the ability to enable 3D rendering of segmentations using the vtkSurfaceNets3D filter. This includes the option to apply built-in smoothing during surface generation.
    
To access this functionality, users can now select "Use Surface Nets (fast)" within the newly introduced "Experimental" menu found under the "Show 3D" button.
    
Furthermore, the menu now includes the "Use Surface Nets Smoothing (faster)" option to enable the vtkSurfaceNets3D filter's built-in smoothing functionality, implemented with `vtkConstrainedSmoothingFilter`.
    
Using the Surface Nets approach provide a more efficient alternative:
* With the currently used smoothing method, rendering is ~7x faster than using flying edges.
* With the built-in smoothing, rendering is ~16x faster than flying edges with the current smoothing method.

### Notes related to the SMP implementation

* Using `TBB` improves performance of both conversion methods.

* `Slicer_VTK_SMP_IMPLEMENTATION_TYPE` is set to `TBB` by default only on Windows, `Sequential` is used on Linux and macOS.

* Setting `Slicer_VTK_SMP_IMPLEMENTATION_TYPE` to `TBB` locally in a Linux build tree worked as expected and allowed to confirm improved performance.  In a follow-up pull-request, we will have to:
  * Test enabling TBB in built tree for macOS and for docker-based Slicer linux environment
  * Confirm packaging work as expected

_Original pull request description updated by @jcfr_
