### PR TITLE
BUG: Update VTK to fix RGBA volume rendering

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "b142c0d088f9f29fa42b4137b24abf5ce232d27b") # slicer-v9.2.20230607-1ff325c54
+    set(_git_tag "3e45140d5ed4c38ff93bbfd4af033216f9fc820c") # slicer-v9.2.20230607-1ff325c54
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
List of VTK changes:

---

Revision: 3e45140d5ed4c38ff93bbfd4af033216f9fc820c
Author: Steve Pieper <pieper@isomics.com>
Date: 2023-10-10 1:58:01 PM
Message:
BUG: use alpha to calculate RGBA lighting (#43)

Implements the feature and fixes discussed in this thread: https://discourse.slicer.org/t/volume-rendering-colorized-with-segmentation/26689/6

Basically allows RGBA volumes to be shaded according to their alpha component so that something like a CT or microCT can define an rgb value at spatial regions, while getting opacity and gradient information from the alpha channel (e.g. the Hounsfield unit).

Also always uses the 0 channel for defining the lighting parameters. This part is WIP since it may be more appropriate to set the alpha channel lighting parameters in this scenario.  Currently, at least in 3D Slicer, only the 0 compnent's lighting parameters are being set, so they are being used here.

---

Revision: 50d4bdd2cac3274d22f929d9a49ddf9dadf1ed7a
Author: Andras Lasso <lasso@queensu.ca>
Date: 2023-10-10 11:18:42 AM
Message:
ENH: Add background masking mode to vtkImageMedian3D

Background voxels can be excluded from median filter computation. This is useful for dilating label volumes.