### PR TITLE
ENH: Simplify single-image capture in ScreenCapture module

### DIFF
--- a/Docs/user_guide/modules/screencapture.md
+++ b/Docs/user_guide/modules/screencapture.md
@@ -8,9 +8,10 @@ This module is for creating videos, image sequences, or lightbox image from 3D a
 
 ### Input
 
-- **Main view:** This view will be changed during the animation (rotated, sweeped, etc.).
-- **Capture all views:** If enabled then all the view in the view layout will be captured. If disabled then only the main view will be captured. By capturing all views, it is possible to see the animated view (such as a moving slice) in 3D and in other slice views.
-- **Animation mode:** specifies how the main view will be modified during capture.
+- **Main view:** This view is used for capturing (rotated, sweeped, etc.).
+- **Capture all views:** When enabled, all views in the layout will be captured. Otherwise, only the main view is captured. By capturing all views, it is possible to see the animated view (such as a moving slice) in 3D and in other slice views.
+- **Capture mode:** specifies how the main view will be modified during capture.
+  - **single frame:** Acquire a single frame of selected main view or all views if "Capture all views" is enabled.
   - **3D rotation:** Acquire video of a rotating 3D view. For smooth repeated display of a 360-degree rotation it is recommended to choose 31 or 61 as "Number of images".
   - **slice sweep:** Acquire video while going through selected range of image frames (for slice viewer only).
   - **slice fade:** Acquire video while fading between the foreground and background image (for slice viewer only).).
@@ -39,7 +40,7 @@ This module is for creating videos, image sequences, or lightbox image from 3D a
 
     ![lightbox image](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_screencapture_lightbox.png)
 
-- **Number of images:** Defines how many frames are generated in the specified range. Higher number results in smoother animation but larger video file. If **single** option is enabled then a single image is captured (and counter in the filename is automatically incremented, therefore it can be used to acquire many screenshots manually).
+- **Number of images:** Defines how many frames are generated in the specified range. Higher number results in smoother animation but larger video file. If **single frame** capture mode is selected then a single image is captured (and counter in the filename is automatically incremented, therefore it can be used to acquire many screenshots manually).
 - **Output directory:** Output image or video will be saved in this directory.
 - **Output file name:** Output file name for video and lightbox.
 - **Video format:**
@@ -67,7 +68,7 @@ This module is for creating videos, image sequences, or lightbox image from 3D a
 - **Image file name pattern:** Defines image file naming pattern. `%05d` will be replaced by the image number (5 numbers, padded with zeros). This is only used if image series output is selected.
 - **Lightbox image columns:** Number of columns in the generated lighbox image.
 - **Maximum number of images:** Specifies the maximum range of the "number of images" slider. Useful for creating very long animations.
-- **Output volume node:** If a single image output is selected then the output can be saved into the selected volume node.
+- **Output volume node:** If "single frame" capture mode is selected then the output can be saved into the selected volume node.
 - **View controllers:** Show view controllers. If unchecked then view controllers will be temporarily hidden during screen capture.
 - **Transparent background:** If checked then images will be captured with transparent background.
 - **Watermark image:** Adds a watermark image to the captured images.

--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -86,7 +86,7 @@ class ScreenCaptureWidget(ScriptedLoadableModuleWidget):
         self.viewNodeSelector.showChildNodeTypes = False
         self.viewNodeSelector.setMRMLScene(slicer.mrmlScene)
         self.viewNodeSelector.setToolTip(_("This slice or 3D view will be updated during capture."
-                                         "Only this view will be captured unless 'Capture of all views' option in output section is enabled."))
+                                         "Only this view will be captured unless 'Capture all views' option is enabled."))
         inputFormLayout.addRow(_("Main view: "), self.viewNodeSelector)
 
         self.captureAllViewsCheckBox = qt.QCheckBox(" ")
@@ -96,8 +96,8 @@ class ScreenCaptureWidget(ScriptedLoadableModuleWidget):
 
         # Mode
         self.animationModeWidget = qt.QComboBox()
-        self.animationModeWidget.setToolTip(_("Select the property that will be adjusted"))
-        inputFormLayout.addRow(_("Animation mode:"), self.animationModeWidget)
+        self.animationModeWidget.setToolTip(_("Specify how the main view will be modified during capture."))
+        inputFormLayout.addRow(_("Capture mode:"), self.animationModeWidget)
 
         # Slice start offset position
         self.sliceStartOffsetLabel = qt.QLabel(_("Start sweep offset:"))
@@ -470,7 +470,7 @@ class ScreenCaptureWidget(ScriptedLoadableModuleWidget):
     def updateOutputType(self, selectionIndex=0):
         outputType = self.outputTypeWidget.currentData
         forceSingleImage = False
-        if self.animationModeWidget.currentData == "NONE":
+        if self.animationModeWidget.currentData == "SINGLE_FRAME":
             outputType = "IMAGE_SERIES"
             forceSingleImage = True
 
@@ -534,11 +534,11 @@ class ScreenCaptureWidget(ScriptedLoadableModuleWidget):
 
             self.animationModeWidget.clear()
             if self.viewNodeType == VIEW_SLICE:
-                self.animationModeWidget.addItem(_("none"), "NONE")
+                self.animationModeWidget.addItem(_("single frame"), "SINGLE_FRAME")
                 self.animationModeWidget.addItem(_("slice sweep"), "SLICE_SWEEP")
                 self.animationModeWidget.addItem(_("slice fade"), "SLICE_FADE")
             if self.viewNodeType == VIEW_3D:
-                self.animationModeWidget.addItem(_("none"), "NONE")
+                self.animationModeWidget.addItem(_("single frame"), "SINGLE_FRAME")
                 self.animationModeWidget.addItem(_("3D rotation"), "3D_ROTATION")
             if sequencesModuleAvailable:
                 self.animationModeWidget.addItem(_("sequence"), "SEQUENCE")
@@ -668,7 +668,7 @@ class ScreenCaptureWidget(ScriptedLoadableModuleWidget):
         videoOutputRequested = (self.outputTypeWidget.currentData == "VIDEO")
         viewNode = self.viewNodeSelector.currentNode()
         numberOfSteps = int(self.numberOfStepsSliderWidget.value)
-        if self.animationModeWidget.currentData == "NONE":
+        if self.animationModeWidget.currentData == "SINGLE_FRAME":
             numberOfSteps = 1
         if numberOfSteps < 2:
             # If a single image is selected


### PR DESCRIPTION
Instead of having an obscure "single" button next to the "number of frames" selector, add a "none" animation mode and make it the default. Options that are not relevant are not just disabled but hidden, to make it easier for the user to find the relevant options.

| Before | After |
|--|--|
| ![image](https://github.com/Slicer/Slicer/assets/307929/34548d95-af41-40ba-a56b-efa82de30eb5) | ![image](https://github.com/Slicer/Slicer/assets/307929/bae4a8a6-950f-4199-aff7-6fca185ded26) |
