### PR TITLE
ENH: Remove FreeSurfer file extensions from qSlicerModelsReader

### DIFF
--- a/Modules/Loadable/Models/qSlicerModelsReader.cxx
+++ b/Modules/Loadable/Models/qSlicerModelsReader.cxx
@@ -89,8 +89,7 @@ qSlicerIO::IOFileType qSlicerModelsReader::fileType()const
 QStringList qSlicerModelsReader::extensions()const
 {
   return QStringList()
-    << "Model (*.vtk *.vtp  *.vtu *.g *.byu *.stl *.ply *.orig"
-         " *.inflated *.sphere *.white *.smoothwm *.pial *.obj *.ucd)";
+    << "Model (*.vtk *.vtp *.vtu *.g *.byu *.stl *.ply *.obj *.ucd)";
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Option to read FreeSurfer files is not handled in Slicer core, and was exported to the SlicerFreeSurfer extension.