### PR TITLE
Improve scripted classes readability renaming setPythonSource parameter and associated internal variable

### DIFF
--- a/Base/Logic/vtkSlicerScriptedLoadableModuleLogic.cxx
+++ b/Base/Logic/vtkSlicerScriptedLoadableModuleLogic.cxx
@@ -52,7 +52,7 @@ public:
 //  static int          APIMethodCount;
 //  static const char * APIMethodNames[2];
 
-  std::string  PythonSource;
+  std::string  PythonSourceFilePath;
   PyObject *   PythonSelf;
 //  PyObject *   PythonAPIMethods[2];
 };
@@ -255,7 +255,7 @@ bool vtkSlicerScriptedLoadableModuleLogic::SetPythonSource(const std::string& fi
 
   //std::cout << "self (" << className << ", instance:" << self << ")" << std::endl;
 
-  this->Internal->PythonSource = filePath;
+  this->Internal->PythonSourceFilePath = filePath;
   this->Internal->PythonSelf = self;
 
   return true;

--- a/Base/Logic/vtkSlicerScriptedLoadableModuleLogic.cxx
+++ b/Base/Logic/vtkSlicerScriptedLoadableModuleLogic.cxx
@@ -177,16 +177,16 @@ void vtkSlicerScriptedLoadableModuleLogic::PrintSelf(ostream& os, vtkIndent inde
 //}
 
 //---------------------------------------------------------------------------
-bool vtkSlicerScriptedLoadableModuleLogic::SetPythonSource(const std::string& pythonSource)
+bool vtkSlicerScriptedLoadableModuleLogic::SetPythonSource(const std::string& filePath)
 {
-  if(pythonSource.find(".py") == std::string::npos &&
-     pythonSource.find(".pyc") == std::string::npos)
+  if(filePath.find(".py") == std::string::npos &&
+     filePath.find(".pyc") == std::string::npos)
     {
     return false;
     }
 
   // Extract filename - It should match the associated python class
-  std::string className = vtksys::SystemTools::GetFilenameWithoutExtension(pythonSource);
+  std::string className = vtksys::SystemTools::GetFilenameWithoutExtension(filePath);
   className+= "Logic";
   //std::cout << "SetPythonSource - className:" << className << std::endl;
 
@@ -199,24 +199,24 @@ bool vtkSlicerScriptedLoadableModuleLogic::SetPythonSource(const std::string& py
   if (!classToInstantiate)
     {
     PyObject * pyRes = nullptr;
-    if (pythonSource.find(".pyc") != std::string::npos)
+    if (filePath.find(".pyc") != std::string::npos)
       {
-      std::string pyRunStr = std::string("with open('") + pythonSource +
-          std::string("', 'rb') as f:import imp;imp.load_module('__main__', f, '") + pythonSource +
+      std::string pyRunStr = std::string("with open('") + filePath +
+          std::string("', 'rb') as f:import imp;imp.load_module('__main__', f, '") + filePath +
           std::string("', ('.pyc', 'rb', 2))");
       pyRes = PyRun_String(
             pyRunStr.c_str(),
             Py_file_input, global_dict, global_dict);
       }
-    else if (pythonSource.find(".py") != std::string::npos)
+    else if (filePath.find(".py") != std::string::npos)
       {
-      std::string pyRunStr = std::string("execfile('") + pythonSource + std::string("')");
+      std::string pyRunStr = std::string("execfile('") + filePath + std::string("')");
       pyRes = PyRun_String(pyRunStr.c_str(),
         Py_file_input, global_dict, global_dict);
       }
     if (!pyRes)
       {
-      vtkErrorMacro(<< "setPythonSource - Failed to execute file" << pythonSource << "!");
+      vtkErrorMacro(<< "setPythonSource - Failed to execute file" << filePath << "!");
       return false;
       }
     Py_DECREF(pyRes);
@@ -225,7 +225,7 @@ bool vtkSlicerScriptedLoadableModuleLogic::SetPythonSource(const std::string& py
   if (!classToInstantiate)
     {
     vtkErrorMacro(<< "SetPythonSource - Failed to load displayable manager class definition from "
-                  << pythonSource);
+                  << filePath);
     return false;
     }
 
@@ -255,7 +255,7 @@ bool vtkSlicerScriptedLoadableModuleLogic::SetPythonSource(const std::string& py
 
   //std::cout << "self (" << className << ", instance:" << self << ")" << std::endl;
 
-  this->Internal->PythonSource = pythonSource;
+  this->Internal->PythonSource = filePath;
   this->Internal->PythonSelf = self;
 
   return true;

--- a/Base/Logic/vtkSlicerScriptedLoadableModuleLogic.h
+++ b/Base/Logic/vtkSlicerScriptedLoadableModuleLogic.h
@@ -38,7 +38,7 @@ public:
   vtkTypeMacro(vtkSlicerScriptedLoadableModuleLogic, vtkSlicerModuleLogic);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  bool SetPythonSource(const std::string& pythonSource);
+  bool SetPythonSource(const std::string& filePath);
 
 protected:
 

--- a/Base/QTCore/qSlicerScriptedFileReader.cxx
+++ b/Base/QTCore/qSlicerScriptedFileReader.cxx
@@ -94,7 +94,7 @@ QString qSlicerScriptedFileReader::pythonSource()const
 }
 
 //-----------------------------------------------------------------------------
-bool qSlicerScriptedFileReader::setPythonSource(const QString& newPythonSource, const QString& _className, bool missingClassIsExpected)
+bool qSlicerScriptedFileReader::setPythonSource(const QString& filePath, const QString& _className, bool missingClassIsExpected)
 {
   Q_D(qSlicerScriptedFileReader);
 
@@ -103,13 +103,13 @@ bool qSlicerScriptedFileReader::setPythonSource(const QString& newPythonSource, 
     return false;
     }
 
-  if(!newPythonSource.endsWith(".py") && !newPythonSource.endsWith(".pyc"))
+  if(!filePath.endsWith(".py") && !filePath.endsWith(".pyc"))
     {
     return false;
     }
 
   // Extract moduleName from the provided filename
-  QString moduleName = QFileInfo(newPythonSource).baseName();
+  QString moduleName = QFileInfo(filePath).baseName();
 
   QString className = _className;
   if (className.isEmpty())
@@ -144,7 +144,7 @@ bool qSlicerScriptedFileReader::setPythonSource(const QString& newPythonSource, 
     PyErr_SetString(PyExc_RuntimeError,
                     QString("qSlicerScriptedFileReader::setPythonSource - "
                             "Failed to load scripted file Reader: "
-                            "class %1 was not found in file %2").arg(className).arg(newPythonSource).toUtf8());
+                            "class %1 was not found in file %2").arg(className).arg(filePath).toUtf8());
     return false;
     }
 
@@ -154,7 +154,7 @@ bool qSlicerScriptedFileReader::setPythonSource(const QString& newPythonSource, 
     return false;
     }
 
-  d->PythonSource = newPythonSource;
+  d->PythonSource = filePath;
 
   return true;
 }

--- a/Base/QTCore/qSlicerScriptedFileReader.h
+++ b/Base/QTCore/qSlicerScriptedFileReader.h
@@ -50,7 +50,7 @@ public:
 
   /// \warning Setting the source is a no-op. See detailed comment in the source code.
   /// If missingClassIsExpected is true (default) then missing class is expected and not treated as an error.
-  bool setPythonSource(const QString& newPythonSource, const QString& className = QLatin1String(""), bool missingClassIsExpected = true);
+  bool setPythonSource(const QString& filePath, const QString& className = QLatin1String(""), bool missingClassIsExpected = true);
 
   /// Convenience method allowing to retrieve the associated scripted instance
   Q_INVOKABLE PyObject* self() const;

--- a/Base/QTCore/qSlicerScriptedFileWriter.cxx
+++ b/Base/QTCore/qSlicerScriptedFileWriter.cxx
@@ -94,7 +94,7 @@ QString qSlicerScriptedFileWriter::pythonSource()const
 }
 
 //-----------------------------------------------------------------------------
-bool qSlicerScriptedFileWriter::setPythonSource(const QString& newPythonSource, const QString& _className, bool missingClassIsExpected)
+bool qSlicerScriptedFileWriter::setPythonSource(const QString& filePath, const QString& _className, bool missingClassIsExpected)
 {
   Q_D(qSlicerScriptedFileWriter);
 
@@ -103,13 +103,13 @@ bool qSlicerScriptedFileWriter::setPythonSource(const QString& newPythonSource, 
     return false;
     }
 
-  if(!newPythonSource.endsWith(".py") && !newPythonSource.endsWith(".pyc"))
+  if(!filePath.endsWith(".py") && !filePath.endsWith(".pyc"))
     {
     return false;
     }
 
   // Extract moduleName from the provided filename
-  QString moduleName = QFileInfo(newPythonSource).baseName();
+  QString moduleName = QFileInfo(filePath).baseName();
 
   QString className = _className;
   if (className.isEmpty())
@@ -144,7 +144,7 @@ bool qSlicerScriptedFileWriter::setPythonSource(const QString& newPythonSource, 
     PyErr_SetString(PyExc_RuntimeError,
                     QString("qSlicerScriptedFileWriter::setPythonSource - "
                             "Failed to load scripted file writer: "
-                            "class %1 was not found in file %2").arg(className).arg(newPythonSource).toUtf8());
+                            "class %1 was not found in file %2").arg(className).arg(filePath).toUtf8());
     return false;
     }
 
@@ -154,7 +154,7 @@ bool qSlicerScriptedFileWriter::setPythonSource(const QString& newPythonSource, 
     return false;
     }
 
-  d->PythonSource = newPythonSource;
+  d->PythonSource = filePath;
 
   return true;
 }

