### PR TITLE
STYLE: Remove unused ivars from vtkMRMLViewInteractorStyle

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
@@ -41,8 +41,6 @@ vtkMRMLViewInteractorStyle::vtkMRMLViewInteractorStyle()
 
   this->FocusedDisplayableManager = nullptr;
   this->MouseMovedSinceButtonDown = false;
-  this->NumberOfClicks = 0;
-  this->DoubleClickIntervalTimeSec = 0.5;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.h
@@ -20,7 +20,6 @@
 
 // VTK includes
 #include "vtkInteractorStyle3D.h"
-#include "vtkSmartPointer.h"
 #include "vtkWeakPointer.h"
 
 // MRML includes
@@ -107,11 +106,6 @@ protected:
   void SetMouseCursor(int cursor);
 
   bool MouseMovedSinceButtonDown;
-
-  /// Measures time elapsed since first button press.
-  vtkSmartPointer<vtkTimerLog> ClickTimer;
-  int NumberOfClicks;
-  double DoubleClickIntervalTimeSec;
 
   vtkWeakPointer<vtkMRMLDisplayableManagerGroup> DisplayableManagers;
   vtkMRMLAbstractDisplayableManager* FocusedDisplayableManager;


### PR DESCRIPTION
Follow-up of 364ff7b6d (`ENH: Use common interactor style for slice and 3D views`) in which these variables became obsolete.