### PR TITLE
Improve Event Delegation in qMRMLThreeDView and qMRMLSliceView

### DIFF
--- a/Docs/developer_guide/script_repository/gui.md
+++ b/Docs/developer_guide/script_repository/gui.md
@@ -1162,8 +1162,8 @@ w.SetEventTranslationClickAndDrag(w.WidgetStateIdle,
 For example, disable slice browsing using mouse wheel and keyboard shortcuts in the red slice viewer:
 
 ```python
-interactorStyle = slicer.app.layoutManager().sliceWidget("Red").sliceView().sliceViewInteractorStyle()
-interactorStyle.SetActionEnabled(interactorStyle.BrowseSlice, False)
+interactorObserver = slicer.app.layoutManager().sliceWidget("Red").sliceView().interactorObserver()
+interactorObserver.SetActionEnabled(interactorStyle.BrowseSlice, False)
 ```
 
 Hide all slice view controllers:

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLCameraDisplayableManagerTest1.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLCameraDisplayableManagerTest1.cxx
@@ -33,6 +33,7 @@
 // VTK includes
 #include <vtkErrorCode.h>
 #include <vtkInteractorEventRecorder.h>
+#include <vtkInteractorStyle3D.h>
 #include <vtkNew.h>
 #include <vtkPNGWriter.h>
 #include <vtkRegressionTestImage.h>
@@ -504,7 +505,7 @@ int vtkMRMLCameraDisplayableManagerTest1(int argc, char* argv[])
   rw->SetInteractor(ri.GetPointer());
 
   // Set Interactor Style
-  vtkNew<vtkMRMLThreeDViewInteractorStyle> iStyle;
+  vtkNew<vtkInteractorStyle3D> iStyle;
   ri->SetInteractorStyle(iStyle.GetPointer());
 
   // MRML scene
@@ -581,6 +582,10 @@ int vtkMRMLCameraDisplayableManagerTest1(int argc, char* argv[])
     return EXIT_FAILURE;
     }
 