--- a/Base/QTCore/qSlicerScriptedFileWriter.h
+++ b/Base/QTCore/qSlicerScriptedFileWriter.h
@@ -49,7 +49,7 @@ public:
 
   /// \warning Setting the source is a no-op. See detailed comment in the source code.
   /// If missingClassIsExpected is true (default) then missing class is expected and not treated as an error.
-  bool setPythonSource(const QString& newPythonSource, const QString& className = QLatin1String(""), bool missingClassIsExpected = true);
+  bool setPythonSource(const QString& filePath, const QString& className = QLatin1String(""), bool missingClassIsExpected = true);
 
   /// Convenience method allowing to retrieve the associated scripted instance
   Q_INVOKABLE PyObject* self() const;

--- a/Base/QTCore/qSlicerScriptedUtils.cxx
+++ b/Base/QTCore/qSlicerScriptedUtils.cxx
@@ -35,31 +35,31 @@
 
 //-----------------------------------------------------------------------------
 bool qSlicerScriptedUtils::loadSourceAsModule(const QString& moduleName,
-                                       const QString& fileName,
+                                       const QString& filePath,
                                        PyObject * global_dict,
                                        PyObject * local_dict)
 {
   PyObject* pyRes = nullptr;
-  if (fileName.endsWith(".py"))
+  if (filePath.endsWith(".py"))
     {
     pyRes = PyRun_String(
           QString("import imp;imp.load_source(%2, %1);del imp;")
-          .arg(qSlicerCorePythonManager::toPythonStringLiteral(fileName))
+          .arg(qSlicerCorePythonManager::toPythonStringLiteral(filePath))
           .arg(qSlicerCorePythonManager::toPythonStringLiteral(moduleName)).toUtf8(),
           Py_file_input, global_dict, local_dict);
     }
-  else if (fileName.endsWith(".pyc"))
+  else if (filePath.endsWith(".pyc"))
     {
     pyRes = PyRun_String(
           QString("with open(%1, 'rb') as f:import imp;imp.load_module(%2, f, %1, ('.pyc', 'rb', 2));del imp")
-          .arg(qSlicerCorePythonManager::toPythonStringLiteral(fileName))
+          .arg(qSlicerCorePythonManager::toPythonStringLiteral(filePath))
           .arg(qSlicerCorePythonManager::toPythonStringLiteral(moduleName)).toUtf8(),
           Py_file_input, global_dict, local_dict);
     }
   if (!pyRes)
     {
     PythonQt::self()->handleError();
-    qCritical() << "loadSourceAsModule - Failed to load file" << fileName
+    qCritical() << "loadSourceAsModule - Failed to load file" << filePath
                 << " as module" << moduleName << "!";
     return false;
     }

--- a/Base/QTCore/qSlicerScriptedUtils_p.h
+++ b/Base/QTCore/qSlicerScriptedUtils_p.h
@@ -56,7 +56,7 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerScriptedUtils
 public:
   typedef qSlicerScriptedUtils Self;
 
-  static bool loadSourceAsModule(const QString& moduleName, const QString& fileName, PyObject * global_dict, PyObject *local_dict);
+  static bool loadSourceAsModule(const QString& moduleName, const QString& filePath, PyObject * global_dict, PyObject *local_dict);
 
   /// \brief Set the value of the attribute named \a attributeName, for module
   /// named \a moduleName, to the value \a attributeValue.

--- a/Base/QTGUI/qSlicerScriptedFileDialog.cxx
+++ b/Base/QTGUI/qSlicerScriptedFileDialog.cxx
@@ -97,7 +97,7 @@ QString qSlicerScriptedFileDialog::pythonSource()const
 }
 
 //-----------------------------------------------------------------------------
-bool qSlicerScriptedFileDialog::setPythonSource(const QString& newPythonSource, const QString& _className, bool missingClassIsExpected)
+bool qSlicerScriptedFileDialog::setPythonSource(const QString& filePath, const QString& _className, bool missingClassIsExpected)
 {
   Q_D(qSlicerScriptedFileDialog);
 
@@ -106,13 +106,13 @@ bool qSlicerScriptedFileDialog::setPythonSource(const QString& newPythonSource, 
     return false;
     }
 
-  if(!newPythonSource.endsWith(".py") && !newPythonSource.endsWith(".pyc"))
+  if(!filePath.endsWith(".py") && !filePath.endsWith(".pyc"))
     {
     return false;
     }
 
   // Extract moduleName from the provided filename
-  QString moduleName = QFileInfo(newPythonSource).baseName();
+  QString moduleName = QFileInfo(filePath).baseName();
 
   QString className = _className;
   if (className.isEmpty())
@@ -191,7 +191,7 @@ bool qSlicerScriptedFileDialog::setPythonSource(const QString& newPythonSource, 
     return false;
     }
 
-  d->PythonSource = newPythonSource;
+  d->PythonSource = filePath;
 
   return true;
 }

