### PR TITLE
COMP: Skip ReadTheDocs build for "hooks" branch

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
+post_checkout:
+  # When a command exits with code 183, Read the Docs will cancel the build immediately.
+  # See https://docs.readthedocs.io/en/stable/build-customization.html#override-the-build-process
+  - exit 183


### PR DESCRIPTION
When a command exits with code 183, Read the Docs will cancel the build immediately.