+  vtkNew<vtkMRMLThreeDViewInteractorStyle> iObserver;
+  iObserver->SetDisplayableManagers(displayableManagerGroup);
+  iObserver->SetInteractor(ri);
+
   // Check if GetDisplayableManagerCount returns 2
   if (displayableManagerGroup->GetDisplayableManagerCount() != 2)
     {
@@ -610,9 +615,9 @@ int vtkMRMLCameraDisplayableManagerTest1(int argc, char* argv[])
 
   // Interactor style should be vtkMRMLThreeDViewInteractorStyle
   vtkInteractorObserver * currentInteractoryStyle = ri->GetInteractorStyle();
-  if (!vtkMRMLThreeDViewInteractorStyle::SafeDownCast(currentInteractoryStyle))
+  if (!vtkInteractorStyle3D::SafeDownCast(currentInteractoryStyle))
     {
-    std::cerr << "Expected interactorStyle: vtkMRMLThreeDViewInteractorStyle" << std::endl;
+    std::cerr << "Expected interactorStyle: vtkInteractorStyle3D" << std::endl;
     std::cerr << "Current RenderWindowInteractor: "
       << (currentInteractoryStyle ? currentInteractoryStyle->GetClassName() : "Null") << std::endl;
     return EXIT_FAILURE;

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLCameraWidgetTest1.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLCameraWidgetTest1.cxx
@@ -15,6 +15,7 @@
 // VTK includes
 #include <vtkErrorCode.h>
 #include <vtkInteractorEventRecorder.h>
+#include <vtkInteractorStyle3D.h>
 #include <vtkNew.h>
 #include <vtkPNGWriter.h>
 #include <vtkRegressionTestImage.h>
@@ -87,7 +88,7 @@ int vtkMRMLCameraWidgetTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
   rw->SetInteractor(ri.GetPointer());
 
   // Set Interactor Style
-  vtkNew<vtkMRMLThreeDViewInteractorStyle> iStyle;
+  vtkNew<vtkInteractorStyle3D> iStyle;
   ri->SetInteractorStyle(iStyle.GetPointer());
 
   // MRML scene
@@ -116,6 +117,10 @@ int vtkMRMLCameraWidgetTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
   vtkSmartPointer<vtkMRMLDisplayableManagerGroup> group = vtkSmartPointer<vtkMRMLDisplayableManagerGroup>::Take(
     factory->InstantiateDisplayableManagers(rr.GetPointer()));
   CHECK_NOT_NULL(group);
+
+  vtkNew<vtkMRMLThreeDViewInteractorStyle> iObserver;
+  iObserver->SetDisplayableManagers(group);
+  iObserver->SetInteractor(ri);
 
   vtkMRMLCameraDisplayableManager * cameraDisplayableManager =vtkMRMLCameraDisplayableManager::SafeDownCast(
     group->GetDisplayableManagerByClassName("vtkMRMLCameraDisplayableManager"));

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLDisplayableManagerFactoriesTest1.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLDisplayableManagerFactoriesTest1.cxx
@@ -18,6 +18,7 @@
 
 // VTK includes
 #include <vtkNew.h>
+#include <vtkInteractorStyle3D.h>
 #include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkRenderer.h>
@@ -100,7 +101,7 @@ int vtkMRMLDisplayableManagerFactoriesTest1(int argc, char* argv[])
   rw->SetInteractor(ri.GetPointer());
 
   // Set Interactor Style
-  vtkNew<vtkMRMLThreeDViewInteractorStyle> iStyle;
+  vtkNew<vtkInteractorStyle3D> iStyle;
   ri->SetInteractorStyle(iStyle.GetPointer());
 
   // ThreeD - Instantiate displayable managers

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLThreeDReformatDisplayableManagerTest1.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLThreeDReformatDisplayableManagerTest1.cxx
@@ -37,6 +37,7 @@
 #include <vtkCamera.h>
 #include <vtkErrorCode.h>
 #include <vtkInteractorEventRecorder.h>
+#include <vtkInteractorStyle3D.h>
 #include <vtkNew.h>
 #include <vtkPNGWriter.h>
 #include <vtkRegressionTestImage.h>
@@ -916,7 +917,7 @@ int vtkMRMLThreeDReformatDisplayableManagerTest1(int argc, char* argv[])
   renderWindow->SetInteractor(renderWindowInteractor.GetPointer());
 
   // Set Interactor Style
-  vtkNew<vtkMRMLThreeDViewInteractorStyle> iStyle;
+  vtkNew<vtkInteractorStyle3D> iStyle;
   renderWindowInteractor->SetInteractorStyle(iStyle.GetPointer());
 
   renderWindow->Render();
@@ -940,7 +941,9 @@ int vtkMRMLThreeDReformatDisplayableManagerTest1(int argc, char* argv[])
   renderCallback->RenderWindow = renderWindow;
   displayableManagerGroup->AddObserver(vtkCommand::UpdateEvent, renderCallback);
 
-  iStyle->SetDisplayableManagers(displayableManagerGroup);
+  vtkNew<vtkMRMLThreeDViewInteractorStyle> iObserver;
+  iObserver->SetDisplayableManagers(displayableManagerGroup);
+  iObserver->SetInteractor(renderWindowInteractor);
 
   vtkNew<vtkMRMLThreeDReformatDisplayableManager> reformatDisplayableManager;
   reformatDisplayableManager->SetMRMLApplicationLogic(applicationLogic);

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLThreeDViewDisplayableManagerFactoryTest1.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLThreeDViewDisplayableManagerFactoryTest1.cxx
@@ -30,6 +30,7 @@
 
 // VTK includes
 #include <vtkNew.h>
+#include <vtkInteractorStyle3D.h>
 #include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkRenderer.h>
@@ -193,7 +194,7 @@ int vtkMRMLThreeDViewDisplayableManagerFactoryTest1(int vtkNotUsed(argc), char* 
   rw->SetInteractor(ri.GetPointer());
 
   // Set Interactor Style
-  vtkNew<vtkMRMLThreeDViewInteractorStyle> iStyle;
+  vtkNew<vtkInteractorStyle3D> iStyle;
   ri->SetInteractorStyle(iStyle.GetPointer());
 
   // MRML scene and ViewNode

--- a/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewInteractorStyle.cxx
@@ -27,6 +27,7 @@
 #include <vtkCamera.h>
 #include <vtkCellPicker.h>
 #include <vtkEvent.h>
+#include <vtkInteractorStyle.h>
 #include <vtkMath.h>
 #include <vtkObjectFactory.h>
 #include <vtkPoints.h>
@@ -110,7 +111,8 @@ bool vtkMRMLThreeDViewInteractorStyle::DelegateInteractionEventToDisplayableMana
   // Get display and world position
   int* displayPositionInt = this->GetInteractor()->GetEventPosition();
   vtkRenderer* pokedRenderer = this->GetInteractor()->FindPokedRenderer(displayPositionInt[0], displayPositionInt[1]);
-  this->SetCurrentRenderer(pokedRenderer);
+  vtkInteractorStyle* interactorStyle = vtkInteractorStyle::SafeDownCast(this->GetInteractor()->GetInteractorStyle());
+  interactorStyle->SetCurrentRenderer(pokedRenderer);
   if (!pokedRenderer || !inputEventData)
     {
     // can happen during application shutdown
@@ -165,7 +167,8 @@ void vtkMRMLThreeDViewInteractorStyle::SetInteractor(vtkRenderWindowInteractor *
 bool vtkMRMLThreeDViewInteractorStyle::QuickPick(int x, int y, double pickPoint[3])
 {
   vtkRenderer* pokedRenderer = this->GetInteractor()->FindPokedRenderer(x, y);
-  this->SetCurrentRenderer(pokedRenderer);
+  vtkInteractorStyle* interactorStyle = vtkInteractorStyle::SafeDownCast(this->GetInteractor()->GetInteractorStyle());
+  interactorStyle->SetCurrentRenderer(pokedRenderer);
   if (pokedRenderer == nullptr)
   {
     vtkDebugMacro("Pick: couldn't find the poked renderer at event position " << x << ", " << y);

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
@@ -25,6 +25,7 @@
 
 // VTK includes
 #include "vtkCallbackCommand.h"
+#include "vtkInteractorStyle.h"
 #include "vtkObjectFactory.h"
 #include "vtkRenderer.h"
 #include "vtkRenderWindow.h"
@@ -36,6 +37,8 @@ vtkStandardNewMacro(vtkMRMLViewInteractorStyle);
 //----------------------------------------------------------------------------
 vtkMRMLViewInteractorStyle::vtkMRMLViewInteractorStyle()
 {
+  this->EventCallbackCommand = vtkCallbackCommand::New();
+  this->EventCallbackCommand->SetClientData(this);
   this->EventCallbackCommand->SetCallback(vtkMRMLViewInteractorStyle::CustomProcessEvents);
 
   this->DisplayableManagerCallbackCommand = vtkCallbackCommand::New();
@@ -49,6 +52,8 @@ vtkMRMLViewInteractorStyle::vtkMRMLViewInteractorStyle()
 //----------------------------------------------------------------------------
 vtkMRMLViewInteractorStyle::~vtkMRMLViewInteractorStyle()
 {
+  this->EventCallbackCommand->Delete();
+
   if (this->DisplayableManagers)
     {
     int numberOfDisplayableManagers = this->DisplayableManagers->GetDisplayableManagerCount();
@@ -71,31 +76,19 @@ void vtkMRMLViewInteractorStyle::PrintSelf(ostream& os, vtkIndent indent)
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnKeyPress()
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::KeyPressEvent))
-    {
-    return;
-    }
-  this->Superclass::OnKeyPress();
+  this->GetInteractorStyle()->OnKeyPress();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnKeyRelease()
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::KeyReleaseEvent))
-    {
-    return;
-    }
-  this->Superclass::OnKeyRelease();
+  this->GetInteractorStyle()->OnKeyRelease();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnChar()
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::CharEvent))
-    {
-    return;
-    }
-  // Do not call this->Superclass::OnChar(), because char OnChar events perform various
+  // Do not call this->GetInteractorStyle->OnChar(), because char OnChar events perform various
   // low-level operations on the actors (change their rendering style to wireframe, pick them,
   // change rendering mode to stereo, etc.), which would interfere with displayable managers.
 }
@@ -104,201 +97,124 @@ void vtkMRMLViewInteractorStyle::OnChar()
 void vtkMRMLViewInteractorStyle::OnMouseMove()
 {
   this->MouseMovedSinceButtonDown = true;
-  if (!this->DelegateInteractionEventToDisplayableManagers(vtkCommand::MouseMoveEvent))
-    {
-    return;
-    }
-  this->Superclass::OnMouseMove();
+  this->GetInteractorStyle()->OnMouseMove();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnRightButtonDown()
 {
   this->MouseMovedSinceButtonDown = false;
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::RightButtonPressEvent))
-    {
-    return;
-    }
-  this->InvokeEvent(vtkCommand::RightButtonPressEvent, nullptr);
+  this->GetInteractorStyle()->OnRightButtonDown();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnRightButtonUp()
 {
-  if (!this->DelegateInteractionEventToDisplayableManagers(vtkCommand::RightButtonReleaseEvent))
-    {
-    this->InvokeEvent(vtkCommand::RightButtonReleaseEvent, nullptr);
-    }
+  this->GetInteractorStyle()->OnRightButtonUp();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnMiddleButtonDown()
 {
   this->MouseMovedSinceButtonDown = false;
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::MiddleButtonPressEvent))
-    {
-    return;
-    }
-  this->InvokeEvent(vtkCommand::MiddleButtonPressEvent, nullptr);
+  this->GetInteractorStyle()->OnMiddleButtonDown();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnMiddleButtonUp()
 {
-  if (!this->DelegateInteractionEventToDisplayableManagers(vtkCommand::MiddleButtonReleaseEvent))
-    {
-    this->InvokeEvent(vtkCommand::MiddleButtonReleaseEvent, nullptr);
-    }
+  this->GetInteractorStyle()->OnMiddleButtonUp();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnLeftButtonDown()
 {
   this->MouseMovedSinceButtonDown = false;
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::LeftButtonPressEvent))
-    {
-    return;
-    }
-  this->InvokeEvent(vtkCommand::LeftButtonPressEvent, nullptr);
+  this->GetInteractorStyle()->OnLeftButtonDown();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnLeftButtonUp()
 {
-  if (!this->DelegateInteractionEventToDisplayableManagers(vtkCommand::LeftButtonReleaseEvent))
-    {
-    this->InvokeEvent(vtkCommand::LeftButtonReleaseEvent, nullptr);
-    }
+  this->GetInteractorStyle()->OnLeftButtonUp();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnEnter()
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::EnterEvent))
-    {
-    return;
-    }
-  this->Superclass::OnEnter();
+  this->GetInteractorStyle()->OnEnter();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnLeave()
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::LeaveEvent))
-    {
-    return;
-    }
-  this->Superclass::OnLeave();
+  this->GetInteractorStyle()->OnLeave();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnMouseWheelForward()
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::MouseWheelForwardEvent))
-    {
-    return;
-    }
-  this->Superclass::OnMouseWheelForward();
+  this->GetInteractorStyle()->OnMouseWheelForward();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnMouseWheelBackward()
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::MouseWheelBackwardEvent))
-    {
-    return;
-    }
-  this->Superclass::OnMouseWheelBackward();
+  this->GetInteractorStyle()->OnMouseWheelBackward();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnButton3D(vtkEventData* eventData)
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(eventData))
-    {
-    return;
-    }
-  this->InvokeEvent(eventData->GetType(), eventData);
+  this->GetInteractorStyle()->OnButton3D(eventData);
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnMove3D(vtkEventData* eventData)
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(eventData))
-    {
-    return;
-    }
-  this->InvokeEvent(eventData->GetType(), eventData);
+  this->GetInteractorStyle()->OnMove3D(eventData);
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnExpose()
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::ExposeEvent))
-    {
-    return;
-    }
-  this->Superclass::OnExpose();
+  this->GetInteractorStyle()->OnExpose();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnConfigure()
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::ConfigureEvent))
-    {
-    return;
-    }
-  this->Superclass::OnConfigure();
+  this->GetInteractorStyle()->OnConfigure();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnPinch()
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::PinchEvent))
-    {
-    return;
-    }
-  this->Superclass::OnPinch();
+  this->GetInteractorStyle()->OnPinch();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnRotate()
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::RotateEvent))
-    {
-    return;
-    }
-  this->Superclass::OnRotate();
+  this->GetInteractorStyle()->OnRotate();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnPan()
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::PanEvent))
-    {
-    return;
-    }
-  this->Superclass::OnPan();
+  this->GetInteractorStyle()->OnPan();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnTap()
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::TapEvent))
-    {
-    return;
-    }
-  this->Superclass::OnTap();
+  this->GetInteractorStyle()->OnTap();
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnLongTap()
 {
-  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::LongTapEvent))
-    {
-    return;
-    }
-  this->Superclass::OnLongTap();
+  this->GetInteractorStyle()->OnLongTap();
 }
 
 //----------------------------------------------------------------------------