--- a/Base/QTGUI/qSlicerScriptedFileDialog.cxx
+++ b/Base/QTGUI/qSlicerScriptedFileDialog.cxx
@@ -53,7 +53,7 @@ public:
 
   mutable qSlicerPythonCppAPI PythonCppAPI;
 
-  QString    PythonSource;
+  QString    PythonSourceFilePath;
   QString    PythonClassName;
 };
 
@@ -93,7 +93,7 @@ qSlicerScriptedFileDialog::~qSlicerScriptedFileDialog() = default;
 QString qSlicerScriptedFileDialog::pythonSource()const
 {
   Q_D(const qSlicerScriptedFileDialog);
-  return d->PythonSource;
+  return d->PythonSourceFilePath;
 }
 
 //-----------------------------------------------------------------------------
@@ -191,7 +191,7 @@ bool qSlicerScriptedFileDialog::setPythonSource(const QString& filePath, const Q
     return false;
     }
 
-  d->PythonSource = filePath;
+  d->PythonSourceFilePath = filePath;
 
   return true;
 }
@@ -215,7 +215,7 @@ bool qSlicerScriptedFileDialog::exec(const qSlicerIO::IOProperties& ioProperties
     }
   if (!PyBool_Check(result))
     {
-    qWarning() << d->PythonSource
+    qWarning() << d->PythonSourceFilePath
                << " - In" << d->PythonClassName << "class, function 'execDialog' "
                << "is expected to return a boolean";
     return false;

--- a/Base/QTGUI/qSlicerScriptedFileDialog.h
+++ b/Base/QTGUI/qSlicerScriptedFileDialog.h
@@ -46,7 +46,7 @@ public:
 
   /// \warning Setting the source is a no-op. See detailed comment in the source code.
   /// If missingClassIsExpected is true (default) then missing class is expected and not treated as an error.
-  bool setPythonSource(const QString& newPythonSource, const QString& className = QLatin1String(""), bool missingClassIsExpected = true);
+  bool setPythonSource(const QString& filePath, const QString& className = QLatin1String(""), bool missingClassIsExpected = true);
 
   /// Convenience method allowing to retrieve the associated scripted instance
   Q_INVOKABLE PyObject* self() const;

--- a/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
@@ -103,7 +103,7 @@ QString qSlicerScriptedLoadableModule::pythonSource()const
 }
 
 //-----------------------------------------------------------------------------
-bool qSlicerScriptedLoadableModule::setPythonSource(const QString& newPythonSource)
+bool qSlicerScriptedLoadableModule::setPythonSource(const QString& filePath)
 {
   Q_D(qSlicerScriptedLoadableModule);
 
@@ -112,13 +112,13 @@ bool qSlicerScriptedLoadableModule::setPythonSource(const QString& newPythonSour
     return false;
     }
 
-  if (!newPythonSource.endsWith(".py") && !newPythonSource.endsWith(".pyc"))
+  if (!filePath.endsWith(".py") && !filePath.endsWith(".pyc"))
     {
     return false;
     }
 
   // Extract moduleName from the provided filename
-  QString moduleName = QFileInfo(newPythonSource).baseName();
+  QString moduleName = QFileInfo(filePath).baseName();
   this->setName(moduleName);
   QString className = moduleName;
 
@@ -139,7 +139,7 @@ bool qSlicerScriptedLoadableModule::setPythonSource(const QString& newPythonSour
     {
     PythonQtObjectPtr local_dict;
     local_dict.setNewRef(PyDict_New());
-    if (!qSlicerScriptedUtils::loadSourceAsModule(moduleName, newPythonSource, global_dict, local_dict))
+    if (!qSlicerScriptedUtils::loadSourceAsModule(moduleName, filePath, global_dict, local_dict))
       {
       return false;
       }
@@ -155,7 +155,7 @@ bool qSlicerScriptedLoadableModule::setPythonSource(const QString& newPythonSour
     PyErr_SetString(PyExc_RuntimeError,
                     QString("qSlicerScriptedLoadableModule::setPythonSource - "
                             "Failed to load scripted loadable module: "
-                            "class %1 was not found in file %2").arg(className).arg(newPythonSource).toLatin1());
+                            "class %1 was not found in file %2").arg(className).arg(filePath).toLatin1());
     PythonQt::self()->handleError();
     return false;
     }
@@ -168,7 +168,7 @@ bool qSlicerScriptedLoadableModule::setPythonSource(const QString& newPythonSour
     return false;
     }
 
-  d->PythonSource = newPythonSource;
+  d->PythonSource = filePath;
 
   if (!qSlicerScriptedUtils::setModuleAttribute(
         "slicer.modules", moduleName + "Instance", self))

--- a/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
@@ -61,7 +61,7 @@ public:
 
   mutable qSlicerPythonCppAPI PythonCppAPI;
 
-  QString    PythonSource;
+  QString    PythonSourceFilePath;
 };
 
 //-----------------------------------------------------------------------------
@@ -99,7 +99,7 @@ qSlicerScriptedLoadableModule::~qSlicerScriptedLoadableModule() = default;
 QString qSlicerScriptedLoadableModule::pythonSource()const
 {
   Q_D(const qSlicerScriptedLoadableModule);
-  return d->PythonSource;
+  return d->PythonSourceFilePath;
 }
 
 //-----------------------------------------------------------------------------
@@ -168,7 +168,7 @@ bool qSlicerScriptedLoadableModule::setPythonSource(const QString& filePath)
     return false;
     }
 
-  d->PythonSource = filePath;
+  d->PythonSourceFilePath = filePath;
 
   if (!qSlicerScriptedUtils::setModuleAttribute(
         "slicer.modules", moduleName + "Instance", self))
