### PR TITLE
BUG: Ensure remaining application events are processed before exiting

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -2066,6 +2066,10 @@ void qSlicerCoreApplication::onAboutToQuit()
     {
     d->ReturnCode = qSlicerCoreApplication::ExitFailure;
     }
+  // Ensure that all events have been processed. This ensures that any pending
+  // messages logged from Python scripts are properly reported and written to
+  // log files before the application exits.
+  this->processEvents();
 #endif
 }
 


### PR DESCRIPTION
This update ensures that any pending messages logged from Python scripts are properly reported and written to log files before the application exits.

This issue was uncovered while working on https://github.com/Slicer/Slicer/pull/7299

To illustrate:

## Before

* :white_check_mark: **With** explicit call to `slicer.app.processEvents()`:
  ```
  rm /tmp/Slicer-jcfr/*.log && \
  ./Slicer --python-code "import logging; logging.debug('EXPECTED DEBUG OUTPUT'); slicer.app.processEvents()" \
    --exit-after-startup 2>&1 > /dev/null && \
    (echo "Slicer exited without error" && cat $(ls -1 /tmp/Slicer-jcfr/*.log) | grep "EXPECTED DEBUG OUTPUT")

  [DEBUG][Python] 23.10.2023 17:35:16 [Python] (<string>:1) - EXPECTED DEBUG OUTPUT
  ```

* :x: **Without** explicit call to `slicer.app.processEvents()`:

  ```
  rm /tmp/Slicer-jcfr/*.log && \
  ./Slicer --python-code "import logging; logging.debug('EXPECTED DEBUG OUTPUT');" \
    --exit-after-startup 2>&1 > /dev/null && \
    (echo "Slicer exited without error" && cat $(ls -1 /tmp/Slicer-jcfr/*.log) | grep "EXPECTED DEBUG OUTPUT")
  ```

Message with `EXPECTED DEBUG OUTPUT` is missing from the log file


## After

* :white_check_mark: **With** explicit call to `slicer.app.processEvents()`:

  ```
  rm /tmp/Slicer-jcfr/*.log && \
  ./Slicer --python-code "import logging; logging.debug('EXPECTED DEBUG OUTPUT'); slicer.app.processEvents()" \
    --exit-after-startup 2>&1 > /dev/null && \
    (echo "Slicer exited without error" && cat $(ls -1 /tmp/Slicer-jcfr/*.log) | grep "EXPECTED DEBUG OUTPUT")

  [DEBUG][Python] 23.10.2023 17:39:25 [Python] (<string>:1) - EXPECTED DEBUG OUTPUT
  ```

* :white_check_mark: **Without** explicit call to `slicer.app.processEvents()`:

  ```
  rm /tmp/Slicer-jcfr/*.log && \
  ./Slicer --python-code "import logging; logging.debug('EXPECTED DEBUG OUTPUT');" \
    --exit-after-startup 2>&1 > /dev/null && \
    (echo "Slicer exited without error" && cat $(ls -1 /tmp/Slicer-jcfr/*.log) | grep "EXPECTED DEBUG OUTPUT")

  [DEBUG][Python] 23.10.2023 17:38:59 [Python] (<string>:1) - EXPECTED DEBUG OUTPUT
  ```