### PR TITLE
BUG: Update VTK to fix segfault when enabling volume rendering

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "3e45140d5ed4c38ff93bbfd4af033216f9fc820c") # slicer-v9.2.20230607-1ff325c54
+    set(_git_tag "97965bba9e1d8f49482ffc61c464b11287cd19e2") # slicer-v9.2.20230607-1ff325c54
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
Follow-up of Slicer/VTK@3e45140d5 (BUG: use alpha to calculate RGBA lighting)
introduced through 57b8434f4 (BUG: Update VTK to fix RGBA volume rendering).

It removes the use of regex leading to segfault in binary compiled using gcc 7.3.1 and introduces an ivar called lightingComponent set based on the value of "independentComponents"

See https://github.com/Slicer/Slicer/issues/7281

List of VTK changes:

```
$ git shortlog 3e45140d5..97965bba9 --no-merges
Jean-Christophe Fillion-Robin (1):
      BUG: Fix generation of volume rendering shader
```

References:
* https://discourse.slicer.org/t/vtk-multivolume-cinematic-volume-rendering/31981/44?u=jcfr
* https://github.com/Slicer/VTK/pull/45