### PR TITLE
BUG: Allow reslicing of 32-bit integer images

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
@@ -653,9 +653,7 @@ void vtkMRMLSliceLayerLogic::UpdateImageDisplay()
 
   vtkImageData *imageData = this->VolumeNode->GetImageData();
   if (imageData != nullptr &&
-      (imageData->GetScalarType() == VTK_LONG ||
-       imageData->GetScalarType() == VTK_UNSIGNED_LONG ||
-       imageData->GetScalarType() == VTK_LONG_LONG ||
+      (imageData->GetScalarType() == VTK_LONG_LONG ||
        imageData->GetScalarType() == VTK_UNSIGNED_LONG_LONG))
     {
     vtkErrorMacro("Reslicing can only be done on types representable as double.  Node " <<


### PR DESCRIPTION
Follow-up to #4982. 32-bit integer data types can fit losslessly into the 53-bit mantissa of a 64-bit `double`, and this fix has been working fine for us for the last few months.