### PR TITLE
DOC: Simplify bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,11 +13,23 @@ assignees: ''
 
 ## Steps to reproduce
 
-<!-- Generally, Slicer developers can only fix those issues that they can reproduce on their computers. To achieve this, please describe in this section what you did and what happened. Attach a few screenshots if possible. Use one of the Slicer sample data sets (in Sample Data module) as inputs. If you cannot reproduce the problem with sample data sets then you can upload your data somewhere and provide a download link here (make sure to remove all patient information from the data before sharing). If the problem occurs by using the application from custom code, create a short self-contained example as described at http://sscce.org -->
-
-## Expected behavior
-
-<!-- Describe what you expected to happen. -->
+<!--
+    Generally, Slicer developers can only fix those issues that they can reproduce on their computers.
+    
+    To achieve this, please:
+    * Describe in this section what you did, what you expected to happen, and what happened instead.
+    * Attach a few screenshots if possible.
+    * Use one of the Slicer sample data sets (in Sample Data module) as inputs. If you cannot reproduce the problem with sample data sets then you can upload your data somewhere and provide a download link here (make sure to remove all patient information from the data before sharing).
+  
+    If the problem cannot be reproduced by using the graphical user interface but only by running custom Python or C++ code then please create a short self-contained example as described at http://sscce.org
+  
+    To describe "Actual behavior" and "Expected behavior" you may use the following format:
+    1. Do A
+    2. Do B => Slicer does Y - OK
+    3. Do C => Slicer does Z => ERROR: Slicer should do W instead
+    4. Do D => Slicer does Z - OK
+    5. Do B => Slicer does Y => ERROR: Slicer should do X instead
+-->
 
 ## Environment
 - Slicer version: Slicer-5.??.?-YYYY-MM-DD


### PR DESCRIPTION
Removed expected behavior section, as it is normally described in the "Steps to reproduce" section (what you did + what you expected to happen + what happened instead).