### PR TITLE
ENH: Add test for the `slicer.util.loadFiberBundle` method

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -296,6 +296,12 @@ slicer_add_python_unittest(
   )
 
 slicer_add_python_unittest(
+  SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_util_load_data.py
+  SLICER_ARGS --no-main-window --disable-cli-modules
+  TESTNAME_PREFIX nomainwindow_
+  )
+
+slicer_add_python_unittest(
   SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_util_save.py
   SLICER_ARGS --no-main-window --disable-cli-modules --disable-scripted-loadable-modules DATA{${INPUT}/MR-head.nrrd}
   TESTNAME_PREFIX nomainwindow_

--- a/Base/Python/slicer/tests/test_slicer_util_load_data.py
+++ b/Base/Python/slicer/tests/test_slicer_util_load_data.py
@@ -13,12 +13,23 @@ class SlicerUtilLoadDataTests(unittest.TestCase):
 
     def test_loadFiberBundle(self):
 
-        def _load(fiberBundleFilePath):
+        def _checkNode(node, returnNode):
 
-            node = slicer.util.loadFiberBundle(fiberBundleFilePath)
+            if returnNode:
+                # Deprecated
+                self.assertIsInstance(node, tuple)
+                self.assertEqual(len(node), 2)
+                self.assertTrue(node[0])
+                node = node[1]
             self.assertIsInstance(node, slicer.vtkMRMLFiberBundleNode)
-            node = slicer.util.loadFiberBundle(fiberBundleFilePath)
-            self.assertIsInstance(node, slicer.vtkMRMLFiberBundleNode)
+
+        def _load(fiberBundleFilePath, returnNode=False):
+
+            node = slicer.util.loadFiberBundle(fiberBundleFilePath, returnNode=returnNode)
+            _checkNode(node, returnNode)
+
+            node = slicer.util.loadFiberBundle(fiberBundleFilePath, returnNode=returnNode)
+            _checkNode(node, returnNode)
 
         hash_algorithm = "SHA256"
         checksum = "e1848e4d0b90d6c7442b2474c513d0464c6f141253c25aee6f5bcda4c828deac"
@@ -35,5 +46,13 @@ class SlicerUtilLoadDataTests(unittest.TestCase):
             if slicer.app.ioManager().registeredFileReaderCount("FiberBundleFile") == 0:
                 with self.assertRaisesRegex(RuntimeError, "FiberBundleFile reader not registered") as cm:
                     _load(fiberBundleFilePath)
+
+                with self.assertRaisesRegex(RuntimeError, "FiberBundleFile reader not registered") as cm:
+                    # Deprecated
+                    _load(fiberBundleFilePath, returnNode=True)
+
             else:
                 _load(fiberBundleFilePath)
+
+                # Deprecated
+                _load(fiberBundleFilePath, returnNode=True)

--- a/Base/Python/slicer/tests/test_slicer_util_load_data.py
+++ b/Base/Python/slicer/tests/test_slicer_util_load_data.py
@@ -9,16 +9,13 @@ import slicer
 class SlicerUtilLoadDataTests(unittest.TestCase):
 
     def setUp(self):
-
         pass
-
 
     def test_loadFiberBundle(self):
 
         def _load(fiberBundleFilePath):
 
-            success, node = slicer.util.loadFiberBundle(fiberBundleFilePath, returnNode=True)
-            self.assertTrue(success)
+            node = slicer.util.loadFiberBundle(fiberBundleFilePath)
             self.assertIsInstance(node, slicer.vtkMRMLFiberBundleNode)
             node = slicer.util.loadFiberBundle(fiberBundleFilePath)
             self.assertIsInstance(node, slicer.vtkMRMLFiberBundleNode)

--- a/Base/Python/slicer/tests/test_slicer_util_load_data.py
+++ b/Base/Python/slicer/tests/test_slicer_util_load_data.py
@@ -1,0 +1,42 @@
+import tempfile
+import unittest
+from pathlib import Path
+from urllib.parse import urljoin
+
+import slicer
+
+
+class SlicerUtilLoadDataTests(unittest.TestCase):
+
+    def setUp(self):
+
+        pass
+
+
+    def test_loadFiberBundle(self):
+
+        def _load(fiberBundleFilePath):
+
+            success, node = slicer.util.loadFiberBundle(fiberBundleFilePath, returnNode=True)
+            self.assertTrue(success)
+            self.assertIsInstance(node, slicer.vtkMRMLFiberBundleNode)
+            node = slicer.util.loadFiberBundle(fiberBundleFilePath)
+            self.assertIsInstance(node, slicer.vtkMRMLFiberBundleNode)
+
+        hash_algorithm = "SHA256"
+        checksum = "e1848e4d0b90d6c7442b2474c513d0464c6f141253c25aee6f5bcda4c828deac"
+        url = urljoin(slicer.util.TESTING_DATA_URL, f"{hash_algorithm}/{checksum}")
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+
+            file_basename = "tractography.vtk"
+            fiberBundleFilePath = Path(tmpdirname).joinpath(file_basename)
+            downloadSuccess = slicer.util.downloadFile(
+                url, fiberBundleFilePath, checksum=f"{hash_algorithm}:{checksum}", reDownloadIfChecksumInvalid=True)
+            self.assertTrue(downloadSuccess)
+
+            if slicer.app.ioManager().registeredFileReaderCount("FiberBundleFile") == 0:
+                with self.assertRaisesRegex(RuntimeError, "FiberBundleFile reader not registered") as cm:
+                    _load(fiberBundleFilePath)
+            else:
+                _load(fiberBundleFilePath)

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -780,13 +780,34 @@ def loadColorTable(filename, returnNode=False):
 
 
 def loadFiberBundle(filename, returnNode=False):
-    """Load node from file.
+    """Load fiber bundle node from file.
+
+    .. warning::
+    To ensure the FiberBundleFile reader is registered, the ``SlicerDMRI``
+    extension needs to be installed.
 
     :param filename: full path of the file to load.
     :param returnNode: Deprecated.
     :return: loaded node (if multiple nodes are loaded then a list of nodes).
       If returnNode is True then a status flag and loaded node are returned.
     """
+
+    # Check if SlicerDMRI is installed
+    extension_name = "SlicerDMRI"
+    em = slicer.app.extensionsManagerModel()
+    if not em.isExtensionInstalled(extension_name):
+        errorMessage = f"{extension_name} not installed."
+        errorMessage += "\n" + f"Install the {extension_name} extension"
+
+    # Check if the appropriate reader is registered
+    if slicer.app.ioManager().registeredFileReaderCount("FiberBundleFile") == 0:
+        errorMessage += f"FiberBundleFile reader not registered: failed to read data from file: {filename}"
+        errorMessage += "\n" + f"Try reinstalling the {extension_name} extension"
+
+    if userMessages.GetNumberOfMessages() > 0:
+        errorMessage += "\n" + userMessages.GetAllMessagesAsString()
+        raise RuntimeError(errorMessage)
+
     return loadNodeFromFile(filename, "FiberBundleFile", {}, returnNode)
 
 

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -779,7 +779,7 @@ def loadColorTable(filename, returnNode=False):
     return loadNodeFromFile(filename, "ColorTableFile", {}, returnNode)
 
 
-def loadFiberBundle(filename):
+def loadFiberBundle(filename, returnNode=False):
     """Load fiber bundle node from file.
 
     .. warning::
@@ -788,8 +788,10 @@ def loadFiberBundle(filename):
       extension may need to be installed.
 
     :param filename: full path of the file to load.
+    :param returnNode: Deprecated.
 
     :return: loaded node (if multiple nodes are loaded then a list of nodes).
+      If returnNode is True then a status flag and loaded node are returned.
 
     :raises RuntimeError: in case of failure
     """
@@ -825,7 +827,7 @@ def loadFiberBundle(filename):
 
         raise RuntimeError(errorMessage)
 
-    return loadNodeFromFile(filename, readerType, {})
+    return loadNodeFromFile(filename, readerType, {}, returnNode)
 
 
 def loadAnnotationFiducial(filename, returnNode=False):


### PR DESCRIPTION
- ENH: Check for extension and registered reader for fiber bundle data
- ENH: Add test for the `slicer.util.loadFiberBundle` method