### PR TITLE
ENH: Update VTK and vtkAddon for ColorizeVolume module in Sandbox extension

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -202,7 +202,7 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG 87e5df9ac609a2d7a21991f7cba37c5b51482d7e
+  GIT_TAG 03f7dfdd3a7eef955bb033df61d0fc19028ac2a6
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_vtkAddon Slicer_REMOTE_DEPENDENCIES vtkAddon)

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "97965bba9e1d8f49482ffc61c464b11287cd19e2") # slicer-v9.2.20230607-1ff325c54
+    set(_git_tag "4bfb0f049af04aec4177182b8b774b605c04fdbe") # slicer-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
The updated VTK branch has been cleaned up to remove the update to `vtkImageLabelDilate3D` and backport changes already integrated in upstream VTK or being contributed through merge requests.

Instead of using the modified `vtkImageMedian3D` filter, the extension has been updated to use the `vtkImageLabelDilate3D` provided through the vtkAddon project.

The `vtkImageLabelDilate3D` is used when coloring a scalar volume using segmentation and we want to make sure that labels cover the underlying structure and a bit further (to color also the transition of the masked voxels).

For reference:

* integration of `vtkImageLabelDilate3D` into upstream VTK is discussed at https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10588

* updates originally introduced through 57b8434f4 (BUG: Update VTK to fix RGBA volume rendering) and 37144f2ec (BUG: Update VTK to fix segfault when enabling volume rendering) are now being contributed into upstream VTK through https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10639


List of VTK changes:

```
$ git shortlog 97965bba9..4bfb0f049 --no-merges
Lucas Givord (1):
      [Backport] vtkMultiVolume: fix wrong ambient computation

Steve Pieper (1):
      [Backport MR-10639] VolumeOpenGL2: Use alpha to calculate RGBA lighting
```

List of vtkAddon changes:

```
$ git shortlog 8bdd3d7bf..03f7dfdd3 --no-merges 
Andras Lasso (1):
      ENH: Add vtkImageLabelDilate3D filter
```