### PR TITLE
COMP: Fix "ci" GitHub workflow ensuring Slicer package is uploaded

### DIFF
--- a/.github/actions/slicer-build/entrypoint.sh
+++ b/.github/actions/slicer-build/entrypoint.sh
@@ -15,4 +15,4 @@ mv ${package_filepath} $GITHUB_WORKSPACE/
 package=$(basename $package_filepath)
 echo "package [${package}]"
 
-echo "::set-output name=package::$package"
+echo "package=$package" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
               - "CMakeLists.txt"
 
       - name: 'Build Slicer'
+        id: slicer-build
         if: steps.changes.outputs.paths-to-include == 'true'
         uses: ./.github/actions/slicer-build
 


### PR DESCRIPTION
Set the step id to `slicer-build` to ensure the use of `${{ steps.slicer-build.outputs.package }}` in the _Upload Slicer package_ step effectively lookup the package.

Follow up of these pull requests:
* https://github.com/Slicer/Slicer/pull/6051
* https://github.com/Slicer/Slicer/pull/6053

Also fix the following warning:

> The `set-output` command is deprecated and will be disabled soon.
> Please upgrade to using Environment Files.
> For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


Temporarily including the following patch to the pull-request allowed to test the changes:

```diff
diff --git a/.github/actions/slicer-build/entrypoint.sh b/.github/actions/slicer-build/entrypoint.sh
index 2caf49c7f02..50e709c8579 100755
--- a/.github/actions/slicer-build/entrypoint.sh
+++ b/.github/actions/slicer-build/entrypoint.sh
@@ -6,13 +6,16 @@ set -o
 
 cp -r $GITHUB_WORKSPACE /usr/src/Slicer
 
-/usr/src/Slicer-build/BuildSlicer.sh
-package_filepath=$(head -n1 /usr/src/Slicer-build/Slicer-build/PACKAGE_FILE.txt)
+#/usr/src/Slicer-build/BuildSlicer.sh
+#package_filepath=$(head -n1 /usr/src/Slicer-build/Slicer-build/PACKAGE_FILE.txt)
+package_filepath=/usr/src/Slicer-build/Slicer-build/Slicer-5.5.0-2023-09-26-linux-amd64.tar.gz
+echo "Dummy package" > $package_filepath
 echo "package_filepath [${package_filepath}]"
 
 mv ${package_filepath} $GITHUB_WORKSPACE/
 
 package=$(basename $package_filepath)
 echo "package [${package}]"
+echo "GITHUB_OUTPUT [$GITHUB_OUTPUT]"
 
 echo "package=$package" >> $GITHUB_OUTPUT
```

and confirm it was working as expected:

| | |
|--|--|
| ![image](https://github.com/Slicer/Slicer/assets/219043/26b37d6b-c027-440b-aa89-de3c0f412b1f) | ![image](https://github.com/Slicer/Slicer/assets/219043/71e8aa62-eee5-413e-9c46-0909240fd4e2) |