@@ -313,7 +229,12 @@ bool vtkMRMLViewInteractorStyle::DelegateInteractionEventToDisplayableManagers(u
   vtkNew<vtkMRMLInteractionEventData> ed;
   ed->SetType(event);
 
-  return this->DelegateInteractionEventToDisplayableManagers(ed);
+  bool delegated = this->DelegateInteractionEventToDisplayableManagers(ed);
+  if (delegated)
+    {
+    this->EventCallbackCommand->SetAbortFlag(1);
+    }
+  return delegated;
 }
 
 //----------------------------------------------------------------------------
@@ -421,7 +342,11 @@ bool vtkMRMLViewInteractorStyle::DelegateInteractionEventDataToDisplayableManage
 
   // This prevents desynchronized update of displayable managers during user interaction
   // (ie. slice intersection widget or segmentations lagging behind during slice translation)
-  this->FocusedDisplayableManager->GetMRMLApplicationLogic()->PauseRender();
+  vtkMRMLApplicationLogic* appLogic = this->FocusedDisplayableManager->GetMRMLApplicationLogic();
+  if(appLogic)
+    {
+    this->FocusedDisplayableManager->GetMRMLApplicationLogic()->PauseRender();
+    }
   bool processed = this->FocusedDisplayableManager->ProcessInteractionEvent(eventData);
   int cursor = VTK_CURSOR_DEFAULT;
   if (processed)
