### PR TITLE
COMP: Update vtkAddon to fix vtkImageLabelDilate3D build on recent compiler

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -202,7 +202,7 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG 03f7dfdd3a7eef955bb033df61d0fc19028ac2a6
+  GIT_TAG 960c2e3c8aa5155951930b53f1590f3db8f94d80
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_vtkAddon Slicer_REMOTE_DEPENDENCIES vtkAddon)


### PR DESCRIPTION
Follow-up of 1aeac28119 (ENH: Update VTK and vtkAddon for ColorizeVolume module in Sandbox extension)

List of vkAddon changes:

```
$ git shortlog 03f7dfdd3..960c2e3c8 --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Update vtkImageLabelDilate3D adding includes for used STL containers
```