### PR TITLE
ENH: Show segment ID in tooltip for segments in subject hierarchy

### DIFF
--- a/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentsPlugin.cxx
+++ b/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentsPlugin.cxx
@@ -345,6 +345,14 @@ QString qSlicerSubjectHierarchySegmentsPlugin::tooltip(vtkIdType itemID)const
     return tooltipString;
     }
 
+  // Get segmentation node and segment
+  vtkMRMLSegmentationNode* segmentationNode =
+    vtkSlicerSegmentationsModuleLogic::GetSegmentationNodeForSegmentSubjectHierarchyItem(itemID, scene);
+  if (!segmentationNode)
+    {
+    qCritical() << Q_FUNC_INFO << ": Unable to find segmentation node for segment subject hierarchy item " << shNode->GetItemName(itemID).c_str();
+    return tooltipString;
+    }
   vtkSegment* segment = vtkSlicerSegmentationsModuleLogic::GetSegmentForSegmentSubjectHierarchyItem(itemID, scene);
   if (!segment)
     {
@@ -395,7 +403,8 @@ QString qSlicerSubjectHierarchySegmentsPlugin::tooltip(vtkIdType itemID)const
       tags.append(QString::fromStdString(tagIt->first) + ": " + QString::fromStdString(tagIt->second));
       }
     }
-  tooltipString.append(tr("Segment - Representations: %1, Color: (%2, %3, %4)\nTags: %5")
+  tooltipString.append(tr("Segment - ID: %1, Representations: %2, Color: (%3, %4, %5)\nTags: %6")
+    .arg(QString::fromStdString(segmentationNode->GetSegmentation()->GetSegmentIdBySegment(segment)))
     .arg(representations)
     .arg((int)(color[0]*255)).arg((int)(color[1]*255)).arg((int)(color[2]*255))
     .arg(tags));


### PR DESCRIPTION
Many times it would have come in handy to be able to see the segment ID for certain segments in a segmentation in the subject hierarchy tooltip. This commits adds this information.

![image](https://github.com/Slicer/Slicer/assets/1325980/490e7e64-aa0a-4cc6-9450-7c5072116440)
