### PR TITLE
BUG: Use log filename to get app version and revision

### DIFF
--- a/Base/QTApp/qSlicerErrorReportDialog.cxx
+++ b/Base/QTApp/qSlicerErrorReportDialog.cxx
@@ -84,12 +84,12 @@ qSlicerErrorReportDialog::qSlicerErrorReportDialog(QWidget* parentWidget)
     QStringList stringList = fileName.split("_", QString::SkipEmptyParts);
     itemApp->setText(stringList.at(0));
     itemApp->setData(Qt::UserRole, fileString);
-    itemVersion->setText(qSlicerApplication::application()->applicationVersion());
-    itemRevision->setText(qSlicerApplication::application()->revision());
     if (stringList.size() >= 6) // compatibility for log files with and without app version in filename
       {
       QDateTime dt = QDateTime::fromString(QString(stringList.at(3)), "yyyyMMdd");
       QDateTime tm = QDateTime::fromString(QString(stringList.at(4)), "hhmmss");
+      itemVersion->setText(stringList.at(1));
+      itemRevision->setText(stringList.at(2));
       itemDate->setText(locale.toString(dt, "ddd yyyy-MM-dd"));
       itemTime->setText(locale.toString(tm, "hh:mm:ss"));
       }
@@ -97,6 +97,8 @@ qSlicerErrorReportDialog::qSlicerErrorReportDialog(QWidget* parentWidget)
       {
       QDateTime dt = QDateTime::fromString(QString(stringList.at(2)), "yyyyMMdd");
       QDateTime tm = QDateTime::fromString(QString(stringList.at(3)), "hhmmss");
+      itemVersion->setText(QString("unknown"));
+      itemRevision->setText(stringList.at(1));
       itemDate->setText(locale.toString(dt, "ddd yyyy-MM-dd"));
       itemTime->setText(locale.toString(tm, "hh:mm:ss"));
       }

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -1021,7 +1021,7 @@ void qSlicerApplication::setupFileLogging()
     .arg(tempDir)
     .arg(this->applicationName())
     .arg(qSlicerApplication::application()->applicationVersion())
-    .arg(this->revision())
+    .arg(qSlicerApplication::application()->mainApplicationRevision())
     .arg(QDateTime::currentDateTime().toString("yyyyMMdd_hhmmss"))
     .arg(QRandomGenerator::global()->generate() % 1000, 3, 10, QLatin1Char('0'));
   logFilePaths.prepend(currentLogFilePath);


### PR DESCRIPTION
Introduced in https://github.com/Slicer/Slicer/pull/7225#issuecomment-1729384982

This PR uses the log filename to get app version and revision number to report in the error report dialog:
![image](https://github.com/Slicer/Slicer/assets/88200986/aaba0cea-35c1-40bd-937f-e5ab9a5b957b)

`ENH: Report custom application revision in log filename` uses the custom-app revision number rather than the slicer revision number. This won't change anything from the slicer side, but could be beneficial for custom applications. (needs to be tested) 
