### PR TITLE
COMP: Mark parameter as not used unconditionally

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraDisplayableManager.cxx
@@ -202,11 +202,7 @@ void vtkMRMLCameraDisplayableManager::ProcessMRMLNodesEvents(vtkObject *caller,
 
 //---------------------------------------------------------------------------
 void vtkMRMLCameraDisplayableManager::OnMRMLNodeModified(
-#ifndef NDEBUG
- vtkMRMLNode* node)
-#else
   vtkMRMLNode* vtkNotUsed(node))
-#endif
 {
   this->RequestRender();
 }


### PR DESCRIPTION
Mark parameter as not used unconditionally.

Fixes:
```
Libs/MRML/DisplayableManager/vtkMRMLCameraDisplayableManager.cxx:
 In member function
 ‘virtual void vtkMRMLCameraDisplayableManager::OnMRMLNodeModified(vtkMRMLNode*)’:
Libs/MRML/DisplayableManager/vtkMRMLCameraDisplayableManager.cxx:206:15:
 warning: unused parameter ‘node’ [-Wunused-parameter]
  206 |  vtkMRMLNode* node)
      |  ~~~~~~~~~~~~~^~~~
```

raised when building 3D Slicer.