### PR TITLE
ENH: Enable TBB as default VTK SMP implementation on all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,12 +561,7 @@ mark_as_superbuild(Slicer_VTK_RENDERING_BACKEND)
 set(Slicer_VTK_RENDERING_USE_${Slicer_VTK_RENDERING_BACKEND}_BACKEND 1)
 
 # Slicer build is only tested with Sequential and TBB. OpenMP might work.
-# Use TBB by default only on Windows, as it has not been tested on other platforms.
-if(WIN32)
-  set(Slicer_DEFAULT_VTK_SMP_IMPLEMENTATION_TYPE "TBB")
-else()
-  set(Slicer_DEFAULT_VTK_SMP_IMPLEMENTATION_TYPE "Sequential")
-endif()
+set(Slicer_DEFAULT_VTK_SMP_IMPLEMENTATION_TYPE "TBB")
 set(Slicer_VTK_SMP_IMPLEMENTATION_TYPE ${Slicer_DEFAULT_VTK_SMP_IMPLEMENTATION_TYPE}
   CACHE STRING "Which multi-threaded parallelism implementation to use in VTK. Options are Sequential or TBB.")
 set_property(CACHE Slicer_VTK_SMP_IMPLEMENTATION_TYPE


### PR DESCRIPTION
Follow-up de4a89a1b4 (ENH: Support 3D rendering of segmentation using Surface Nets) integrated through PR-7224 and ensure similar performance increase an all platforms including Linux and macOS.

With TBB enabled:
- Flying Edges with Standard Smoothing is ~ x2 faster
- Surface Nets with Standard Smoothing is ~ x4 faster
- Surface Nets with Internal Smoothing is ~ x4 faster

Related pull requests and issues:
* https://github.com/Slicer/Slicer/pull/7224#issuecomment-1774327464
* https://github.com/Slicer/Slicer/pull/6405
* https://github.com/Slicer/Slicer/pull/6404
* https://github.com/Slicer/Slicer/pull/5965
* https://github.com/Slicer/Slicer/pull/5903

Before integrating, test build and packaging:
* [x] on `metroplex` Linux build machine using `slicer/buildenv-qt5-centos7:latest`[^1]
* [x] on `computron` macOS build machine

[^1]: https://github.com/Slicer/SlicerBuildEnvironment#docker-based-environments