@@ -222,7 +222,7 @@ void qSlicerScriptedLoadableModule::registerFileDialog()
 {
   Q_D(qSlicerScriptedLoadableModule);
   QScopedPointer<qSlicerScriptedFileDialog> fileDialog(new qSlicerScriptedFileDialog(this));
-  bool ret = fileDialog->setPythonSource(d->PythonSource);
+  bool ret = fileDialog->setPythonSource(d->PythonSourceFilePath);
   if (!ret)
     {
     return;
@@ -236,13 +236,13 @@ void qSlicerScriptedLoadableModule::registerIO()
 {
   Q_D(qSlicerScriptedLoadableModule);
   QScopedPointer<qSlicerScriptedFileWriter> fileWriter(new qSlicerScriptedFileWriter(this));
-  bool ret = fileWriter->setPythonSource(d->PythonSource);
+  bool ret = fileWriter->setPythonSource(d->PythonSourceFilePath);
   if (ret)
     {
     qSlicerApplication::application()->ioManager()->registerIO(fileWriter.take());
     }
   QScopedPointer<qSlicerScriptedFileReader> fileReader(new qSlicerScriptedFileReader(this));
-  ret = fileReader->setPythonSource(d->PythonSource);
+  ret = fileReader->setPythonSource(d->PythonSourceFilePath);
   if (ret)
     {
     qSlicerApplication::application()->ioManager()->registerIO(fileReader.take());
@@ -260,7 +260,7 @@ qSlicerAbstractModuleRepresentation* qSlicerScriptedLoadableModule::createWidget
     }
 
   QScopedPointer<qSlicerScriptedLoadableModuleWidget> widget(new qSlicerScriptedLoadableModuleWidget);
-  bool ret = widget->setPythonSource(d->PythonSource);
+  bool ret = widget->setPythonSource(d->PythonSourceFilePath);
   if (!ret)
     {
     return nullptr;

--- a/Base/QTGUI/qSlicerScriptedLoadableModule.h
+++ b/Base/QTGUI/qSlicerScriptedLoadableModule.h
@@ -55,7 +55,7 @@ public:
   ~qSlicerScriptedLoadableModule() override;
 
   QString pythonSource()const;
-  bool setPythonSource(const QString& newPythonSource);
+  bool setPythonSource(const QString& filePath);
 
   QString title()const override ;
   void setTitle(const QString& newTitle);

--- a/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.cxx
@@ -52,7 +52,7 @@ public:
 
   mutable qSlicerPythonCppAPI PythonCppAPI;
 
-  QString    PythonSource;
+  QString    PythonSourceFilePath;
 };
 
 //-----------------------------------------------------------------------------
@@ -88,7 +88,7 @@ qSlicerScriptedLoadableModuleWidget::~qSlicerScriptedLoadableModuleWidget() = de
 QString qSlicerScriptedLoadableModuleWidget::pythonSource()const
 {
   Q_D(const qSlicerScriptedLoadableModuleWidget);
-  return d->PythonSource;
+  return d->PythonSourceFilePath;
 }
 
 //-----------------------------------------------------------------------------
@@ -165,7 +165,7 @@ bool qSlicerScriptedLoadableModuleWidget::setPythonSource(const QString& filePat
     return false;
     }
 
-  d->PythonSource = filePath;
+  d->PythonSourceFilePath = filePath;
 
   if (!qSlicerScriptedUtils::setModuleAttribute(
         "slicer.modules", className, self))
@@ -228,7 +228,7 @@ bool qSlicerScriptedLoadableModuleWidget::setEditedNode(vtkMRMLNode* node,
   // Parse result
   if (!PyBool_Check(result))
     {
-    qWarning() << d->PythonSource << ": qSlicerScriptedLoadableModuleWidget: Function 'setEditedNode' is expected to return a boolean";
+    qWarning() << d->PythonSourceFilePath << ": qSlicerScriptedLoadableModuleWidget: Function 'setEditedNode' is expected to return a boolean";
     return false;
     }
 
@@ -252,7 +252,7 @@ double qSlicerScriptedLoadableModuleWidget::nodeEditable(vtkMRMLNode* node)
   // Parse result
   if (!PyFloat_Check(result))
     {
-    qWarning() << d->PythonSource << ": qSlicerScriptedLoadableModuleWidget: Function 'nodeEditable' is expected to return a floating point number!";
+    qWarning() << d->PythonSourceFilePath << ": qSlicerScriptedLoadableModuleWidget: Function 'nodeEditable' is expected to return a floating point number!";
     return 0.0;
     }
 

--- a/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.cxx
@@ -92,7 +92,7 @@ QString qSlicerScriptedLoadableModuleWidget::pythonSource()const
 }
 
 //-----------------------------------------------------------------------------
-bool qSlicerScriptedLoadableModuleWidget::setPythonSource(const QString& newPythonSource, const QString& _className)
+bool qSlicerScriptedLoadableModuleWidget::setPythonSource(const QString& filePath, const QString& _className)
 {
   Q_D(qSlicerScriptedLoadableModuleWidget);
 
@@ -101,13 +101,13 @@ bool qSlicerScriptedLoadableModuleWidget::setPythonSource(const QString& newPyth
     return false;
     }
 
-  if (!newPythonSource.endsWith(".py") && !newPythonSource.endsWith(".pyc"))
+  if (!filePath.endsWith(".py") && !filePath.endsWith(".pyc"))
     {
     return false;
     }
 
   // Extract moduleName from the provided filename
-  QString moduleName = QFileInfo(newPythonSource).baseName();
+  QString moduleName = QFileInfo(filePath).baseName();
 
   QString className = _className;
   if (className.isEmpty())
@@ -136,7 +136,7 @@ bool qSlicerScriptedLoadableModuleWidget::setPythonSource(const QString& newPyth
     {
     PythonQtObjectPtr local_dict;
     local_dict.setNewRef(PyDict_New());
-    if (!qSlicerScriptedUtils::loadSourceAsModule(moduleName, newPythonSource, global_dict, local_dict))
+    if (!qSlicerScriptedUtils::loadSourceAsModule(moduleName, filePath, global_dict, local_dict))
       {
       return false;
       }
@@ -152,7 +152,7 @@ bool qSlicerScriptedLoadableModuleWidget::setPythonSource(const QString& newPyth
     PyErr_SetString(PyExc_RuntimeError,
                     QString("qSlicerScriptedLoadableModuleWidget::setPythonSource - "
                             "Failed to load scripted loadable module widget: "
-                            "class %1 was not found in %2").arg(className).arg(newPythonSource).toUtf8());
+                            "class %1 was not found in %2").arg(className).arg(filePath).toUtf8());
     PythonQt::self()->handleError();
     return false;
     }
@@ -165,7 +165,7 @@ bool qSlicerScriptedLoadableModuleWidget::setPythonSource(const QString& newPyth
     return false;
     }
 
-  d->PythonSource = newPythonSource;
+  d->PythonSource = filePath;
 
   if (!qSlicerScriptedUtils::setModuleAttribute(
         "slicer.modules", className, self))

--- a/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.h
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.h
@@ -45,7 +45,7 @@ public:
   ~qSlicerScriptedLoadableModuleWidget() override;
 
   QString pythonSource()const;
-  bool setPythonSource(const QString& newPythonSource, const QString& className = QLatin1String(""));
+  bool setPythonSource(const QString& filePath, const QString& className = QLatin1String(""));
 
   /// Convenience method allowing to retrieve the associated scripted instance
   Q_INVOKABLE PyObject* self() const;

--- a/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.cxx
@@ -61,7 +61,7 @@ public:
   static int          APIMethodCount;
   static const char * APIMethodNames[8];
 
-  std::string  PythonSource;
+  std::string  PythonSourceFilePath;
   PyObject *   PythonSelf;
   PyObject *   PythonAPIMethods[8];
 };
@@ -355,6 +355,6 @@ void vtkMRMLScriptedDisplayableManager::SetPythonSource(const std::string& fileP
 
   //std::cout << "self (" << className << ", instance:" << self << ")" << std::endl;
 
-  this->Internal->PythonSource = filePath;
+  this->Internal->PythonSourceFilePath = filePath;
   this->Internal->PythonSelf = self;
 }

--- a/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.cxx
@@ -274,16 +274,16 @@ void vtkMRMLScriptedDisplayableManager::OnMRMLDisplayableNodeModifiedEvent(vtkOb
 }
 
 //---------------------------------------------------------------------------
-void vtkMRMLScriptedDisplayableManager::SetPythonSource(const std::string& pythonSource)
+void vtkMRMLScriptedDisplayableManager::SetPythonSource(const std::string& filePath)
 {
-  if(pythonSource.find(".py") == std::string::npos &&
-     pythonSource.find(".pyc") == std::string::npos)
+  if(filePath.find(".py") == std::string::npos &&
+     filePath.find(".pyc") == std::string::npos)
     {
     return;
     }
 
   // Extract filename - It should match the associated python class
-  std::string className = vtksys::SystemTools::GetFilenameWithoutExtension(pythonSource);
+  std::string className = vtksys::SystemTools::GetFilenameWithoutExtension(filePath);
   //std::cout << "SetPythonSource - className:" << className << std::endl;
 
   // Get a reference to the main module and global dictionary
@@ -295,16 +295,16 @@ void vtkMRMLScriptedDisplayableManager::SetPythonSource(const std::string& pytho
   if (!classToInstantiate)
     {
     PyObject * pyRes = nullptr;
-    if (pythonSource.find(".py") != std::string::npos)
+    if (filePath.find(".py") != std::string::npos)
       {
-      std::string pyRunStr = std::string("exec(open('") + pythonSource + std::string("').read())");
+      std::string pyRunStr = std::string("exec(open('") + filePath + std::string("').read())");
       pyRes = PyRun_String(pyRunStr.c_str(),
                            Py_file_input, global_dict, global_dict);
       }
-    else if (pythonSource.find(".pyc") != std::string::npos)
+    else if (filePath.find(".pyc") != std::string::npos)
       {
-      std::string pyRunStr = std::string("with open('") + pythonSource +
-          std::string("', 'rb') as f:import imp;imp.load_module('__main__', f, '") + pythonSource +
+      std::string pyRunStr = std::string("with open('") + filePath +
+          std::string("', 'rb') as f:import imp;imp.load_module('__main__', f, '") + filePath +
           std::string("', ('.pyc', 'rb', 2))");
       pyRes = PyRun_String(
             pyRunStr.c_str(),
@@ -312,7 +312,7 @@ void vtkMRMLScriptedDisplayableManager::SetPythonSource(const std::string& pytho
       }
     if (!pyRes)
       {
-      vtkErrorMacro(<< "setPythonSource - Failed to execute file" << pythonSource << "!");
+      vtkErrorMacro(<< "setPythonSource - Failed to execute file" << filePath << "!");
       return;
       }
     Py_DECREF(pyRes);
@@ -321,7 +321,7 @@ void vtkMRMLScriptedDisplayableManager::SetPythonSource(const std::string& pytho
   if (!classToInstantiate)
     {
     vtkErrorMacro(<< "SetPythonSource - Failed to load displayable manager class definition from "
-                  << pythonSource);
+                  << filePath);
     return;
     }
 
@@ -355,6 +355,6 @@ void vtkMRMLScriptedDisplayableManager::SetPythonSource(const std::string& pytho
 
   //std::cout << "self (" << className << ", instance:" << self << ")" << std::endl;
 
-  this->Internal->PythonSource = pythonSource;
+  this->Internal->PythonSource = filePath;
   this->Internal->PythonSelf = self;
 }

--- a/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.h
@@ -35,7 +35,7 @@ public:
   vtkTypeMacro(vtkMRMLScriptedDisplayableManager,vtkMRMLAbstractDisplayableManager);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  void SetPythonSource(const std::string& pythonSource);
+  void SetPythonSource(const std::string& filePath);
 
 protected:
   vtkMRMLScriptedDisplayableManager();

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedEffect.cxx
@@ -73,7 +73,7 @@ public:
 
   mutable qSlicerPythonCppAPI PythonCppAPI;
 
-  QString PythonSource;
+  QString PythonSourceFilePath;
 };
 
 //-----------------------------------------------------------------------------
@@ -122,7 +122,7 @@ qSlicerSegmentEditorScriptedEffect::~qSlicerSegmentEditorScriptedEffect() = defa
 QString qSlicerSegmentEditorScriptedEffect::pythonSource()const
 {
   Q_D(const qSlicerSegmentEditorScriptedEffect);
-  return d->PythonSource;
+  return d->PythonSourceFilePath;
 }
 
 //-----------------------------------------------------------------------------
@@ -198,7 +198,7 @@ bool qSlicerSegmentEditorScriptedEffect::setPythonSource(const QString newPython
     return false;
     }
 
-  d->PythonSource = newPythonSource;
+  d->PythonSourceFilePath = newPythonSource;
 
   if (!qSlicerScriptedUtils::setModuleAttribute(
         "slicer", moduleName, self))
@@ -268,7 +268,7 @@ const QString qSlicerSegmentEditorScriptedEffect::helpText()const
   // Parse result
   if (!PyUnicode_Check(result))
     {
-    qWarning() << d->PythonSource << ": qSlicerSegmentEditorScriptedEffect: Function 'helpText' is expected to return a string!";
+    qWarning() << d->PythonSourceFilePath << ": qSlicerSegmentEditorScriptedEffect: Function 'helpText' is expected to return a string!";
     return this->Superclass::helpText();
     }
 
@@ -283,7 +283,7 @@ qSlicerSegmentEditorAbstractEffect* qSlicerSegmentEditorScriptedEffect::clone()
   PyObject* result = d->PythonCppAPI.callMethod(d->CloneMethod);
   if (!result)
     {
-    qCritical() << d->PythonSource << ": clone: Failed to call mandatory clone method! If it is implemented, please see python output for errors.";
+    qCritical() << d->PythonSourceFilePath << ": clone: Failed to call mandatory clone method! If it is implemented, please see python output for errors.";
     return nullptr;
     }
 
@@ -293,7 +293,7 @@ qSlicerSegmentEditorAbstractEffect* qSlicerSegmentEditorScriptedEffect::clone()
     resultVariant.value<QObject*>() );
   if (!clonedEffect)
     {
-    qCritical() << d->PythonSource << ": clone: Invalid cloned effect object returned from python!";
+    qCritical() << d->PythonSourceFilePath << ": clone: Invalid cloned effect object returned from python!";
     return nullptr;
     }
   return clonedEffect;
@@ -365,7 +365,7 @@ bool qSlicerSegmentEditorScriptedEffect::processInteractionEvents(vtkRenderWindo
     }
   if (!PyBool_Check(result))
     {
-    qWarning() << d->PythonSource
+    qWarning() << d->PythonSourceFilePath
                << " - function 'processInteractionEvents' "
                << "is expected to return a boolean";
     return false;

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedLabelEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedLabelEffect.cxx
@@ -124,7 +124,7 @@ QString qSlicerSegmentEditorScriptedLabelEffect::pythonSource()const
 }
 
 //-----------------------------------------------------------------------------
-bool qSlicerSegmentEditorScriptedLabelEffect::setPythonSource(const QString newPythonSource)
+bool qSlicerSegmentEditorScriptedLabelEffect::setPythonSource(const QString filePath)
 {
   Q_D(qSlicerSegmentEditorScriptedLabelEffect);
 
@@ -133,13 +133,13 @@ bool qSlicerSegmentEditorScriptedLabelEffect::setPythonSource(const QString newP
     return false;
     }
 
-  if (!newPythonSource.endsWith(".py") && !newPythonSource.endsWith(".pyc"))
+  if (!filePath.endsWith(".py") && !filePath.endsWith(".pyc"))
     {
     return false;
     }
 
   // Extract moduleName from the provided filename
-  QString moduleName = QFileInfo(newPythonSource).baseName();
+  QString moduleName = QFileInfo(filePath).baseName();
 
   // In case the effect is within the main module file
   QString className = moduleName;
@@ -165,7 +165,7 @@ bool qSlicerSegmentEditorScriptedLabelEffect::setPythonSource(const QString newP
     {
     PythonQtObjectPtr local_dict;
     local_dict.setNewRef(PyDict_New());
-    if (!qSlicerScriptedUtils::loadSourceAsModule(moduleName, newPythonSource, global_dict, local_dict))
+    if (!qSlicerScriptedUtils::loadSourceAsModule(moduleName, filePath, global_dict, local_dict))
       {
       return false;
       }
@@ -181,7 +181,7 @@ bool qSlicerSegmentEditorScriptedLabelEffect::setPythonSource(const QString newP
     PyErr_SetString(PyExc_RuntimeError,
                     QString("qSlicerSegmentEditorScriptedLabelEffect::setPythonSource - "
                             "Failed to load segment editor scripted effect: "
-                            "class %1 was not found in %2").arg(className).arg(newPythonSource).toUtf8());
+                            "class %1 was not found in %2").arg(className).arg(filePath).toUtf8());
     PythonQt::self()->handleError();
     return false;
     }
@@ -194,7 +194,7 @@ bool qSlicerSegmentEditorScriptedLabelEffect::setPythonSource(const QString newP
     return false;
     }
 
-  d->PythonSource = newPythonSource;
+  d->PythonSource = filePath;
 
   if (!qSlicerScriptedUtils::setModuleAttribute(
         "slicer", className, self))

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedLabelEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedLabelEffect.cxx
@@ -71,7 +71,7 @@ public:
 
   mutable qSlicerPythonCppAPI PythonCppAPI;
 
-  QString PythonSource;
+  QString PythonSourceFilePath;
 };
 
 //-----------------------------------------------------------------------------
@@ -120,7 +120,7 @@ qSlicerSegmentEditorScriptedLabelEffect::~qSlicerSegmentEditorScriptedLabelEffec
 QString qSlicerSegmentEditorScriptedLabelEffect::pythonSource()const
 {
   Q_D(const qSlicerSegmentEditorScriptedLabelEffect);
-  return d->PythonSource;
+  return d->PythonSourceFilePath;
 }
 
 //-----------------------------------------------------------------------------
@@ -194,7 +194,7 @@ bool qSlicerSegmentEditorScriptedLabelEffect::setPythonSource(const QString file
     return false;
     }
 
-  d->PythonSource = filePath;
+  d->PythonSourceFilePath = filePath;
 
   if (!qSlicerScriptedUtils::setModuleAttribute(
         "slicer", className, self))
@@ -259,7 +259,7 @@ const QString qSlicerSegmentEditorScriptedLabelEffect::helpText()const
   // Parse result
   if (!PyUnicode_Check(result))
     {
-    qWarning() << d->PythonSource << ": qSlicerSegmentEditorScriptedLabelEffect: Function 'helpText' is expected to return a string!";
+    qWarning() << d->PythonSourceFilePath << ": qSlicerSegmentEditorScriptedLabelEffect: Function 'helpText' is expected to return a string!";
     return this->Superclass::helpText();
     }
 
@@ -274,7 +274,7 @@ qSlicerSegmentEditorAbstractEffect* qSlicerSegmentEditorScriptedLabelEffect::clo
   PyObject* result = d->PythonCppAPI.callMethod(d->CloneMethod);
   if (!result)
     {
-    qCritical() << d->PythonSource << ": clone: Failed to call mandatory clone method! If it is implemented, please see python output for errors.";
+    qCritical() << d->PythonSourceFilePath << ": clone: Failed to call mandatory clone method! If it is implemented, please see python output for errors.";
     return nullptr;
     }
 
@@ -284,7 +284,7 @@ qSlicerSegmentEditorAbstractEffect* qSlicerSegmentEditorScriptedLabelEffect::clo
     resultVariant.value<QObject*>() );
   if (!clonedEffect)
     {
-    qCritical() << d->PythonSource << ": clone: Invalid cloned effect object returned from python!";
+    qCritical() << d->PythonSourceFilePath << ": clone: Invalid cloned effect object returned from python!";
     return nullptr;
     }
   return clonedEffect;
@@ -356,7 +356,7 @@ bool qSlicerSegmentEditorScriptedLabelEffect::processInteractionEvents(vtkRender
     }
   if (!PyBool_Check(result))
     {
-    qWarning() << d->PythonSource
+    qWarning() << d->PythonSourceFilePath
                << " - function 'processInteractionEvents' "
                << "is expected to return a boolean";
     return false;

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedLabelEffect.h
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedLabelEffect.h
@@ -58,8 +58,8 @@ public:
   Q_INVOKABLE QString pythonSource()const;
 
   /// Set python source for the implemented effect
-  /// \param newPythonSource Python file path
-  Q_INVOKABLE bool setPythonSource(const QString newPythonSource);
+  /// \param filePath Python file path
+  Q_INVOKABLE bool setPythonSource(const QString filePath);
 
   /// Convenience method allowing to retrieve the associated scripted instance
   Q_INVOKABLE PyObject* self() const;

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedPaintEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedPaintEffect.cxx
@@ -116,7 +116,7 @@ QString qSlicerSegmentEditorScriptedPaintEffect::pythonSource()const
 }
 
 //-----------------------------------------------------------------------------
-bool qSlicerSegmentEditorScriptedPaintEffect::setPythonSource(const QString newPythonSource)
+bool qSlicerSegmentEditorScriptedPaintEffect::setPythonSource(const QString filePath)
 {
   Q_D(qSlicerSegmentEditorScriptedPaintEffect);
 
@@ -125,13 +125,13 @@ bool qSlicerSegmentEditorScriptedPaintEffect::setPythonSource(const QString newP
     return false;
     }
 
-  if (!newPythonSource.endsWith(".py") && !newPythonSource.endsWith(".pyc"))
+  if (!filePath.endsWith(".py") && !filePath.endsWith(".pyc"))
     {
     return false;
     }
 
   // Extract moduleName from the provided filename
-  QString moduleName = QFileInfo(newPythonSource).baseName();
+  QString moduleName = QFileInfo(filePath).baseName();
 
   // In case the effect is within the main module file
   QString className = moduleName;
@@ -157,7 +157,7 @@ bool qSlicerSegmentEditorScriptedPaintEffect::setPythonSource(const QString newP
     {
     PythonQtObjectPtr local_dict;
     local_dict.setNewRef(PyDict_New());
-    if (!qSlicerScriptedUtils::loadSourceAsModule(moduleName, newPythonSource, global_dict, local_dict))
+    if (!qSlicerScriptedUtils::loadSourceAsModule(moduleName, filePath, global_dict, local_dict))
       {
       return false;
       }
@@ -173,7 +173,7 @@ bool qSlicerSegmentEditorScriptedPaintEffect::setPythonSource(const QString newP
     PyErr_SetString(PyExc_RuntimeError,
                     QString("qSlicerSegmentEditorScriptedPaintEffect::setPythonSource - "
                             "Failed to load segment editor scripted effect: "
-                            "class %1 was not found in %2").arg(className).arg(newPythonSource).toUtf8());
+                            "class %1 was not found in %2").arg(className).arg(filePath).toUtf8());
     PythonQt::self()->handleError();
     return false;
     }
@@ -186,7 +186,7 @@ bool qSlicerSegmentEditorScriptedPaintEffect::setPythonSource(const QString newP
     return false;
     }
 
-  d->PythonSource = newPythonSource;
+  d->PythonSource = filePath;
 
   if (!qSlicerScriptedUtils::setModuleAttribute(
         "slicer", className, self))

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedPaintEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedPaintEffect.cxx
@@ -65,7 +65,7 @@ public:
 
   mutable qSlicerPythonCppAPI PythonCppAPI;
 
-  QString PythonSource;
+  QString PythonSourceFilePath;
 };
 
 //-----------------------------------------------------------------------------
@@ -112,7 +112,7 @@ qSlicerSegmentEditorScriptedPaintEffect::~qSlicerSegmentEditorScriptedPaintEffec
 QString qSlicerSegmentEditorScriptedPaintEffect::pythonSource()const
 {
   Q_D(const qSlicerSegmentEditorScriptedPaintEffect);
-  return d->PythonSource;
+  return d->PythonSourceFilePath;
 }
 
 //-----------------------------------------------------------------------------
@@ -186,7 +186,7 @@ bool qSlicerSegmentEditorScriptedPaintEffect::setPythonSource(const QString file
     return false;
     }
 
-  d->PythonSource = filePath;
+  d->PythonSourceFilePath = filePath;
 
   if (!qSlicerScriptedUtils::setModuleAttribute(
         "slicer", className, self))
@@ -244,7 +244,7 @@ const QString qSlicerSegmentEditorScriptedPaintEffect::helpText()const
   // Parse result
   if (!PyUnicode_Check(result))
     {
-    qWarning() << d->PythonSource << ": qSlicerSegmentEditorScriptedPaintEffect: Function 'helpText' is expected to return a string!";
+    qWarning() << d->PythonSourceFilePath << ": qSlicerSegmentEditorScriptedPaintEffect: Function 'helpText' is expected to return a string!";
     return this->Superclass::helpText();
     }
 
@@ -259,7 +259,7 @@ qSlicerSegmentEditorAbstractEffect* qSlicerSegmentEditorScriptedPaintEffect::clo
   PyObject* result = d->PythonCppAPI.callMethod(d->CloneMethod);
   if (!result)
     {
-    qCritical() << d->PythonSource << ": clone: Failed to call mandatory clone method! If it is implemented, please see python output for errors.";
+    qCritical() << d->PythonSourceFilePath << ": clone: Failed to call mandatory clone method! If it is implemented, please see python output for errors.";
     return nullptr;
     }
 
@@ -269,7 +269,7 @@ qSlicerSegmentEditorAbstractEffect* qSlicerSegmentEditorScriptedPaintEffect::clo
     resultVariant.value<QObject*>() );
   if (!clonedEffect)
     {
-    qCritical() << d->PythonSource << ": clone: Invalid cloned effect object returned from python!";
+    qCritical() << d->PythonSourceFilePath << ": clone: Invalid cloned effect object returned from python!";
     return nullptr;
     }
   return clonedEffect;

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedPaintEffect.h
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedPaintEffect.h
@@ -59,8 +59,8 @@ public:
   Q_INVOKABLE QString pythonSource()const;
 
   /// Set python source for the implemented effect
-  /// \param newPythonSource Python file path
-  Q_INVOKABLE bool setPythonSource(const QString newPythonSource);
+  /// \param filePath Python file path
+  Q_INVOKABLE bool setPythonSource(const QString filePath);
 
   /// Convenience method allowing to retrieve the associated scripted instance
   Q_INVOKABLE PyObject* self() const;

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.cxx
@@ -71,7 +71,7 @@ public:
 
   mutable qSlicerPythonCppAPI PythonCppAPI;
 
-  QString PythonSource;
+  QString PythonSourceFilePath;
 };
 
 //-----------------------------------------------------------------------------
@@ -124,7 +124,7 @@ qSlicerSubjectHierarchyScriptedPlugin::~qSlicerSubjectHierarchyScriptedPlugin() 
 QString qSlicerSubjectHierarchyScriptedPlugin::pythonSource()const
 {
   Q_D(const qSlicerSubjectHierarchyScriptedPlugin);
-  return d->PythonSource;
+  return d->PythonSourceFilePath;
 }
 
 //-----------------------------------------------------------------------------
@@ -198,7 +198,7 @@ bool qSlicerSubjectHierarchyScriptedPlugin::setPythonSource(const QString filePa
     return false;
     }
 
-  d->PythonSource = filePath;
+  d->PythonSourceFilePath = filePath;
 
   if (!qSlicerScriptedUtils::setModuleAttribute(
         "slicer", className, self))
@@ -239,7 +239,7 @@ double qSlicerSubjectHierarchyScriptedPlugin::canOwnSubjectHierarchyItem(vtkIdTy
   // Parse result
   if (!PyFloat_Check(result))
     {
-    qWarning() << d->PythonSource << ": " << Q_FUNC_INFO << ": Function 'canOwnSubjectHierarchyItem' is expected to return a floating point number!";
+    qWarning() << d->PythonSourceFilePath << ": " << Q_FUNC_INFO << ": Function 'canOwnSubjectHierarchyItem' is expected to return a floating point number!";
     return this->Superclass::canOwnSubjectHierarchyItem(itemID);
     }
 
@@ -260,7 +260,7 @@ const QString qSlicerSubjectHierarchyScriptedPlugin::roleForPlugin()const
   // Parse result
   if (!PyUnicode_Check(result))
     {
-    qWarning() << d->PythonSource << ": " << Q_FUNC_INFO << ": Function 'roleForPlugin' is expected to return a string!";
+    qWarning() << d->PythonSourceFilePath << ": " << Q_FUNC_INFO << ": Function 'roleForPlugin' is expected to return a string!";
     return this->Superclass::roleForPlugin();
     }
 
@@ -282,7 +282,7 @@ const QString qSlicerSubjectHierarchyScriptedPlugin::helpText()const
   // Parse result
   if (!PyUnicode_Check(result))
     {
-    qWarning() << d->PythonSource << ": " << Q_FUNC_INFO << ": Function 'helpText' is expected to return a string!";
+    qWarning() << d->PythonSourceFilePath << ": " << Q_FUNC_INFO << ": Function 'helpText' is expected to return a string!";
     return this->Superclass::helpText();
     }
 
@@ -483,7 +483,7 @@ double qSlicerSubjectHierarchyScriptedPlugin::canAddNodeToSubjectHierarchy(
   // Parse result
   if (!PyFloat_Check(result))
     {
-    qWarning() << d->PythonSource << ": " << Q_FUNC_INFO << ": Function 'canAddNodeToSubjectHierarchy' is expected to return a floating point number!";
+    qWarning() << d->PythonSourceFilePath << ": " << Q_FUNC_INFO << ": Function 'canAddNodeToSubjectHierarchy' is expected to return a floating point number!";
     return this->Superclass::canAddNodeToSubjectHierarchy(node, parentItemID);
     }
 
@@ -510,7 +510,7 @@ double qSlicerSubjectHierarchyScriptedPlugin::canReparentItemInsideSubjectHierar
   // Parse result
   if (!PyFloat_Check(result))
     {
-    qWarning() << d->PythonSource << ": " << Q_FUNC_INFO << ": Function 'canReparentItemInsideSubjectHierarchy' is expected to return a floating point number!";
+    qWarning() << d->PythonSourceFilePath << ": " << Q_FUNC_INFO << ": Function 'canReparentItemInsideSubjectHierarchy' is expected to return a floating point number!";
     return this->Superclass::canReparentItemInsideSubjectHierarchy(itemID, parentItemID);
     }
 
@@ -537,7 +537,7 @@ bool qSlicerSubjectHierarchyScriptedPlugin::reparentItemInsideSubjectHierarchy(
   // Parse result
   if (!PyBool_Check(result))
     {
-    qWarning() << d->PythonSource << ": " << Q_FUNC_INFO << ": Function 'reparentItemInsideSubjectHierarchy' is expected to return a boolean!";
+    qWarning() << d->PythonSourceFilePath << ": " << Q_FUNC_INFO << ": Function 'reparentItemInsideSubjectHierarchy' is expected to return a boolean!";
     return this->Superclass::reparentItemInsideSubjectHierarchy(itemID, parentItemID);
     }
 
@@ -561,7 +561,7 @@ QString qSlicerSubjectHierarchyScriptedPlugin::displayedItemName(vtkIdType itemI
   // Parse result
   if (!PyUnicode_Check(result))
     {
-    qWarning() << d->PythonSource << ": " << Q_FUNC_INFO << ": Function 'displayedItemName' is expected to return a string!";
+    qWarning() << d->PythonSourceFilePath << ": " << Q_FUNC_INFO << ": Function 'displayedItemName' is expected to return a string!";
     return this->Superclass::displayedItemName(itemID);
     }
 
@@ -585,7 +585,7 @@ QString qSlicerSubjectHierarchyScriptedPlugin::tooltip(vtkIdType itemID)const
   // Parse result
   if (!PyUnicode_Check(result))
     {
-    qWarning() << d->PythonSource << ": " << Q_FUNC_INFO << ": Function 'tooltip' is expected to return a string!";
+    qWarning() << d->PythonSourceFilePath << ": " << Q_FUNC_INFO << ": Function 'tooltip' is expected to return a string!";
     return this->Superclass::tooltip(itemID);
     }
 
@@ -625,7 +625,7 @@ int qSlicerSubjectHierarchyScriptedPlugin::getDisplayVisibility(vtkIdType itemID
   // Parse result
   if (!PyLong_Check(result))
     {
-    qWarning() << d->PythonSource << ": " << Q_FUNC_INFO << ": Function 'getDisplayVisibility' is expected to return an integer!";
+    qWarning() << d->PythonSourceFilePath << ": " << Q_FUNC_INFO << ": Function 'getDisplayVisibility' is expected to return an integer!";
     return this->Superclass::getDisplayVisibility(itemID);
     }
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.cxx
@@ -128,7 +128,7 @@ QString qSlicerSubjectHierarchyScriptedPlugin::pythonSource()const
 }
 
 //-----------------------------------------------------------------------------
-bool qSlicerSubjectHierarchyScriptedPlugin::setPythonSource(const QString newPythonSource)
+bool qSlicerSubjectHierarchyScriptedPlugin::setPythonSource(const QString filePath)
 {
   Q_D(qSlicerSubjectHierarchyScriptedPlugin);
 
@@ -137,13 +137,13 @@ bool qSlicerSubjectHierarchyScriptedPlugin::setPythonSource(const QString newPyt
     return false;
     }
 
-  if (!newPythonSource.endsWith(".py") && !newPythonSource.endsWith(".pyc"))
+  if (!filePath.endsWith(".py") && !filePath.endsWith(".pyc"))
     {
     return false;
     }
 
   // Extract moduleName from the provided filename
-  QString moduleName = QFileInfo(newPythonSource).baseName();
+  QString moduleName = QFileInfo(filePath).baseName();
 
   // In case the plugin is within the main module file
   QString className = moduleName;
@@ -169,7 +169,7 @@ bool qSlicerSubjectHierarchyScriptedPlugin::setPythonSource(const QString newPyt
     {
     PythonQtObjectPtr local_dict;
     local_dict.setNewRef(PyDict_New());
-    if (!qSlicerScriptedUtils::loadSourceAsModule(moduleName, newPythonSource, global_dict, local_dict))
+    if (!qSlicerScriptedUtils::loadSourceAsModule(moduleName, filePath, global_dict, local_dict))
       {
       return false;
       }
@@ -185,7 +185,7 @@ bool qSlicerSubjectHierarchyScriptedPlugin::setPythonSource(const QString newPyt
     PyErr_SetString(PyExc_RuntimeError,
                     QString("qSlicerSubjectHierarchyScriptedPlugin::setPythonSource - "
                             "Failed to load subject hierarchy scripted plugin: "
-                            "class %1 was not found in %2").arg(className).arg(newPythonSource).toUtf8());
+                            "class %1 was not found in %2").arg(className).arg(filePath).toUtf8());
     PythonQt::self()->handleError();
     return false;
     }
@@ -198,7 +198,7 @@ bool qSlicerSubjectHierarchyScriptedPlugin::setPythonSource(const QString newPyt
     return false;
     }
 
-  d->PythonSource = newPythonSource;
+  d->PythonSource = filePath;
 
   if (!qSlicerScriptedUtils::setModuleAttribute(
         "slicer", className, self))

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.h
@@ -72,8 +72,8 @@ public:
   Q_INVOKABLE QString pythonSource()const;
 
   /// Set python source for the implemented plugin
-  /// \param newPythonSource Python file path
-  Q_INVOKABLE bool setPythonSource(const QString newPythonSource);
+  /// \param filePath Python file path
+  Q_INVOKABLE bool setPythonSource(const QString filePath);
 
   /// Convenience method allowing to retrieve the associated scripted instance
   Q_INVOKABLE PyObject* self() const;


### PR DESCRIPTION
_Changes implemented following the comment of @pieper in https://github.com/Slicer/Slicer/pull/7351#discussion_r1383991595._

---

This more accurately conveys the variable's purpose, avoiding any ambiguity between "python code" and "python script".

* Improve `setPythonSource` API readability renaming parameter from `newPythonSource` to `filePath`


* Improve code readability renaming scripted class internal variable from `PythonSource` to `PythonSourceFilePath`