@@ -429,7 +354,10 @@ bool vtkMRMLViewInteractorStyle::DelegateInteractionEventDataToDisplayableManage
     cursor = this->FocusedDisplayableManager->GetMouseCursor();
     }
   this->FocusedDisplayableManager->SetMouseCursor(cursor);
-  this->FocusedDisplayableManager->GetMRMLApplicationLogic()->ResumeRender();
+  if(appLogic)
+    {
+    this->FocusedDisplayableManager->GetMRMLApplicationLogic()->ResumeRender();
+    }
   return processed;
 }
 
@@ -465,17 +393,162 @@ void vtkMRMLViewInteractorStyle::CustomProcessEvents(vtkObject* object,
   // replace callback method calls. We make sure here that displayable managers
   // get the chance to process the events first (except when we are in an
   // interaction state - such as zooming, panning, etc).
-  if (self->State != VTKIS_NONE || !self->DelegateInteractionEventToDisplayableManagers(event))
+
+  if (/*self->GetInteractorStyle()->GetState() != VTKIS_NONE || */!self->DelegateInteractionEventToDisplayableManagers(event) || self->GetInteractorStyle()->GetState() != VTKIS_NONE)
     {
     // Displayable managers did not processed it
-    Superclass::ProcessEvents(object, event, clientdata, calldata);
+    vtkMRMLViewInteractorStyle::ProcessEvents(object, event, clientdata, calldata);
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::ProcessEvents(vtkObject* vtkNotUsed(object),
+  unsigned long event, void* clientdata, void* calldata)
+{
+  vtkMRMLViewInteractorStyle* self
+    = reinterpret_cast<vtkMRMLViewInteractorStyle *>(clientdata);
+
+  switch(event)
+    {
+    /// Mouse functions
+    case vtkCommand::MouseMoveEvent:
+      self->OnMouseMove();
+      break;
+    case vtkCommand::RightButtonPressEvent:
+      self->OnRightButtonDown();
+      break;
+    case vtkCommand::RightButtonReleaseEvent:
+      self->OnRightButtonUp();
+      break;
+    case vtkCommand::MiddleButtonPressEvent:
+      self->OnMiddleButtonDown();
+      break;
+    case vtkCommand::MiddleButtonReleaseEvent:
+      self->OnMiddleButtonUp();
+      break;
+    case vtkCommand::LeftButtonPressEvent:
+      self->OnLeftButtonDown();
+      break;
+    case vtkCommand::LeftButtonReleaseEvent:
+      self->OnLeftButtonUp();
+      break;
+    case vtkCommand::EnterEvent:
+      self->OnEnter();
+      break;
+    case vtkCommand::LeaveEvent:
+      self->OnLeave();
+      break;
+    case vtkCommand::MouseWheelForwardEvent:
+      self->OnMouseWheelForward();
+      break;
+    case vtkCommand::MouseWheelBackwardEvent:
+      self->OnMouseWheelBackward();
+      break;
+
+    // Touch gesture interaction events
+    case vtkCommand::PinchEvent:
+      self->OnPinch();
+      break;
+    case vtkCommand::RotateEvent:
+      self->OnRotate();
+      break;
+    case vtkCommand::PanEvent:
+      self->OnPan();
+      break;
+    case vtkCommand::TapEvent:
+      self->OnTap();
+      break;
+    case vtkCommand::LongTapEvent:
+      self->OnLongTap();
+      break;
+
+    /// Keyboard functions
+    case vtkCommand::KeyPressEvent:
+      self->OnConfigure();
+      break;
+    case vtkCommand::KeyReleaseEvent:
+      self->OnKeyRelease();
+      break;
+    case vtkCommand::CharEvent:
+      self->OnChar();
+      break;
+
+    /// 3D event bindings
+    case vtkCommand::Button3DEvent:
+      self->OnButton3D(static_cast<vtkEventData*>(calldata));
+      break;
+    case vtkCommand::Move3DEvent:
+      self->OnMove3D(static_cast<vtkEventData*>(calldata));
+      break;
+
+    case vtkCommand::ExposeEvent:
+      self->OnExpose();
+      break;
+    case vtkCommand::ConfigureEvent:
+      self->OnConfigure();
+      break;
+
+    default:
+      break;
     }
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::SetInteractor(vtkRenderWindowInteractor *interactor)
 {
-  this->Superclass::SetInteractor(interactor);
+  if (interactor == this->Interactor)
+    {
+    return;
+    }
+  // if we already have an Interactor then stop observing it
+  if (this->Interactor)
+    {
+    this->Interactor->RemoveObserver(this->EventCallbackCommand);
+    }
+  this->Interactor = interactor;
+
+  if (interactor)
+    {
+    float priority = 0.0f;
+
+    // Mouse
+    interactor->AddObserver(vtkCommand::MouseMoveEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::RightButtonPressEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::RightButtonReleaseEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::MiddleButtonPressEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::MiddleButtonReleaseEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::LeftButtonPressEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::LeftButtonReleaseEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::EnterEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::LeaveEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::MouseWheelForwardEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::MouseWheelBackwardEvent, this->EventCallbackCommand, priority);
+
+    // Touch gesture
+    interactor->AddObserver(vtkCommand::PinchEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::RotateEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::PanEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::TapEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::LongTapEvent, this->EventCallbackCommand, priority);
+
+    // Keyboard
+    interactor->AddObserver(vtkCommand::KeyPressEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::KeyReleaseEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::CharEvent, this->EventCallbackCommand, priority);
+
+    // 3D event bindings
+    interactor->AddObserver(vtkCommand::Button3DEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::Move3DEvent, this->EventCallbackCommand, priority);
+
+    interactor->AddObserver(vtkCommand::ExposeEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::ConfigureEvent, this->EventCallbackCommand, priority);
+    }
+}
+
+//----------------------------------------------------------------------------
+vtkInteractorStyle* vtkMRMLViewInteractorStyle::GetInteractorStyle()
+{
+  return vtkInteractorStyle::SafeDownCast(this->GetInteractor()->GetInteractorStyle());
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.h
@@ -19,16 +19,19 @@
 #define __vtkMRMLViewInteractorStyle_h
 
 // VTK includes
-#include "vtkInteractorStyle3D.h"
+#include "vtkObject.h"
 #include "vtkWeakPointer.h"
 
 // MRML includes
 #include "vtkMRMLDisplayableManagerExport.h"
 
+class vtkCallbackCommand;
+class vtkEventData;
+class vtkInteractorStyle;
 class vtkMRMLAbstractDisplayableManager;
 class vtkMRMLDisplayableManagerGroup;
 class vtkMRMLInteractionEventData;
-class vtkTimerLog;
+class vtkRenderWindowInteractor;
 
 /// \brief Common base class for processing interaction events in MRML views
 ///
@@ -37,43 +40,44 @@ class vtkTimerLog;
 /// Some additional high-level events (such as click and double-click)
 /// are generated here.
 class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLViewInteractorStyle :
-  public vtkInteractorStyle3D
+  public vtkObject
 {
 public:
   static vtkMRMLViewInteractorStyle *New();
-  vtkTypeMacro(vtkMRMLViewInteractorStyle,vtkInteractorStyle3D);
+  vtkTypeMacro(vtkMRMLViewInteractorStyle,vtkObject);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  void OnMouseMove() override;
-  void OnEnter() override;
-  void OnLeave() override;
-  void OnLeftButtonDown() override;
-  void OnLeftButtonUp() override;
-  void OnMiddleButtonDown() override;
-  void OnMiddleButtonUp() override;
-  void OnRightButtonDown() override;
-  void OnRightButtonUp() override;
-  void OnMouseWheelForward() override;
-  void OnMouseWheelBackward() override;
+  /// Mouse functions
+  virtual void OnMouseMove();
+  virtual void OnEnter();
+  virtual void OnLeave();
+  virtual void OnLeftButtonDown();
+  virtual void OnLeftButtonUp();
+  virtual void OnMiddleButtonDown();
+  virtual void OnMiddleButtonUp();
+  virtual void OnRightButtonDown();
+  virtual void OnRightButtonUp();
+  virtual void OnMouseWheelForward();
+  virtual void OnMouseWheelBackward();
 
   // Touch gesture interaction events
-  void OnPinch() override;
-  void OnRotate() override;
-  void OnPan() override;
-  void OnTap() override;
-  void OnLongTap() override;
+  virtual void OnPinch();
+  virtual void OnRotate();
+  virtual void OnPan();
+  virtual void OnTap();
+  virtual void OnLongTap();
 
   /// Keyboard functions
-  void OnChar() override;
-  void OnKeyPress() override;
-  void OnKeyRelease() override;
+  virtual void OnChar();
+  virtual void OnKeyPress();
+  virtual void OnKeyRelease();
 
   /// 3D event bindings
-  void OnButton3D(vtkEventData* eventData) override;
-  void OnMove3D(vtkEventData* eventData) override;
+  virtual void OnButton3D(vtkEventData* eventData);
+  virtual void OnMove3D(vtkEventData* eventData);
 
-  void OnExpose() override;
-  void OnConfigure() override;
+  virtual void OnExpose();
+  virtual void OnConfigure();
 
   virtual void SetDisplayableManagers(vtkMRMLDisplayableManagerGroup* displayableManagers);
 
@@ -93,15 +97,19 @@ public:
   /// Return true if the event is processed.
   virtual bool DelegateInteractionEventDataToDisplayableManagers(vtkMRMLInteractionEventData* eventData);
 
-  ///
-  /// Reimplemented to set additional observers
-  void SetInteractor(vtkRenderWindowInteractor *interactor) override;
+  vtkGetObjectMacro(Interactor, vtkRenderWindowInteractor);
+  virtual void SetInteractor(vtkRenderWindowInteractor *interactor);
 
 protected:
   vtkMRMLViewInteractorStyle();
   ~vtkMRMLViewInteractorStyle() override;
 
+  vtkRenderWindowInteractor* Interactor{nullptr};
+  vtkInteractorStyle* GetInteractorStyle();
+
+  vtkCallbackCommand* EventCallbackCommand;
   static void CustomProcessEvents(vtkObject* object, unsigned long event, void* clientdata, void* calldata);
+  static void ProcessEvents(vtkObject* object, unsigned long event, void* clientdata, void* calldata);
 
   vtkCallbackCommand* DisplayableManagerCallbackCommand;
   static void DisplayableManagerCallback(vtkObject *object, unsigned long event, void *clientData, void *callData);

--- a/Libs/MRML/Widgets/qMRMLSliceView.h
+++ b/Libs/MRML/Widgets/qMRMLSliceView.h
@@ -51,6 +51,12 @@ public:
   explicit qMRMLSliceView(QWidget* parent = nullptr);
   ~qMRMLSliceView() override;
 
+  /// Sets the interactor of the view
+  void setInteractor(vtkRenderWindowInteractor* interactor) override;
+
+  /// Returns the interactor observer of the view
+  Q_INVOKABLE vtkMRMLSliceViewInteractorStyle* interactorObserver()const;
+
   /// Add a displayable manager to the view,
   /// the displayable manager is proper to the 2D view and is not shared
   /// with other views.
@@ -72,7 +78,8 @@ public:
   /// Get the 3D View node observed by view.
   Q_INVOKABLE vtkMRMLSliceNode* mrmlSliceNode()const;
 
-  /// Returns the interactor style of the view
+  /// Returns the interactor observer of the view
+  /// \deprecated Use interactorObserver()
   Q_INVOKABLE vtkMRMLSliceViewInteractorStyle* sliceViewInteractorStyle()const;
 
   /// Convert device coordinates to XYZ coordinates. The x and y

--- a/Libs/MRML/Widgets/qMRMLSliceView_p.h
+++ b/Libs/MRML/Widgets/qMRMLSliceView_p.h
@@ -50,6 +50,7 @@
 class vtkMRMLDisplayableManagerGroup;
 class vtkMRMLSliceNode;
 class vtkMRMLCameraNode;
+class vtkMRMLSliceViewInteractorStyle;
 class vtkObject;
 
 //-----------------------------------------------------------------------------
@@ -77,6 +78,7 @@ protected:
   void initDisplayableManagers();
 
   vtkMRMLDisplayableManagerGroup*    DisplayableManagerGroup;
+  vtkMRMLSliceViewInteractorStyle*   InteractorObserver;
   vtkMRMLScene*                      MRMLScene;
   vtkMRMLSliceNode*                  MRMLSliceNode;
   QColor                             InactiveBoxColor;

--- a/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
@@ -66,7 +66,7 @@ void qMRMLSliceWidgetPrivate::init()
   vtkMRMLSliceLogic* sliceLogic = this->SliceController->sliceLogic();
 
   this->SliceVerticalController->setSliceLogic(sliceLogic);
-  this->SliceView->sliceViewInteractorStyle()->SetSliceLogic(sliceLogic);
+  this->SliceView->interactorObserver()->SetSliceLogic(sliceLogic);
 
   connect(this->SliceView, SIGNAL(resized(QSize)),
           this, SLOT(setSliceViewSize(QSize)));

--- a/Libs/MRML/Widgets/qMRMLThreeDView.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.h
@@ -32,6 +32,7 @@ class qMRMLThreeDViewPrivate;
 class vtkMRMLAbstractDisplayableManager;
 class vtkMRMLCameraNode;
 class vtkMRMLScene;
+class vtkMRMLThreeDViewInteractorStyle;
 class vtkMRMLViewNode;
 class vtkCollection;
 
@@ -50,6 +51,12 @@ public:
   explicit qMRMLThreeDView(QWidget* parent = nullptr);
   ~qMRMLThreeDView() override;
 
+  /// Sets the interactor of the view
+  void setInteractor(vtkRenderWindowInteractor* interactor) override;
+
+  /// Returns the interactor observer of the view
+  Q_INVOKABLE vtkMRMLThreeDViewInteractorStyle* interactorObserver()const;
+
   /// Add a displayable manager to the view,
   /// the displayable manager is proper to the 3D view and is not shared
   /// with other views.
@@ -67,9 +74,6 @@ public:
 
   /// Get the 3D View node observed by view.
   Q_INVOKABLE vtkMRMLViewNode* mrmlViewNode()const;
-
-  /// Returns the interactor style of the view
-  //vtkInteractorObserver* interactorStyle()const;
 
   /// Methods to rotate/reset the camera,
   /// Can defined a view axis by its index (from 0 to 5)

--- a/Libs/MRML/Widgets/qMRMLThreeDView_p.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDView_p.h
@@ -43,6 +43,7 @@
 class vtkMRMLDisplayableManagerGroup;
 class vtkMRMLViewNode;
 class vtkMRMLCameraNode;
+class vtkMRMLThreeDViewInteractorStyle;
 class vtkObject;
 
 //-----------------------------------------------------------------------------
@@ -70,6 +71,7 @@ protected:
   void initDisplayableManagers();
 
   vtkMRMLDisplayableManagerGroup*    DisplayableManagerGroup;
+  vtkMRMLThreeDViewInteractorStyle*  InteractorObserver;
   vtkMRMLScene*                      MRMLScene;
   vtkMRMLViewNode*                   MRMLViewNode;
 };


### PR DESCRIPTION
This pull request is aimed at streamlining the review process and testing by consolidating several independent changes, each of which will be contributed separately.

The primary focus for review in this pull request is the last commit, titled `ENH: Improve Event Delegation in qMRMLThreeDView and qMRMLSliceView`.

In this commit, we've refactored `vtkMRMLThreeDViewInteractorStyle` and `vtkMRMLSliceViewInteractorStyle` to inherit from `vtkObject` and have implemented event delegation to MRML displayable managers and their associated widgets by observing the interactor style.

This enhancement allows for the association of specialized interactor styles, such as `vtkOpenXRInteractorStyle` or `vtkOpenVRInteractorStyle`, with the render window while still maintaining MRML-specific event delegation.

### Dependent Changes

The introduction of the commit `ENH: Allow virtual func to be called during MRML(ThreeD|Slice)View pimpl init` necessitates an update to CTK, which can be found in the following pull request:
* https://github.com/commontk/CTK/pull/1153

**Update:** CTK pull request https://github.com/commontk/CTK/pull/1153 has been integrated upstream and corresponding `External_CTK.cmake` update has been added to this pull request by integrating the commits being contributed in the following pull request:
* https://github.com/Slicer/Slicer/pull/7325

Associated independent changes are being contributed in these pull requests:
* https://github.com/Slicer/Slicer/pull/7315
* https://github.com/Slicer/Slicer/pull/7316
* https://github.com/Slicer/Slicer/pull/7318
* https://github.com/Slicer/Slicer/pull/7319
* https://github.com/Slicer/Slicer/pull/7320
* https://github.com/Slicer/Slicer/pull/7321
* https://github.com/Slicer/Slicer/pull/7322 
* https://github.com/Slicer/Slicer/pull/7323 
* https://github.com/Slicer/Slicer/pull/7324
* https://github.com/Slicer/Slicer/pull/7325