### PR TITLE
ENH: Make datetime string in error dialog more readable

### DIFF
--- a/Base/QTApp/Resources/UI/qSlicerErrorReportDialog.ui
+++ b/Base/QTApp/Resources/UI/qSlicerErrorReportDialog.ui
@@ -114,7 +114,20 @@
     </layout>
    </item>
    <item row="2" column="0" colspan="2">
-    <widget class="ctkPathListWidget" name="RecentLogFilesComboBox"/>
+    <widget class="QTableWidget" name="RecentLogFilesComboBox">
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustIgnored</enum>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <attribute name="horizontalHeaderCascadingSectionResizes">
+      <bool>false</bool>
+     </attribute>
+    </widget>
    </item>
    <item row="3" column="0">
     <widget class="QLabel" name="RecentLogFilesLabel_2">
@@ -126,11 +139,6 @@
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>ctkPathListWidget</class>
-   <extends>QListView</extends>
-   <header>ctkPathListWidget.h</header>
-  </customwidget>
   <customwidget>
    <class>ctkPushButton</class>
    <extends>QPushButton</extends>

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -1017,9 +1017,10 @@ void qSlicerApplication::setupFileLogging()
 
   // Add new log file path for the current session
   QString tempDir = this->temporaryPath();
-  QString currentLogFilePath = QString("%1/%2_%3_%4_%5.log")
+  QString currentLogFilePath = QString("%1/%2_%3_%4_%5_%6.log")
     .arg(tempDir)
     .arg(this->applicationName())
+    .arg(qSlicerApplication::application()->applicationVersion())
     .arg(this->revision())
     .arg(QDateTime::currentDateTime().toString("yyyyMMdd_hhmmss"))
     .arg(QRandomGenerator::global()->generate() % 1000, 3, 10, QLatin1Char('0'));


### PR DESCRIPTION
Making the log file display more human-readable would contribute to the improvement of the error reporting workflow.  This would allow users to more easily determine which log file(s) are related to their error.

This PR changes the displayed text of the log entries in the error dialog while preserving the original function and tooltip. 

| Current | This PR |
|---------|----------|
|![image](https://github.com/Slicer/Slicer/assets/88200986/18a0ec1a-0566-44fa-b21e-689d93086a49)|![image](https://github.com/Slicer/Slicer/assets/88200986/f4db6592-586e-40f0-aefc-47721a3aceef)|

