### PR TITLE
STYLE: Remove unreachable "break" statement after "return" outside of "switch"

### DIFF
--- a/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
@@ -41,7 +41,6 @@ QString activePlaceActionText(qSlicerMouseModeToolBar& mouseModeToolBar)
     if (action->objectName() == QString("PlaceWidgetAction"))
       {
       return action->text();
-      break;
       }
     }
   return QString();
@@ -55,7 +54,6 @@ QString getActiveActionText(qSlicerMouseModeToolBar& mouseModeToolBar)
     if (action->isChecked())
       {
       return action->text();
-      break;
       }
 
     }

--- a/Libs/MRML/Core/vtkMRMLPlotChartNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLPlotChartNode.cxx
@@ -328,7 +328,6 @@ int vtkMRMLPlotChartNode::GetPlotSeriesNodeIndexFromID(const char *plotSeriesNod
     if (id && !strcmp(plotSeriesNodeID, id))
       {
       return plotIndex;
-      break;
       }
     }
 


### PR DESCRIPTION
To identify all location if a `break;` statement following `return;`, the entire codebase was inspected using a command like the following:

```
$ ack --ignore-dir=CLI  "break\;" -C2 | ack "return"
```