### PR TITLE
BUG: Fix nodes not getting removed in vtkMRMLSequenceNode::SetDataNodeAtValue

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSequenceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSequenceNode.h
@@ -186,7 +186,7 @@ protected:
   struct IndexEntryType
     {
     std::string IndexValue;
-    vtkMRMLNode* DataNode;
+    vtkWeakPointer<vtkMRMLNode> DataNode;
     std::string DataNodeID; // only used temporarily, during scene load
     };
 

--- a/Modules/Loadable/Sequences/Testing/Cxx/vtkMRMLSequenceNodeTest1.cxx
+++ b/Modules/Loadable/Sequences/Testing/Cxx/vtkMRMLSequenceNodeTest1.cxx
@@ -113,6 +113,41 @@ int vtkMRMLSequenceNodeTest1( int, char * [] )
   seqNode->UpdateIndexValue("96", "32");
   CHECK_BOOL(SequenceSortedByIndex(seqNode.GetPointer()), true);
 
+  // Check if nodes are correctly removed from the internal sequence scene.
+  seqNode->RemoveAllDataNodes();
+  vtkMRMLScene* scene = seqNode->GetSequenceScene();
+  CHECK_NOT_NULL(scene);
+  CHECK_INT(scene->GetNumberOfNodes(), 0);
+  CHECK_INT(seqNode->GetNumberOfDataNodes(), 0);
+
+  // Check if number of data nodes == number of nodes in the sequence scene after adding.
+  for (int i = 0; i < numberOfDataNodes; ++i)
+    {
+    std::ostringstream valueStr;
+    valueStr << i;
+    seqNode->SetDataNodeAtValue(dataNode, valueStr.str());
+    }
+  CHECK_INT(scene->GetNumberOfNodes(), numberOfDataNodes);
+  CHECK_INT(seqNode->GetNumberOfDataNodes(), numberOfDataNodes);
+
+  // Check if nodes are correctly removed from the internal sequence scene.
+  for (int i = 0; i < numberOfDataNodes; ++i)
+    {
+    std::ostringstream valueStr;
+    valueStr << i;
+    seqNode->RemoveDataNodeAtValue(valueStr.str());
+    }
+  CHECK_INT(scene->GetNumberOfNodes(), 0);
+  CHECK_INT(seqNode->GetNumberOfDataNodes(), 0);
+
+  // Check if only one node is added to the sequence scene if the same value is added multiple times.
+  for (int i = 0; i < 10; ++i)
+    {
+    seqNode->SetDataNodeAtValue(dataNode, "0");
+    }
+  CHECK_INT(scene->GetNumberOfNodes(), 1);
+  CHECK_INT(seqNode->GetNumberOfDataNodes(), 1);
+
   /*
   bool res = true;
   TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();


### PR DESCRIPTION
When SetDataNodeAtValue is called, the new data node is deep-copied into the internal sequence scene, and replaces the old node in the index list if one exists. The old node however is not removed from the scene, causing the number of nodes to grow larger every time SetDataNodeAtValue was called for a value with an existing data node.

Fixed by removing the old node from the scene if one already exists for the specified value. This commit also changes the node pointer in IndexEntryType to a vtkWeakPointer.

Fixes #7328