### PR TITLE
ENH: Add StippleMapper2D to represent thick slab as dashed lines

### DIFF
--- a/Libs/MRML/DisplayableManager/CMakeLists.txt
+++ b/Libs/MRML/DisplayableManager/CMakeLists.txt
@@ -118,6 +118,7 @@ set(KIT_SRCS
   vtkMRMLSliceIntersectionInteractionRepresentationHelper.cxx
   vtkMRMLRubberBandWidgetRepresentation.cxx
   vtkMRMLWindowLevelWidget.cxx
+  vtkMRMLOpenGLLineStippleMapper2D.cxx
 
   # Proxy classes
   vtkMRMLLightBoxRendererManagerProxy.cxx
@@ -137,6 +138,20 @@ if(MRMLDisplayableManager_USE_PYTHON)
     WRAP_EXCLUDE
     )
 endif()
+
+# --------------------------------------------------------------------------
+# Shaders
+# --------------------------------------------------------------------------
+set(shader_files
+  glsl/vtkLineStippleGS.glsl
+  )
+foreach(file IN LISTS shader_files)
+  # Header and source files are generated in the current binary directory.
+  vtk_encode_string(
+    INPUT         "${file}"
+    SOURCE_OUTPUT source)
+  list(APPEND KIT_SRCS "${source}")
+endforeach()
 
 # --------------------------------------------------------------------------
 set(lib_name ${PROJECT_NAME})

