### PR TITLE
COMP: Use `GetLayoutName()` instead of `GetActiveTag()`

### DIFF
--- a/Libs/MRML/Core/vtkMRMLCameraNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLCameraNode.cxx
@@ -132,7 +132,7 @@ void vtkMRMLCameraNode::ReadXMLAttributes(const char** atts)
       {
       // Legacy, was replaced by active tag, try to set ActiveTag instead
       // to link to the main viewer
-      if (!this->GetActiveTag() && this->Scene)
+      if (!this->GetLayoutName() && this->Scene)
         {
         vtkMRMLViewNode* vnode = vtkMRMLViewNode::SafeDownCast(
           this->Scene->GetFirstNodeByClass("vtkMRMLViewNode"));


### PR DESCRIPTION
Use `vtkMRMLCameraNode::GetLayoutName()` instead of `vtkMRMLCameraNode::GetActiveTag()`.

Fixes:
```
vtkMRMLCameraNode.cxx:405   WARN| vtkMRMLCameraNode (0x55d39e09e730):
vtkMRMLCameraNode::GetActiveTag() is deprecated.
Use vtkMRMLCameraNode::GetLayoutName() instead.
```

raised when running the `vtkMRMLFiberBundleNodeTest1` in the SlicerDMRI extension.