### PR TITLE
BUG: Fix a typo in qSlicerSigmentationSettingsPanel signal/slot connection

### DIFF
--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsSettingsPanel.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsSettingsPanel.cxx
@@ -119,7 +119,7 @@ void qSlicerSegmentationsSettingsPanelPrivate::init()
   QObject::connect(this->EditDefaultTerminologyEntryPushButton, SIGNAL(clicked()),
                    q, SLOT(onEditDefaultTerminologyEntry()));
   QObject::connect(this->DefaultOverwriteModeComboBox, SIGNAL(currentIndexChanged(QString)),
-                   q, SIGNAL(setDefaultOverwriteMode(QString)));
+                   q, SLOT(setDefaultOverwriteMode(QString)));
 
   // Update default segmentation node from settings when startup completed.
   QObject::connect(qSlicerApplication::application(), SIGNAL(startupCompleted()),


### PR DESCRIPTION
There is no signal called setDefaultOverwriteMode in the qSlicerSigmentationSettingPanel.
Qt emits a warning during the Slicer execution process.