--- a/Libs/MRML/DisplayableManager/glsl/vtkLineStippleGS.glsl
+++ b/Libs/MRML/DisplayableManager/glsl/vtkLineStippleGS.glsl
@@ -1,0 +1,25 @@
+#version 150
+
+layout(lines) in;
+layout(line_strip, max_vertices=2) out;
+
+uniform ivec2 ViewportSize;
+noperspective out float stippleCoord;
+
+void main()
+{
+  int i=0;
+  vec4 pos0 = gl_in[0].gl_Position;
+  vec2 p0 = pos0.xy / pos0.w * ViewportSize;
+  gl_Position = pos0;
+  stippleCoord = 0.0;
+  EmitVertex();
+
+  i=1;
+  vec4 pos1 = gl_in[i].gl_Position;
+  vec2 p1 = pos1.xy / pos1.w * ViewportSize;
+  float len = length(p0.xy - p1.xy);
+  stippleCoord = len / 32;
+  gl_Position = pos1;
+  EmitVertex();
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLOpenGLLineStippleMapper2D.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLOpenGLLineStippleMapper2D.cxx
@@ -1,0 +1,63 @@
+
+#include "vtkMRMLOpenGLLineStippleMapper2D.h"
+
+#include <vtkActor2D.h>
+#include <vtkObjectFactory.h>
+#include <vtkOpenGLShaderProperty.h>
+#include <vtkOpenGLUniforms.h>
+#include <vtkShaderProgram.h>
+#include <vtkViewport.h>
+
+// Bring in our shader symbols.
+#include "vtkLineStippleGS.h"
+
+//------------------------------------------------------------------------------
+vtkStandardNewMacro(vtkMRMLOpenGLLineStippleMapper2D);
+
+//------------------------------------------------------------------------------
+void vtkMRMLOpenGLLineStippleMapper2D::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLOpenGLLineStippleMapper2D::ReplaceShaderTCoord(
+  std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* vtkNotUsed(ren), vtkActor2D* vtkNotUsed(act))
+{
+  std::string FSSource = shaders[vtkShader::Fragment]->GetSource();
+
+  vtkShaderProgram::Substitute(
+    FSSource, "//VTK::TCoord::Dec",
+    "noperspective in float stippleCoord;\n"
+    "uniform int StipplePattern;");
+
+  vtkShaderProgram::Substitute(
+    FSSource, "//VTK::TCoord::Impl",
+    "int stip = 0x1 & (StipplePattern >> int(fract(stippleCoord)*16.0));\n"
+    "if (stip == 0)\n"
+    "{\n"
+    "  discard;\n"
+    "}");
+
+  shaders[vtkShader::Fragment]->SetSource(FSSource);
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLOpenGLLineStippleMapper2D::ReplaceShaderValues(
+  std::map<vtkShader::Type, vtkShader*> shaders, vtkViewport* viewport, vtkActor2D* act)
+{
+  this->Superclass::ReplaceShaderValues(shaders, viewport, act);
+
+  // Replace geometry shader ignoring all prior replacements
+  shaders[vtkShader::Geometry]->SetSource(vtkLineStippleGS);
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLOpenGLLineStippleMapper2D::SetMapperShaderParameters(
+  vtkOpenGLHelper& cellBO, vtkViewport* viewport, vtkActor2D* actor)
+{
+  this->Superclass::SetMapperShaderParameters(cellBO, viewport, actor);
+
+  cellBO.Program->SetUniformi("StipplePattern", 0xF0F0);
+  cellBO.Program->SetUniform2i("ViewportSize", viewport->GetSize());
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLOpenGLLineStippleMapper2D.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLOpenGLLineStippleMapper2D.h
@@ -1,0 +1,57 @@
+/**
+ * @class   vtkMRMLOpenGLLineStippleMapper2D
+ * @brief   2D stippled line support for OpenGL
+ *
+ * vtkMRMLOpenGLLineStippleMapper2D provides support for 2D stippled line for
+ * Slicer under OpenGL.
+ *
+ */
+
+#ifndef vtkMRMLOpenGLLineStippleMapper2D_h
+#define vtkMRMLOpenGLLineStippleMapper2D_h
+
+#include "vtkMRMLDisplayableManagerExport.h"
+
+#include "vtkOpenGLPolyDataMapper2D.h"
+#include "vtkShader.h"
+#include <map>
+
+class vtkActor2D;
+class vtkViewport;
+
+class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLOpenGLLineStippleMapper2D : public vtkOpenGLPolyDataMapper2D
+{
+public:
+  vtkTypeMacro(vtkMRMLOpenGLLineStippleMapper2D, vtkOpenGLPolyDataMapper2D);
+  static vtkMRMLOpenGLLineStippleMapper2D* New();
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+protected:
+  vtkMRMLOpenGLLineStippleMapper2D() = default;
+  ~vtkMRMLOpenGLLineStippleMapper2D() override = default;
+
+  /**
+   * Perform string replacements on the shader templates, called from
+   * ReplaceShaderValues
+   */
+  void ReplaceShaderTCoord(
+    std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* ren, vtkActor2D* act) override;
+
+  /**
+   * Perform string replacements on the shader templates
+   */
+  void ReplaceShaderValues(
+    std::map<vtkShader::Type, vtkShader*> shaders, vtkViewport* viewport, vtkActor2D* act) override;
+
+  /**
+   * Set the shader parameters related to the mapper/input data, called by UpdateShader
+   */
+  void SetMapperShaderParameters(
+    vtkOpenGLHelper& cellBO, vtkViewport* viewport, vtkActor2D* act) override;
+
+private:
+  vtkMRMLOpenGLLineStippleMapper2D(const vtkMRMLOpenGLLineStippleMapper2D&) = delete;
+  void operator=(const vtkMRMLOpenGLLineStippleMapper2D&) = delete;
+};
+
+#endif

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.cxx
@@ -24,6 +24,7 @@
 
 #include "vtkMRMLApplicationLogic.h"
 #include "vtkMRMLModelDisplayNode.h"
+#include "vtkMRMLOpenGLLineStippleMapper2D.h"
 #include "vtkMRMLSliceDisplayNode.h"
 #include "vtkMRMLSliceLogic.h"
 #include "vtkMRMLSliceNode.h"
@@ -140,7 +141,7 @@ class SliceIntersectionInteractionDisplayPipeline
       this->ThickSlabLine1FirstHalf = vtkSmartPointer<vtkLineSource>::New();
       this->ThickSlabLine1FirstHalf->SetResolution(THICK_SLAB_LINE_RESOLUTION);
       this->ThickSlabLine1FirstHalf->Update();
-      this->ThickSlabLine1FirstHalfMapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+      this->ThickSlabLine1FirstHalfMapper = vtkSmartPointer<vtkMRMLOpenGLLineStippleMapper2D>::New();
       this->ThickSlabLine1FirstHalfProperty = vtkSmartPointer<vtkProperty2D>::New();
       this->ThickSlabLine1FirstHalfActor = vtkSmartPointer<vtkActor2D>::New();
       this->ThickSlabLine1FirstHalfActor->SetVisibility(false); // invisible until slice node is set
@@ -152,7 +153,7 @@ class SliceIntersectionInteractionDisplayPipeline
       this->ThickSlabLine1SecondHalf = vtkSmartPointer<vtkLineSource>::New();
       this->ThickSlabLine1SecondHalf->SetResolution(THICK_SLAB_LINE_RESOLUTION);
       this->ThickSlabLine1SecondHalf->Update();
-      this->ThickSlabLine1SecondHalfMapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+      this->ThickSlabLine1SecondHalfMapper = vtkSmartPointer<vtkMRMLOpenGLLineStippleMapper2D>::New();
       this->ThickSlabLine1SecondHalfProperty = vtkSmartPointer<vtkProperty2D>::New();
       this->ThickSlabLine1SecondHalfActor = vtkSmartPointer<vtkActor2D>::New();
       this->ThickSlabLine1SecondHalfActor->SetVisibility(false); // invisible until slice node is set
@@ -164,7 +165,7 @@ class SliceIntersectionInteractionDisplayPipeline
       this->ThickSlabLine2FirstHalf = vtkSmartPointer<vtkLineSource>::New();
       this->ThickSlabLine2FirstHalf->SetResolution(THICK_SLAB_LINE_RESOLUTION);
       this->ThickSlabLine2FirstHalf->Update();
-      this->ThickSlabLine2FirstHalfMapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+      this->ThickSlabLine2FirstHalfMapper = vtkSmartPointer<vtkMRMLOpenGLLineStippleMapper2D>::New();
       this->ThickSlabLine2FirstHalfProperty = vtkSmartPointer<vtkProperty2D>::New();
       this->ThickSlabLine2FirstHalfActor = vtkSmartPointer<vtkActor2D>::New();
       this->ThickSlabLine2FirstHalfActor->SetVisibility(false); // invisible until slice node is set
@@ -176,7 +177,7 @@ class SliceIntersectionInteractionDisplayPipeline
       this->ThickSlabLine2SecondHalf = vtkSmartPointer<vtkLineSource>::New();
       this->ThickSlabLine2SecondHalf->SetResolution(THICK_SLAB_LINE_RESOLUTION);
       this->ThickSlabLine2SecondHalf->Update();
-      this->ThickSlabLine2SecondHalfMapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+      this->ThickSlabLine2SecondHalfMapper = vtkSmartPointer<vtkMRMLOpenGLLineStippleMapper2D>::New();
       this->ThickSlabLine2SecondHalfProperty = vtkSmartPointer<vtkProperty2D>::New();
       this->ThickSlabLine2SecondHalfActor = vtkSmartPointer<vtkActor2D>::New();
       this->ThickSlabLine2SecondHalfActor->SetVisibility(false); // invisible until slice node is set

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionRepresentation2D.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionRepresentation2D.cxx
@@ -18,6 +18,7 @@
 #include <deque>
 
 #include "vtkMRMLApplicationLogic.h"
+#include "vtkMRMLOpenGLLineStippleMapper2D.h"
 #include "vtkMRMLSliceDisplayNode.h"
 #include "vtkMRMLSliceLogic.h"
 #include "vtkMRMLSliceNode.h"
@@ -58,13 +59,13 @@ public:
     this->Actor->SetVisibility(false); // invisible until slice node is set
 
     this->ThickSlabLine1LineSource = vtkSmartPointer<vtkLineSource>::New();
-    this->ThickSlabLine1Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+    this->ThickSlabLine1Mapper = vtkSmartPointer<vtkMRMLOpenGLLineStippleMapper2D>::New();
     this->ThickSlabLine1Property = vtkSmartPointer<vtkProperty2D>::New();
     this->ThickSlabLine1Actor = vtkSmartPointer<vtkActor2D>::New();
     this->ThickSlabLine1Actor->SetVisibility(false); // invisible until slice node is set
 
     this->ThickSlabLine2LineSource = vtkSmartPointer<vtkLineSource>::New();
-    this->ThickSlabLine2Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+    this->ThickSlabLine2Mapper = vtkSmartPointer<vtkMRMLOpenGLLineStippleMapper2D>::New();
     this->ThickSlabLine2Property = vtkSmartPointer<vtkProperty2D>::New();
     this->ThickSlabLine2Actor = vtkSmartPointer<vtkActor2D>::New();
     this->ThickSlabLine2Actor->SetVisibility(false); // invisible until slice node is set


### PR DESCRIPTION
Workaround VTK issue 15799 adding a dedicated mapper allowing to represent lines based on a stipple pattern.

See https://gitlab.kitware.com/vtk/vtk/-/issues/15799


**Before** (without dashed lines): ![image](https://github.com/Slicer/Slicer/assets/219043/2f8c6a37-6272-4bff-9bdc-f496bf0eec96)
**After**:  (with dashed lines) ![image](https://github.com/Slicer/Slicer/assets/219043/743ef7f4-0af9-43c8-bb77-a69461f19ca4)

### Issue when scaling down viewer

When **Interactive** thick slab handles are enabled, there are two line actors (and mappers) used to represent each lines:

```
       Line1FirstHalf         Line1SecondHalf
<-----------------------><----------------------->

<-----------------------><----------------------->
       Line2FirstHalf         Line2SecondHalf
```

In this particular case, the stipple pattern is not properly rendered:


| | |
|--|--|
| Single line actor & mapper per line  | ![image](https://github.com/Slicer/Slicer/assets/219043/2dffa2b7-2b3e-46c0-8bcd-12d655f4c84c) |
| Two line actors & mappers per line (**interactive**) | ![image](https://github.com/Slicer/Slicer/assets/219043/d74543d7-9b69-48a9-917a-ddc9f6b8778c) |





