### PR TITLE
BUG: Fix parameter node wrapper observers not being removed

### DIFF
--- a/Base/Python/slicer/parameterNodeWrapper/wrapper.py
+++ b/Base/Python/slicer/parameterNodeWrapper/wrapper.py
@@ -3,6 +3,7 @@
 import logging
 import typing
 from typing import Optional
+import weakref
 
 import qt
 
@@ -86,8 +87,16 @@ class _CachedParameterWrapper(_ParameterWrapper):
     def __init__(self, parameter: _Parameter, parameterNode):
         super().__init__(parameter, parameterNode)
         self._value = self.parameter.read(self.parameterNode)
-        self._observerTag: int = parameterNode.AddObserver(vtk.vtkCommand.ModifiedEvent, self._onModified)
+        # Important: We don't want to increase the reference to self here by including it in the AddObserver callback.
+        # This would prevent the object from being garbage collected, and the observers from being removed when the object goes out of scope.
+        # Instead, we create a weakref to self and use it in a lambda function.
+        _selfWeakRef = weakref.ref(self)
+        self._observerTag: int = parameterNode.AddObserver(vtk.vtkCommand.ModifiedEvent,
+                                                           lambda caller, event: _selfWeakRef()._onModified(caller, event))
         self._currentlyWriting: bool = False
+
+    def __del__(self):
+        self.parameterNode.RemoveObserver(self._observerTag)
 
     def _onModified(self, caller, event):
         if not self._currentlyWriting:


### PR DESCRIPTION
Whenever a parameter node wrapper was instantiated, it attached a ModifiedEvent observer for each cached attribute in the node, however these observers were never removed.

This commit adds a RemoveObserver call to the `__del__ `method to ensure that the observer is removed when the wrapper object is deleted. This commit also ensures that the object can be deleted by using a weak reference in the AddObserver callback.

**Before:**
```
parameterNode.AddObserver(vtk.vtkCommand.ModifiedEvent, self._onModified)
```

Using this approach the python reference count is increased and kept by VTK for as long as the observer is attached to the self._onModified method.

**After**
````
_selfWeakRef = weakref.ref(self)
self._observerTag: int = parameterNode.AddObserver(vtk.vtkCommand.ModifiedEvent, lambda caller, event: _selfWeakRef()._onModified(caller, event))
````

Using this approach, only a weak reference to the object is given to VTK, which allows the object to be deleted before the observer is removed. Since the `__del__` function will remove the observer, there is no danger of the weak pointer becoming invalid.