### PR TITLE
BUG: Use main project version for macOS short version string in bundle

### DIFF
--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -467,7 +467,7 @@ macro(slicerMacroBuildApplication)
       )
     if("${Slicer_RELEASE_TYPE}" STREQUAL "Stable")
       set_target_properties(${slicerapp_target} PROPERTIES
-        MACOSX_BUNDLE_SHORT_VERSION_STRING "${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR}.${Slicer_VERSION_PATCH}"
+        MACOSX_BUNDLE_SHORT_VERSION_STRING "${Slicer_MAIN_PROJECT_VERSION_MAJOR}.${Slicer_MAIN_PROJECT_VERSION_MINOR}.${Slicer_MAIN_PROJECT_VERSION_PATCH}"
         )
     endif()
   endif()


### PR DESCRIPTION
This ensures that the custom application version number is used to the macOS 'Quick Look' feature

Follow on fix to: https://github.com/Slicer/Slicer/commit/d004e4e394bba81d92df506b70b4b263656c094d for another version string that was missed in the initial fix.

Example of the bug:

![Screenshot 2023-10-10 10 17 21](https://github.com/Slicer/Slicer/assets/25040869/b3e0ab14-83e7-4f6d-a2ab-fc4613fba98b)
