### PR TITLE
Fix SampleData module

### DIFF
--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -905,7 +905,7 @@ class SampleDataLogic:
         if not success:
             self.logMessage('\t' + _('Load failed!'), logging.ERROR)
             return False
-        self.logMessage('<b>' + _('Load finished'), '</b><p></p>')
+        self.logMessage('<b>' + _('Load finished') + '</b><p></p>')
         return True
 
     def loadNode(self, uri, name, fileType='VolumeFile', fileProperties={}):

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -1120,16 +1120,16 @@ class SampleDataTest(ScriptedLoadableModuleTest):
 
     def test_sampleDataSourcesByCategory(self):
         self.assertTrue(len(SampleDataLogic.sampleDataSourcesByCategory()) > 0)
-        self.assertTrue(len(SampleDataLogic.sampleDataSourcesByCategory('BuiltIn')) > 0)
+        self.assertTrue(len(SampleDataLogic.sampleDataSourcesByCategory('General')) > 0)
         self.assertTrue(len(SampleDataLogic.sampleDataSourcesByCategory('Not_A_Registered_Category')) == 0)
 
     def test_categoryVisibility(self):
         slicer.util.selectModule("SampleData")
         widget = slicer.modules.SampleDataWidget
-        widget.setCategoryVisible('BuiltIn', False)
-        self.assertFalse(widget.isCategoryVisible('BuiltIn'))
-        widget.setCategoryVisible('BuiltIn', True)
-        self.assertTrue(widget.isCategoryVisible('BuiltIn'))
+        widget.setCategoryVisible('General', False)
+        self.assertFalse(widget.isCategoryVisible('General'))
+        widget.setCategoryVisible('General', True)
+        self.assertTrue(widget.isCategoryVisible('General'))
 
     def test_setCategoriesFromSampleDataSources(self):
         slicer.util.selectModule("SampleData")


### PR DESCRIPTION
Restore the passing of the following tests addressing regressions introduced in d3f49ed35 (BUG: Make more strings translatable) introduced through:
* https://github.com/Slicer/Slicer/pull/7243

Tests fixed:

* `py_Slicer4Minute`
* `py_ShaderProperties`
* `py_RSNA2012ProstateDemo`
* `py_VolumeRenderingSceneClose`
* `py_SubjectHierarchyGenericSelfTest`
* `py_SampleData`
* `py_SlicerRestoreSceneViewCrashIssue3445`
* `py_RSNAVisTutorial`
* `py_JRC2013Vis`
* `py_AtlasTests`

Tested on a local build generated on Ubuntu 20.04
