### PR TITLE
Remove obsolete OnInteractorStyleEvent

### DIFF
--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
@@ -488,13 +488,6 @@ void vtkMRMLMarkupsDisplayableManager::OnMRMLSliceNodeModifiedEvent()
 }
 
 //---------------------------------------------------------------------------
-void vtkMRMLMarkupsDisplayableManager::OnInteractorStyleEvent(int eventid)
-{
-  Superclass::OnInteractorStyleEvent(eventid);
-
-}
-
-//---------------------------------------------------------------------------
 vtkSlicerMarkupsWidget* vtkMRMLMarkupsDisplayableManager::GetWidget(vtkMRMLMarkupsDisplayNode * node)
 {
   return this->Helper->GetWidget(node);

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.h
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.h
@@ -139,9 +139,6 @@ protected:
   /// \sa IsManageable(vtkMRMLNode*), IsCorrectDisplayableManager()
   virtual bool IsManageable(const char* nodeClassName);
 
-  /// Respond to interactor style events
-  void OnInteractorStyleEvent(int eventid) override;
-
   /// Accessor for internal flag that disables interactor style event processing
   vtkGetMacro(DisableInteractorStyleEventsProcessing, int);
 

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
@@ -1648,21 +1648,6 @@ void vtkMRMLVolumeRenderingDisplayableManager::ProcessMRMLNodesEvents(vtkObject*
   this->Internal->RemoveOrphanPipelines();
 }
 
-//----------------------------------------------------------------------------
-void vtkMRMLVolumeRenderingDisplayableManager::OnInteractorStyleEvent(int eventID)
-{
-  switch (eventID)
-    {
-    case vtkCommand::EndInteractionEvent:
-    case vtkCommand::StartInteractionEvent:
-      this->Internal->UpdatePipelineTransforms(nullptr);
-      break;
-    default:
-      break;
-    }
-  this->Superclass::OnInteractorStyleEvent(eventID);
-}
-
 //---------------------------------------------------------------------------
 void vtkMRMLVolumeRenderingDisplayableManager::UpdateFromMRML()
 {

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.h
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.h
@@ -83,8 +83,6 @@ protected:
 
   void ProcessMRMLNodesEvents(vtkObject * caller, unsigned long event, void * callData) override;
 
-  void OnInteractorStyleEvent(int eventID) override;
-
 protected:
   vtkSlicerVolumeRenderingLogic *VolumeRenderingLogic{nullptr};
 


### PR DESCRIPTION
Following changes introduced in https://github.com/Slicer/Slicer/commit/abff04f36a7394b4378d7dd852989356ff8193a5 (`ENH: Reimplement volume rendering displayable manager`), the event handling mechanisms was restructured. As a result, the invocation of "UpdatePipelineTransforms()" within the "OnInteractorStyleEvent" function became obsolete.

Furthermore, note that the call to the "OnInteractorStyleEvent" function stopped working following the alterations made in https://github.com/Slicer/Slicer/commit/a0ad2a32824dee03c15182c00d71391b11dc80c2 (`ENH: Handle 3D events in MRML interactor style and markups VTK widgets`). This change removed the installation of the interactor style observer from "SetAndObserveInteractorStyle()".

Also removes empty `vtkMRMLMarkupsDisplayableManager::OnInteractorStyleEvent()` function.