### PR TITLE
STYLE: Trim trailing whitespaces in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,14 +15,14 @@ assignees: ''
 
 <!--
     Generally, Slicer developers can only fix those issues that they can reproduce on their computers.
-    
+
     To achieve this, please:
     * Describe in this section what you did, what you expected to happen, and what happened instead.
     * Attach a few screenshots if possible.
     * Use one of the Slicer sample data sets (in Sample Data module) as inputs. If you cannot reproduce the problem with sample data sets then you can upload your data somewhere and provide a download link here (make sure to remove all patient information from the data before sharing).
-  
+
     If the problem cannot be reproduced by using the graphical user interface but only by running custom Python or C++ code then please create a short self-contained example as described at http://sscce.org
-  
+
     To describe "Actual behavior" and "Expected behavior" you may use the following format:
     1. Do A
     2. Do B => Slicer does Y - OK


### PR DESCRIPTION
Since the pull request updating the issue template was created and approved before 1886057da4 (ENH: Update pre-commit config to include "trailing-whitespace"), trailing whitespaces were inadvertently introduced.

Related pull requests:
* https://github.com/Slicer/Slicer/pull/7332