### PR TITLE
BUG: Ensure DICOMCommand.start() returns process output 

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -75,8 +75,8 @@ class DICOMProcess:
         self.connections = {}
         self.exeDir = self.getDCMTKToolsPath()
         self.exeExtension = ".exe" if os.name == "nt" else ""
-        self.stdout = None
-        self.stderr = None
+        self._stdout = None
+        self._stderr = None
 
     def __del__(self):
         self.stop()
@@ -129,9 +129,9 @@ class DICOMProcess:
             logging.debug(f"DICOM process standard out is: {stdout}")
             logging.debug(f"DICOM process standard error is: {stderr}")
 
-        self.stdout = stdout
-        self.stderr = stderr
-        return self.stdout, self.stderr
+        self._stdout = stdout
+        self._stderr = stderr
+        return self._stdout, self._stderr
 
     def stop(self) -> None:
         """Stop the running standalone process."""
@@ -166,7 +166,7 @@ class DICOMCommand(DICOMProcess):
         self.process.waitForFinished()
         if self.process.exitStatus() == qt.QProcess.CrashExit or self.process.exitCode() != 0:
             raise UserWarning(f"Could not run {self.executable} with {self.args}")
-        return self.stdout
+        return self._stdout
 
 
 class DICOMStoreSCPProcess(DICOMProcess):

--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -101,15 +101,34 @@ class DICOMProcess:
         logging.debug(f"Process {self.cmd} now in state {self.PROCESS_STATE_NAMES[newState]}")
         stdout = None
         stderr = None
-        if newState == 0 and self.process:
+        if newState == qt.QProcess.NotRunning and self.process:
             stdout = self.process.readAllStandardOutput()
             stderr = self.process.readAllStandardError()
 
-            logging.debug(f"DICOM process exit status is: {self.process.exitStatus()}")
-            logging.debug(f"DICOM process exit code is: {self.process.exitCode()}")
-            logging.debug(f"DICOM process error is: {self.process.error()}")
+            exitStatusAsString = "NormalExit"
+            if self.process.exitStatus() == qt.QProcess.CrashExit:
+                exitStatusAsString = "CrashExit"
+
+            logging.debug(f"DICOM process exit status is: {exitStatusAsString}")
+
+            if self.process.exitStatus() == qt.QProcess.NormalExit:
+                # exitCode is not valid unless exitStatus() returns NormalExit
+                logging.debug(f"DICOM process exit code is: {self.process.exitCode()}")
+
+            if self.process.exitStatus() == qt.QProcess.CrashExit:
+                processError = {
+                    qt.QProcess.FailedToStart: "FailedToStart",
+                    qt.QProcess.Crashed: "Crashed",
+                    qt.QProcess.Timedout: "Timedout",
+                    qt.QProcess.WriteError: "WriteError",
+                    qt.QProcess.ReadError: "ReadError",
+                    qt.QProcess.UnknownError: "UnknownError",
+                }.get(self.process.error())
+                logging.debug(f"DICOM process error is: {processError}")
+
             logging.debug(f"DICOM process standard out is: {stdout}")
             logging.debug(f"DICOM process standard error is: {stderr}")
+
         self.stdout = stdout
         self.stderr = stderr
         return self.stdout, self.stderr


### PR DESCRIPTION
Resolve `py_nomainwindow_DCMTKPrivateDictTest` failure caused by a regression introduced in commit adb997269 (`COMP: Refactor DICOMProcess and DICOMCommand`).

The issue stemmed from the refactoring commit, which guaranteed that the `start()` function of the base class was consistently invoked. This resulted in the connection of the "onStateChanged()" signal and the immediate reading of standard output and error.

Subsequently, any further calls to `self.process.readAllStandardOutput()` were returning an empty string. This fix restores the expected behavior.

### Test results

_Command below executed on local build done on Ubuntu 20.04_

```
ctest -R "(py_nomainwindow_qSlicerDICOMModuleGenericTest|py_nomainwindow_qSlicerDICOMPatcherModuleGenericTest|py_DICOMPatcher|CreateDICOMSeriesTest|py_DICOMReaders|py_nomainwindow_DCMTKPrivateDictTest)"

Test project /path/to/Slicer-Release/Slicer-build
    Start 450: py_nomainwindow_qSlicerDICOMModuleGenericTest
1/6 Test #450: py_nomainwindow_qSlicerDICOMModuleGenericTest ..........   Passed    4.39 sec
    Start 451: py_nomainwindow_qSlicerDICOMPatcherModuleGenericTest
2/6 Test #451: py_nomainwindow_qSlicerDICOMPatcherModuleGenericTest ...   Passed    3.60 sec
    Start 452: py_DICOMPatcher
3/6 Test #452: py_DICOMPatcher ........................................   Passed    4.96 sec
    Start 523: CreateDICOMSeriesTest
4/6 Test #523: CreateDICOMSeriesTest ..................................   Passed    0.35 sec
    Start 599: py_nomainwindow_DCMTKPrivateDictTest
5/6 Test #599: py_nomainwindow_DCMTKPrivateDictTest ...................   Passed    2.26 sec
    Start 607: py_DICOMReaders
6/6 Test #607: py_DICOMReaders ........................................   Passed    8.00 sec

100% tests passed, 0 tests failed out of 6

```