### PR TITLE
STYLE: Simplify list membership test in DICOMScalarVolumePlugin

### DIFF
--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -226,7 +226,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
                 value = value.replace(",", "_")  # remove commas so it can be used as an index
                 if tag not in subseriesValues:
                     subseriesValues[tag] = []
-                if not subseriesValues[tag].__contains__(value):
+                if value not in subseriesValues[tag]:
                     subseriesValues[tag].append(value)
                 if (tag, value) not in subseriesFiles:
                     subseriesFiles[tag, value] = []


### PR DESCRIPTION
Following-up of f0b2690c3 (ENH: Add support for ctkDICOMDatabase tag precaching) where the original use of "__contains__" was introduced.

See https://docs.python.org/3/reference/expressions.html#in