### PR TITLE
ENH: Avoid floating SH combobox popup by default

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -69,7 +69,7 @@ public:
 qMRMLSubjectHierarchyComboBoxPrivate::qMRMLSubjectHierarchyComboBoxPrivate(qMRMLSubjectHierarchyComboBox& object)
   : q_ptr(&object)
   , MaximumNumberOfShownItems(20)
-  , AlignPopupVertically(true)
+  , AlignPopupVertically(false)
   , ShowCurrentItemParents(true)
   , TreeView(nullptr)
   , NoItemLabel(nullptr)


### PR DESCRIPTION
Align pop-up vertically to combo box can lead to pop-up being rendered outside the limit of the main window.
Here is a proposal to disable it by default and render the pop-up tree below the combo box to be consistent with other combo boxes behavior.