### PR TITLE
BUG: Fix incorrect enter/exit called after scripted module reload

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -1414,10 +1414,10 @@ def reloadScriptedModule(moduleName):
     for item in items:
         parent.layout().removeItem(item)
 
-    # create new widget inside existing parent
-    widget = eval("reloaded_module.%s(parent)" % widgetName)
-    widget.setup()
-    setattr(slicer.modules, widgetName, widget)
+    # Creates new widget at slicer.modules.{widgetName}.
+    # Also ensures that qSlicerScriptedLoadableModuleWidget has references to updated enter/exit/setup methods.
+    # See https://github.com/Slicer/Slicer/issues/7424
+    widget.parent.reload()
 
     return reloaded_module
 

--- a/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.cxx
@@ -177,6 +177,18 @@ bool qSlicerScriptedLoadableModuleWidget::setPythonSource(const QString& filePat
 }
 
 //-----------------------------------------------------------------------------
+void qSlicerScriptedLoadableModuleWidget::reload()
+{
+  Q_D(qSlicerScriptedLoadableModuleWidget);
+  if (!QFileInfo::exists(d->PythonSourceFilePath))
+    {
+    return;
+    }
+  this->setPythonSource(this->pythonSource());
+  this->setup();
+}
+
+//-----------------------------------------------------------------------------
 PyObject* qSlicerScriptedLoadableModuleWidget::self() const
 {
   Q_D(const qSlicerScriptedLoadableModuleWidget);

--- a/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.h
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.h
@@ -47,6 +47,8 @@ public:
   QString pythonSource()const;
   bool setPythonSource(const QString& filePath, const QString& className = QLatin1String(""));
 
+  Q_INVOKABLE void reload();
+
   /// Convenience method allowing to retrieve the associated scripted instance
   Q_INVOKABLE PyObject* self() const;
 


### PR DESCRIPTION
When a scripted loadable module was reloaded using slicer.util.reloadScriptedModule, pythonSource was not changed in qSlicerScriptedLoadableModuleWidget. As a result, the previous enter/exit methods continued to be used by the scripted module.

Fixed by making setPythonSource accessible in Python, and using it to instantiate the new widget object.

Fix #7211