### PR TITLE
BUG: Fix crash for debug build due to invalid assert in MRMLViewInteractorStyle

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
@@ -482,7 +482,7 @@ void vtkMRMLViewInteractorStyle::SetInteractor(vtkRenderWindowInteractor *intera
 void vtkMRMLViewInteractorStyle::DisplayableManagerCallback(vtkObject *object, unsigned long event, void *clientData, void *callData)
 {
   vtkMRMLViewInteractorStyle* self = reinterpret_cast<vtkMRMLViewInteractorStyle *>(clientData);
-  assert(!object->IsA("vtkMRMLAbstractDisplayableManager"));
+  assert(object->IsA("vtkMRMLAbstractDisplayableManager"));
   self->ProcessDisplayableManagerEvents(vtkMRMLAbstractDisplayableManager::SafeDownCast(object), event, callData);
 }
 


### PR DESCRIPTION
Issue is only visible in debug mode as `assert` is not in release build

In debug mode the assertion fails preventing slicer from starting up 