### PR TITLE
BUG: Update VTK to remove unnecessary messages in vtkTransformPolyDataFilter

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "b261e0c1b8b679a6af4bcdbbe01ea134750fd472") # slicer-v9.2.20230607-1ff325c54
+    set(_git_tag "b142c0d088f9f29fa42b4137b24abf5ce232d27b") # slicer-v9.2.20230607-1ff325c54
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
`vtkTransformPolyDataFilter` is often used in pipelines where it is completely valid to have empty input.
For example, when slicing through a mesh with a plane, the output may be empty if the plane does not happen to intersect any part of the mesh. Logging an error pollutes the error log and if performed too frequently then it may slow down an application.

List of VTK changes:

```
$ git shortlog b261e0c1b..b142c0d08 --no-merges
Andras Lasso (1):
      [Backport] Remove unnecessary "No input data" error message in vtkTransformPolyDataFilter
```