### PR TITLE
ENH: Simplify vtkMRMLViewInteractorStyle::SetMouseCursor

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
@@ -422,9 +422,9 @@ bool vtkMRMLViewInteractorStyle::DelegateInteractionEventDataToDisplayableManage
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::SetMouseCursor(int cursor)
 {
-  if (this->GetCurrentRenderer() && this->GetCurrentRenderer()->GetRenderWindow())
+  if (this->GetInteractor() && this->GetInteractor()->GetRenderWindow())
     {
-    this->GetCurrentRenderer()->GetRenderWindow()->SetCurrentCursor(cursor);
+    this->GetInteractor()->GetRenderWindow()->SetCurrentCursor(cursor);
     }
 }
 


### PR DESCRIPTION
Instead of relying on the "CurrentRenderer" indirectly set by "vtkInteractorStyle::FindPokedRenderer", directly retrieve the render window from the interactor.