### PR TITLE
BUG: Update CTK to adjust the size of the delete DICOM object dialog

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "5657c58a72c2db3e9fcc04f88211859eccd21067"
+    "b9ef9b8aa1938676ce0ac105a3deb0e1bfc235a1"
     QUIET
     )
 


### PR DESCRIPTION
When deleting many patients (or studies or series) it can occur that the confirmation dialog that is created with all the deleted object names is taller than the screen height, so the buttons are cut off and not available.

This ensures that the said dialog cannot be higher than the DICOM browser.

List of CTK changes:

```
$ git shortlog 5657c58a7..b9ef9b8a --no-merges
Csaba Pinter (1):
      BUG: Make sure the delete DICOM object dialog is not too tall
```