### PR TITLE
COMP: Update GitHub workflow to remove deprecated use of "::set-output"

### DIFF
--- a/.github/workflows/update-slicer-certificate-bundle.yml
+++ b/.github/workflows/update-slicer-certificate-bundle.yml
@@ -25,9 +25,9 @@ jobs:
         run: |
           sha=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${{ env.CERTDATA_OWNER }}/${{ env.CERTDATA_REPO }}/commits?path=${{ env.CERTDATA_PATH }}&sha=master&per_page=1" | jq ".[0] | .sha" -r)
-          echo "::set-output name=sha::${sha}"
+          echo "sha=${sha}" >> $GITHUB_OUTPUT
           download_url="https://github.com/${{ env.CERTDATA_OWNER }}/${{ env.CERTDATA_REPO }}/blob/${sha}/${{ env.CERTDATA_PATH }}?raw=true"
-          echo "::set-output name=download_url::${download_url}"
+          echo "download_url=${download_url}" >> $GITHUB_OUTPUT
 
       - name: Download certdata.txt from https://github.com/mozilla/gecko-dev
         run: |
@@ -48,7 +48,7 @@ jobs:
         id: head_branch
         run: |
           sha=$(git rev-parse ${{ github.ref }})
-          echo "::set-output name=sha::${sha}"
+          echo "sha=${sha}" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         id: cpr


### PR DESCRIPTION
This commit applies a fix similar to c410ead7b (`COMP: Fix "ci" GitHub workflow removing deprecated use of "::set-output"`) to the "update-slicer-certificate-bundle" GitHub Actions workflow.

For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


![image](https://github.com/Slicer/Slicer/assets/219043/8b8a76da-12f3-4b42-8729-3a6888f057ff)
