### PR TITLE
ENH: Remove unused API to set/get displayable manager interactor abort flags

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractDisplayableManager.cxx
@@ -886,54 +886,6 @@ void vtkMRMLAbstractDisplayableManager::OnInteractorEvent(int vtkNotUsed(eventid
 }
 
 //---------------------------------------------------------------------------
-void vtkMRMLAbstractDisplayableManager::SetInteractorStyleAbortFlag(int f)
-{
-  this->Internal->InteractorStyleCallBackCommand->SetAbortFlag(f);
-}
-
-//---------------------------------------------------------------------------
-int vtkMRMLAbstractDisplayableManager::GetInteractorStyleAbortFlag()
-{
-  return this->Internal->InteractorStyleCallBackCommand->GetAbortFlag();
-}
-
-//---------------------------------------------------------------------------
-void vtkMRMLAbstractDisplayableManager::InteractorStyleAbortFlagOn()
-{
-  this->Internal->InteractorStyleCallBackCommand->AbortFlagOn();
-}
-
-//---------------------------------------------------------------------------
-void vtkMRMLAbstractDisplayableManager::InteractorStyleAbortFlagOff()
-{
-  this->Internal->InteractorStyleCallBackCommand->AbortFlagOff();
-}
-
-//---------------------------------------------------------------------------
-void vtkMRMLAbstractDisplayableManager::SetInteractorAbortFlag(int f)
-{
-  this->Internal->InteractorCallBackCommand->SetAbortFlag(f);
-}
-
-//---------------------------------------------------------------------------
-int vtkMRMLAbstractDisplayableManager::GetInteractorAbortFlag()
-{
-  return this->Internal->InteractorCallBackCommand->GetAbortFlag();
-}
-
-//---------------------------------------------------------------------------
-void vtkMRMLAbstractDisplayableManager::InteractorAbortFlagOn()
-{
-  this->Internal->InteractorCallBackCommand->AbortFlagOn();
-}
-
-//---------------------------------------------------------------------------
-void vtkMRMLAbstractDisplayableManager::InteractorAbortFlagOff()
-{
-  this->Internal->InteractorCallBackCommand->AbortFlagOff();
-}
-
-//---------------------------------------------------------------------------
 void vtkMRMLAbstractDisplayableManager::SetLightBoxRendererManagerProxy(vtkMRMLLightBoxRendererManagerProxy* mgr)
 {
   this->Internal->LightBoxRendererManagerProxy = mgr;

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractDisplayableManager.h
@@ -263,18 +263,6 @@ protected:
   /// \sa AddInteractorObservableEvent RemoveInteractorObservableEvent
   virtual void OnInteractorEvent(int eventid);
 
-  /// Set the Abort flag on the InteractorStyle event callback
-  void SetInteractorStyleAbortFlag(int f);
-  int GetInteractorStyleAbortFlag();
-  void InteractorStyleAbortFlagOn();
-  void InteractorStyleAbortFlagOff();
-
-  /// Set the Abort flag on the Interactor event callback
-  void SetInteractorAbortFlag(int f);
-  int GetInteractorAbortFlag();
-  void InteractorAbortFlagOn();
-  void InteractorAbortFlagOff();
-
 private:
 
   vtkMRMLAbstractDisplayableManager(const vtkMRMLAbstractDisplayableManager&) = delete;


### PR DESCRIPTION
The `InteractorStyleAbort` API was originally introduced in 8ded9a0bb (`ENH: eliminated conflict between crosshair navigation and window level`).

Then, it was superseded by the `InteractorAbort` API in 0b9b33983 (`BUG: #2629.  Window level controls conflicted with crosshair navigation`)

Ultimately, the last uses of either the `InteractorStyleAbort` or `InteractorAbort` API were removed in dc2c09580 (`ENH: Improved crosshair usability, added display in 3D view`)