### PR TITLE
Fix intersection interaction representation helper

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.cxx
@@ -901,8 +901,7 @@ vtkMRMLSliceIntersectionInteractionRepresentation::vtkMRMLSliceIntersectionInter
   this->InteractionSize = INTERACTION_SIZE_PIXELS;
 
   // Helper
-  vtkNew<vtkMRMLSliceIntersectionInteractionRepresentationHelper> helper;
-  this->Helper = helper;
+  this->Helper = vtkSmartPointer<vtkMRMLSliceIntersectionInteractionRepresentationHelper>::New();
 }
 
 //----------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.h
@@ -189,7 +189,7 @@ class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLSliceIntersectionInteractionRepr
     class vtkInternal;
     vtkInternal* Internal;
 
-    vtkMRMLSliceIntersectionInteractionRepresentationHelper* Helper;
+    vtkSmartPointer<vtkMRMLSliceIntersectionInteractionRepresentationHelper> Helper;
 
   private:
     vtkMRMLSliceIntersectionInteractionRepresentation(const vtkMRMLSliceIntersectionInteractionRepresentation&) = delete;

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentationHelper.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentationHelper.cxx
@@ -17,56 +17,20 @@
 
 #include "vtkMRMLSliceIntersectionInteractionRepresentationHelper.h"
 
-
-#include <deque>
-#define _USE_MATH_DEFINES
-#include <math.h>
-
-#include "vtkMRMLApplicationLogic.h"
-#include "vtkMRMLDisplayableNode.h"
-#include "vtkMRMLInteractionNode.h"
-#include "vtkMRMLModelDisplayNode.h"
-#include "vtkMRMLScene.h"
-#include "vtkMRMLSliceLogic.h"
-#include "vtkMRMLSliceNode.h"
-#include "vtkMRMLSliceCompositeNode.h"
-
-#include "vtkActor2D.h"
-#include "vtkArcSource.h"
-#include "vtkAppendPolyData.h"
-#include "vtkAssemblyPath.h"
-#include "vtkCallbackCommand.h"
-#include "vtkCamera.h"
-#include "vtkCellArray.h"
-#include "vtkCommand.h"
-#include "vtkConeSource.h"
-#include "vtkCoordinate.h"
-#include "vtkCursor2D.h"
-#include "vtkCylinderSource.h"
-#include "vtkGlyph2D.h"
-#include "vtkInteractorObserver.h"
-#include "vtkLeaderActor2D.h"
-#include "vtkLine.h"
-#include "vtkLineSource.h"
-#include "vtkMath.h"
-#include "vtkMatrix3x3.h"
-#include "vtkMatrix4x4.h"
-#include "vtkObjectFactory.h"
-#include "vtkPoints.h"
-#include "vtkPolyDataAlgorithm.h"
-#include "vtkPolyDataMapper2D.h"
-#include "vtkProperty2D.h"
-#include "vtkPlane.h"
-#include "vtkRenderer.h"
-#include "vtkRenderWindow.h"
-#include "vtkSphereSource.h"
-#include "vtkTransform.h"
-#include "vtkTransformPolyDataFilter.h"
-#include "vtkTubeFilter.h"
-#include "vtkWindow.h"
+// VTK includes
+#include <vtkMath.h>
+#include <vtkMatrix3x3.h>
+#include <vtkMatrix4x4.h>
+#include <vtkObjectFactory.h>
+#include <vtkPlane.h>
+#include <vtkTransform.h>
 
 // MRML includes
 #include <vtkMRMLInteractionEventData.h>
+#include <vtkMRMLSliceNode.h>
+
+// STD includes
+#include <deque>
 
 // Handles
 static const double SLICEOFFSET_HANDLE_DEFAULT_POSITION[3] = { 0.0,0.0,0.0 };
@@ -87,7 +51,6 @@ vtkMRMLSliceIntersectionInteractionRepresentationHelper::~vtkMRMLSliceIntersecti
 //----------------------------------------------------------------------
 void vtkMRMLSliceIntersectionInteractionRepresentationHelper::PrintSelf(ostream & os, vtkIndent indent)
 {
-  //Superclass typedef defined in vtkTypeMacro() found in vtkSetGet.h
   this->Superclass::PrintSelf(os, indent);
 }
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentationHelper.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentationHelper.h
@@ -17,10 +17,7 @@
 
 /**
  * @class   vtkMRMLSliceIntersectionInteractionRepresentationHelper
- * @brief   represent intersections of other slice views in the current slice view
- *
- * @sa
- * vtkSliceIntersectionWidget vtkWidgetRepresentation vtkAbstractWidget
+ * @brief   utility class to compute slice intersection interactions
 */
 
 #ifndef vtkMRMLSliceIntersectionInteractionRepresentationHelper_h
@@ -29,12 +26,12 @@
 #include "vtkMRMLDisplayableManagerExport.h" // For export macro
 
 // VTK includes
-#include <vtkMRMLAbstractWidgetRepresentation.h>
+#include <vtkObject.h>
 class vtkPoints;
 class vtkMatrix4x4;
 class vtkMRMLSliceNode;
 
-class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLSliceIntersectionInteractionRepresentationHelper : public vtkMRMLAbstractWidgetRepresentation
+class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLSliceIntersectionInteractionRepresentationHelper : public vtkObject
 {
   public:
     /**
@@ -46,7 +43,7 @@ class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLSliceIntersectionInteractionRepr
     /**
      * Standard methods for instances of this class.
      */
-    vtkTypeMacro(vtkMRMLSliceIntersectionInteractionRepresentationHelper, vtkMRMLAbstractWidgetRepresentation);
+    vtkTypeMacro(vtkMRMLSliceIntersectionInteractionRepresentationHelper, vtkObject);
     void PrintSelf(ostream& os, vtkIndent indent) override;
     //@}
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentationHelper.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentationHelper.h
@@ -27,26 +27,12 @@
 #define vtkMRMLSliceIntersectionInteractionRepresentationHelper_h
 
 #include "vtkMRMLDisplayableManagerExport.h" // For export macro
-#include "vtkMRMLAbstractWidgetRepresentation.h"
 
-#include "vtkMRMLSliceNode.h"
-
-class vtkMRMLApplicationLogic;
-class vtkMRMLModelDisplayNode;
-class vtkMRMLSliceLogic;
-
-class vtkProperty2D;
-class vtkActor2D;
-class vtkPolyDataMapper2D;
-class vtkPolyData;
+// VTK includes
+#include <vtkMRMLAbstractWidgetRepresentation.h>
 class vtkPoints;
-class vtkCellArray;
-class vtkTextProperty;
-class vtkLeaderActor2D;
-class vtkTextMapper;
-class vtkTransform;
-class vtkActor2D;
-class vtkMRMLInteractionEventData;
+class vtkMatrix4x4;
+class vtkMRMLSliceNode;
 
 class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLSliceIntersectionInteractionRepresentationHelper : public vtkMRMLAbstractWidgetRepresentation
 {


### PR DESCRIPTION
Follow-up of https://github.com/Slicer/Slicer/commit/bc5d5b45fcb1949a2545ee1c2e2c1f35976698ac (`ENH: Add interactive slice intersections widget`) integrated through:
* https://github.com/Slicer/Slicer/pull/6124

Simplify and fix the `SliceIntersectionInteractionRepresentationHelper` class

This change is done anticipating the integration of:
* https://github.com/Slicer/Slicer/pull/7093