### PR TITLE
BUG: Fix ExtensionWizard error message reporting when drag-and-dropping script

### DIFF
--- a/Modules/Scripted/ExtensionWizard/ExtensionWizard.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizard.py
@@ -404,7 +404,7 @@ class ExtensionWizardWidget:
                     text = ("The module factory manager reported an error. "
                             "One or more of the requested module(s) and/or "
                             "dependencies thereof may not have been loaded.")
-                    slicer.util.errorDisplay(text, parent, windowTitle="Error loading module(s)",
+                    slicer.util.errorDisplay(text, parent=parent, windowTitle="Error loading module(s)",
                                              standardButtons=qt.QMessageBox.Close)
 
     # ---------------------------------------------------------------------------


### PR DESCRIPTION
This commit addresses a regression introduced in 34651fbbb (`BUG: Fix error message when drag-and-dropping nodes`) through the following pull request:
* https://github.com/Slicer/Slicer/pull/7303

The problem stemmed from the `errorDisplay()` function, which expects the argument to be provided as `text, windowTitle=None, parent=None, standardButtons=None, **kwargs`.

Specifying `parent` as a keyword argument is then required to avoid the following error:

```
Traceback (most recent call last):
  File "/path/to/Slicer-Release/Slicer-build/lib/Slicer-5.5/qt-scripted-modules/ExtensionWizard.py", line 518, in dropEvent
    ExtensionWizardWidget.loadModules(modules=self.foundModules)
  File "/path/to/Slicer-Release/Slicer-build/lib/Slicer-5.5/qt-scripted-modules/ExtensionWizard.py", line 407, in loadModules
    slicer.util.errorDisplay(text, parent, windowTitle="Error loading module(s)",
TypeError: errorDisplay() got multiple values for argument 'windowTitle'
```

| Before | After | 
|--|--|
| ![image](https://github.com/Slicer/Slicer/assets/219043/35343102-e053-4cb0-8bc9-6ad22f6f3be8) | ![image](https://github.com/Slicer/Slicer/assets/219043/31cc35dc-471c-4671-bd5b-202e50210b71) |
