### PR TITLE
ENH: Allow virtual func to be called during MRML(ThreeD|Slice)View pimpl init

### DIFF
--- a/Libs/MRML/Widgets/qMRMLSliceView.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceView.cxx
@@ -128,7 +128,7 @@ void qMRMLSliceViewPrivate::vtkInternalLightBoxRendererManagerProxy::SetLightBox
 
 //---------------------------------------------------------------------------
 qMRMLSliceViewPrivate::qMRMLSliceViewPrivate(qMRMLSliceView& object)
-  : q_ptr(&object)
+  : ctkVTKSliceViewPrivate(object)
 {
   this->DisplayableManagerGroup = nullptr;
   this->MRMLScene = nullptr;
@@ -154,6 +154,8 @@ qMRMLSliceViewPrivate::~qMRMLSliceViewPrivate()
 void qMRMLSliceViewPrivate::init()
 {
   Q_Q(qMRMLSliceView);
+
+  this->ctkVTKSliceViewPrivate::init();
 
   // Highlight first RenderWindowItem
   q->setHighlightedBoxColor(this->InactiveBoxColor);
@@ -269,8 +271,8 @@ void qMRMLSliceViewPrivate::updateWidgetFromMRML()
 // qMRMLSliceView methods
 
 // --------------------------------------------------------------------------
-qMRMLSliceView::qMRMLSliceView(QWidget* _parent) : Superclass(_parent)
-  , d_ptr(new qMRMLSliceViewPrivate(*this))
+qMRMLSliceView::qMRMLSliceView(QWidget* _parent)
+  : Superclass(new qMRMLSliceViewPrivate(*this), _parent)
 {
   Q_D(qMRMLSliceView);
   d->init();

--- a/Libs/MRML/Widgets/qMRMLSliceView.h
+++ b/Libs/MRML/Widgets/qMRMLSliceView.h
@@ -112,9 +112,6 @@ public slots:
   /// Set the current \a viewNode to observe
   void setMRMLSliceNode(vtkMRMLSliceNode* newSliceNode);
 
-protected:
-  QScopedPointer<qMRMLSliceViewPrivate> d_ptr;
-
 private:
   Q_DECLARE_PRIVATE(qMRMLSliceView);
   Q_DISABLE_COPY(qMRMLSliceView);

--- a/Libs/MRML/Widgets/qMRMLSliceView_p.h
+++ b/Libs/MRML/Widgets/qMRMLSliceView_p.h
@@ -34,6 +34,7 @@
 
 // CTK includes
 #include <ctkVTKObject.h>
+#include <ctkVTKSliceView_p.h>
 
 // qMRML includes
 #include "qMRMLSliceView.h"
@@ -52,18 +53,16 @@ class vtkMRMLCameraNode;
 class vtkObject;
 
 //-----------------------------------------------------------------------------
-class qMRMLSliceViewPrivate: public QObject
+class qMRMLSliceViewPrivate: public ctkVTKSliceViewPrivate
 {
   Q_OBJECT
   QVTK_OBJECT
   Q_DECLARE_PUBLIC(qMRMLSliceView);
-protected:
-  qMRMLSliceView* const q_ptr;
 public:
   qMRMLSliceViewPrivate(qMRMLSliceView& object);
   ~qMRMLSliceViewPrivate() override;
 
-  virtual void init();
+  void init() override;
 
   void setMRMLScene(vtkMRMLScene* scene);
 

--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -63,7 +63,7 @@
 
 //---------------------------------------------------------------------------
 qMRMLThreeDViewPrivate::qMRMLThreeDViewPrivate(qMRMLThreeDView& object)
-  : q_ptr(&object)
+  : ctkVTKRenderViewPrivate(object)
 {
   this->DisplayableManagerGroup = nullptr;
   this->MRMLScene = nullptr;
@@ -83,6 +83,9 @@ qMRMLThreeDViewPrivate::~qMRMLThreeDViewPrivate()
 void qMRMLThreeDViewPrivate::init()
 {
   Q_Q(qMRMLThreeDView);
+
+  this->ctkVTKRenderViewPrivate::init();
+
   q->setRenderEnabled(this->MRMLScene != nullptr);
 
   vtkNew<vtkMRMLThreeDViewInteractorStyle> interactorStyle;
@@ -246,8 +249,8 @@ void ClickCallbackFunction (
 }
 
 // --------------------------------------------------------------------------
-qMRMLThreeDView::qMRMLThreeDView(QWidget* _parent) : Superclass(_parent)
-  , d_ptr(new qMRMLThreeDViewPrivate(*this))
+qMRMLThreeDView::qMRMLThreeDView(QWidget* _parent)
+  : Superclass(new qMRMLThreeDViewPrivate(*this), _parent)
 {
   Q_D(qMRMLThreeDView);
   d->init();

--- a/Libs/MRML/Widgets/qMRMLThreeDView.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.h
@@ -118,9 +118,6 @@ public slots:
   /// account when computing the boundaries
   virtual void resetFocalPoint();
 
-protected:
-  QScopedPointer<qMRMLThreeDViewPrivate> d_ptr;
-
 private:
   Q_DECLARE_PRIVATE(qMRMLThreeDView);
   Q_DISABLE_COPY(qMRMLThreeDView);

--- a/Libs/MRML/Widgets/qMRMLThreeDView_p.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDView_p.h
@@ -33,6 +33,7 @@
 //
 
 // CTK includes
+#include <ctkVTKRenderView_p.h>
 #include <ctkPimpl.h>
 #include <ctkVTKObject.h>
 
@@ -45,18 +46,16 @@ class vtkMRMLCameraNode;
 class vtkObject;
 
 //-----------------------------------------------------------------------------
-class qMRMLThreeDViewPrivate: public QObject
+class qMRMLThreeDViewPrivate: public ctkVTKRenderViewPrivate
 {
   Q_OBJECT
   QVTK_OBJECT
   Q_DECLARE_PUBLIC(qMRMLThreeDView);
-protected:
-  qMRMLThreeDView* const q_ptr;
 public:
   qMRMLThreeDViewPrivate(qMRMLThreeDView& object);
   ~qMRMLThreeDViewPrivate() override;
 
-  virtual void init();
+  void init() override;
 
   void setMRMLScene(vtkMRMLScene* scene);
 

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "4888deb1d7f2e72b5458182da1a54369e5e52887"
+    "f53820a4e6ebfc9649897577a6157d94833e9699"
     QUIET
     )
 


### PR DESCRIPTION
The CTK update adds protected constructor to `ctkVTKRenderView` and `ctkVTKSliceView` for associating a derived pimpl.

This is required to have the complete virtual function chain executed when virtual function are called in the `qMRMLThreeDViewPrivate::init()` or `qMRMLSliceViewPrivate::init()` function.