### PR TITLE
BUG: AddSynchronizedSequenceNodeID caused browser to stop operating correctly

### DIFF
--- a/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.cxx
+++ b/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.cxx
@@ -835,7 +835,6 @@ std::string vtkMRMLSequenceBrowserNode::AddSynchronizedSequenceNode(const char* 
 //----------------------------------------------------------------------------
 std::string vtkMRMLSequenceBrowserNode::AddSynchronizedSequenceNodeID(const char* synchronizedSequenceNodeId)
 {
-  bool oldModify = this->StartModify();
   std::string rolePostfix = this->GetSynchronizationPostfixFromSequenceID(synchronizedSequenceNodeId);
   if (!rolePostfix.empty())
     {
@@ -848,6 +847,7 @@ std::string vtkMRMLSequenceBrowserNode::AddSynchronizedSequenceNodeID(const char
     // first sequence, initialize selected item number
     this->SetSelectedItemNumber(0);
     }
+  bool oldModify = this->StartModify();
   this->SynchronizationPostfixes.push_back(rolePostfix);
   std::string sequenceNodeReferenceRole = SEQUENCE_NODE_REFERENCE_ROLE_BASE + rolePostfix;
   this->SetAndObserveNodeReferenceID(sequenceNodeReferenceRole.c_str(), synchronizedSequenceNodeId);


### PR DESCRIPTION
From @che85:

When you run the following code, sequence browser is not reacting anymore:

```python
import SampleData
sampleDataLogic = SampleData.SampleDataLogic()
inputVolSeq = sampleDataLogic.downloadSample("CTPCardioSeq")
browserNode = slicer.mrmlScene.GetFirstNodeByClass('vtkMRMLSequenceBrowserNode')
testSequenceNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSequenceNode", "OutTransformSeq")
browserNode.AddSynchronizedSequenceNodeID(testSequenceNode.GetID())

browserNode.RemoveSynchronizedSequenceNode(testSequenceNode.GetID())
# NB: after adding the same sequence node again, the browser is not responding
browserNode.AddSynchronizedSequenceNodeID(testSequenceNode.GetID())
```

Return statement was called after StartModify but before EndModify.
