### PR TITLE
PERF: Improve performance when removing segmentation from SH tree

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.cxx
@@ -1245,6 +1245,10 @@ void vtkSubjectHierarchyItem::ReparentChildrenToParent()
 //---------------------------------------------------------------------------
 void vtkSubjectHierarchyItem::RemoveAllChildren()
 {
+  // If the item has many children, then it may invoke a large number of events.
+  // To avoid this, block Modified events on the data node until all of the children are removed.
+  MRMLNodeModifyBlocker blocker(this->DataNode);
+
   std::vector<vtkIdType> childIDs;
   this->GetAllChildren(childIDs);
   while (childIDs.size())

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
@@ -327,6 +327,8 @@ void qSlicerSubjectHierarchyPluginLogic::onNodeAboutToBeRemoved(vtkObject* scene
   vtkIdType itemID = shNode->GetItemByDataNode(dataNode);
   if (itemID)
     {
+    // Block render to avoid unnecessary view updates.
+    SlicerRenderBlocker renderBlocker;
     shNode->RemoveItem(itemID, false, false);
     }
 }


### PR DESCRIPTION
When removing a vtkMRMLSegmentationNode using the SubjectHierarchy tree, all of the virtual children would be removing before the segmentation. This caused a large number of updates in various segmentation widgets as all of the widgets were regenerated when each of the segments were removed from the segmentation node.

This commit improves performance by blocking modification events on the segmentation node (or any other node with virtual children), until all of the children have been removed. Rendering is also blocked during the item removal to prevent unnecessary updates of the views.