### PR TITLE
BUG: Fix difficult to see slice offset text in Slicer dark mode

### DIFF
--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -118,7 +118,6 @@ qMRMLSliceControllerWidgetPrivate::~qMRMLSliceControllerWidgetPrivate() = defaul
 void qMRMLSliceControllerWidgetPrivate::setColor(QColor barColor)
 {
   this->Superclass::setColor(barColor);
-  this->SliceOffsetSlider->spinBox()->setStyleSheet("background-color: transparent");
 }
 
 //---------------------------------------------------------------------------
@@ -409,6 +408,8 @@ void qMRMLSliceControllerWidgetPrivate::init()
     ctkDoubleSpinBox::DecimalsByShortcuts |
     ctkDoubleSpinBox::DecimalsByKey |
     ctkDoubleSpinBox::DecimalsAsMin );
+  // Slice controller background color is independent from the color palette, therefore the color of text and controls are hardcoded to black
+  this->SliceOffsetSlider->spinBox()->setStyleSheet("color: black; background-color: transparent;");
 
   //this->SliceOffsetSlider->spinBox()->setParent(this->PopupWidget);
   ctkDoubleSpinBox* spinBox = this->SliceOffsetSlider->spinBox();

--- a/Libs/MRML/Widgets/qMRMLViewControllerBar.cxx
+++ b/Libs/MRML/Widgets/qMRMLViewControllerBar.cxx
@@ -115,6 +115,8 @@ void qMRMLViewControllerBarPrivate::init()
   this->ViewLabel = new QLabel(q);
   this->ViewLabel->setObjectName("ViewLabel");
   this->ViewLabel->setAlignment(Qt::AlignHCenter | Qt::AlignCenter);
+  // Slice controller background color is independent from the color palette, therefore the color of text and controls are hardcoded to black
+  this->ViewLabel->setStyleSheet("color: black; background-color: transparent;");
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
   this->ViewLabel->setMinimumWidth(this->ViewLabel->fontMetrics().horizontalAdvance("XX"));
 #else
@@ -195,9 +197,6 @@ void qMRMLViewControllerBarPrivate::setColor(QColor barColor)
   palette.setBrush(QPalette::Window, gradient);
   palette.setBrush(QPalette::Text, Qt::black);
   this->BarWidget->setPalette(palette);
-
-  QPalette labelPalette(barColor.lighter(130));
-  this->ViewLabel->setPalette(labelPalette);
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
This is work for #7233.

https://github.com/Slicer/Slicer/commit/8e70f763b0b351db00d8851871e68f11469d1a2e introduced this issue of light text being used for the slice offset text when in Slicer dark mode. Dark text was correctly being used in Slicer light mode. This change uses dark text regardless of current Slicer style.

|`main` | This PR |
|--------|---------|
|![image](https://github.com/Slicer/Slicer/assets/15837524/2c02fa42-c177-44ed-93ed-fd9b2c19834f)|![image](https://github.com/Slicer/Slicer/assets/15837524/8aa9675a-0798-4025-8934-d96af67239df)|