### PR TITLE
COMP: Fix parallel build error adding missing PyPI dependency for python-dateutil

### DIFF
--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -120,6 +120,9 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [python-dateutil]
   python-dateutil==2.8.2 --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
   # [/python-dateutil]
+  # [six]
+  six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
+  # [/six]
   # [typing-extensions]
   typing-extensions==4.8.0 --hash=sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0
   # [/typing-extensions]


### PR DESCRIPTION
Fix the error reported below ensuring "python-dateutil" dependency "six" is explicitly specified within its external project, ensuring it is not installed as side effect of an unrelated external project.


```
$ cat /path/to/python-extension-manager-ssl-requirements-install-err.log

ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    six>=1.5 from https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl (from python-dateutil==2.8.2->-r /Users/svc-dashboard/D/P/A/python-extension-manager-ssl-requirements-requirements.txt (line 87))
WARNING: There was an error checking the latest version of pip.
```