### PR TITLE
ENH: Update vtkAddon to include vtkImageLabelDilate3D filter

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -202,7 +202,7 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG 87e5df9ac609a2d7a21991f7cba37c5b51482d7e
+  GIT_TAG 8bdd3d7bf0b81a947c5ed82754387b76c2bfd3f5
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_vtkAddon Slicer_REMOTE_DEPENDENCIES vtkAddon)


### PR DESCRIPTION
Adds one commit:

Revision: 8bdd3d7bf0b81a947c5ed82754387b76c2bfd3f5
Author: Andras Lasso <lasso@queensu.ca>
Date: 2023-10-25 5:35:17 PM
Message:
ENH: Add vtkImageLabelDilate3D filter (#41)

Used when coloring a scalar volume using segmentation and we want to make sure that labels cover the underlying structure and a bit further (to color also the transition of the masked voxels). ----
Modified: CMakeLists.txt
Added: vtkImageLabelDilate3D.cxx
Added: vtkImageLabelDilate3D.h