### PR TITLE
Two small fixes

### DIFF
--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsSettingsPanel.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsSettingsPanel.cxx
@@ -119,7 +119,7 @@ void qSlicerSegmentationsSettingsPanelPrivate::init()
   QObject::connect(this->EditDefaultTerminologyEntryPushButton, SIGNAL(clicked()),
                    q, SLOT(onEditDefaultTerminologyEntry()));
   QObject::connect(this->DefaultOverwriteModeComboBox, SIGNAL(currentIndexChanged(QString)),
-                   q, SIGNAL(setDefaultOverwriteMode(QString)));
+                   q, SLOT(setDefaultOverwriteMode(QString)));
 
   // Update default segmentation node from settings when startup completed.
   QObject::connect(qSlicerApplication::application(), SIGNAL(startupCompleted()),

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -177,7 +177,7 @@ class DataProbeInfoWidget:
 
         # default - non label scalar volume
         numberOfComponents = imageData.GetNumberOfScalarComponents()
-        if numberOfComponents > 3:
+        if numberOfComponents > 4:
             return _("{numberOfComponents} components").format(numberOfComponents=numberOfComponents)
         for c in range(numberOfComponents):
             component = imageData.GetScalarComponentAsDouble(ijk[0], ijk[1], ijk[2], c)


### PR DESCRIPTION
This PR contains small fixes, see details in the commits. Do not squash merge.

<del>Add masked median filter needed for RGBA volume generation - see https://github.com/Slicer/VTK/pull/43.</del> _moved masked median filter to VTK (Merge https://github.com/Slicer/VTK/pull/44)_
