### PR TITLE
COMP: Update CTK to include build-system fixes

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "b9ef9b8aa1938676ce0ac105a3deb0e1bfc235a1"
+    "4888deb1d7f2e72b5458182da1a54369e5e52887"
     QUIET
     )
 


### PR DESCRIPTION
See https://github.com/commontk/CTK/compare/b9ef9b8aa...4888deb1d

List of CTK changes:

```
$ git shortlog b9ef9b8aa..4888deb1d --no-merges
Jean-Christophe Fillion-Robin (4):
      COMP: Fix CTK PluginFramework library build
      COMP: Fix configuration without explicitly setting CTK_QT_VERSION
      COMP: Fix CMake 3.26 warning in ctkLinkerAsNeededFlagCheck project
      COMP: Add install rules for PluginFramework CMake modules
```