### PR TITLE
ENH: Simplify paint/erase diameter options for more concise UI

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect_p.h
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect_p.h
@@ -59,6 +59,7 @@ class QFrame;
 class QCheckBox;
 class QToolButton;
 class qMRMLSliceWidget;
+class qMRMLSliderWidget;
 class qMRMLSpinBox;
 class vtkActor2D;
 class vtkGlyph3D;
@@ -128,7 +129,6 @@ protected:
 
 public slots:
   void onDiameterUnitsClicked();
-  void onQuickDiameterButtonClicked();
   void onDiameterValueChanged(double);
 
 public:
@@ -177,9 +177,9 @@ public:
 
   QFrame* PaintOptionsFrame;
   QFrame* BrushDiameterFrame;
-  qMRMLSpinBox* BrushDiameterSpinBox;
-  ctkDoubleSlider* BrushDiameterSlider;
-  QToolButton* BrushDiameterRelativeToggle;
+  QFrame* BrushDiameterSizeFrame;
+  qMRMLSliderWidget* BrushDiameterSliderWidget;
+  QToolButton* BrushDiameterIsAbsoluteButton;
   QCheckBox* BrushSphereCheckbox;
   QCheckBox* EditIn3DViewsCheckbox;
   QCheckBox* ColorSmudgeCheckbox;


### PR DESCRIPTION
Currently the diameter of the tool could be changed in 3 different ways - by SpinBox, Slider, and a set of buttons. This change simplifies the options to be more concise by only have a slider and spinbox along with the button to toggle between absolute and relative sizing. The design is based on the existing Markups module glyph size widget options.

| `main` | This PR |
|--------|----------|
|![image](https://github.com/Slicer/Slicer/assets/15837524/2db8d69a-37c6-4a73-b6a7-6f3574aad564)|![image](https://github.com/Slicer/Slicer/assets/15837524/1d0771a5-f6dd-4d5b-babe-eadffad8c906)|
|![image](https://github.com/Slicer/Slicer/assets/15837524/34827e75-8fd0-416a-9dd1-fd5db36b5fad)|![image](https://github.com/Slicer/Slicer/assets/15837524/0500efd9-c649-41e8-9773-b3f5aec42dd8)|

Markups module glyph size widget option for reference:
![image](https://github.com/Slicer/Slicer/assets/15837524/27d23990-a6d4-4a6c-8937-340c77cb6df1)
