### PR TITLE
Remove use of deprecated ${CMAKE_CFG_INTDIR} variable

### DIFF
--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -494,7 +494,7 @@ macro(slicerMacroBuildApplication)
         POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 ${PYTHON_LIBRARY_PATH}/${_python_library_name_we}.dll
-                ${_slicerapp_output_dir}/${CMAKE_CFG_INTDIR}
+                ${_slicerapp_output_dir}/$<CONFIG>
         COMMENT "Copy '${_python_library_name_we}.dll' along side '${slicerapp_target}' executable. See Slicer issue #1180"
         )
     endif()

--- a/CMake/SlicerPackageAndUploadTarget.cmake
+++ b/CMake/SlicerPackageAndUploadTarget.cmake
@@ -130,7 +130,7 @@ set(${varname} \"${${varname}}\")")
     COMMAND ${CMAKE_COMMAND} -E echo "CPack log: ${_cpack_output_file}"
     COMMAND ${CMAKE_COMMAND}
       -DPACKAGEUPLOAD:BOOL=1
-      -DCONFIG:STRING=${CMAKE_CFG_INTDIR}
+      -DCONFIG:STRING=$<CONFIG>
       -DCPACK_OUTPUT_FILE:FILEPATH=${_cpack_output_file}
       -DSCRIPT_ARGS_FILE:FILEPATH=${script_args_file}
       -P ${CMAKE_CURRENT_LIST_FILE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -739,7 +739,7 @@ include(CTest)
 set(__conf_types "")
 if(CMAKE_CONFIGURATION_TYPES)
   # We need to pass the configuration type on the test command line.
-  set(__conf_types -C "${CMAKE_CFG_INTDIR}")
+  set(__conf_types -C "$<CONFIG>")
 endif()
 add_custom_target(Experimental ${CMAKE_CTEST_COMMAND} ${__conf_types} -D Experimental)
 

--- a/Extensions/CMake/SlicerBlockUploadExtension.cmake
+++ b/Extensions/CMake/SlicerBlockUploadExtension.cmake
@@ -129,18 +129,8 @@ if(CTEST_EXTRA_VERBOSE)
 endif()
 
 #-----------------------------------------------------------------------------
-# Set CTEST_BUILD_CONFIGURATION here
-# See https://www.cmake.org/cmake/help/cmake-2-8-docs.html#variable:CMAKE_CFG_INTDIR
-if(CMAKE_CONFIGURATION_TYPES)
-  set(CTEST_BUILD_CONFIGURATION ${CMAKE_CFG_INTDIR})
-else()
-  set(CTEST_BUILD_CONFIGURATION ${CMAKE_BUILD_TYPE})
-endif()
-set(EXTENSION_COMMAND_BUILD_CONF_ARG_LIST
-  -C ${CTEST_BUILD_CONFIGURATION}
-  -DCTEST_BUILD_CONFIGURATION:STRING=${CTEST_BUILD_CONFIGURATION}
-  )
-set(dollar "$")
+# The CTEST_BUILD_CONFIGURATION variable associated with the upload and test commands
+# defined below is set in the extension dashboard script.
 set(EXTENSION_COMMAND_BUILD_CONF_WRAPPER_ARG_LIST
   -C ${dollar}{CTEST_BUILD_CONFIGURATION}
   -DCTEST_BUILD_CONFIGURATION:STRING=${dollar}{CTEST_BUILD_CONFIGURATION}

--- a/Extensions/CMake/SlicerExtensionPackageAndUploadTarget.cmake
+++ b/Extensions/CMake/SlicerExtensionPackageAndUploadTarget.cmake
@@ -155,7 +155,7 @@ set(${varname} \"${${varname}}\")")
     COMMAND ${CMAKE_COMMAND} -E echo "CPack log: ${_cpack_output_file}"
     COMMAND ${CMAKE_COMMAND}
       -DPACKAGEUPLOAD:BOOL=1
-      -DCONFIG:STRING=${CMAKE_CFG_INTDIR}
+      -DCONFIG:STRING=$<CONFIG>
       -DCPACK_OUTPUT_FILE:FILEPATH=${_cpack_output_file}
       -DSCRIPT_ARGS_FILE:FILEPATH=${script_args_file}
       -P ${CMAKE_CURRENT_LIST_FILE}

--- a/SuperBuild/External_JsonCpp.cmake
+++ b/SuperBuild/External_JsonCpp.cmake
@@ -75,7 +75,12 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
     set(lib_prefix "lib")
     set(lib_ext "so")
   endif()
-  set(${proj}_LIBRARY ${${proj}_DIR}/src/lib_json/${CMAKE_CFG_INTDIR}/${lib_prefix}jsoncpp.${lib_ext})
+  if(DEFINED CMAKE_CONFIGURATION_TYPES)
+    set(lib_cfg_dir "$<CONFIG>")
+  else()
+    set(lib_cfg_dir ".")
+  endif()
+  set(${proj}_LIBRARY ${${proj}_DIR}/src/lib_json/${lib_cfg_dir}/${lib_prefix}jsoncpp.${lib_ext})
 
   #-----------------------------------------------------------------------------
   # Launcher setting specific to build tree

--- a/SuperBuild/External_OpenSSL.cmake
+++ b/SuperBuild/External_OpenSSL.cmake
@@ -318,7 +318,7 @@ this version of visual studio [${MSVC_VERSION}]. You could either:
     set(OpenSSL_DIR ${EP_SOURCE_DIR})
     set(_openssl_base_dir ${OpenSSL_DIR})
     if(DEFINED CMAKE_CONFIGURATION_TYPES)
-      set(OpenSSL_DIR ${OpenSSL_DIR}/${CMAKE_CFG_INTDIR})
+      set(OpenSSL_DIR ${OpenSSL_DIR}/$<CONFIG>)
       set(_copy_release_directory 1)
     else()
       set(OpenSSL_DIR ${OpenSSL_DIR}/${CMAKE_BUILD_TYPE})


### PR DESCRIPTION
Starting with CMake 3.21, use of CMAKE_CFG_INTDIR has been deprecated.