### PR TITLE
Update Ruff configuration enabling pydocstyle rules

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -46,7 +46,6 @@ extend-ignore = [
   "C419",    # Unnecessary list comprehension.
 
   "D10",     # undocumented-public-*
-  "D200",    # One-line docstring should fit on one line
   "D202",    # No blank lines allowed after function docstring"
   "D205",    # 1 blank line required between summary line and description
   "D209",    # Multi-line docstring closing quotes should be on a separate line

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -8,6 +8,7 @@ select = [
   "B",           # flake8-bugbear
   "C4",          # flake8-comprehensions
   "E", "F", "W", # flake8
+  "D",           # pydocstyle
 #  "EXE",         # flake8-executable
 #  "G",           # flake8-logging-format
   "ICN",         # flake8-import-conventions
@@ -43,6 +44,18 @@ extend-ignore = [
   "C408",    # Unnecessary `dict` call (rewrite as a literal)
   "C418",    # Unnecessary `dict` literal passed to `dict()` (remove the outer call to `dict()`)
   "C419",    # Unnecessary list comprehension.
+
+  "D10",     # undocumented-public-*
+  "D200",    # One-line docstring should fit on one line
+  "D202",    # No blank lines allowed after function docstring"
+  "D204",    # 1 blank line required after class docstring
+  "D205",    # 1 blank line required between summary line and description
+  "D207",    # Docstring is under-indented
+  "D208",    # Docstring is over-indented
+  "D209",    # Multi-line docstring closing quotes should be on a separate line
+  "D210",    # No whitespaces allowed surrounding docstring text
+  "D301",    # escape-sequence-in-docstring
+  "D4",
 
   "E401",    # Multiple imports on one line
   "E714",    # Test for object identity should be `is not`
@@ -110,6 +123,9 @@ extend-ignore = [
   "UP031",   # Use format specifiers instead of percent format
   "UP032",   # Use f-string instead of `format` call
 ]
+
+[lint.pydocstyle]
+convention = "pep257"
 
 [per-file-ignores]
 # Module imported but unused

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -48,10 +48,7 @@ extend-ignore = [
   "D10",     # undocumented-public-*
   "D200",    # One-line docstring should fit on one line
   "D202",    # No blank lines allowed after function docstring"
-  "D204",    # 1 blank line required after class docstring
   "D205",    # 1 blank line required between summary line and description
-  "D207",    # Docstring is under-indented
-  "D208",    # Docstring is over-indented
   "D209",    # Multi-line docstring closing quotes should be on a separate line
   "D210",    # No whitespaces allowed surrounding docstring text
   "D301",    # escape-sequence-in-docstring

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -50,7 +50,6 @@ extend-ignore = [
   "D202",    # No blank lines allowed after function docstring"
   "D205",    # 1 blank line required between summary line and description
   "D209",    # Multi-line docstring closing quotes should be on a separate line
-  "D210",    # No whitespaces allowed surrounding docstring text
   "D301",    # escape-sequence-in-docstring
   "D4",
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -48,7 +48,6 @@ extend-ignore = [
   "D10",     # undocumented-public-*
   "D202",    # No blank lines allowed after function docstring"
   "D205",    # 1 blank line required between summary line and description
-  "D209",    # Multi-line docstring closing quotes should be on a separate line
   "D301",    # escape-sequence-in-docstring
   "D4",
 

--- a/Applications/SlicerApp/Testing/Python/AtlasTests.py
+++ b/Applications/SlicerApp/Testing/Python/AtlasTests.py
@@ -127,7 +127,7 @@ class AtlasTestsTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 
@@ -184,7 +184,7 @@ class AtlasTestsTest(ScriptedLoadableModuleTest):
         self.perform_AtlasTest(downloads, "I")
 
     def perform_AtlasTest(self, downloads, testVolumePattern):
-        """ Perform the actual atlas test.
+        """Perform the actual atlas test.
         This includes: download and load the given data, touch all
         model hierarchies, and restore all scene views.
         downloads : dictionary of URIs and fileNames

--- a/Applications/SlicerApp/Testing/Python/AtlasTests.py
+++ b/Applications/SlicerApp/Testing/Python/AtlasTests.py
@@ -127,13 +127,11 @@ class AtlasTestsTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_AbdominalAtlasTest()
         self.setUp()

--- a/Applications/SlicerApp/Testing/Python/BRAINSFitRigidRegistrationCrashIssue4139.py
+++ b/Applications/SlicerApp/Testing/Python/BRAINSFitRigidRegistrationCrashIssue4139.py
@@ -80,13 +80,11 @@ class BRAINSFitRigidRegistrationCrashIssue4139Test(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_BRAINSFitRigidRegistrationCrashIssue4139()
 

--- a/Applications/SlicerApp/Testing/Python/BRAINSFitRigidRegistrationCrashIssue4139.py
+++ b/Applications/SlicerApp/Testing/Python/BRAINSFitRigidRegistrationCrashIssue4139.py
@@ -80,7 +80,7 @@ class BRAINSFitRigidRegistrationCrashIssue4139Test(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 
@@ -91,7 +91,7 @@ class BRAINSFitRigidRegistrationCrashIssue4139Test(ScriptedLoadableModuleTest):
         self.test_BRAINSFitRigidRegistrationCrashIssue4139()
 
     def test_BRAINSFitRigidRegistrationCrashIssue4139(self):
-        """ Ideally you should have several levels of tests.  At the lowest level
+        """Ideally you should have several levels of tests.  At the lowest level
         tests should exercise the functionality of the logic with different inputs
         (both valid and invalid).  At higher levels your tests should emulate the
         way the user would interact with your code and confirm that it still works

--- a/Applications/SlicerApp/Testing/Python/CLIEventTest.py
+++ b/Applications/SlicerApp/Testing/Python/CLIEventTest.py
@@ -83,12 +83,10 @@ class CLIEventTestLogic(VTKObservationMixin):
 class CLIEventTestTest(ScriptedLoadableModuleTest):
 
     def setUp(self):
-        """Reset the state for testing.
-        """
+        """Reset the state for testing."""
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_CLIStatusEventTestSynchronous()
         self.test_CLIStatusEventTestAsynchronous()

--- a/Applications/SlicerApp/Testing/Python/CLIEventTest.py
+++ b/Applications/SlicerApp/Testing/Python/CLIEventTest.py
@@ -83,7 +83,7 @@ class CLIEventTestLogic(VTKObservationMixin):
 class CLIEventTestTest(ScriptedLoadableModuleTest):
 
     def setUp(self):
-        """ Reset the state for testing.
+        """Reset the state for testing.
         """
 
     def runTest(self):

--- a/Applications/SlicerApp/Testing/Python/DICOMReaders.py
+++ b/Applications/SlicerApp/Testing/Python/DICOMReaders.py
@@ -48,7 +48,7 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         self.delayDisplay("Closing the scene")
         layoutManager = slicer.app.layoutManager()
@@ -64,7 +64,7 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
         self.test_MissingSlices()
 
     def test_AlternateReaders(self):
-        """ Test the DICOM loading of sample testing data
+        """Test the DICOM loading of sample testing data
         """
         testPass = True
 
@@ -206,7 +206,7 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
         return testPass
 
     def test_MissingSlices(self):
-        """ Test behavior of the readers when slices are missing
+        """Test behavior of the readers when slices are missing
 
         To edit and run this test from the python console, paste this below:
 

--- a/Applications/SlicerApp/Testing/Python/DICOMReaders.py
+++ b/Applications/SlicerApp/Testing/Python/DICOMReaders.py
@@ -43,29 +43,24 @@ class DICOMReadersWidget(ScriptedLoadableModuleWidget):
 
 
 class DICOMReadersTest(ScriptedLoadableModuleTest):
-    """
-    This is the test case
-    """
+    """This is the test case"""
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         self.delayDisplay("Closing the scene")
         layoutManager = slicer.app.layoutManager()
         layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView)
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_AlternateReaders()
         self.setUp()
         self.test_MissingSlices()
 
     def test_AlternateReaders(self):
-        """Test the DICOM loading of sample testing data
-        """
+        """Test the DICOM loading of sample testing data"""
         testPass = True
 
         self.delayDisplay("Starting the DICOM test")

--- a/Applications/SlicerApp/Testing/Python/DICOMReaders.py
+++ b/Applications/SlicerApp/Testing/Python/DICOMReaders.py
@@ -210,7 +210,7 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
 
         To edit and run this test from the python console, paste this below:
 
-    reloadScriptedModule('DICOMReaders'); import DICOMReaders; tester = DICOMReaders.DICOMReadersTest(); tester.setUp(); tester.test_MissingSlices()
+        reloadScriptedModule('DICOMReaders'); import DICOMReaders; tester = DICOMReaders.DICOMReadersTest(); tester.setUp(); tester.test_MissingSlices()
 
         """
         testPass = True

--- a/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
+++ b/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
@@ -64,18 +64,14 @@ class FiducialLayoutSwitchBug1914Logic(ScriptedLoadableModuleLogic):
 
 
 class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
-    """
-    This is the test case for your scripted module.
-    """
+    """This is the test case for your scripted module."""
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_FiducialLayoutSwitchBug1914()
 

--- a/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
+++ b/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
@@ -69,7 +69,7 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
+++ b/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
@@ -151,21 +151,17 @@ class JRC2013VisLogic(ScriptedLoadableModuleLogic):
 
 
 class JRC2013VisTest(ScriptedLoadableModuleTest):
-    """
-    This is the test case for your scripted module.
-    """
+    """This is the test case for your scripted module."""
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         self.delayDisplay("Closing the scene")
         layoutManager = slicer.app.layoutManager()
         layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView)
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_Part1DICOM()
         self.setUp()
@@ -176,8 +172,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
         self.test_Part4Lung()
 
     def test_Part1DICOM(self):
-        """Test the DICOM part of the test using the head atlas
-        """
+        """Test the DICOM part of the test using the head atlas"""
         import os
         self.delayDisplay("Starting the DICOM test")
         #
@@ -306,8 +301,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
         DICOMUtils.closeTemporaryDatabase(originalDatabaseDirectory)
 
     def test_Part2Head(self):
-        """Test using the head atlas - may not be needed - Slicer4Minute is already tested
-        """
+        """Test using the head atlas - may not be needed - Slicer4Minute is already tested"""
         self.delayDisplay("Starting the test")
         #
         # first, get some data
@@ -382,8 +376,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
             self.delayDisplay("Test caused exception!\n" + str(e))
 
     def test_Part3Liver(self):
-        """Test using the liver example data
-        """
+        """Test using the liver example data"""
         self.delayDisplay("Starting the test")
         #
         # first, get some data
@@ -450,8 +443,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
             self.delayDisplay("Test caused exception!\n" + str(e))
 
     def test_Part4Lung(self):
-        """Test using the lung data
-        """
+        """Test using the lung data"""
 
         self.delayDisplay("Starting the test")
         #

--- a/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
+++ b/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
@@ -156,7 +156,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         self.delayDisplay("Closing the scene")
         layoutManager = slicer.app.layoutManager()
@@ -176,7 +176,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
         self.test_Part4Lung()
 
     def test_Part1DICOM(self):
-        """ Test the DICOM part of the test using the head atlas
+        """Test the DICOM part of the test using the head atlas
         """
         import os
         self.delayDisplay("Starting the DICOM test")
@@ -306,7 +306,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
         DICOMUtils.closeTemporaryDatabase(originalDatabaseDirectory)
 
     def test_Part2Head(self):
-        """ Test using the head atlas - may not be needed - Slicer4Minute is already tested
+        """Test using the head atlas - may not be needed - Slicer4Minute is already tested
         """
         self.delayDisplay("Starting the test")
         #
@@ -382,7 +382,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
             self.delayDisplay("Test caused exception!\n" + str(e))
 
     def test_Part3Liver(self):
-        """ Test using the liver example data
+        """Test using the liver example data
         """
         self.delayDisplay("Starting the test")
         #
@@ -450,7 +450,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
             self.delayDisplay("Test caused exception!\n" + str(e))
 
     def test_Part4Lung(self):
-        """ Test using the lung data
+        """Test using the lung data
         """
 
         self.delayDisplay("Starting the test")

--- a/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
+++ b/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
@@ -146,6 +146,7 @@ class JRC2013VisLogic(ScriptedLoadableModuleLogic):
     this class and make use of the functionality without
     requiring an instance of the Widget
     """
+
     pass
 
 

--- a/Applications/SlicerApp/Testing/Python/KneeAtlasTest.py
+++ b/Applications/SlicerApp/Testing/Python/KneeAtlasTest.py
@@ -4,8 +4,7 @@ import AtlasTests
 
 
 class testClass:
-    """Run the knee atlas test by itself
-    """
+    """Run the knee atlas test by itself"""
 
     def setUp(self):
         print("Import the atlas tests...")

--- a/Applications/SlicerApp/Testing/Python/KneeAtlasTest.py
+++ b/Applications/SlicerApp/Testing/Python/KneeAtlasTest.py
@@ -4,7 +4,7 @@ import AtlasTests
 
 
 class testClass:
-    """ Run the knee atlas test by itself
+    """Run the knee atlas test by itself
     """
 
     def setUp(self):

--- a/Applications/SlicerApp/Testing/Python/RSNA2012ProstateDemo.py
+++ b/Applications/SlicerApp/Testing/Python/RSNA2012ProstateDemo.py
@@ -61,9 +61,7 @@ class RSNA2012ProstateDemoTest(ScriptedLoadableModuleTest):
         self.test_RSNA2012ProstateDemo()
 
     def test_RSNA2012ProstateDemo(self):
-        """
-        Replicate one of the crashes in issue 2512
-        """
+        """Replicate one of the crashes in issue 2512"""
 
         print("Running RSNA2012ProstateDemo Test case:")
 

--- a/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
@@ -136,7 +136,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         self.delayDisplay("Closing the scene")
         layoutManager = slicer.app.layoutManager()
@@ -154,7 +154,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
         self.test_Part3PETCT()
 
     def test_Part1Ruler(self, enableScreenshotsFlag=0, screenshotScaleFactor=1):
-        """ Test using rulers
+        """Test using rulers
         """
         self.enableScreenshots = enableScreenshotsFlag
         self.screenshotScaleFactor = screenshotScaleFactor
@@ -208,7 +208,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
             self.delayDisplay("Test caused exception!\n" + str(e))
 
     def test_Part3PETCT(self, enableScreenshotsFlag=0, screenshotScaleFactor=1):
-        """ Test using the PETCT module
+        """Test using the PETCT module
         """
         self.enableScreenshots = enableScreenshotsFlag
         self.screenshotScaleFactor = screenshotScaleFactor
@@ -304,7 +304,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
             self.delayDisplay("Test caused exception!\n" + str(e))
 
     def test_Part2ChangeTracker(self, enableScreenshotsFlag=0, screenshotScaleFactor=1):
-        """ Test the ChangeTracker module
+        """Test the ChangeTracker module
         """
         self.enableScreenshots = enableScreenshotsFlag
         self.screenshotScaleFactor = screenshotScaleFactor

--- a/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
@@ -136,16 +136,14 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         self.delayDisplay("Closing the scene")
         layoutManager = slicer.app.layoutManager()
         layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView)
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_Part1Ruler()
         self.setUp()
@@ -154,8 +152,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
         self.test_Part3PETCT()
 
     def test_Part1Ruler(self, enableScreenshotsFlag=0, screenshotScaleFactor=1):
-        """Test using rulers
-        """
+        """Test using rulers"""
         self.enableScreenshots = enableScreenshotsFlag
         self.screenshotScaleFactor = screenshotScaleFactor
 
@@ -208,8 +205,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
             self.delayDisplay("Test caused exception!\n" + str(e))
 
     def test_Part3PETCT(self, enableScreenshotsFlag=0, screenshotScaleFactor=1):
-        """Test using the PETCT module
-        """
+        """Test using the PETCT module"""
         self.enableScreenshots = enableScreenshotsFlag
         self.screenshotScaleFactor = screenshotScaleFactor
 
@@ -304,8 +300,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
             self.delayDisplay("Test caused exception!\n" + str(e))
 
     def test_Part2ChangeTracker(self, enableScreenshotsFlag=0, screenshotScaleFactor=1):
-        """Test the ChangeTracker module
-        """
+        """Test the ChangeTracker module"""
         self.enableScreenshots = enableScreenshotsFlag
         self.screenshotScaleFactor = screenshotScaleFactor
 

--- a/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
@@ -124,6 +124,7 @@ class RSNAQuantTutorialLogic(ScriptedLoadableModuleLogic):
     this class and make use of the functionality without
     requiring an instance of the Widget
     """
+
     pass
 
 

--- a/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
@@ -159,16 +159,14 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         self.delayDisplay("Closing the scene")
         layoutManager = slicer.app.layoutManager()
         layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView)
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_Part1DICOM()
         self.setUp()
@@ -179,8 +177,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
         self.test_Part4Lung()
 
     def test_Part1DICOM(self, enableScreenshotsFlag=0, screenshotScaleFactor=1):
-        """Test the DICOM part of the test using the head atlas
-        """
+        """Test the DICOM part of the test using the head atlas"""
         self.enableScreenshots = enableScreenshotsFlag
         self.screenshotScaleFactor = screenshotScaleFactor
 
@@ -297,8 +294,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
         DICOMUtils.closeTemporaryDatabase(originalDatabaseDirectory)
 
     def test_Part2Head(self, enableScreenshotsFlag=0, screenshotScaleFactor=1):
-        """Test using the head atlas - may not be needed - Slicer4Minute is already tested
-        """
+        """Test using the head atlas - may not be needed - Slicer4Minute is already tested"""
         self.enableScreenshots = enableScreenshotsFlag
         self.screenshotScaleFactor = screenshotScaleFactor
 
@@ -396,8 +392,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
             self.delayDisplay("Test caused exception!\n" + str(e))
 
     def test_Part3Liver(self, enableScreenshotsFlag=0, screenshotScaleFactor=1):
-        """Test using the liver example data
-        """
+        """Test using the liver example data"""
         self.enableScreenshots = enableScreenshotsFlag
         self.screenshotScaleFactor = screenshotScaleFactor
 
@@ -468,8 +463,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
             self.delayDisplay("Test caused exception!\n" + str(e))
 
     def test_Part4Lung(self, enableScreenshotsFlag=0, screenshotScaleFactor=1):
-        """Test using the lung data
-        """
+        """Test using the lung data"""
         self.enableScreenshots = enableScreenshotsFlag
         self.screenshotScaleFactor = screenshotScaleFactor
 

--- a/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
@@ -159,7 +159,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         self.delayDisplay("Closing the scene")
         layoutManager = slicer.app.layoutManager()
@@ -179,7 +179,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
         self.test_Part4Lung()
 
     def test_Part1DICOM(self, enableScreenshotsFlag=0, screenshotScaleFactor=1):
-        """ Test the DICOM part of the test using the head atlas
+        """Test the DICOM part of the test using the head atlas
         """
         self.enableScreenshots = enableScreenshotsFlag
         self.screenshotScaleFactor = screenshotScaleFactor
@@ -297,7 +297,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
         DICOMUtils.closeTemporaryDatabase(originalDatabaseDirectory)
 
     def test_Part2Head(self, enableScreenshotsFlag=0, screenshotScaleFactor=1):
-        """ Test using the head atlas - may not be needed - Slicer4Minute is already tested
+        """Test using the head atlas - may not be needed - Slicer4Minute is already tested
         """
         self.enableScreenshots = enableScreenshotsFlag
         self.screenshotScaleFactor = screenshotScaleFactor
@@ -396,7 +396,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
             self.delayDisplay("Test caused exception!\n" + str(e))
 
     def test_Part3Liver(self, enableScreenshotsFlag=0, screenshotScaleFactor=1):
-        """ Test using the liver example data
+        """Test using the liver example data
         """
         self.enableScreenshots = enableScreenshotsFlag
         self.screenshotScaleFactor = screenshotScaleFactor
@@ -468,7 +468,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
             self.delayDisplay("Test caused exception!\n" + str(e))
 
     def test_Part4Lung(self, enableScreenshotsFlag=0, screenshotScaleFactor=1):
-        """ Test using the lung data
+        """Test using the lung data
         """
         self.enableScreenshots = enableScreenshotsFlag
         self.screenshotScaleFactor = screenshotScaleFactor

--- a/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
@@ -147,6 +147,7 @@ class RSNAVisTutorialLogic(ScriptedLoadableModuleLogic):
     Uses ScriptedLoadableModuleLogic base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
+
     pass
 
 

--- a/Applications/SlicerApp/Testing/Python/SliceLinkLogic.py
+++ b/Applications/SlicerApp/Testing/Python/SliceLinkLogic.py
@@ -102,13 +102,11 @@ class SliceLinkLogicTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_SliceLinkLogic1()
 

--- a/Applications/SlicerApp/Testing/Python/SliceLinkLogic.py
+++ b/Applications/SlicerApp/Testing/Python/SliceLinkLogic.py
@@ -102,7 +102,7 @@ class SliceLinkLogicTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 
@@ -113,7 +113,7 @@ class SliceLinkLogicTest(ScriptedLoadableModuleTest):
         self.test_SliceLinkLogic1()
 
     def test_SliceLinkLogic1(self):
-        """ Ideally you should have several levels of tests.  At the lowest level
+        """Ideally you should have several levels of tests.  At the lowest level
         tests should exercise the functionality of the logic with different inputs
         (both valid and invalid).  At higher levels your tests should emulate the
         way the user would interact with your code and confirm that it still works

--- a/Applications/SlicerApp/Testing/Python/Slicer4Minute.py
+++ b/Applications/SlicerApp/Testing/Python/Slicer4Minute.py
@@ -102,7 +102,7 @@ class Slicer4MinuteTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 
@@ -113,7 +113,7 @@ class Slicer4MinuteTest(ScriptedLoadableModuleTest):
         self.test_Slicer4Minute1()
 
     def test_Slicer4Minute1(self):
-        """ Tests parts of the Slicer4Minute tutorial.
+        """Tests parts of the Slicer4Minute tutorial.
 
         Currently testing 'Part 2' which covers volumes, models, visibility and clipping.
         """

--- a/Applications/SlicerApp/Testing/Python/Slicer4Minute.py
+++ b/Applications/SlicerApp/Testing/Python/Slicer4Minute.py
@@ -102,13 +102,11 @@ class Slicer4MinuteTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_Slicer4Minute1()
 

--- a/Applications/SlicerApp/Testing/Python/SlicerAppTesting.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerAppTesting.py
@@ -49,8 +49,7 @@ def dropcache():
 
 
 def run(executable, arguments=[], verbose=True, shell=False, drop_cache=False):
-    """Run ``executable`` with provided ``arguments``.
-    """
+    """Run ``executable`` with provided ``arguments``."""
     if drop_cache:
         dropcache()
     if verbose:
@@ -69,24 +68,21 @@ def run(executable, arguments=[], verbose=True, shell=False, drop_cache=False):
 
 
 def runSlicer(slicer_executable, arguments=[], verbose=True, **kwargs):
-    """Run ``slicer_executable`` with provided ``arguments``.
-    """
+    """Run ``slicer_executable`` with provided ``arguments``."""
     args = ["--no-splash"]
     args.extend(arguments)
     return run(slicer_executable, args, verbose, **kwargs)
 
 
 def runSlicerAndExit(slicer_executable, arguments=[], verbose=True, **kwargs):
-    """Run ``slicer_executable`` with provided ``arguments`` and exit.
-    """
+    """Run ``slicer_executable`` with provided ``arguments`` and exit."""
     args = ["--exit-after-startup"]
     args.extend(arguments)
     return runSlicer(slicer_executable, args, verbose, **kwargs)
 
 
 def timecall(method, **kwargs):
-    """Wrap ``method`` and return its execution time.
-    """
+    """Wrap ``method`` and return its execution time."""
     repeat = 1
     if "repeat" in kwargs:
         repeat = kwargs["repeat"]

--- a/Applications/SlicerApp/Testing/Python/SlicerBoundsTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerBoundsTest.py
@@ -50,8 +50,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def assertListAlmostEquals(self, list, expected):
@@ -59,8 +58,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
             self.assertAlmostEqual(list_item, expected_item)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_Volume()
         self.test_Model()
@@ -70,8 +68,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
         self.delayDisplay("Test completed.")
 
     def test_Volume(self):
-        """Test the GetRASBounds & GetBounds method on a volume.
-        """
+        """Test the GetRASBounds & GetBounds method on a volume."""
         # self.delayDisplay("Starting test_Volume")
         import SampleData
         volumeNode = SampleData.downloadSample("CTAAbdomenPanoramix")
@@ -101,8 +98,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_Volume passed!')
 
     def test_Model(self):
-        """Test the GetRASBounds & GetBounds method on a model.
-        """
+        """Test the GetRASBounds & GetBounds method on a model."""
         # self.delayDisplay("Starting test_Model")
         # Setup
         cubeSource = vtk.vtkCubeSource()
@@ -149,8 +145,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_Model passed!')
 
     def test_Segmentation(self):
-        """Test the GetRASBounds & GetBounds method on a segmentation.
-        """
+        """Test the GetRASBounds & GetBounds method on a segmentation."""
         # self.delayDisplay("Starting test_Segmentation")
         cubeSource = vtk.vtkCubeSource()
         cubeSource.SetXLength(500)
@@ -201,8 +196,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_Segmentation passed!')
 
     def test_Markup(self):
-        """Test the GetRASBounds & GetBounds method on a markup.
-        """
+        """Test the GetRASBounds & GetBounds method on a markup."""
         # self.delayDisplay("Starting test_Markup")
         markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
         markupNode.AddControlPoint([1.0, 0.0, 0.0])
@@ -235,8 +229,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_Markup passed!')
 
     def test_ROI(self):
-        """Test the GetRASBounds & GetBounds method on a ROI.
-        """
+        """Test the GetRASBounds & GetBounds method on a ROI."""
         # self.delayDisplay("Starting test_ROI")
         roiNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsROINode")
         roiNode.SetXYZ(100, 300, -0.689)

--- a/Applications/SlicerApp/Testing/Python/SlicerBoundsTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerBoundsTest.py
@@ -50,7 +50,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 
@@ -70,7 +70,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
         self.delayDisplay("Test completed.")
 
     def test_Volume(self):
-        """ Test the GetRASBounds & GetBounds method on a volume.
+        """Test the GetRASBounds & GetBounds method on a volume.
         """
         # self.delayDisplay("Starting test_Volume")
         import SampleData
@@ -101,7 +101,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_Volume passed!')
 
     def test_Model(self):
-        """ Test the GetRASBounds & GetBounds method on a model.
+        """Test the GetRASBounds & GetBounds method on a model.
         """
         # self.delayDisplay("Starting test_Model")
         # Setup
@@ -149,7 +149,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_Model passed!')
 
     def test_Segmentation(self):
-        """ Test the GetRASBounds & GetBounds method on a segmentation.
+        """Test the GetRASBounds & GetBounds method on a segmentation.
         """
         # self.delayDisplay("Starting test_Segmentation")
         cubeSource = vtk.vtkCubeSource()
@@ -201,7 +201,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_Segmentation passed!')
 
     def test_Markup(self):
-        """ Test the GetRASBounds & GetBounds method on a markup.
+        """Test the GetRASBounds & GetBounds method on a markup.
         """
         # self.delayDisplay("Starting test_Markup")
         markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
@@ -235,7 +235,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_Markup passed!')
 
     def test_ROI(self):
-        """ Test the GetRASBounds & GetBounds method on a ROI.
+        """Test the GetRASBounds & GetBounds method on a ROI.
         """
         # self.delayDisplay("Starting test_ROI")
         roiNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsROINode")

--- a/Applications/SlicerApp/Testing/Python/SlicerDisplayNodeSequenceTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerDisplayNodeSequenceTest.py
@@ -48,7 +48,7 @@ class SlicerDisplayNodeSequenceTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Applications/SlicerApp/Testing/Python/SlicerDisplayNodeSequenceTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerDisplayNodeSequenceTest.py
@@ -48,13 +48,11 @@ class SlicerDisplayNodeSequenceTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_ScalarVolumeDisplayNodeSequence()
         self.delayDisplay("Test completed.")

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
@@ -211,7 +211,7 @@ class SlicerMRBMultipleSaveRestore(ScriptedLoadableModuleTest):
         self.delayDisplay("Test Finished")
 
     def storeSceneView(self, name, description=""):
-        """  Store a scene view into the current scene.
+        """Store a scene view into the current scene.
         TODO: this might move to slicer.util
         """
         layoutManager = slicer.app.layoutManager()

--- a/Applications/SlicerApp/Testing/Python/SlicerOrientationSelectorTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerOrientationSelectorTest.py
@@ -78,13 +78,11 @@ class SlicerOrientationSelectorTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_SlicerOrientationSelectorTest()
 

--- a/Applications/SlicerApp/Testing/Python/SlicerOrientationSelectorTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerOrientationSelectorTest.py
@@ -78,7 +78,7 @@ class SlicerOrientationSelectorTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 
@@ -89,7 +89,7 @@ class SlicerOrientationSelectorTestTest(ScriptedLoadableModuleTest):
         self.test_SlicerOrientationSelectorTest()
 
     def test_SlicerOrientationSelectorTest(self):
-        """ Ideally you should have several levels of tests.  At the lowest level
+        """Ideally you should have several levels of tests.  At the lowest level
         tests should exercise the functionality of the logic with different inputs
         (both valid and invalid).  At higher levels your tests should emulate the
         way the user would interact with your code and confirm that it still works

--- a/Applications/SlicerApp/Testing/Python/SlicerRestoreSceneViewCrashIssue3445.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerRestoreSceneViewCrashIssue3445.py
@@ -55,6 +55,7 @@ class SlicerRestoreSceneViewCrashIssue3445Logic(ScriptedLoadableModuleLogic):
     Uses ScriptedLoadableModuleLogic base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
+
     pass
 
 

--- a/Applications/SlicerApp/Testing/Python/SlicerRestoreSceneViewCrashIssue3445.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerRestoreSceneViewCrashIssue3445.py
@@ -67,7 +67,7 @@ class SlicerRestoreSceneViewCrashIssue3445Test(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 
@@ -78,7 +78,7 @@ class SlicerRestoreSceneViewCrashIssue3445Test(ScriptedLoadableModuleTest):
         self.test_SlicerRestoreSceneViewCrashIssue3445()
 
     def test_SlicerRestoreSceneViewCrashIssue3445(self):
-        """ Ideally you should have several levels of tests.  At the lowest level
+        """Ideally you should have several levels of tests.  At the lowest level
         tests should exercise the functionality of the logic with different inputs
         (both valid and invalid).  At higher levels your tests should emulate the
         way the user would interact with your code and confirm that it still works

--- a/Applications/SlicerApp/Testing/Python/SlicerRestoreSceneViewCrashIssue3445.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerRestoreSceneViewCrashIssue3445.py
@@ -67,13 +67,11 @@ class SlicerRestoreSceneViewCrashIssue3445Test(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_SlicerRestoreSceneViewCrashIssue3445()
 

--- a/Applications/SlicerApp/Testing/Python/SlicerSceneObserverTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerSceneObserverTest.py
@@ -4,8 +4,7 @@ import vtk
 
 
 class testClass:
-    """Check that slicer exits correctly after adding an observer to the mrml scene
-    """
+    """Check that slicer exits correctly after adding an observer to the mrml scene"""
 
     def callback(self, caller, event):
         print(f"Got {event} from {caller}")

--- a/Applications/SlicerApp/Testing/Python/SlicerSceneObserverTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerSceneObserverTest.py
@@ -4,7 +4,7 @@ import vtk
 
 
 class testClass:
-    """ Check that slicer exits correctly after adding an observer to the mrml scene
+    """Check that slicer exits correctly after adding an observer to the mrml scene
     """
 
     def callback(self, caller, event):

--- a/Applications/SlicerApp/Testing/Python/SlicerScriptedFileReaderWriterTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerScriptedFileReaderWriterTest.py
@@ -141,8 +141,7 @@ class SlicerScriptedFileReaderWriterTestFileWriter:
 
 class SlicerScriptedFileReaderWriterTestTest(ScriptedLoadableModuleTest):
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_Writer()
         self.test_Reader()

--- a/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest1.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest1.py
@@ -76,7 +76,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 
@@ -100,7 +100,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         self.test_3D_boundsUpdateROI()
 
     def test_3D_interactionDefaults(self):
-        """ Test that the interaction widget exists in the 3D view.
+        """Test that the interaction widget exists in the 3D view.
         """
         logic = SlicerTransformInteractionTest1Logic()
 
@@ -138,7 +138,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_3D_interactionDefaults passed!')
 
     def test_3D_interactionVolume(self):
-        """ Test that the interaction widget interacts correctly in the 3D view.
+        """Test that the interaction widget interacts correctly in the 3D view.
         """
         logic = SlicerTransformInteractionTest1Logic()
 
@@ -299,7 +299,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_3D_interactionVolume passed!')
 
     def test_3D_interaction2Models(self):
-        """ Test that the interaction widget works with multiple models.
+        """Test that the interaction widget works with multiple models.
         """
         # self.delayDisplay("Starting test_3D_interaction2Models")
         #
@@ -419,7 +419,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_3D_interaction2Models passed!')
 
     def test_3D_parentTransform(self):
-        """ Test that the interaction widget works with a parent transform.
+        """Test that the interaction widget works with a parent transform.
         """
         # self.delayDisplay('Starting test_3D_parentTransform')
         #
@@ -511,7 +511,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_3D_parentTransform passed!')
 
     def test_3D_interactionSerialization(self):
-        """ Test that the serialization the interaction properties.
+        """Test that the serialization the interaction properties.
         """
         logic = SlicerTransformInteractionTest1Logic()
 
@@ -552,7 +552,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         self.assertTrue(widget.GetEnabled())
 
     def test_3D_boundsUpdateROI(self):
-        """ Test that the bounds update with an ROI.
+        """Test that the bounds update with an ROI.
         """
         logic = SlicerTransformInteractionTest1Logic()
 

--- a/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest1.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest1.py
@@ -76,8 +76,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def assertTransform(self, t, expected):
@@ -89,8 +88,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
                 self.assertAlmostEqual(m.GetElement(i, j), expected[i][j])
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_3D_interactionDefaults()
         self.test_3D_interactionVolume()
@@ -100,8 +98,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         self.test_3D_boundsUpdateROI()
 
     def test_3D_interactionDefaults(self):
-        """Test that the interaction widget exists in the 3D view.
-        """
+        """Test that the interaction widget exists in the 3D view."""
         logic = SlicerTransformInteractionTest1Logic()
 
         # self.delayDisplay("Starting test_3D_interactionDefaults")
@@ -138,8 +135,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_3D_interactionDefaults passed!')
 
     def test_3D_interactionVolume(self):
-        """Test that the interaction widget interacts correctly in the 3D view.
-        """
+        """Test that the interaction widget interacts correctly in the 3D view."""
         logic = SlicerTransformInteractionTest1Logic()
 
         import SampleData
@@ -299,8 +295,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_3D_interactionVolume passed!')
 
     def test_3D_interaction2Models(self):
-        """Test that the interaction widget works with multiple models.
-        """
+        """Test that the interaction widget works with multiple models."""
         # self.delayDisplay("Starting test_3D_interaction2Models")
         #
         # Setup:
@@ -419,8 +414,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_3D_interaction2Models passed!')
 
     def test_3D_parentTransform(self):
-        """Test that the interaction widget works with a parent transform.
-        """
+        """Test that the interaction widget works with a parent transform."""
         # self.delayDisplay('Starting test_3D_parentTransform')
         #
         # Setup:
@@ -511,8 +505,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         # self.delayDisplay('test_3D_parentTransform passed!')
 
     def test_3D_interactionSerialization(self):
-        """Test that the serialization the interaction properties.
-        """
+        """Test that the serialization the interaction properties."""
         logic = SlicerTransformInteractionTest1Logic()
 
         # self.delayDisplay("Starting test_3D_interactionSerialization")
@@ -552,8 +545,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         self.assertTrue(widget.GetEnabled())
 
     def test_3D_boundsUpdateROI(self):
-        """Test that the bounds update with an ROI.
-        """
+        """Test that the bounds update with an ROI."""
         logic = SlicerTransformInteractionTest1Logic()
 
         # self.delayDisplay("Starting test_3D_boundsUpdateROI")

--- a/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest1.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest1.py
@@ -52,8 +52,8 @@ class SlicerTransformInteractionTest1Logic(ScriptedLoadableModuleLogic):
 
     def addTransform(self):
         """Create and add a transform node with a display node to the
-           mrmlScene.
-           Returns the transform node and its display node
+        mrmlScene.
+        Returns the transform node and its display node
         """
         transformNode = slicer.mrmlScene.AddNode(slicer.vtkMRMLTransformNode())
         transformDisplayNode = slicer.mrmlScene.AddNode(slicer.vtkMRMLTransformDisplayNode())

--- a/Applications/SlicerApp/Testing/Python/SlicerUnitTestTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerUnitTestTest.py
@@ -3,7 +3,7 @@ import random
 
 
 class SlicerUnitTestTest(unittest.TestCase):
-    """ See https://docs.python.org/library/unittest.html#basic-example
+    """See https://docs.python.org/library/unittest.html#basic-example
     """
 
     def setUp(self):

--- a/Applications/SlicerApp/Testing/Python/SlicerUnitTestTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerUnitTestTest.py
@@ -3,8 +3,7 @@ import random
 
 
 class SlicerUnitTestTest(unittest.TestCase):
-    """See https://docs.python.org/library/unittest.html#basic-example
-    """
+    """See https://docs.python.org/library/unittest.html#basic-example"""
 
     def setUp(self):
         self.seq = list(range(10))

--- a/Applications/SlicerApp/Testing/Python/SlicerUnitTestWithErrorsTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerUnitTestWithErrorsTest.py
@@ -2,7 +2,7 @@ import unittest
 
 
 class SlicerUnitTestWithErrorsTest(unittest.TestCase):
-    """ See https://docs.python.org/library/unittest.html#basic-example
+    """See https://docs.python.org/library/unittest.html#basic-example
     """
 
     def test_expectedtofail(self):

--- a/Applications/SlicerApp/Testing/Python/SlicerUnitTestWithErrorsTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerUnitTestWithErrorsTest.py
@@ -2,8 +2,7 @@ import unittest
 
 
 class SlicerUnitTestWithErrorsTest(unittest.TestCase):
-    """See https://docs.python.org/library/unittest.html#basic-example
-    """
+    """See https://docs.python.org/library/unittest.html#basic-example"""
 
     def test_expectedtofail(self):
         self.assertTrue(False)

--- a/Applications/SlicerApp/Testing/Python/TwoCLIsInARowTest.py
+++ b/Applications/SlicerApp/Testing/Python/TwoCLIsInARowTest.py
@@ -113,13 +113,11 @@ class TwoCLIsInARowTestLogic(ScriptedLoadableModuleLogic):
 class TwoCLIsInARowTestTest(ScriptedLoadableModuleTest):
 
     def setUp(self):
-        """Reset the state for testing.
-        """
+        """Reset the state for testing."""
         pass
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_TwoCLIsInARowTest()
 

--- a/Applications/SlicerApp/Testing/Python/TwoCLIsInARowTest.py
+++ b/Applications/SlicerApp/Testing/Python/TwoCLIsInARowTest.py
@@ -113,7 +113,7 @@ class TwoCLIsInARowTestLogic(ScriptedLoadableModuleLogic):
 class TwoCLIsInARowTestTest(ScriptedLoadableModuleTest):
 
     def setUp(self):
-        """ Reset the state for testing.
+        """Reset the state for testing.
         """
         pass
 

--- a/Applications/SlicerApp/Testing/Python/TwoCLIsInParallelTest.py
+++ b/Applications/SlicerApp/Testing/Python/TwoCLIsInParallelTest.py
@@ -102,13 +102,11 @@ class TwoCLIsInParallelTestLogic(ScriptedLoadableModuleLogic):
 class TwoCLIsInParallelTestTest(ScriptedLoadableModuleTest):
 
     def setUp(self):
-        """Reset the state for testing.
-        """
+        """Reset the state for testing."""
         pass
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_TwoCLIsInParallelTest()
 

--- a/Applications/SlicerApp/Testing/Python/TwoCLIsInParallelTest.py
+++ b/Applications/SlicerApp/Testing/Python/TwoCLIsInParallelTest.py
@@ -102,7 +102,7 @@ class TwoCLIsInParallelTestLogic(ScriptedLoadableModuleLogic):
 class TwoCLIsInParallelTestTest(ScriptedLoadableModuleTest):
 
     def setUp(self):
-        """ Reset the state for testing.
+        """Reset the state for testing.
         """
         pass
 

--- a/Applications/SlicerApp/Testing/Python/UtilTest.py
+++ b/Applications/SlicerApp/Testing/Python/UtilTest.py
@@ -60,13 +60,11 @@ class UtilTestLogic(ScriptedLoadableModuleLogic):
 class UtilTestTest(ScriptedLoadableModuleTest):
 
     def setUp(self):
-        """Reset the state for testing.
-        """
+        """Reset the state for testing."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_setSliceViewerLayers()
         self.test_loadUI()

--- a/Applications/SlicerApp/Testing/Python/UtilTest.py
+++ b/Applications/SlicerApp/Testing/Python/UtilTest.py
@@ -60,7 +60,7 @@ class UtilTestLogic(ScriptedLoadableModuleLogic):
 class UtilTestTest(ScriptedLoadableModuleTest):
 
     def setUp(self):
-        """ Reset the state for testing.
+        """Reset the state for testing.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Applications/SlicerApp/Testing/Python/ViewControllersSliceInterpolationBug1926.py
+++ b/Applications/SlicerApp/Testing/Python/ViewControllersSliceInterpolationBug1926.py
@@ -73,7 +73,7 @@ class ViewControllersSliceInterpolationBug1926Test(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 
@@ -84,7 +84,7 @@ class ViewControllersSliceInterpolationBug1926Test(ScriptedLoadableModuleTest):
         self.test_ViewControllersSliceInterpolationBug19261()
 
     def test_ViewControllersSliceInterpolationBug19261(self):
-        """ Ideally you should have several levels of tests.  At the lowest level
+        """Ideally you should have several levels of tests.  At the lowest level
         tests should exercise the functionality of the logic with different inputs
         (both valid and invalid).  At higher levels your tests should emulate the
         way the user would interact with your code and confirm that it still works

--- a/Applications/SlicerApp/Testing/Python/ViewControllersSliceInterpolationBug1926.py
+++ b/Applications/SlicerApp/Testing/Python/ViewControllersSliceInterpolationBug1926.py
@@ -73,13 +73,11 @@ class ViewControllersSliceInterpolationBug1926Test(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_ViewControllersSliceInterpolationBug19261()
 

--- a/Applications/SlicerApp/Testing/Python/WebEngine.py
+++ b/Applications/SlicerApp/Testing/Python/WebEngine.py
@@ -114,14 +114,12 @@ class WebEngineTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         self.gotResponse = False
         self.gotCorrectResponse = False
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_WebEngine1()
 
@@ -137,8 +135,7 @@ class WebEngineTest(ScriptedLoadableModuleTest):
             print((js, result))
 
     def test_WebEngine1(self):
-        """Testing WebEngine
-        """
+        """Testing WebEngine"""
 
         self.delayDisplay("Starting the test")
 

--- a/Applications/SlicerApp/Testing/Python/WebEngine.py
+++ b/Applications/SlicerApp/Testing/Python/WebEngine.py
@@ -114,7 +114,7 @@ class WebEngineTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         self.gotResponse = False
         self.gotCorrectResponse = False
@@ -137,7 +137,7 @@ class WebEngineTest(ScriptedLoadableModuleTest):
             print((js, result))
 
     def test_WebEngine1(self):
-        """ Testing WebEngine
+        """Testing WebEngine
         """
 
         self.delayDisplay("Starting the test")

--- a/Applications/SlicerApp/Testing/Python/sceneImport2428.py
+++ b/Applications/SlicerApp/Testing/Python/sceneImport2428.py
@@ -75,13 +75,11 @@ class sceneImport2428Test(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_sceneImport24281()
 

--- a/Applications/SlicerApp/Testing/Python/sceneImport2428.py
+++ b/Applications/SlicerApp/Testing/Python/sceneImport2428.py
@@ -75,7 +75,7 @@ class sceneImport2428Test(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 
@@ -86,7 +86,7 @@ class sceneImport2428Test(ScriptedLoadableModuleTest):
         self.test_sceneImport24281()
 
     def test_sceneImport24281(self):
-        """ Ideally you should have several levels of tests.  At the lowest level
+        """Ideally you should have several levels of tests.  At the lowest level
         tests should exercise the functionality of the logic with different inputs
         (both valid and invalid).  At higher levels your tests should emulate the
         way the user would interact with your code and confirm that it still works

--- a/Base/Python/mrml.py
+++ b/Base/Python/mrml.py
@@ -1,5 +1,6 @@
 """This module loads all the classes from the MRML library into its
-namespace."""
+namespace.
+"""
 
 from MRMLCLIPython import *
 from MRMLCorePython import *

--- a/Base/Python/mrml.py
+++ b/Base/Python/mrml.py
@@ -1,4 +1,4 @@
-""" This module loads all the classes from the MRML library into its
+"""This module loads all the classes from the MRML library into its
 namespace."""
 
 from MRMLCLIPython import *

--- a/Base/Python/sitkUtils.py
+++ b/Base/Python/sitkUtils.py
@@ -29,7 +29,7 @@ def PushVolumeToSlicer(sitkimage, targetNode=None, name=None, className="vtkMRML
 
 def PullVolumeFromSlicer(nodeObjectOrName):
     """ Given a slicer MRML image node or name, return the SimpleITK
-        image object.
+    image object.
     """
     EnsureRegistration()
     myNodeFullITKAddress = GetSlicerITKReadWriteAddress(nodeObjectOrName)
@@ -39,7 +39,7 @@ def PullVolumeFromSlicer(nodeObjectOrName):
 
 def GetSlicerITKReadWriteAddress(nodeObjectOrName):
     """ This function will return the ITK FileIO formatted text address
-            so that the image can be read directly from the MRML scene
+    so that the image can be read directly from the MRML scene
     """
     myNode = nodeObjectOrName if isinstance(nodeObjectOrName, slicer.vtkMRMLNode) else slicer.util.getNode(nodeObjectOrName)
     myNodeSceneAddress = myNode.GetScene().GetAddressAsString("").replace("Addr=", "")

--- a/Base/Python/sitkUtils.py
+++ b/Base/Python/sitkUtils.py
@@ -49,8 +49,7 @@ def GetSlicerITKReadWriteAddress(nodeObjectOrName):
 
 
 def EnsureRegistration():
-    """Make sure MRMLIDImageIO reader is registered.
-    """
+    """Make sure MRMLIDImageIO reader is registered."""
     if "MRMLIDImageIO" in sitk.ImageFileReader().GetRegisteredImageIOs():
         # already registered
         return

--- a/Base/Python/sitkUtils.py
+++ b/Base/Python/sitkUtils.py
@@ -6,7 +6,7 @@ __sitk__MRMLIDImageIO_Registered__ = False
 
 
 def PushVolumeToSlicer(sitkimage, targetNode=None, name=None, className="vtkMRMLScalarVolumeNode"):
-    """ Given a SimpleITK image, push it back to slicer for viewing
+    """Given a SimpleITK image, push it back to slicer for viewing
 
     :param targetNode: Target node that will store the image. If None then a new node will be created.
     :param className: if a new target node is created then this parameter determines node class. For label volumes, set it to vtkMRMLLabelMapVolumeNode.
@@ -28,7 +28,7 @@ def PushVolumeToSlicer(sitkimage, targetNode=None, name=None, className="vtkMRML
 
 
 def PullVolumeFromSlicer(nodeObjectOrName):
-    """ Given a slicer MRML image node or name, return the SimpleITK
+    """Given a slicer MRML image node or name, return the SimpleITK
     image object.
     """
     EnsureRegistration()
@@ -38,7 +38,7 @@ def PullVolumeFromSlicer(nodeObjectOrName):
 
 
 def GetSlicerITKReadWriteAddress(nodeObjectOrName):
-    """ This function will return the ITK FileIO formatted text address
+    """This function will return the ITK FileIO formatted text address
     so that the image can be read directly from the MRML scene
     """
     myNode = nodeObjectOrName if isinstance(nodeObjectOrName, slicer.vtkMRMLNode) else slicer.util.getNode(nodeObjectOrName)

--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -419,7 +419,7 @@ class ScriptedLoadableModuleTest(unittest.TestCase):
         slicer.util.delayDisplay(message, msec)
 
     def takeScreenshot(self, name, description, type=-1):
-        """ Take a screenshot of the selected viewport and store as and
+        """Take a screenshot of the selected viewport and store as and
         annotation snapshot node. Convenience method for automated testing.
 
         If self.enableScreenshots is False then only a message is displayed but screenshot

--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -50,8 +50,7 @@ This work is partially supported by PAR-07-249: R01CA131718 NA-MIC Virtual Colon
         slicer.selfTests[self.moduleName] = self.runTest
 
     def resourcePath(self, filename):
-        """Return the absolute path of the module ``Resources`` directory.
-        """
+        """Return the absolute path of the module ``Resources`` directory."""
         scriptedModulesPath = os.path.dirname(self.parent.path)
         return os.path.join(scriptedModulesPath, "Resources", filename)
 
@@ -69,9 +68,7 @@ This work is partially supported by PAR-07-249: R01CA131718 NA-MIC Virtual Colon
         return linkText
 
     def runTest(self, msec=100, **kwargs):
-        """
-        :param msec: delay to associate with :func:`ScriptedLoadableModuleTest.delayDisplay()`.
-        """
+        """:param msec: delay to associate with :func:`ScriptedLoadableModuleTest.delayDisplay()`."""
         # Name of the test case class is expected to be <ModuleName>Test
         module = importlib.import_module(self.__module__)
         className = self.moduleName + "Test"
@@ -111,8 +108,7 @@ class ScriptedLoadableModuleWidget:
             "moduleAboutToBeUnloaded(QString)", self._onModuleAboutToBeUnloaded)
 
     def resourcePath(self, filename):
-        """Return the absolute path of the module ``Resources`` directory.
-        """
+        """Return the absolute path of the module ``Resources`` directory."""
         scriptedModulesPath = os.path.dirname(slicer.util.modulePath(self.moduleName))
         return os.path.join(scriptedModulesPath, "Resources", filename)
 
@@ -234,9 +230,7 @@ class ScriptedLoadableModuleWidget:
         self.setupDeveloperSection()
 
     def onReload(self):
-        """
-        Reload scripted module widget representation.
-        """
+        """Reload scripted module widget representation."""
 
         # Print a clearly visible separator to make it easier
         # to distinguish new error messages (during/after reload)
@@ -472,7 +466,5 @@ class ScriptedLoadableModuleTest(unittest.TestCase):
         annotationLogic.CreateSnapShot(name, description, type, self.screenshotScaleFactor, imageData)
 
     def runTest(self):
-        """
-        Run a default selection of tests here.
-        """
+        """Run a default selection of tests here."""
         logging.warning("No test is defined in " + self.__class__.__name__)

--- a/Base/Python/slicer/__init__.py
+++ b/Base/Python/slicer/__init__.py
@@ -1,4 +1,4 @@
-""" This module sets up root logging and loads the Slicer library modules into its namespace.
+"""This module sets up root logging and loads the Slicer library modules into its namespace.
 
 
 .. warning::

--- a/Base/Python/slicer/cli.py
+++ b/Base/Python/slicer/cli.py
@@ -3,7 +3,8 @@
 
 def createNode(cliModule, parameters=None):
     """Creates a new vtkMRMLCommandLineModuleNode for a specific module, with
-    optional parameters"""
+    optional parameters
+    """
     if not cliModule:
         return None
     cliLogic = cliModule.logic()

--- a/Base/Python/slicer/cli.py
+++ b/Base/Python/slicer/cli.py
@@ -1,4 +1,4 @@
-""" This module is a place holder for convenient functions allowing to interact with CLI."""
+"""This module is a place holder for convenient functions allowing to interact with CLI."""
 
 
 def createNode(cliModule, parameters=None):

--- a/Base/Python/slicer/logic.py
+++ b/Base/Python/slicer/logic.py
@@ -1,4 +1,4 @@
-""" This module loads all the classes from the vtkSlicerBaseLogic library into its
+"""This module loads all the classes from the vtkSlicerBaseLogic library into its
 namespace."""
 
 from SlicerBaseLogicPython import *

--- a/Base/Python/slicer/logic.py
+++ b/Base/Python/slicer/logic.py
@@ -1,4 +1,5 @@
 """This module loads all the classes from the vtkSlicerBaseLogic library into its
-namespace."""
+namespace.
+"""
 
 from SlicerBaseLogicPython import *

--- a/Base/Python/slicer/parameterNodeWrapper/__init__.py
+++ b/Base/Python/slicer/parameterNodeWrapper/__init__.py
@@ -1,4 +1,4 @@
-""" The parameter node wrapper allows wrapping around a ``vtkMRMLScriptedModuleNode`` parameter node with typed member
+"""The parameter node wrapper allows wrapping around a ``vtkMRMLScriptedModuleNode`` parameter node with typed member
 access."""
 
 from .default import *

--- a/Base/Python/slicer/parameterNodeWrapper/__init__.py
+++ b/Base/Python/slicer/parameterNodeWrapper/__init__.py
@@ -1,5 +1,6 @@
 """The parameter node wrapper allows wrapping around a ``vtkMRMLScriptedModuleNode`` parameter node with typed member
-access."""
+access.
+"""
 
 from .default import *
 from .guiConnectors import *

--- a/Base/Python/slicer/parameterNodeWrapper/default.py
+++ b/Base/Python/slicer/parameterNodeWrapper/default.py
@@ -2,9 +2,7 @@ __all__ = ["Default"]
 
 
 class Default:
-    """
-    Annotation to denote the default value for a parameter.
-    """
+    """Annotation to denote the default value for a parameter."""
 
     def __init__(self, value=None, *, generator=None):
         """
@@ -33,9 +31,7 @@ class Default:
 
 
 def extractDefault(annotations):
-    """
-    Given a list of annotations, returns the first Default annotation, if any
-    """
+    """Given a list of annotations, returns the first Default annotation, if any"""
     defaults = [x for x in annotations if isinstance(x, Default)]
     nonDefaults = [x for x in annotations if not isinstance(x, Default)]
     if len(defaults) > 1:

--- a/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
@@ -40,26 +40,20 @@ __all__ = [
 
 @dataclasses.dataclass
 class Decimals:
-    """
-    Annotation for Qt's setDecimals methods for spinboxes and sliders.
-    """
+    """Annotation for Qt's setDecimals methods for spinboxes and sliders."""
 
     value: int
 
 
 @dataclasses.dataclass
 class SingleStep:
-    """
-    Annotation for Qt's setSingleStep methods for spinboxes and sliders.
-    """
+    """Annotation for Qt's setSingleStep methods for spinboxes and sliders."""
 
     value: Union[float, int]
 
 
 class GuiConnector(abc.ABC):
-    """
-    Base class for converting from widgets to a datatype.
-    """
+    """Base class for converting from widgets to a datatype."""
 
     @staticmethod
     @abc.abstractmethod
@@ -73,9 +67,7 @@ class GuiConnector(abc.ABC):
     @staticmethod
     @abc.abstractmethod
     def create(widget, datatype):
-        """
-        Creates a new connector adapting the given widget object to the given (possibly annotated) datatype.
-        """
+        """Creates a new connector adapting the given widget object to the given (possibly annotated) datatype."""
         raise NotImplementedError("Must implement create")
 
     def __init__(self):
@@ -97,37 +89,27 @@ class GuiConnector(abc.ABC):
 
     @abc.abstractmethod
     def _connect(self):
-        """
-        Make the necessary connection(s) to the widget.
-        """
+        """Make the necessary connection(s) to the widget."""
         raise NotImplementedError("Must implement _connect")
 
     @abc.abstractmethod
     def _disconnect(self):
-        """
-        Make the necessary disconnection(s) to the widget.
-        """
+        """Make the necessary disconnection(s) to the widget."""
         raise NotImplementedError("Must implement _disconnect")
 
     @abc.abstractmethod
     def widget(self):
-        """
-        Returns the underlying widget.
-        """
+        """Returns the underlying widget."""
         raise NotImplementedError("Must implement widget")
 
     @abc.abstractmethod
     def read(self):
-        """
-        Returns the value from the widget as the given datatype.
-        """
+        """Returns the value from the widget as the given datatype."""
         raise NotImplementedError("Must implement read")
 
     @abc.abstractmethod
     def write(self, value) -> None:
-        """
-        Writes the given value to the widget.
-        """
+        """Writes the given value to the widget."""
         raise NotImplementedError("Must implement write")
 
 
@@ -135,9 +117,7 @@ _registeredGuiConnectors = []
 
 
 def _processGuiConnector(classtype):
-    """
-    Registers a GuiConnector for use by createGuiConnector.
-    """
+    """Registers a GuiConnector for use by createGuiConnector."""
     if not issubclass(classtype, GuiConnector):
         raise TypeError("Must be a GuiConnector subclass")
     global _registeredGuiConnectors
@@ -157,9 +137,7 @@ def createGuiConnector(widget, datatype) -> GuiConnector:
 
 
 def parameterNodeGuiConnector(classtype=None):
-    """
-    Class decorator to register a new parameter node gui connector.
-    """
+    """Class decorator to register a new parameter node gui connector."""
     def wrap(cls):
         return _processGuiConnector(cls)
 
@@ -710,9 +688,7 @@ def _getDottedParameterName(parentStack):
 
 
 def _getPackNameToWidgetMap(widget):
-    """
-    Returns the dotted parameter names as keys and the widgets that represents that name as values
-    """
+    """Returns the dotted parameter names as keys and the widgets that represents that name as values"""
     parentStacks = _extractCorrectWidgets(widget)
     return {_getDottedParameterName(p): p[-1] for p in parentStacks}
 

--- a/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
@@ -43,6 +43,7 @@ class Decimals:
     """
     Annotation for Qt's setDecimals methods for spinboxes and sliders.
     """
+
     value: int
 
 
@@ -51,6 +52,7 @@ class SingleStep:
     """
     Annotation for Qt's setSingleStep methods for spinboxes and sliders.
     """
+
     value: Union[float, int]
 
 
@@ -726,6 +728,7 @@ class WidgetChildrenToParameterPackConnector(GuiConnector):
     This is useful when generating widgets for the parameterPack though, as it supports a more
     nested structure where the interior widgets don't need to know anything about the their parents.
     """
+
     @staticmethod
     def canRepresent(widget, datatype) -> bool:
         if not pack.isParameterPack(datatype):

--- a/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
@@ -1,6 +1,7 @@
 """The guiConnection module is responsible for adapting different input widget types (widgets that represent a value
 of some kind) to a common interface. This is then used by the parameterNodeWrapper to bind parameters to widgets.
-This module is extensible such that users can add new widgets and datatypes from within other slicer modules."""
+This module is extensible such that users can add new widgets and datatypes from within other slicer modules.
+"""
 
 import abc
 import dataclasses

--- a/Base/Python/slicer/parameterNodeWrapper/guiCreation.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiCreation.py
@@ -74,9 +74,7 @@ _registeredGuiCreators = []
 
 
 def _processGuiCreator(classtype):
-    """
-    Registers a GuiCreator so it can be used by createGui.
-    """
+    """Registers a GuiCreator so it can be used by createGui."""
     if not issubclass(classtype, GuiCreator):
         raise TypeError("Must be a GuiCreator subclass")
     global _registeredGuiCreators
@@ -85,9 +83,7 @@ def _processGuiCreator(classtype):
 
 
 def createGui(datatype) -> qt.QWidget:
-    """
-    Creates the most appropriate widget to represent the given, possibly annotated, data type.
-    """
+    """Creates the most appropriate widget to represent the given, possibly annotated, data type."""
     values = [(creator.representationValue(datatype), creator) for creator in _registeredGuiCreators]
     best = max(values, key=lambda v: v[0])
     if best[0] > 0:
@@ -96,9 +92,7 @@ def createGui(datatype) -> qt.QWidget:
 
 
 def parameterNodeGuiCreator(classtype=None):
-    """
-    Class decorator to register a new parameter node gui creator.
-    """
+    """Class decorator to register a new parameter node gui creator."""
     def wrap(cls):
         return _processGuiCreator(cls)
 

--- a/Base/Python/slicer/parameterNodeWrapper/guiCreation.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiCreation.py
@@ -1,6 +1,7 @@
 """The guiCreation module is responsible for creating widgets for given datatypes.
 This module is extensible such that users can add new widgets and datatypes from within
-other slicer modules."""
+other slicer modules.
+"""
 
 import abc
 import dataclasses

--- a/Base/Python/slicer/parameterNodeWrapper/parameterPack.py
+++ b/Base/Python/slicer/parameterNodeWrapper/parameterPack.py
@@ -380,6 +380,7 @@ class _ParameterPackInstanceValidator(Validator):
     Validates that a value is either a particular type or an ObservedParameterPack that is observing
     that type.
     """
+
     def __init__(self, type_):
         self.type = type_
 
@@ -393,6 +394,7 @@ class ParameterPackSerializer(Serializer):
     """
     Serializer for any parameterPack.
     """
+
     @staticmethod
     def canSerialize(type_) -> bool:
         return hasattr(type_, "_is_parameterPack") and getattr(type_, "_is_parameterPack")

--- a/Base/Python/slicer/parameterNodeWrapper/parameterPack.py
+++ b/Base/Python/slicer/parameterNodeWrapper/parameterPack.py
@@ -1,5 +1,6 @@
 """The parameterPack module allows creation of aggregate objects that can be used in a
-parameterNodeWrapper."""
+parameterNodeWrapper.
+"""
 
 import copy
 import dataclasses

--- a/Base/Python/slicer/parameterNodeWrapper/parameterPack.py
+++ b/Base/Python/slicer/parameterNodeWrapper/parameterPack.py
@@ -108,9 +108,7 @@ def _strMethod(self) -> str:
 
 
 def isParameterPack(obj):
-    """
-    Returns true if the given object is a parameterPack, false otherwise.
-    """
+    """Returns true if the given object is a parameterPack, false otherwise."""
     return getattr(obj, "_is_parameterPack", False)
 
 
@@ -138,9 +136,7 @@ def _checkMember(packObjectOrClass, membername: str):
 
 
 def _getValue(self, membername: str):
-    """
-    Gets a value in a parameterPack from the parameter's name, as a string.
-    """
+    """Gets a value in a parameterPack from the parameter's name, as a string."""
     _checkTopMember(self, membername)
     topname, subname = splitPossiblyDottedName(membername)
     topnameValue = getattr(self, topname)
@@ -151,9 +147,7 @@ def _getValue(self, membername: str):
 
 
 def _setValue(self, membername: str, value):
-    """
-    Sets a value in a parameterPack given the parameter's name, as a string.
-    """
+    """Sets a value in a parameterPack given the parameter's name, as a string."""
     _checkTopMember(self, membername)
     topname, subname = splitPossiblyDottedName(membername)
     if subname is None:
@@ -166,9 +160,7 @@ def _setValue(self, membername: str, value):
 def _makeDataTypeFunc(classvar):
     @staticmethod
     def dataType(membername):
-        """
-        Returns the annotated data type of a parameter in a parameterPack, given the parameter's name as a string.
-        """
+        """Returns the annotated data type of a parameter in a parameterPack, given the parameter's name as a string."""
         _checkTopMember(classvar, membername)
         topname, subname = splitPossiblyDottedName(membername)
         datatype = classvar.allParameters[topname].unalteredType
@@ -180,9 +172,7 @@ def _makeDataTypeFunc(classvar):
 
 
 def _processParameterPack(classtype):
-    """
-    Takes a parameterPack class description and creates the full parameterPack class.
-    """
+    """Takes a parameterPack class description and creates the full parameterPack class."""
     members = typing.get_type_hints(classtype, include_extras=True)
     if len(members) == 0:
         raise ValueError("Unable to find any members in parameterPack")
@@ -266,9 +256,7 @@ def nestedParameterNames(parameterPackClassOrInstance) -> list[str]:
 
 
 def parameterPack(classtype=None):
-    """
-    Class decorator to make an parameterPack.
-    """
+    """Class decorator to make an parameterPack."""
     def wrap(cls):
         return _processParameterPack(cls)
 
@@ -391,9 +379,7 @@ class _ParameterPackInstanceValidator(Validator):
 
 @parameterNodeSerializer
 class ParameterPackSerializer(Serializer):
-    """
-    Serializer for any parameterPack.
-    """
+    """Serializer for any parameterPack."""
 
     @staticmethod
     def canSerialize(type_) -> bool:

--- a/Base/Python/slicer/parameterNodeWrapper/serializers.py
+++ b/Base/Python/slicer/parameterNodeWrapper/serializers.py
@@ -67,9 +67,7 @@ class Serializer(abc.ABC):
 
     @abc.abstractmethod
     def default(self):
-        """
-        The default value to use if another default is not specified.
-        """
+        """The default value to use if another default is not specified."""
         raise NotImplementedError("default is not implemented")
 
     @abc.abstractmethod
@@ -92,16 +90,12 @@ class Serializer(abc.ABC):
 
     @abc.abstractmethod
     def read(self, parameterNode, name: str):
-        """
-        Reads and returns the value with the given name from the parameterNode.
-        """
+        """Reads and returns the value with the given name from the parameterNode."""
         raise NotImplementedError("read is not implemented")
 
     @abc.abstractmethod
     def remove(self, parameterNode, name: str) -> None:
-        """
-        Removes the value of the given name from the parameterNode.
-        """
+        """Removes the value of the given name from the parameterNode."""
         raise NotImplementedError("remove is not implemented")
 
     @staticmethod
@@ -181,9 +175,7 @@ _registeredSerializers = []
 
 
 def _processSerializer(classtype):
-    """
-    Registers a Serializer so it can be used by createSerializer.
-    """
+    """Registers a Serializer so it can be used by createSerializer."""
 
     if not issubclass(classtype, Serializer):
         raise Exception("Must be a serializer type.")
@@ -193,9 +185,7 @@ def _processSerializer(classtype):
 
 
 def parameterNodeSerializer(classtype=None):
-    """
-    Class decorator to register a new parameter node serializer
-    """
+    """Class decorator to register a new parameter node serializer"""
     def wrap(cls):
         return _processSerializer(cls)
 
@@ -241,9 +231,7 @@ def createSerializerFromAnnotatedType(annotatedType):
 
 @parameterNodeSerializer
 class NumberSerializer(Serializer):
-    """
-    Serializer for numeric types (e.g. int, float).
-    """
+    """Serializer for numeric types (e.g. int, float)."""
 
     @staticmethod
     def canSerialize(type_) -> bool:
@@ -257,9 +245,7 @@ class NumberSerializer(Serializer):
         return None
 
     def __init__(self, type):
-        """
-        Constructs a serializer for the given numeric type.
-        """
+        """Constructs a serializer for the given numeric type."""
         self.type = type
 
     def default(self):
@@ -321,9 +307,7 @@ class StringSerializer(Serializer):
 
 @parameterNodeSerializer
 class PathSerializer(Serializer):
-    """
-    Serializer for pathlib types (Path, PosixPath, WindowsPath, PurePath, PurePosixPath, PureWindowsPath).
-    """
+    """Serializer for pathlib types (Path, PosixPath, WindowsPath, PurePath, PurePosixPath, PureWindowsPath)."""
 
     @staticmethod
     def canSerialize(type_) -> bool:
@@ -338,9 +322,7 @@ class PathSerializer(Serializer):
         return None
 
     def __init__(self, pathtype):
-        """
-        Constructs a serializer for the given pathlib type.
-        """
+        """Constructs a serializer for the given pathlib type."""
         self.type = pathtype
 
     def default(self):
@@ -364,9 +346,7 @@ class PathSerializer(Serializer):
 
 @parameterNodeSerializer
 class BoolSerializer(Serializer):
-    """
-    Serializer for bool.
-    """
+    """Serializer for bool."""
 
     @staticmethod
     def canSerialize(type_) -> bool:
@@ -400,9 +380,7 @@ class BoolSerializer(Serializer):
 
 @parameterNodeSerializer
 class NodeSerializer(Serializer):
-    """
-    Serializer for any instance (including subclasses) of slicer.vtkMRMLNode.
-    """
+    """Serializer for any instance (including subclasses) of slicer.vtkMRMLNode."""
 
     @staticmethod
     def canSerialize(type_) -> bool:
@@ -546,9 +524,7 @@ class ObservedList(collections.abc.MutableSequence):
 
 @parameterNodeSerializer
 class ListSerializer(Serializer):
-    """
-    Serializer for lists of a type.
-    """
+    """Serializer for lists of a type."""
 
     @staticmethod
     def canSerialize(type_) -> bool:
@@ -711,9 +687,7 @@ class TupleSerializer(Serializer):
 
 
 class ObservedDict(collections.abc.MutableMapping):
-    """
-    A dict-like class that will write values to a parameter node on change.
-    """
+    """A dict-like class that will write values to a parameter node on change."""
 
     def __init__(self, parameterNode, dictSerializer, name, startingValue):
         self._parameterNode = parameterNode

--- a/Base/Python/slicer/parameterNodeWrapper/serializers.py
+++ b/Base/Python/slicer/parameterNodeWrapper/serializers.py
@@ -896,6 +896,7 @@ class UnionSerializer(Serializer):
     Serializer for multiple types. This supports typing.Union[A, B] as well as
     typing.Optional[A]
     """
+
     @staticmethod
     def canSerialize(type_) -> bool:
         return typing.get_origin(type_) == typing.Union

--- a/Base/Python/slicer/parameterNodeWrapper/util.py
+++ b/Base/Python/slicer/parameterNodeWrapper/util.py
@@ -33,9 +33,7 @@ def unannotatedType(possiblyAnnotatedType):
 
 
 def findFirstAnnotation(annotationsList, annotationType):
-    """
-    Given a list of annotations, returns the first one of the given type
-    """
+    """Given a list of annotations, returns the first one of the given type"""
     extracted = [annotation for annotation in annotationsList if isinstance(annotation, annotationType)]
     return extracted[0] if extracted else None
 

--- a/Base/Python/slicer/parameterNodeWrapper/validators.py
+++ b/Base/Python/slicer/parameterNodeWrapper/validators.py
@@ -1,5 +1,6 @@
 """The validators module is responsible for defining classes that can be used to place invariants on single parameters
-of a parameterPack or parameterNodeWrapper."""
+of a parameterPack or parameterNodeWrapper.
+"""
 
 import abc
 

--- a/Base/Python/slicer/parameterNodeWrapper/validators.py
+++ b/Base/Python/slicer/parameterNodeWrapper/validators.py
@@ -21,6 +21,7 @@ class Validator(abc.ABC):
     Base class from which all parameterNodeWrapper validators derive.
     Validators must derive from this class to be used.
     """
+
     @abc.abstractmethod
     def validate(self, value) -> None:
         """

--- a/Base/Python/slicer/parameterNodeWrapper/validators.py
+++ b/Base/Python/slicer/parameterNodeWrapper/validators.py
@@ -32,9 +32,7 @@ class Validator(abc.ABC):
 
 
 def extractValidators(annotations):
-    """
-    Given a list of annotations, separates the annotations that are Validators from the ones that are not.
-    """
+    """Given a list of annotations, separates the annotations that are Validators from the ones that are not."""
     def isValidator(x) -> None:
         return isinstance(x, Validator) or (isinstance(x, type) and issubclass(x, Validator))
 
@@ -45,9 +43,7 @@ def extractValidators(annotations):
 
 
 class IsNone(Validator):
-    """
-    Validates that the input value is None.
-    """
+    """Validates that the input value is None."""
 
     def __repr__(self) -> str:
         return f"IsNone()"
@@ -58,9 +54,7 @@ class IsNone(Validator):
 
 
 class NotNone(Validator):
-    """
-    Validates that any input value is not None.
-    """
+    """Validates that any input value is not None."""
 
     def __repr__(self) -> str:
         return f"NotNone()"
@@ -71,9 +65,7 @@ class NotNone(Validator):
 
 
 class IsInstance(Validator):
-    """
-    Validates that any input value is an instance of a given type.
-    """
+    """Validates that any input value is an instance of a given type."""
 
     def __init__(self, classtype):
         self.classtype = classtype
@@ -87,9 +79,7 @@ class IsInstance(Validator):
 
 
 class WithinRange(Validator):
-    """
-    Validates that any input value is within the given range (inclusive).
-    """
+    """Validates that any input value is within the given range (inclusive)."""
 
     def __init__(self, minimum, maximum):
         self.minimum = minimum
@@ -104,9 +94,7 @@ class WithinRange(Validator):
 
 
 class Minimum(Validator):
-    """
-    Validates that any input value is greater than or equal to the given value.
-    """
+    """Validates that any input value is greater than or equal to the given value."""
 
     def __init__(self, minimum):
         self.minimum = minimum
@@ -120,9 +108,7 @@ class Minimum(Validator):
 
 
 class Maximum(Validator):
-    """
-    Validates that any input value is less than or equal to the given value.
-    """
+    """Validates that any input value is less than or equal to the given value."""
 
     def __init__(self, maximum):
         self.maximum = maximum
@@ -136,9 +122,7 @@ class Maximum(Validator):
 
 
 class Choice(Validator):
-    """
-    Validates that any input value is in the list of valid choices.
-    """
+    """Validates that any input value is in the list of valid choices."""
 
     def __init__(self, choices):
         self.choices = choices
@@ -152,9 +136,7 @@ class Choice(Validator):
 
 
 class Exclude(Validator):
-    """
-    Validates that any input value is not in the list of invalid choices.
-    """
+    """Validates that any input value is not in the list of invalid choices."""
 
     def __init__(self, excludedValues):
         self.excludedValues = excludedValues
@@ -168,9 +150,7 @@ class Exclude(Validator):
 
 
 class RangeBounds(Validator):
-    """
-    Validates that the values in a range are within the given overall bounds.
-    """
+    """Validates that the values in a range are within the given overall bounds."""
 
     def __init__(self, minimum, maximum):
         self.minimum = minimum

--- a/Base/Python/slicer/parameterNodeWrapper/wrapper.py
+++ b/Base/Python/slicer/parameterNodeWrapper/wrapper.py
@@ -65,9 +65,7 @@ class _ParameterWrapper:
         return self.parameter.isIn(self.parameterNode)
 
     def read(self):
-        """
-        Gets the value of this parameter in the given parameter node.
-        """
+        """Gets the value of this parameter in the given parameter node."""
         return self.parameter.read(self.parameterNode)
 
     def write(self, value) -> None:
@@ -289,9 +287,7 @@ def _makeDataTypeFunc(classvar):
 
 
 def _processClass(classtype):
-    """
-    Takes a parameterNodeWrapper class description and creates the full parameterNodeWrapper class.
-    """
+    """Takes a parameterNodeWrapper class description and creates the full parameterNodeWrapper class."""
     members = typing.get_type_hints(classtype, include_extras=True)
     allParameters: dict[str, ParameterInfo] = dict()
     for name, nametype in members.items():
@@ -349,9 +345,7 @@ def isParameterNodeWrapper(classOrObj):
 
 
 def parameterNodeWrapper(classtype=None):
-    """
-    Class decorator to make a parameter node wrapper that supports typed property access and GUI binding.
-    """
+    """Class decorator to make a parameter node wrapper that supports typed property access and GUI binding."""
     def wrap(cls):
         return _processClass(cls)
 

--- a/Base/Python/slicer/release/wiki.py
+++ b/Base/Python/slicer/release/wiki.py
@@ -143,7 +143,8 @@ class Wiki:
 
     def version_pages(self, release_version):
         """Copy ``Documentation/Nightly`` and ``Template:Documentation/Nightly``
-        pages into ``release_version`` namespace."""
+        pages into ``release_version`` namespace.
+        """
         self.doc.versionPages(
             "Nightly", release_version,
             ["Documentation", "Template:Documentation"])

--- a/Base/Python/slicer/slicerqt.py
+++ b/Base/Python/slicer/slicerqt.py
@@ -17,9 +17,7 @@ except:
 
 # -----------------------------------------------------------------------------
 class _LogReverseLevelFilter(logging.Filter):
-    """
-    Rejects log records that are at or above the specified level
-    """
+    """Rejects log records that are at or above the specified level"""
 
     def __init__(self, levelLimit):
         self._levelLimit = levelLimit
@@ -30,9 +28,7 @@ class _LogReverseLevelFilter(logging.Filter):
 
 # -----------------------------------------------------------------------------
 class SlicerApplicationLogHandler(logging.Handler):
-    """
-    Writes logging records to Slicer application log.
-    """
+    """Writes logging records to Slicer application log."""
 
     def __init__(self):
         logging.Handler.__init__(self)
@@ -64,9 +60,7 @@ class SlicerApplicationLogHandler(logging.Handler):
 
 # -----------------------------------------------------------------------------
 def initLogging(logger):
-    """
-    Initialize logging by creating log handlers and setting default log level.
-    """
+    """Initialize logging by creating log handlers and setting default log level."""
 
     # Prints debug messages to Slicer application log.
     # Only debug level messages are logged this way, as higher level messages are printed on console
@@ -191,8 +185,7 @@ class _Internal:
             setattr(slicer.modules, "dicomtonrrdconverter", moduleManager.module(moduleName))
 
     def unsetSlicerModule(self, moduleName):
-        """Remove attribute from ``slicer.modules``
-        """
+        """Remove attribute from ``slicer.modules``"""
         if hasattr(slicer.modules, moduleName + "Instance"):
             delattr(slicer.modules, moduleName + "Instance")
         if hasattr(slicer.modules, moduleName + "Widget"):

--- a/Base/Python/slicer/slicerqt.py
+++ b/Base/Python/slicer/slicerqt.py
@@ -93,7 +93,8 @@ def getSlicerRCFileName():
     If a .slicerrc.py file is found in slicer.app.slicerHome folder then that will be used.
     If that is not found then the path defined in SLICERRC environment variable will be used.
     If that environment variable is not specified then .slicerrc.py in the user's home folder
-    will be used ('~/.slicerrc.py')."""
+    will be used ('~/.slicerrc.py').
+    """
     import os
     rcfile = os.path.join(slicer.app.slicerHome, ".slicerrc.py")
     if not os.path.exists(rcfile):

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
@@ -114,6 +114,7 @@ class CustomIntSerializer(Serializer):
     Stores ints as their negative.
     Used to test being able to use a specific serializer.
     """
+
     @staticmethod
     def canSerialize(type_) -> bool:
         return type_ == int

--- a/Base/Python/slicer/tests/test_slicer_python_lzma.py
+++ b/Base/Python/slicer/tests/test_slicer_python_lzma.py
@@ -2,8 +2,7 @@ import unittest
 
 
 class SlicerPythonLzmaTests(unittest.TestCase):
-    """This test verifies that Python is build with lzma enabled.
-    """
+    """This test verifies that Python is build with lzma enabled."""
 
     def setUp(self):
         pass

--- a/Base/Python/slicer/tests/test_slicer_python_sqlite3.py
+++ b/Base/Python/slicer/tests/test_slicer_python_sqlite3.py
@@ -5,8 +5,7 @@ import shutil
 
 
 class SlicerPythonSqlite3Tests(unittest.TestCase):
-    """This test verifies that Python is build with sqlite3 enabled.
-    """
+    """This test verifies that Python is build with sqlite3 enabled."""
 
     def setUp(self):
         self.tempDir = slicer.util.tempDirectory()

--- a/Base/Python/slicer/tests/test_slicer_util_chdir.py
+++ b/Base/Python/slicer/tests/test_slicer_util_chdir.py
@@ -7,6 +7,7 @@ class SlicerUtilChdirTests(unittest.TestCase):
     """Available in Python 3.11 as ``TestChdir`` found in ``Lib/test/test_contextlib.py``
     and adapted from https://github.com/python/cpython/pull/28271
     """
+
     def test_simple(self):
         old_cwd = os.getcwd()
         target = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../slicer"))

--- a/Base/Python/slicer/tests/test_slicer_util_save.py
+++ b/Base/Python/slicer/tests/test_slicer_util_save.py
@@ -16,7 +16,8 @@ class SlicerUtilSaveTests(unittest.TestCase):
 
     def test_saveNode(self):
         """Test that nodes are saved correctly and that they are loaded correctly with the default reader
-        even if they are saved with generic (.nrrd) and not composite (.seg.nrrd) file extension."""
+        even if they are saved with generic (.nrrd) and not composite (.seg.nrrd) file extension.
+        """
 
         # Volume node
         volumeNode = slicer.util.getNode("MR-head")

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -168,7 +168,8 @@ def importClassesFromDirectory(directory, dest_module_name, type_info, filematch
 
 def importModuleObjects(from_module_name, dest_module_name, type_info):
     """Import object of type 'type_info' (str or type) from module identified
-    by 'from_module_name' into the module identified by 'dest_module_name'."""
+    by 'from_module_name' into the module identified by 'dest_module_name'.
+    """
 
     # Obtain a reference to the module identified by 'dest_module_name'
     import sys
@@ -2548,7 +2549,8 @@ def itkImageFromVolume(volumeNode):
 
 def itkImageFromVolumeModified(volumeNode):
     """Indicate that modification of a ITK image returned by :py:meth:`itkImageFromVolume` (or
-    associated with a volume node using :py:meth:`updateVolumeFromITKImage`) has been completed."""
+    associated with a volume node using :py:meth:`updateVolumeFromITKImage`) has been completed.
+    """
     imageData = volumeNode.GetImageData()
     pointData = imageData.GetPointData() if imageData else None
     if pointData:

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -250,8 +250,7 @@ def pythonShell():
 
 
 def showStatusMessage(message, duration=0):
-    """Display ``message`` in the status bar.
-    """
+    """Display ``message`` in the status bar."""
     mw = mainWindow()
     if not mw or not mw.statusBar():
         return False
@@ -348,8 +347,7 @@ def loadUI(path):
 
 
 def startQtDesigner(args=None):
-    """Start Qt Designer application to allow editing UI files.
-    """
+    """Start Qt Designer application to allow editing UI files."""
     import slicer
     cmdLineArguments = []
     if args is not None:
@@ -435,8 +433,7 @@ def addParameterEditWidgetConnections(parameterEditWidgets, updateParameterNodeF
 
 
 def removeParameterEditWidgetConnections(parameterEditWidgets, updateParameterNodeFromGUI):
-    """Remove connections created by :py:meth:`addParameterEditWidgetConnections`.
-    """
+    """Remove connections created by :py:meth:`addParameterEditWidgetConnections`."""
 
     for (widget, parameterName) in parameterEditWidgets:
         widgetClassName = widget.className()

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -260,7 +260,7 @@ def showStatusMessage(message, duration=0):
 
 
 def findChildren(widget=None, name="", text="", title="", className=""):
-    """ Return a list of child widgets that meet all the given criteria.
+    """Return a list of child widgets that meet all the given criteria.
 
     If no criteria are provided, the function will return all widgets descendants.
     If no widget is provided, slicer.util.mainWindow() is used.
@@ -328,7 +328,7 @@ def findChild(widget, name):
 
 
 def loadUI(path):
-    """ Load UI file ``path`` and return the corresponding widget.
+    """Load UI file ``path`` and return the corresponding widget.
 
     :raises RuntimeError: if the UI file is not found or if no
      widget was instantiated.
@@ -348,7 +348,7 @@ def loadUI(path):
 
 
 def startQtDesigner(args=None):
-    """ Start Qt Designer application to allow editing UI files.
+    """Start Qt Designer application to allow editing UI files.
     """
     import slicer
     cmdLineArguments = []
@@ -361,7 +361,7 @@ def startQtDesigner(args=None):
 
 
 def childWidgetVariables(widget):
-    """ Get child widgets as attributes of an object.
+    """Get child widgets as attributes of an object.
 
     Each named child widget is accessible as an attribute of the returned object,
     with the attribute name matching the child widget name.
@@ -384,7 +384,7 @@ def childWidgetVariables(widget):
 
 
 def addParameterEditWidgetConnections(parameterEditWidgets, updateParameterNodeFromGUI):
-    """ Add connections to get notification of a widget change.
+    """Add connections to get notification of a widget change.
 
     The function is useful for calling updateParameterNodeFromGUI method in scripted module widgets.
 
@@ -435,7 +435,7 @@ def addParameterEditWidgetConnections(parameterEditWidgets, updateParameterNodeF
 
 
 def removeParameterEditWidgetConnections(parameterEditWidgets, updateParameterNodeFromGUI):
-    """ Remove connections created by :py:meth:`addParameterEditWidgetConnections`.
+    """Remove connections created by :py:meth:`addParameterEditWidgetConnections`.
     """
 
     for (widget, parameterName) in parameterEditWidgets:
@@ -453,7 +453,7 @@ def removeParameterEditWidgetConnections(parameterEditWidgets, updateParameterNo
 
 
 def updateParameterEditWidgetsFromNode(parameterEditWidgets, parameterNode):
-    """ Update widgets from values stored in a vtkMRMLScriptedModuleNode.
+    """Update widgets from values stored in a vtkMRMLScriptedModuleNode.
 
     The function is useful for implementing updateGUIFromParameterNode.
 
@@ -487,7 +487,7 @@ def updateParameterEditWidgetsFromNode(parameterEditWidgets, parameterNode):
 
 
 def updateNodeFromParameterEditWidgets(parameterEditWidgets, parameterNode):
-    """ Update vtkMRMLScriptedModuleNode from widgets.
+    """Update vtkMRMLScriptedModuleNode from widgets.
 
     The function is useful for implementing updateParameterNodeFromGUI.
 
@@ -513,7 +513,7 @@ def updateNodeFromParameterEditWidgets(parameterEditWidgets, parameterNode):
 
 def setSliceViewerLayers(background="keep-current", foreground="keep-current", label="keep-current",
                          foregroundOpacity=None, labelOpacity=None, fit=False, rotateToVolumePlane=False):
-    """ Set the slice views with the given nodes.
+    """Set the slice views with the given nodes.
 
     If node ID is not specified (or value is 'keep-current') then the layer will not be modified.
 
@@ -3315,7 +3315,7 @@ def downloadFile(url, targetFilePath, checksum=None, reDownloadIfChecksumInvalid
 
 
 def extractArchive(archiveFilePath, outputDir, expectedNumberOfExtractedFiles=None):
-    """ Extract file ``archiveFilePath`` into folder ``outputDir``.
+    """Extract file ``archiveFilePath`` into folder ``outputDir``.
 
     Number of expected files unzipped may be specified in ``expectedNumberOfExtractedFiles``.
     If folder contains the same number of files as expected (if specified), then it will be
@@ -3398,7 +3398,7 @@ def extractAlgoAndDigest(checksum):
 
 def downloadAndExtractArchive(url, archiveFilePath, outputDir, \
                               expectedNumberOfExtractedFiles=None, numberOfTrials=3, checksum=None):
-    """ Downloads an archive from ``url`` as ``archiveFilePath``, and extracts it to ``outputDir``.
+    """Downloads an archive from ``url`` as ``archiveFilePath``, and extracts it to ``outputDir``.
 
     This combined function tests the success of the download by the extraction step,
     and re-downloads if extraction failed.

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -1472,6 +1472,7 @@ def resetSliceViews():
 
 class MRMLNodeNotFoundException(Exception):
     """Exception raised when a requested MRML node was not found."""
+
     pass
 
 
@@ -1584,7 +1585,7 @@ class RenderBlocker:
       with slicer.util.RenderBlocker():
         # Do things
 
-  """
+    """
 
     def __enter__(self):
         import slicer
@@ -3456,6 +3457,7 @@ class chdir:
 
       Available in CTK as ``ctkScopedCurrentDir`` C++ class
     """
+
     def __init__(self, path):
         self.path = path
         self._old_cwd = []

--- a/Base/Python/tests/test_sitkUtils.py
+++ b/Base/Python/tests/test_sitkUtils.py
@@ -10,8 +10,7 @@ class SitkUtilsTests(unittest.TestCase):
         pass
 
     def test_SimpleITK_SlicerPushPull(self):
-        """Download the MRHead node
-        """
+        """Download the MRHead node"""
         import SampleData
         SampleData.downloadSample("MRHead")
         volumeNode1 = slicer.util.getNode("MRHead")

--- a/Base/Python/tests/test_sitkUtils.py
+++ b/Base/Python/tests/test_sitkUtils.py
@@ -10,7 +10,7 @@ class SitkUtilsTests(unittest.TestCase):
         pass
 
     def test_SimpleITK_SlicerPushPull(self):
-        """ Download the MRHead node
+        """Download the MRHead node
         """
         import SampleData
         SampleData.downloadSample("MRHead")

--- a/Base/Python/vtkAddon.py
+++ b/Base/Python/vtkAddon.py
@@ -1,4 +1,4 @@
-""" This module loads all the classes from the vtkAddon library into its
+"""This module loads all the classes from the vtkAddon library into its
 namespace."""
 
 from vtkAddonPython import *

--- a/Base/Python/vtkAddon.py
+++ b/Base/Python/vtkAddon.py
@@ -1,4 +1,5 @@
 """This module loads all the classes from the vtkAddon library into its
-namespace."""
+namespace.
+"""
 
 from vtkAddonPython import *

--- a/Base/Python/vtkITK.py
+++ b/Base/Python/vtkITK.py
@@ -1,4 +1,4 @@
-""" This module loads all the classes from the vtkITK library into its
+"""This module loads all the classes from the vtkITK library into its
 namespace."""
 
 from vtkITKPython import *

--- a/Base/Python/vtkITK.py
+++ b/Base/Python/vtkITK.py
@@ -1,4 +1,5 @@
 """This module loads all the classes from the vtkITK library into its
-namespace."""
+namespace.
+"""
 
 from vtkITKPython import *

--- a/Base/Python/vtkSegmentationCore.py
+++ b/Base/Python/vtkSegmentationCore.py
@@ -1,4 +1,4 @@
-""" This module loads all the classes from the vtkSegmentationCore library into its
+"""This module loads all the classes from the vtkSegmentationCore library into its
 namespace."""
 
 from vtkSegmentationCorePython import *

--- a/Base/Python/vtkSegmentationCore.py
+++ b/Base/Python/vtkSegmentationCore.py
@@ -1,4 +1,5 @@
 """This module loads all the classes from the vtkSegmentationCore library into its
-namespace."""
+namespace.
+"""
 
 from vtkSegmentationCorePython import *

--- a/Base/Python/vtkTeem.py
+++ b/Base/Python/vtkTeem.py
@@ -1,4 +1,4 @@
-""" This module loads all the classes from the vtkTeem library into its
+"""This module loads all the classes from the vtkTeem library into its
 namespace."""
 
 from vtkTeemPython import *

--- a/Base/Python/vtkTeem.py
+++ b/Base/Python/vtkTeem.py
@@ -1,4 +1,5 @@
 """This module loads all the classes from the vtkTeem library into its
-namespace."""
+namespace.
+"""
 
 from vtkTeemPython import *

--- a/Extensions/Testing/ScriptedLoadableExtensionTemplate/ScriptedLoadableModuleTemplate/ScriptedLoadableModuleTemplate.py
+++ b/Extensions/Testing/ScriptedLoadableExtensionTemplate/ScriptedLoadableModuleTemplate/ScriptedLoadableModuleTemplate.py
@@ -171,8 +171,7 @@ class ScriptedLoadableModuleTemplateLogic(ScriptedLoadableModuleLogic):
         return True
 
     def isValidInputOutputData(self, inputVolumeNode, outputVolumeNode):
-        """Validates if the output is not the same as input
-        """
+        """Validates if the output is not the same as input"""
         if not inputVolumeNode:
             logging.debug("isValidInputOutputData failed: no input volume node defined")
             return False
@@ -185,9 +184,7 @@ class ScriptedLoadableModuleTemplateLogic(ScriptedLoadableModuleLogic):
         return True
 
     def run(self, inputVolume, outputVolume, imageThreshold):
-        """
-        Run the actual algorithm
-        """
+        """Run the actual algorithm"""
 
         if not self.isValidInputOutputData(inputVolume, outputVolume):
             slicer.util.errorDisplay(_("Input volume is the same as output volume. Choose a different output volume."))
@@ -212,13 +209,11 @@ class ScriptedLoadableModuleTemplateTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_ScriptedLoadableModuleTemplate1()
 

--- a/Extensions/Testing/ScriptedLoadableExtensionTemplate/ScriptedLoadableModuleTemplate/ScriptedLoadableModuleTemplate.py
+++ b/Extensions/Testing/ScriptedLoadableExtensionTemplate/ScriptedLoadableModuleTemplate/ScriptedLoadableModuleTemplate.py
@@ -212,7 +212,7 @@ class ScriptedLoadableModuleTemplateTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 
@@ -223,7 +223,7 @@ class ScriptedLoadableModuleTemplateTest(ScriptedLoadableModuleTest):
         self.test_ScriptedLoadableModuleTemplate1()
 
     def test_ScriptedLoadableModuleTemplate1(self):
-        """ Ideally you should have several levels of tests.  At the lowest level
+        """Ideally you should have several levels of tests.  At the lowest level
         tests should exercise the functionality of the logic with different inputs
         (both valid and invalid).  At higher levels your tests should emulate the
         way the user would interact with your code and confirm that it still works

--- a/Extensions/Testing/ScriptedSegmentEditorEffectExtensionTemplate/ScriptedSegmentEditorEffectModuleTemplate/SegmentEditorScriptedSegmentEditorEffectModuleTemplate.py
+++ b/Extensions/Testing/ScriptedSegmentEditorEffectExtensionTemplate/ScriptedSegmentEditorEffectModuleTemplate/SegmentEditorScriptedSegmentEditorEffectModuleTemplate.py
@@ -40,13 +40,11 @@ class SegmentEditorScriptedSegmentEditorEffectModuleTemplateTest(ScriptedLoadabl
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_ScriptedSegmentEditorEffectModuleTemplate1()
 

--- a/Extensions/Testing/ScriptedSegmentEditorEffectExtensionTemplate/ScriptedSegmentEditorEffectModuleTemplate/SegmentEditorScriptedSegmentEditorEffectModuleTemplate.py
+++ b/Extensions/Testing/ScriptedSegmentEditorEffectExtensionTemplate/ScriptedSegmentEditorEffectModuleTemplate/SegmentEditorScriptedSegmentEditorEffectModuleTemplate.py
@@ -40,7 +40,7 @@ class SegmentEditorScriptedSegmentEditorEffectModuleTemplateTest(ScriptedLoadabl
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Loadable/Colors/Testing/Python/ColorLegendSelfTest.py
+++ b/Modules/Loadable/Colors/Testing/Python/ColorLegendSelfTest.py
@@ -75,7 +75,7 @@ class ColorLegendSelfTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
         # Timeout delay

--- a/Modules/Loadable/Colors/Testing/Python/ColorLegendSelfTest.py
+++ b/Modules/Loadable/Colors/Testing/Python/ColorLegendSelfTest.py
@@ -70,20 +70,16 @@ class ColorLegendSelfTestWidget(ScriptedLoadableModuleWidget):
 
 
 class ColorLegendSelfTestTest(ScriptedLoadableModuleTest):
-    """
-    This is the test case for your scripted module.
-    """
+    """This is the test case for your scripted module."""
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
         # Timeout delay
         self.delayMs = 700
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_ColorLegendSelfTest1()
 

--- a/Modules/Loadable/CropVolume/Testing/Python/CropVolumeSelfTest.py
+++ b/Modules/Loadable/CropVolume/Testing/Python/CropVolumeSelfTest.py
@@ -38,9 +38,7 @@ class CropVolumeSelfTestWidget(ScriptedLoadableModuleWidget):
 
 
 class CropVolumeSelfTestTest(ScriptedLoadableModuleTest):
-    """
-    This is the test case for your scripted module.
-    """
+    """This is the test case for your scripted module."""
 
     def setUp(self):
         slicer.mrmlScene.Clear(0)
@@ -50,9 +48,7 @@ class CropVolumeSelfTestTest(ScriptedLoadableModuleTest):
         self.test_CropVolumeSelfTest()
 
     def test_CropVolumeSelfTest(self):
-        """
-        Replicate the crashe in issue 3117
-        """
+        """Replicate the crashe in issue 3117"""
 
         print("Running CropVolumeSelfTest Test case:")
 

--- a/Modules/Loadable/Markups/Testing/Python/AddManyMarkupsFiducialTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/AddManyMarkupsFiducialTest.py
@@ -146,9 +146,7 @@ class AddManyMarkupsFiducialTestWidget(ScriptedLoadableModuleWidget):
 class AddManyMarkupsFiducialTestLogic(ScriptedLoadableModuleLogic):
 
     def run(self, nodeType, numberOfNodes=10, numberOfControlPoints=10, rOffset=0, usefewerModifyCalls=False, locked=False, labelsHidden=False):
-        """
-        Run the actual algorithm
-        """
+        """Run the actual algorithm"""
         print(f"Running test to add {numberOfNodes} nodes markups with {numberOfControlPoints} control points")
         print("Index\tTime to add fid\tDelta between adds")
         print("%(index)04s\t" % {"index": "i"}, "t\tdt'")
@@ -220,13 +218,11 @@ class AddManyMarkupsFiducialTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_AddManyMarkupsFiducialTest1()
 

--- a/Modules/Loadable/Markups/Testing/Python/AddManyMarkupsFiducialTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/AddManyMarkupsFiducialTest.py
@@ -220,7 +220,7 @@ class AddManyMarkupsFiducialTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInCompareViewersSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInCompareViewersSelfTest.py
@@ -73,9 +73,7 @@ class MarkupsInCompareViewersSelfTestWidget(ScriptedLoadableModuleWidget):
 class MarkupsInCompareViewersSelfTestLogic(ScriptedLoadableModuleLogic):
 
     def run(self):
-        """
-        Run the actual algorithm
-        """
+        """Run the actual algorithm"""
         print("Running test of the markups in compare viewers")
 
         #
@@ -183,18 +181,14 @@ class MarkupsInCompareViewersSelfTestLogic(ScriptedLoadableModuleLogic):
 
 
 class MarkupsInCompareViewersSelfTestTest(ScriptedLoadableModuleTest):
-    """
-    This is the test case for your scripted module.
-    """
+    """This is the test case for your scripted module."""
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_MarkupsInCompareViewersSelfTest1()
 

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInCompareViewersSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInCompareViewersSelfTest.py
@@ -188,7 +188,7 @@ class MarkupsInCompareViewersSelfTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
@@ -139,9 +139,7 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
         self.nodeEvents.append(eventId)
 
     def run(self):
-        """
-        Run the actual algorithm
-        """
+        """Run the actual algorithm"""
         print("Running test of the markups in different views")
 
         #
@@ -315,18 +313,14 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
 
 
 class MarkupsInViewsSelfTestTest(ScriptedLoadableModuleTest):
-    """
-    This is the test case for your scripted module.
-    """
+    """This is the test case for your scripted module."""
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_MarkupsInViewsSelfTest1()
 

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
@@ -320,7 +320,7 @@ class MarkupsInViewsSelfTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Loadable/Markups/Testing/Python/NeurosurgicalPlanningTutorialMarkupsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/NeurosurgicalPlanningTutorialMarkupsSelfTest.py
@@ -128,21 +128,17 @@ class NeurosurgicalPlanningTutorialMarkupsSelfTestLogic(ScriptedLoadableModuleLo
 
 
 class NeurosurgicalPlanningTutorialMarkupsSelfTestTest(ScriptedLoadableModuleTest):
-    """
-    This is the test case for your scripted module.
-    """
+    """This is the test case for your scripted module."""
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
         # reset to conventional layout
         lm = slicer.app.layoutManager()
         lm.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_NeurosurgicalPlanningTutorialMarkupsSelfTest1()
 

--- a/Modules/Loadable/Markups/Testing/Python/NeurosurgicalPlanningTutorialMarkupsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/NeurosurgicalPlanningTutorialMarkupsSelfTest.py
@@ -133,7 +133,7 @@ class NeurosurgicalPlanningTutorialMarkupsSelfTestTest(ScriptedLoadableModuleTes
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
         # reset to conventional layout

--- a/Modules/Loadable/Markups/Testing/Python/PluggableMarkupsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/PluggableMarkupsSelfTest.py
@@ -141,9 +141,7 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
         ]
 
     def test_unregister_existing_markups(self):
-        """
-        This unregisters existing registered markups
-        """
+        """This unregisters existing registered markups"""
 
         markupsWidget = slicer.modules.markups.widgetRepresentation()
         if markupsWidget is None:
@@ -166,9 +164,7 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
                 raise Exception("Create PushButton for %s is present after unregistration" % markupNode.GetMarkupType())
 
     def test_register_markups(self):
-        """
-        This registers all known markups
-        """
+        """This registers all known markups"""
         markupsWidget = slicer.modules.markups.widgetRepresentation()
         if markupsWidget is None:
             raise Exception("Couldn't get the Markups module widget")
@@ -187,9 +183,7 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
                 raise Exception("Create PushButton for %s is not present" % markupNode.GetMarkupType())
 
     def test_unregister_additional_options_widgets(self):
-        """
-        This unregisters all the additional options widgets
-        """
+        """This unregisters all the additional options widgets"""
         markupsWidget = slicer.modules.markups.widgetRepresentation()
         if markupsWidget is None:
             raise Exception("Couldn't get the Markups module widget")
@@ -212,9 +206,7 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
                 raise Exception("%s does still exist" % objectName)
 
     def test_register_additional_options_widgets(self):
-        """
-        This reigisters additional options widgets
-        """
+        """This reigisters additional options widgets"""
 
         additionalOptionsWidgetsFactory = slicer.qMRMLMarkupsOptionsWidgetsFactory().instance()
 
@@ -232,9 +224,7 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
                 raise Exception("%s does not exist" % additionalOptionsWidget.objectName)
 
     def run(self):
-        """
-        Run the tests
-        """
+        """Run the tests"""
         slicer.util.delayDisplay("Running integration tests for Pluggable Markups")
 
         self.test_unregister_existing_markups()
@@ -246,9 +236,7 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
 
 
 class PluggableMarkupsSelfTestTest(ScriptedLoadableModuleTest):
-    """
-    This is the test case
-    """
+    """This is the test case"""
 
     def setUp(self):
         logic = PluggableMarkupsSelfTestLogic()

--- a/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py
+++ b/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py
@@ -50,7 +50,7 @@ class MarkupsWidgetsSelfTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py
+++ b/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py
@@ -45,20 +45,16 @@ class MarkupsWidgetsSelfTestLogic(ScriptedLoadableModuleLogic):
 
 
 class MarkupsWidgetsSelfTestTest(ScriptedLoadableModuleTest):
-    """
-    This is the test case for your scripted module.
-    """
+    """This is the test case for your scripted module."""
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
         self.delayMs = 700
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_MarkupsWidgetsSelfTest_FullTest1()
 

--- a/Modules/Loadable/Plots/Testing/Python/PlotsSelfTest.py
+++ b/Modules/Loadable/Plots/Testing/Python/PlotsSelfTest.py
@@ -46,18 +46,14 @@ class PlotsSelfTestLogic(ScriptedLoadableModuleLogic):
 
 
 class PlotsSelfTestTest(ScriptedLoadableModuleTest):
-    """
-    This is the test case for your scripted module.
-    """
+    """This is the test case for your scripted module."""
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_PlotsSelfTest_FullTest1()
 

--- a/Modules/Loadable/Plots/Testing/Python/PlotsSelfTest.py
+++ b/Modules/Loadable/Plots/Testing/Python/PlotsSelfTest.py
@@ -51,7 +51,7 @@ class PlotsSelfTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
+++ b/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
@@ -128,7 +128,7 @@ class AddStorableDataAfterSceneViewTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
+++ b/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
@@ -99,9 +99,7 @@ class AddStorableDataAfterSceneViewTestLogic(ScriptedLoadableModuleLogic):
     """
 
     def run(self, enableScreenshots=0):
-        """
-        Run the test via GUI
-        """
+        """Run the test via GUI"""
 
         logging.info("Processing started")
 
@@ -128,13 +126,11 @@ class AddStorableDataAfterSceneViewTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_AddStorableDataAfterSceneViewTest1()
 

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/AbstractScriptedSegmentEditorAutoCompleteEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/AbstractScriptedSegmentEditorAutoCompleteEffect.py
@@ -21,8 +21,8 @@ __all__ = ["AbstractScriptedSegmentEditorAutoCompleteEffect"]
 
 class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEditorEffect):
     """ AutoCompleteEffect is an effect that can create a full segmentation
-        from a partial segmentation (not all slices are segmented or only
-        part of the target structures are painted).
+    from a partial segmentation (not all slices are segmented or only
+    part of the target structures are painted).
     """
 
     def __init__(self, scriptedEffect):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/AbstractScriptedSegmentEditorAutoCompleteEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/AbstractScriptedSegmentEditorAutoCompleteEffect.py
@@ -20,7 +20,7 @@ __all__ = ["AbstractScriptedSegmentEditorAutoCompleteEffect"]
 #
 
 class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEditorEffect):
-    """ AutoCompleteEffect is an effect that can create a full segmentation
+    """AutoCompleteEffect is an effect that can create a full segmentation
     from a partial segmentation (not all slices are segmented or only
     part of the target structures are painted).
     """

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorDrawEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorDrawEffect.py
@@ -12,7 +12,7 @@ from SegmentEditorEffects import *
 
 class SegmentEditorDrawEffect(AbstractScriptedSegmentEditorLabelEffect):
     """ DrawEffect is a LabelEffect implementing the interactive draw
-        tool in the segment editor
+    tool in the segment editor
     """
 
     def __init__(self, scriptedEffect):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorDrawEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorDrawEffect.py
@@ -11,7 +11,7 @@ from SegmentEditorEffects import *
 
 
 class SegmentEditorDrawEffect(AbstractScriptedSegmentEditorLabelEffect):
-    """ DrawEffect is a LabelEffect implementing the interactive draw
+    """DrawEffect is a LabelEffect implementing the interactive draw
     tool in the segment editor
     """
 
@@ -163,7 +163,7 @@ class SegmentEditorDrawEffect(AbstractScriptedSegmentEditorLabelEffect):
 # DrawPipeline
 #
 class DrawPipeline:
-    """ Visualization objects and pipeline for each slice view for drawing
+    """Visualization objects and pipeline for each slice view for drawing
     """
 
     def __init__(self, scriptedEffect, sliceWidget):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorDrawEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorDrawEffect.py
@@ -163,8 +163,7 @@ class SegmentEditorDrawEffect(AbstractScriptedSegmentEditorLabelEffect):
 # DrawPipeline
 #
 class DrawPipeline:
-    """Visualization objects and pipeline for each slice view for drawing
-    """
+    """Visualization objects and pipeline for each slice view for drawing"""
 
     def __init__(self, scriptedEffect, sliceWidget):
         self.scriptedEffect = scriptedEffect

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorFillBetweenSlicesEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorFillBetweenSlicesEffect.py
@@ -9,7 +9,7 @@ from SegmentEditorEffects import *
 
 
 class SegmentEditorFillBetweenSlicesEffect(AbstractScriptedSegmentEditorAutoCompleteEffect):
-    """ AutoCompleteEffect is an effect that can create a full segmentation
+    """AutoCompleteEffect is an effect that can create a full segmentation
     from a partial segmentation (not all slices are segmented or only
     part of the target structures are painted).
     """

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorFillBetweenSlicesEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorFillBetweenSlicesEffect.py
@@ -10,8 +10,8 @@ from SegmentEditorEffects import *
 
 class SegmentEditorFillBetweenSlicesEffect(AbstractScriptedSegmentEditorAutoCompleteEffect):
     """ AutoCompleteEffect is an effect that can create a full segmentation
-        from a partial segmentation (not all slices are segmented or only
-        part of the target structures are painted).
+    from a partial segmentation (not all slices are segmented or only
+    part of the target structures are painted).
     """
 
     def __init__(self, scriptedEffect):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorGrowFromSeedsEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorGrowFromSeedsEffect.py
@@ -12,7 +12,7 @@ from SegmentEditorEffects import *
 
 
 class SegmentEditorGrowFromSeedsEffect(AbstractScriptedSegmentEditorAutoCompleteEffect):
-    """ AutoCompleteEffect is an effect that can create a full segmentation
+    """AutoCompleteEffect is an effect that can create a full segmentation
     from a partial segmentation (not all slices are segmented or only
     part of the target structures are painted).
     """

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorGrowFromSeedsEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorGrowFromSeedsEffect.py
@@ -13,8 +13,8 @@ from SegmentEditorEffects import *
 
 class SegmentEditorGrowFromSeedsEffect(AbstractScriptedSegmentEditorAutoCompleteEffect):
     """ AutoCompleteEffect is an effect that can create a full segmentation
-        from a partial segmentation (not all slices are segmented or only
-        part of the target structures are painted).
+    from a partial segmentation (not all slices are segmented or only
+    part of the target structures are painted).
     """
 
     def __init__(self, scriptedEffect):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorIslandsEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorIslandsEffect.py
@@ -12,8 +12,7 @@ from SegmentEditorEffects import *
 
 
 class SegmentEditorIslandsEffect(AbstractScriptedSegmentEditorEffect):
-    """Operate on connected components (islands) within a segment
-    """
+    """Operate on connected components (islands) within a segment"""
 
     def __init__(self, scriptedEffect):
         scriptedEffect.name = "Islands"  # no tr (don't translate it because modules find effects by name)

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorIslandsEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorIslandsEffect.py
@@ -12,7 +12,7 @@ from SegmentEditorEffects import *
 
 
 class SegmentEditorIslandsEffect(AbstractScriptedSegmentEditorEffect):
-    """ Operate on connected components (islands) within a segment
+    """Operate on connected components (islands) within a segment
     """
 
     def __init__(self, scriptedEffect):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorLevelTracingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorLevelTracingEffect.py
@@ -13,7 +13,7 @@ from SegmentEditorEffects import *
 
 class SegmentEditorLevelTracingEffect(AbstractScriptedSegmentEditorLabelEffect):
     """ LevelTracingEffect is a LabelEffect implementing level tracing fill
-        using intensity-based isolines
+    using intensity-based isolines
     """
 
     def __init__(self, scriptedEffect):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorLevelTracingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorLevelTracingEffect.py
@@ -151,8 +151,7 @@ class SegmentEditorLevelTracingEffect(AbstractScriptedSegmentEditorLabelEffect):
 # LevelTracingPipeline
 #
 class LevelTracingPipeline:
-    """Visualization objects and pipeline for each slice view for level tracing
-    """
+    """Visualization objects and pipeline for each slice view for level tracing"""
 
     def __init__(self, effect, sliceWidget):
         self.effect = effect

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorLevelTracingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorLevelTracingEffect.py
@@ -12,7 +12,7 @@ from SegmentEditorEffects import *
 
 
 class SegmentEditorLevelTracingEffect(AbstractScriptedSegmentEditorLabelEffect):
-    """ LevelTracingEffect is a LabelEffect implementing level tracing fill
+    """LevelTracingEffect is a LabelEffect implementing level tracing fill
     using intensity-based isolines
     """
 
@@ -151,7 +151,7 @@ class SegmentEditorLevelTracingEffect(AbstractScriptedSegmentEditorLabelEffect):
 # LevelTracingPipeline
 #
 class LevelTracingPipeline:
-    """ Visualization objects and pipeline for each slice view for level tracing
+    """Visualization objects and pipeline for each slice view for level tracing
     """
 
     def __init__(self, effect, sliceWidget):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorLogicalEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorLogicalEffect.py
@@ -11,8 +11,7 @@ from SegmentEditorEffects import *
 
 
 class SegmentEditorLogicalEffect(AbstractScriptedSegmentEditorEffect):
-    """LogicalEffect is an MorphologyEffect to erode a layer of pixels from a segment
-    """
+    """LogicalEffect is an MorphologyEffect to erode a layer of pixels from a segment"""
 
     def __init__(self, scriptedEffect):
         scriptedEffect.name = "Logical operators"  # no tr (don't translate it because modules find effects by name)

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorLogicalEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorLogicalEffect.py
@@ -11,7 +11,7 @@ from SegmentEditorEffects import *
 
 
 class SegmentEditorLogicalEffect(AbstractScriptedSegmentEditorEffect):
-    """ LogicalEffect is an MorphologyEffect to erode a layer of pixels from a segment
+    """LogicalEffect is an MorphologyEffect to erode a layer of pixels from a segment
     """
 
     def __init__(self, scriptedEffect):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorMarginEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorMarginEffect.py
@@ -12,7 +12,7 @@ from SegmentEditorEffects import *
 
 
 class SegmentEditorMarginEffect(AbstractScriptedSegmentEditorEffect):
-    """ MaringEffect grows or shrinks the segment by a specified margin
+    """MaringEffect grows or shrinks the segment by a specified margin
     """
 
     def __init__(self, scriptedEffect):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorMarginEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorMarginEffect.py
@@ -12,8 +12,7 @@ from SegmentEditorEffects import *
 
 
 class SegmentEditorMarginEffect(AbstractScriptedSegmentEditorEffect):
-    """MaringEffect grows or shrinks the segment by a specified margin
-    """
+    """MaringEffect grows or shrinks the segment by a specified margin"""
 
     def __init__(self, scriptedEffect):
         scriptedEffect.name = "Margin"  # no tr (don't translate it because modules find effects by name)

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorMaskVolumeEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorMaskVolumeEffect.py
@@ -7,8 +7,7 @@ from slicer.i18n import tr as _
 
 
 class SegmentEditorMaskVolumeEffect(AbstractScriptedSegmentEditorEffect):
-    """This effect fills a selected volume node inside and/or outside a segment with a chosen value.
-    """
+    """This effect fills a selected volume node inside and/or outside a segment with a chosen value."""
 
     def __init__(self, scriptedEffect):
         scriptedEffect.name = "Mask volume"  # no tr (don't translate it because modules find effects by name)

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorSmoothingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorSmoothingEffect.py
@@ -12,8 +12,7 @@ from SegmentEditorEffects import *
 
 
 class SegmentEditorSmoothingEffect(AbstractScriptedSegmentEditorPaintEffect):
-    """SmoothingEffect is an Effect that smoothes a selected segment
-    """
+    """SmoothingEffect is an Effect that smoothes a selected segment"""
 
     def __init__(self, scriptedEffect):
         scriptedEffect.name = "Smoothing"  # no tr (don't translate it because modules find effects by name)
@@ -199,8 +198,7 @@ If segments overlap, segment higher in the segments table will have priority. <b
         slicer.app.processEvents()
 
     def onApply(self, maskImage=None, maskExtent=None):
-        """maskImage: contains nonzero where smoothing will be applied
-        """
+        """maskImage: contains nonzero where smoothing will be applied"""
         smoothingMethod = self.scriptedEffect.parameter("SmoothingMethod")
         applyToAllVisibleSegments = int(self.scriptedEffect.parameter("ApplyToAllVisibleSegments")) != 0 \
             if self.scriptedEffect.parameter("ApplyToAllVisibleSegments") else False

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorSmoothingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorSmoothingEffect.py
@@ -12,7 +12,7 @@ from SegmentEditorEffects import *
 
 
 class SegmentEditorSmoothingEffect(AbstractScriptedSegmentEditorPaintEffect):
-    """ SmoothingEffect is an Effect that smoothes a selected segment
+    """SmoothingEffect is an Effect that smoothes a selected segment
     """
 
     def __init__(self, scriptedEffect):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorThresholdEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorThresholdEffect.py
@@ -938,8 +938,7 @@ class SegmentEditorThresholdEffect(AbstractScriptedSegmentEditorEffect):
 # PreviewPipeline
 #
 class PreviewPipeline:
-    """Visualization objects and pipeline for each slice view for threshold preview
-    """
+    """Visualization objects and pipeline for each slice view for threshold preview"""
 
     def __init__(self):
         self.lookupTable = vtk.vtkLookupTable()

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorThresholdEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorThresholdEffect.py
@@ -133,7 +133,8 @@ class SegmentEditorThresholdEffect(AbstractScriptedSegmentEditorEffect):
 
     def restorePreviewedSegmentTransparency(self):
         """Restore previewed segment's opacity that was temporarily
-        made transparen by calling setCurrentSegmentTransparent()."""
+        made transparen by calling setCurrentSegmentTransparent().
+        """
         segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
         if not segmentationNode:
             return

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorThresholdEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorThresholdEffect.py
@@ -13,11 +13,11 @@ from slicer.i18n import tr as _
 
 class SegmentEditorThresholdEffect(AbstractScriptedSegmentEditorEffect):
     """ ThresholdEffect is an Effect implementing the global threshold
-        operation in the segment editor
+    operation in the segment editor
 
-        This is also an example for scripted effects, and some methods have no
-        function. The methods that are not needed (i.e. the default implementation in
-        qSlicerSegmentEditorAbstractEffect is satisfactory) can simply be omitted.
+    This is also an example for scripted effects, and some methods have no
+    function. The methods that are not needed (i.e. the default implementation in
+    qSlicerSegmentEditorAbstractEffect is satisfactory) can simply be omitted.
     """
 
     def __init__(self, scriptedEffect):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorThresholdEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorThresholdEffect.py
@@ -12,7 +12,7 @@ from slicer.i18n import tr as _
 
 
 class SegmentEditorThresholdEffect(AbstractScriptedSegmentEditorEffect):
-    """ ThresholdEffect is an Effect implementing the global threshold
+    """ThresholdEffect is an Effect implementing the global threshold
     operation in the segment editor
 
     This is also an example for scripted effects, and some methods have no
@@ -938,7 +938,7 @@ class SegmentEditorThresholdEffect(AbstractScriptedSegmentEditorEffect):
 # PreviewPipeline
 #
 class PreviewPipeline:
-    """ Visualization objects and pipeline for each slice view for threshold preview
+    """Visualization objects and pipeline for each slice view for threshold preview
     """
 
     def __init__(self):

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationWidgetsTest1.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationWidgetsTest1.py
@@ -10,7 +10,7 @@ from slicer.ScriptedLoadableModule import *
 class SegmentationWidgetsTest1(ScriptedLoadableModuleTest):
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationWidgetsTest1.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationWidgetsTest1.py
@@ -10,13 +10,11 @@ from slicer.ScriptedLoadableModule import *
 class SegmentationWidgetsTest1(ScriptedLoadableModuleTest):
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_SegmentationWidgetsTest1()
 

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest1.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest1.py
@@ -13,13 +13,11 @@ from slicer.util import TESTING_DATA_URL
 class SegmentationsModuleTest1(unittest.TestCase):
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_SegmentationsModuleTest1()
 

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest1.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest1.py
@@ -13,7 +13,7 @@ from slicer.util import TESTING_DATA_URL
 class SegmentationsModuleTest1(unittest.TestCase):
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest2.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest2.py
@@ -20,7 +20,7 @@ class SegmentationsModuleTest2(unittest.TestCase):
 
     # ------------------------------------------------------------------------------
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest2.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest2.py
@@ -20,14 +20,12 @@ class SegmentationsModuleTest2(unittest.TestCase):
 
     # ------------------------------------------------------------------------------
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     # ------------------------------------------------------------------------------
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_SegmentationsModuleTest2()
 

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyCorePluginsSelfTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyCorePluginsSelfTest.py
@@ -63,13 +63,10 @@ class SubjectHierarchyCorePluginsSelfTestLogic(ScriptedLoadableModuleLogic):
 
 
 class SubjectHierarchyCorePluginsSelfTestTest(ScriptedLoadableModuleTest):
-    """
-    This is the test case for your scripted module.
-    """
+    """This is the test case for your scripted module."""
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
         self.delayMs = 700
@@ -81,8 +78,7 @@ class SubjectHierarchyCorePluginsSelfTestTest(ScriptedLoadableModuleTest):
         # logFile.close()
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_SubjectHierarchyCorePluginsSelfTest_FullTest1()
 

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyCorePluginsSelfTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyCorePluginsSelfTest.py
@@ -68,7 +68,7 @@ class SubjectHierarchyCorePluginsSelfTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyFoldersTest1.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyFoldersTest1.py
@@ -11,13 +11,11 @@ from slicer.util import DATA_STORE_URL
 class SubjectHierarchyFoldersTest1(unittest.TestCase):
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_SubjectHierarchyFoldersTest1()
 

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyFoldersTest1.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyFoldersTest1.py
@@ -11,7 +11,7 @@ from slicer.util import DATA_STORE_URL
 class SubjectHierarchyFoldersTest1(unittest.TestCase):
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
@@ -69,13 +69,10 @@ class SubjectHierarchyGenericSelfTestLogic(ScriptedLoadableModuleLogic):
 
 
 class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
-    """
-    This is the test case for your scripted module.
-    """
+    """This is the test case for your scripted module."""
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear()
 
         self.delayMs = 700
@@ -87,8 +84,7 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
         # logFile.close()
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_SubjectHierarchyGenericSelfTest_FullTest1()
 

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
@@ -74,7 +74,7 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear()
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/Python/AbstractScriptedSubjectHierarchyPlugin.py
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/Python/AbstractScriptedSubjectHierarchyPlugin.py
@@ -10,20 +10,20 @@ import slicer
 class AbstractScriptedSubjectHierarchyPlugin:
     """ Abstract scripted subject hierarchy plugin for python scripted plugins
 
-        USAGE: Instantiate scripted subject hierarchy plugin adaptor class from
-          module (e.g. from setup function), and set python source:
+    USAGE: Instantiate scripted subject hierarchy plugin adaptor class from
+    module (e.g. from setup function), and set python source:
 
-        from SubjectHierarchyPlugins import *
-        ...
-        class [Module]Widget(ScriptedLoadableModuleWidget):
-          ...
-          def setup(self):
-            ...
-            scriptedPlugin = slicer.qSlicerSubjectHierarchyScriptedPlugin(None)
-            scriptedPlugin.setPythonSource(VolumeClipSubjectHierarchyPlugin.filePath)
-            ...
+    from SubjectHierarchyPlugins import *
+    ...
+    class [Module]Widget(ScriptedLoadableModuleWidget):
+    ...
+    def setup(self):
+    ...
+    scriptedPlugin = slicer.qSlicerSubjectHierarchyScriptedPlugin(None)
+    scriptedPlugin.setPythonSource(VolumeClipSubjectHierarchyPlugin.filePath)
+    ...
 
-        Example can be found here: https://slicer.readthedocs.io/en/latest/developer_guide/script_repository.html#subject-hierarchy-plugin-offering-view-context-menu-action
+    Example can be found here: https://slicer.readthedocs.io/en/latest/developer_guide/script_repository.html#subject-hierarchy-plugin-offering-view-context-menu-action
     """
 
     def __init__(self, scriptedPlugin):

--- a/Modules/Loadable/SubjectHierarchy/Widgets/Python/AbstractScriptedSubjectHierarchyPlugin.py
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/Python/AbstractScriptedSubjectHierarchyPlugin.py
@@ -8,7 +8,7 @@ import slicer
 #
 
 class AbstractScriptedSubjectHierarchyPlugin:
-    """ Abstract scripted subject hierarchy plugin for python scripted plugins
+    """Abstract scripted subject hierarchy plugin for python scripted plugins
 
     USAGE: Instantiate scripted subject hierarchy plugin adaptor class from
     module (e.g. from setup function), and set python source:

--- a/Modules/Loadable/Tables/Testing/Python/TablesSelfTest.py
+++ b/Modules/Loadable/Tables/Testing/Python/TablesSelfTest.py
@@ -51,7 +51,7 @@ class TablesSelfTestTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Loadable/Tables/Testing/Python/TablesSelfTest.py
+++ b/Modules/Loadable/Tables/Testing/Python/TablesSelfTest.py
@@ -46,18 +46,14 @@ class TablesSelfTestLogic(ScriptedLoadableModuleLogic):
 
 
 class TablesSelfTestTest(ScriptedLoadableModuleTest):
-    """
-    This is the test case for your scripted module.
-    """
+    """This is the test case for your scripted module."""
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_TablesSelfTest_FullTest1()
 

--- a/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingSceneClose.py
+++ b/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingSceneClose.py
@@ -133,7 +133,7 @@ class VolumeRenderingSceneCloseTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingSceneClose.py
+++ b/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingSceneClose.py
@@ -90,9 +90,7 @@ class VolumeRenderingSceneCloseLogic(ScriptedLoadableModuleLogic):
     """
 
     def run(self):
-        """
-        Run the actual algorithm
-        """
+        """Run the actual algorithm"""
 
         layoutManager = slicer.app.layoutManager()
         layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView)
@@ -133,13 +131,11 @@ class VolumeRenderingSceneCloseTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_VolumeRenderingSceneClose1()
 

--- a/Modules/Scripted/CropVolumeSequence/CropVolumeSequence.py
+++ b/Modules/Scripted/CropVolumeSequence/CropVolumeSequence.py
@@ -295,7 +295,7 @@ class CropVolumeSequenceTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Scripted/CropVolumeSequence/CropVolumeSequence.py
+++ b/Modules/Scripted/CropVolumeSequence/CropVolumeSequence.py
@@ -178,9 +178,7 @@ class CropVolumeSequenceLogic(ScriptedLoadableModuleLogic):
         return proxyVolume.GetTransformNodeID()
 
     def run(self, inputVolSeq, outputVolSeq, cropParameters):
-        """
-        Run the actual algorithm
-        """
+        """Run the actual algorithm"""
 
         logging.info("Processing started")
 
@@ -295,13 +293,11 @@ class CropVolumeSequenceTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_CropVolumeSequence1()
 

--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -777,7 +777,7 @@ class DICOMWidget(ScriptedLoadableModuleWidget):
         self.onListenerStateChanged()
 
     def onListenerStateChanged(self, newState=None):
-        """ Called when the indexer process state changes
+        """Called when the indexer process state changes
         so we can provide feedback to the user
         """
         if hasattr(slicer, "dicomListener") and slicer.dicomListener.process is not None:
@@ -803,7 +803,7 @@ class DICOMWidget(ScriptedLoadableModuleWidget):
             self.ui.toggleListener.checked = True
 
     def onListenerToAddFile(self):
-        """ Called when the indexer is about to add a file to the database.
+        """Called when the indexer is about to add a file to the database.
         Works around issue where ctkDICOMModel has open queries that keep the
         database locked.
         """

--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -448,8 +448,7 @@ class DICOMFileDialog:
 
     @staticmethod
     def isAscii(s):
-        """Return True if string only contains ASCII characters.
-        """
+        """Return True if string only contains ASCII characters."""
         if isinstance(s, str):
             try:
                 s.encode("ascii")
@@ -536,9 +535,7 @@ class DICOMFileDialog:
 #
 
 class DICOMWidget(ScriptedLoadableModuleWidget):
-    """
-    Slicer module that creates the Qt GUI for interacting with DICOM
-    """
+    """Slicer module that creates the Qt GUI for interacting with DICOM"""
 
     # sets up the widget
     def setup(self):
@@ -891,8 +888,7 @@ class DICOMWidget(ScriptedLoadableModuleWidget):
 
 
 class DICOMFileReader:
-    """This reader claims DICOM files with higher-than default confidence
-    """
+    """This reader claims DICOM files with higher-than default confidence"""
 
     def __init__(self, parent):
         self.parent = parent

--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -241,7 +241,8 @@ class DICOM(ScriptedLoadableModule):
         the DICOM module by selecting the module.  Note that
         once the module is constructed (below in setup) another
         connection is made that will also cause the instance-created
-        DICOM browser to be raised by this menu action"""
+        DICOM browser to be raised by this menu action
+        """
         a = self.parent.action()
         a.setText(_("Add DICOM Data"))
         fileMenu = slicer.util.lookupTopLevelWidget("FileMenu")
@@ -426,7 +427,8 @@ class DICOMFileDialog:
 
     def isMimeDataAccepted(self):
         """Checks the dropped data and returns true if it is one or
-        more directories"""
+        more directories
+        """
         self.directoriesToAdd, _ = DICOMFileDialog.pathsFromMimeData(self.qSlicerFileDialog.mimeData())
         self.qSlicerFileDialog.acceptMimeData(len(self.directoriesToAdd) != 0)
 

--- a/Modules/Scripted/DICOMLib/DICOMBrowser.py
+++ b/Modules/Scripted/DICOMLib/DICOMBrowser.py
@@ -191,7 +191,8 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
     def onDirectoryImported(self):
         """The dicom browser will emit multiple directoryImported
         signals during the same operation, so we collapse them
-        into a single check for compatible extensions."""
+        into a single check for compatible extensions.
+        """
         if not hasattr(slicer.app, "extensionsManagerModel"):
             # Slicer may not be built with extensions manager support
             return
@@ -355,7 +356,8 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
 
     def examineForLoading(self):
         """For selected plugins, give user the option
-        of what to load"""
+        of what to load
+        """
 
         (self.loadablesByPlugin, loadEnabled) = self.getLoadablesFromFileLists(self.fileLists)
         DICOMLib.selectHighestConfidenceLoadables(self.loadablesByPlugin)
@@ -460,7 +462,8 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
 
     def loadCheckedLoadables(self):
         """Invoke the load method on each plugin for the loadable
-        (DICOMLoadable or qSlicerDICOMLoadable) instances that are selected"""
+        (DICOMLoadable or qSlicerDICOMLoadable) instances that are selected
+        """
         if self.advancedViewButton.checkState() == 0:
             self.examineForLoading()
 

--- a/Modules/Scripted/DICOMLib/DICOMBrowser.py
+++ b/Modules/Scripted/DICOMLib/DICOMBrowser.py
@@ -363,8 +363,7 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
         self.updateButtonStates()
 
     def getLoadablesFromFileLists(self, fileLists):
-        """Take list of file lists, return loadables by plugin dictionary
-        """
+        """Take list of file lists, return loadables by plugin dictionary"""
 
         loadablesByPlugin = {}
         loadEnabled = False

--- a/Modules/Scripted/DICOMLib/DICOMExportScalarVolume.py
+++ b/Modules/Scripted/DICOMLib/DICOMExportScalarVolume.py
@@ -24,9 +24,7 @@ class DICOMExportScalarVolume:
     """
 
     def __init__(self, studyUID, volumeNode, tags, directory, filenamePrefix=None):
-        """
-        studyUID parameter is not used (studyUID is retrieved from tags).
-        """
+        """studyUID parameter is not used (studyUID is retrieved from tags)."""
         self.studyUID = studyUID
         self.volumeNode = volumeNode
         self.tags = tags

--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -69,7 +69,7 @@ class DICOMLoadable:
 #
 
 class DICOMPlugin:
-    """ Base class for DICOM plugins
+    """Base class for DICOM plugins
     """
 
     def __init__(self):
@@ -126,7 +126,7 @@ class DICOMPlugin:
         return m.digest()
 
     def getCachedLoadables(self, files):
-        """ Helper method to access the results of a previous
+        """Helper method to access the results of a previous
         examination of a list of files"""
         key = self.hashFiles(files)
         if key in self.loadableCache:
@@ -134,7 +134,7 @@ class DICOMPlugin:
         return None
 
     def cacheLoadables(self, files, loadables):
-        """ Helper method to store the results of examining a list
+        """Helper method to store the results of examining a list
         of files for later quick access"""
         key = self.hashFiles(files)
         self.loadableCache[key] = loadables

--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -126,7 +126,8 @@ class DICOMPlugin:
 
     def getCachedLoadables(self, files):
         """Helper method to access the results of a previous
-        examination of a list of files"""
+        examination of a list of files
+        """
         key = self.hashFiles(files)
         if key in self.loadableCache:
             return self.loadableCache[key]
@@ -134,7 +135,8 @@ class DICOMPlugin:
 
     def cacheLoadables(self, files, loadables):
         """Helper method to store the results of examining a list
-        of files for later quick access"""
+        of files for later quick access
+        """
         key = self.hashFiles(files)
         self.loadableCache[key] = loadables
 
@@ -175,7 +177,8 @@ class DICOMPlugin:
 
     def defaultSeriesNodeName(self, seriesUID):
         """Generate a name suitable for use as a mrml node name based
-        on the series level data in the database"""
+        on the series level data in the database
+        """
         instanceFilePaths = slicer.dicomDatabase.filesForSeries(seriesUID, 1)
         if len(instanceFilePaths) == 0:
             return "Unnamed Series"

--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -69,8 +69,7 @@ class DICOMLoadable:
 #
 
 class DICOMPlugin:
-    """Base class for DICOM plugins
-    """
+    """Base class for DICOM plugins"""
 
     def __init__(self):
         # displayed for the user as the plugin handling the load

--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -144,9 +144,7 @@ class DICOMProcess:
 
 
 class DICOMCommand(DICOMProcess):
-    """
-    Run a generic dcmtk command and return the stdout
-    """
+    """Run a generic dcmtk command and return the stdout"""
 
     def __init__(self, cmd: str, args: list[str]):
         super().__init__()
@@ -487,9 +485,7 @@ class DICOMSender:
         return True
 
     def send(self) -> None:
-        """
-        Sends DICOM files to a remote server. Called on instance initialization.
-        """
+        """Sends DICOM files to a remote server. Called on instance initialization."""
         self.progressCallback(
             f"Starting send to {self.destinationUrl.toString()} using {self.protocol} protocol"
         )

--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -97,7 +97,8 @@ class DICOMProcess:
 
     def onStateChanged(self, newState: int):
         """Callback to indicate that the process state has changed
-        and is now either starting, running, or not running."""
+        and is now either starting, running, or not running.
+        """
         logging.debug(f"Process {self.cmd} now in state {self.PROCESS_STATE_NAMES[newState]}")
         stdout = None
         stderr = None

--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -705,7 +705,7 @@ class DICOMTestingQRServer:
         self.qrProcess = None
 
     def makeConfigFile(self, configFile, storageDirectory="."):
-        """ make a config file for the local instance with just
+        """make a config file for the local instance with just
         the parts we need (comments and examples removed).
         For examples and the full syntax
         see dcmqrdb/etc/dcmqrscp.cfg and

--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -646,6 +646,7 @@ class DICOMTestingQRServer:
     TODO: it might make sense to refactor this as a generic tool
     for interacting with DCMTK
     """
+
     # TODO: make this use DICOMProcess superclass
 
     def __init__(self, exeDir=".", tmpDir="./DICOM"):

--- a/Modules/Scripted/DICOMLib/DICOMRecentActivityWidget.py
+++ b/Modules/Scripted/DICOMLib/DICOMRecentActivityWidget.py
@@ -112,8 +112,7 @@ class DICOMRecentActivityWidget(qt.QWidget):
         return recentSeries
 
     def update(self):
-        """Load the table widget with header values for the file
-        """
+        """Load the table widget with header values for the file"""
         self.listWidget.clear()
         secondsPerHour = 60 * 60
         insertsPastHour = 0

--- a/Modules/Scripted/DICOMLib/DICOMSendDialog.py
+++ b/Modules/Scripted/DICOMLib/DICOMSendDialog.py
@@ -7,8 +7,7 @@ import DICOMLib
 
 
 class DICOMSendDialog(qt.QDialog):
-    """Implement the Qt dialog for doing a DICOM Send (storage SCU)
-    """
+    """Implement the Qt dialog for doing a DICOM Send (storage SCU)"""
 
     def __init__(self, files, parent="mainWindow"):
         super().__init__(slicer.util.mainWindow() if parent == "mainWindow" else parent)

--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -192,7 +192,8 @@ def selectHighestConfidenceLoadables(loadablesByPlugin):
     to want are listed at the top of the table and are selected
     by default. Only offer one pre-selected loadable per series
     unless both plugins mark it as selected and they have equal
-    confidence."""
+    confidence.
+    """
 
     # first, get all loadables corresponding to a series
     seriesUIDTag = "0020,000E"

--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -83,8 +83,7 @@ def loadPatientByUID(patientUID, messages=None, progressCallback=None):
 
 # ------------------------------------------------------------------------------
 def getDatabasePatientUIDByPatientName(name):
-    """Get patient UID by patient name for easy loading of a patient
-    """
+    """Get patient UID by patient name for easy loading of a patient"""
     if not slicer.dicomDatabase.isOpen:
         raise OSError("DICOM module or database cannot be accessed")
 
@@ -109,8 +108,7 @@ def loadPatientByName(patientName, messages=None, progressCallback=None):
 
 # ------------------------------------------------------------------------------
 def getDatabasePatientUIDByPatientID(patientID):
-    """Get database patient UID by DICOM patient ID for easy loading of a patient
-    """
+    """Get database patient UID by DICOM patient ID for easy loading of a patient"""
     if not slicer.dicomDatabase.isOpen:
         raise OSError("DICOM module or database cannot be accessed")
 
@@ -343,8 +341,7 @@ def openTemporaryDatabase(directory=None):
 
 # ------------------------------------------------------------------------------
 def closeTemporaryDatabase(originalDatabaseDir, cleanup=True):
-    """Close temporary DICOM database and remove its directory if requested
-    """
+    """Close temporary DICOM database and remove its directory if requested"""
     if slicer.dicomDatabase.isOpen:
         if cleanup:
             slicer.dicomDatabase.initializeDatabase()
@@ -380,8 +377,7 @@ def closeTemporaryDatabase(originalDatabaseDir, cleanup=True):
 
 # ------------------------------------------------------------------------------
 def createTemporaryDatabase(directory=None):
-    """Open temporary DICOM database, return new database object
-    """
+    """Open temporary DICOM database, return new database object"""
     # Specify temporary directory
     if not directory or directory == "":
         from time import gmtime, strftime
@@ -409,8 +405,7 @@ def createTemporaryDatabase(directory=None):
 
 # ------------------------------------------------------------------------------
 def deleteTemporaryDatabase(dicomDatabase, cleanup=True):
-    """Close temporary DICOM database and remove its directory if requested
-    """
+    """Close temporary DICOM database and remove its directory if requested"""
     dicomDatabase.closeDatabase()
 
     if cleanup:
@@ -446,8 +441,7 @@ class TemporaryDICOMDatabase:
 
 # ------------------------------------------------------------------------------
 def importDicom(dicomDataDir, dicomDatabase=None, copyFiles=False):
-    """Import DICOM files from folder into Slicer database
-    """
+    """Import DICOM files from folder into Slicer database"""
     try:
         indexer = ctk.ctkDICOMIndexer()
         assert indexer is not None
@@ -563,8 +557,7 @@ def allSeriesUIDsInDatabase(database=None):
 
 # ------------------------------------------------------------------------------
 def seriesUIDsForFiles(files):
-    """Collect series instance UIDs belonging to a list of files
-    """
+    """Collect series instance UIDs belonging to a list of files"""
     seriesUIDs = set()
     for file in files:
         seriesUID = slicer.dicomDatabase.seriesForFile(file)
@@ -575,8 +568,7 @@ def seriesUIDsForFiles(files):
 
 # ------------------------------------------------------------------------------
 class LoadDICOMFilesToDatabase:
-    """Context manager to conveniently load DICOM files downloaded zipped from the internet
-    """
+    """Context manager to conveniently load DICOM files downloaded zipped from the internet"""
 
     def __init__(self, url, archiveFilePath=None, dicomDataDir=None, \
                  expectedNumberOfFiles=None, selectedPlugins=None, loadedNodes=None, checksum=None):
@@ -738,8 +730,7 @@ def refreshDICOMWidget():
 
 
 def getLoadablesFromFileLists(fileLists, pluginClassNames=None, messages=None, progressCallback=None, pluginInstances=None):
-    """Take list of file lists, return loadables by plugin dictionary
-    """
+    """Take list of file lists, return loadables by plugin dictionary"""
     detailedLogging = slicer.util.settingsValue("DICOM/detailedLogging", False, converter=slicer.util.toBool)
     loadablesByPlugin = {}
     loadEnabled = False

--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -25,7 +25,7 @@ comment = """
 
 # ------------------------------------------------------------------------------
 def loadPatientByUID(patientUID, messages=None, progressCallback=None):
-    """ Load patient by patient UID from DICOM database.
+    """Load patient by patient UID from DICOM database.
     Returns list of loaded node ids.
 
     Example: load all data from a DICOM folder (using a temporary DICOM database)
@@ -83,7 +83,7 @@ def loadPatientByUID(patientUID, messages=None, progressCallback=None):
 
 # ------------------------------------------------------------------------------
 def getDatabasePatientUIDByPatientName(name):
-    """ Get patient UID by patient name for easy loading of a patient
+    """Get patient UID by patient name for easy loading of a patient
     """
     if not slicer.dicomDatabase.isOpen:
         raise OSError("DICOM module or database cannot be accessed")
@@ -98,7 +98,7 @@ def getDatabasePatientUIDByPatientName(name):
 
 # ------------------------------------------------------------------------------
 def loadPatientByName(patientName, messages=None, progressCallback=None):
-    """ Load patient by patient name from DICOM database.
+    """Load patient by patient name from DICOM database.
     Returns list of loaded node ids.
     """
     patientUID = getDatabasePatientUIDByPatientName(patientName)
@@ -109,7 +109,7 @@ def loadPatientByName(patientName, messages=None, progressCallback=None):
 
 # ------------------------------------------------------------------------------
 def getDatabasePatientUIDByPatientID(patientID):
-    """ Get database patient UID by DICOM patient ID for easy loading of a patient
+    """Get database patient UID by DICOM patient ID for easy loading of a patient
     """
     if not slicer.dicomDatabase.isOpen:
         raise OSError("DICOM module or database cannot be accessed")
@@ -135,7 +135,7 @@ def getDatabasePatientUIDByPatientID(patientID):
 
 # ------------------------------------------------------------------------------
 def loadPatientByPatientID(patientID, messages=None, progressCallback=None):
-    """ Load patient from DICOM database by DICOM PatientID.
+    """Load patient from DICOM database by DICOM PatientID.
     Returns list of loaded node ids.
     """
     patientUID = getDatabasePatientUIDByPatientID(patientID)
@@ -146,7 +146,7 @@ def loadPatientByPatientID(patientID, messages=None, progressCallback=None):
 
 # ------------------------------------------------------------------------------
 def loadPatient(uid=None, name=None, patientID=None, messages=None, progressCallback=None):
-    """ Load patient from DICOM database fr uid, name, or patient ID.
+    """Load patient from DICOM database fr uid, name, or patient ID.
     Returns list of loaded node ids.
     """
     if uid is not None:
@@ -161,7 +161,7 @@ def loadPatient(uid=None, name=None, patientID=None, messages=None, progressCall
 
 # ------------------------------------------------------------------------------
 def loadSeriesByUID(seriesUIDs, messages=None, progressCallback=None):
-    """ Load multiple series by UID from DICOM database.
+    """Load multiple series by UID from DICOM database.
     Returns list of loaded node ids.
     """
     if not isinstance(seriesUIDs, list):
@@ -226,7 +226,7 @@ def selectHighestConfidenceLoadables(loadablesByPlugin):
 
 # ------------------------------------------------------------------------------
 def loadByInstanceUID(instanceUID, messages=None, progressCallback=None):
-    """ Load with the most confident loadable that contains the instanceUID from DICOM database.
+    """Load with the most confident loadable that contains the instanceUID from DICOM database.
     This helps in the case where an instance is part of a series which may offer multiple
     loadables, such as when a series has multiple time points where
     each corresponds to a scalar volume and you only want to load the correct one.
@@ -312,7 +312,7 @@ def removeEmptyDirs(path):
 
 # ------------------------------------------------------------------------------
 def openTemporaryDatabase(directory=None):
-    """ Temporarily change the main DICOM database folder location,
+    """Temporarily change the main DICOM database folder location,
     return current database directory. Useful for tests and demos.
     Call closeTemporaryDatabase to restore the original database folder.
     """
@@ -343,7 +343,7 @@ def openTemporaryDatabase(directory=None):
 
 # ------------------------------------------------------------------------------
 def closeTemporaryDatabase(originalDatabaseDir, cleanup=True):
-    """ Close temporary DICOM database and remove its directory if requested
+    """Close temporary DICOM database and remove its directory if requested
     """
     if slicer.dicomDatabase.isOpen:
         if cleanup:
@@ -380,7 +380,7 @@ def closeTemporaryDatabase(originalDatabaseDir, cleanup=True):
 
 # ------------------------------------------------------------------------------
 def createTemporaryDatabase(directory=None):
-    """ Open temporary DICOM database, return new database object
+    """Open temporary DICOM database, return new database object
     """
     # Specify temporary directory
     if not directory or directory == "":
@@ -409,7 +409,7 @@ def createTemporaryDatabase(directory=None):
 
 # ------------------------------------------------------------------------------
 def deleteTemporaryDatabase(dicomDatabase, cleanup=True):
-    """ Close temporary DICOM database and remove its directory if requested
+    """Close temporary DICOM database and remove its directory if requested
     """
     dicomDatabase.closeDatabase()
 
@@ -446,7 +446,7 @@ class TemporaryDICOMDatabase:
 
 # ------------------------------------------------------------------------------
 def importDicom(dicomDataDir, dicomDatabase=None, copyFiles=False):
-    """ Import DICOM files from folder into Slicer database
+    """Import DICOM files from folder into Slicer database
     """
     try:
         indexer = ctk.ctkDICOMIndexer()
@@ -471,7 +471,7 @@ def loadSeriesWithVerification(
     messages=None,
     progressCallback=None,
 ):
-    """ Load series by UID, and verify loadable selection and loaded nodes.
+    """Load series by UID, and verify loadable selection and loaded nodes.
 
     ``selectedPlugins`` example: { 'Scalar Volume':1, 'RT':2 }
     ``expectedLoadedNodes`` example: { 'vtkMRMLScalarVolumeNode':2, 'vtkMRMLSegmentationNode':1 }
@@ -544,7 +544,7 @@ def loadSeriesWithVerification(
 
 # ------------------------------------------------------------------------------
 def allSeriesUIDsInDatabase(database=None):
-    """ Collect all series instance UIDs in a DICOM database (the Slicer one by default)
+    """Collect all series instance UIDs in a DICOM database (the Slicer one by default)
 
     Useful to get list of just imported series UIDs, for example:
     newSeriesUIDs = [x for x in seriesUIDsAfter if x not in seriesUIDsBefore]
@@ -563,7 +563,7 @@ def allSeriesUIDsInDatabase(database=None):
 
 # ------------------------------------------------------------------------------
 def seriesUIDsForFiles(files):
-    """ Collect series instance UIDs belonging to a list of files
+    """Collect series instance UIDs belonging to a list of files
     """
     seriesUIDs = set()
     for file in files:
@@ -724,7 +724,7 @@ def getSortedImageFiles(filePaths: list[str], epsilon: float=0.01) -> tuple[list
 
 # ------------------------------------------------------------------------------
 def refreshDICOMWidget():
-    """ Refresh DICOM browser from database.
+    """Refresh DICOM browser from database.
     It is useful when the database is changed via a database object that is
     different from the one stored in the DICOM browser. There may be multiple
     database connection (through different database objects) in the same process.

--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -428,8 +428,8 @@ def deleteTemporaryDatabase(dicomDatabase, cleanup=True):
 # ------------------------------------------------------------------------------
 class TemporaryDICOMDatabase:
     """Context manager to conveniently use temporary DICOM database.
-       It creates a new DICOM database and temporarily sets it as the main
-       DICOM database in the application (slicer.dicomDatabase).
+    It creates a new DICOM database and temporarily sets it as the main
+    DICOM database in the application (slicer.dicomDatabase).
     """
 
     def __init__(self, directory=None):
@@ -577,6 +577,7 @@ def seriesUIDsForFiles(files):
 class LoadDICOMFilesToDatabase:
     """Context manager to conveniently load DICOM files downloaded zipped from the internet
     """
+
     def __init__(self, url, archiveFilePath=None, dicomDataDir=None, \
                  expectedNumberOfFiles=None, selectedPlugins=None, loadedNodes=None, checksum=None):
         from time import gmtime, strftime

--- a/Modules/Scripted/DICOMPatcher/DICOMPatcher.py
+++ b/Modules/Scripted/DICOMPatcher/DICOMPatcher.py
@@ -195,8 +195,7 @@ class DICOMPatcherWidget(ScriptedLoadableModuleWidget):
         self.logic.importDicomDir(self.outputDirSelector.currentPath)
 
     def addLog(self, text):
-        """Append text to log window
-        """
+        """Append text to log window"""
         self.statusLabel.appendPlainText(text)
         slicer.app.processEvents()  # force update
 
@@ -692,9 +691,7 @@ class DICOMPatcherLogic(ScriptedLoadableModuleLogic):
         self.addLog(f"DICOM patching completed. Patched files are written to:\n{outputDirPath}")
 
     def importDicomDir(self, outputDirPath):
-        """
-        Utility function to import DICOM files from a directory
-        """
+        """Utility function to import DICOM files from a directory"""
         self.addLog("Initiate DICOM importing from folder " + outputDirPath)
         slicer.util.selectModule("DICOM")
         dicomBrowser = slicer.modules.dicom.widgetRepresentation().self().browserWidget.dicomBrowser
@@ -713,13 +710,11 @@ class DICOMPatcherTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_DICOMPatcher1()
 

--- a/Modules/Scripted/DICOMPatcher/DICOMPatcher.py
+++ b/Modules/Scripted/DICOMPatcher/DICOMPatcher.py
@@ -713,7 +713,7 @@ class DICOMPatcherTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 
@@ -724,7 +724,7 @@ class DICOMPatcherTest(ScriptedLoadableModuleTest):
         self.test_DICOMPatcher1()
 
     def test_DICOMPatcher1(self):
-        """ Ideally you should have several levels of tests.  At the lowest level
+        """Ideally you should have several levels of tests.  At the lowest level
         tests should exercise the functionality of the logic with different inputs
         (both valid and invalid).  At higher levels your tests should emulate the
         way the user would interact with your code and confirm that it still works

--- a/Modules/Scripted/DICOMPlugins/DICOMEnhancedUSVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMEnhancedUSVolumePlugin.py
@@ -101,8 +101,7 @@ class DICOMEnhancedUSVolumePluginClass(DICOMPlugin):
         return loadables
 
     def load(self, loadable):
-        """Load the selection
-        """
+        """Load the selection"""
 
         if loadable.grayscale:
             volumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", loadable.name)

--- a/Modules/Scripted/DICOMPlugins/DICOMEnhancedUSVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMEnhancedUSVolumePlugin.py
@@ -13,7 +13,7 @@ from slicer.i18n import tr as _
 #
 
 class DICOMEnhancedUSVolumePluginClass(DICOMPlugin):
-    """ 3D ultrasound loader plugin.
+    """3D ultrasound loader plugin.
     Limitation: ultrasound calibrated regions are not supported (each calibrated region
     would need to be split out to its own volume sequence).
     """
@@ -32,7 +32,7 @@ class DICOMEnhancedUSVolumePluginClass(DICOMPlugin):
         self.detailedLogging = False
 
     def examine(self, fileLists):
-        """ Returns a list of DICOMLoadable instances
+        """Returns a list of DICOMLoadable instances
         corresponding to ways of interpreting the
         fileLists parameter.
         """
@@ -43,7 +43,7 @@ class DICOMEnhancedUSVolumePluginClass(DICOMPlugin):
         return loadables
 
     def examineFiles(self, files):
-        """ Returns a list of DICOMLoadable instances
+        """Returns a list of DICOMLoadable instances
         corresponding to ways of interpreting the
         files parameter.
         """

--- a/Modules/Scripted/DICOMPlugins/DICOMGeAbusPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMGeAbusPlugin.py
@@ -163,8 +163,7 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
         return fieldValues
 
     def load(self, loadable):
-        """Load the selection
-        """
+        """Load the selection"""
 
         filePath = loadable.files[0]
         metadata = self.getMetadata(filePath)

--- a/Modules/Scripted/DICOMPlugins/DICOMGeAbusPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMGeAbusPlugin.py
@@ -20,7 +20,7 @@ from DICOMLib import DICOMLoadable
 #
 
 class DICOMGeAbusPluginClass(DICOMPlugin):
-    """ Image loader plugin for GE Invenia
+    """Image loader plugin for GE Invenia
     ABUS (automated breast ultrasound) images.
     """
 
@@ -38,7 +38,7 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
         self.privateCreators = ["U-Systems", "General Electric Company 01"]
 
     def examine(self, fileLists):
-        """ Returns a list of DICOMLoadable instances
+        """Returns a list of DICOMLoadable instances
         corresponding to ways of interpreting the
         fileLists parameter.
         """
@@ -49,7 +49,7 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
         return loadables
 
     def examineFiles(self, files):
-        """ Returns a list of DICOMLoadable instances
+        """Returns a list of DICOMLoadable instances
         corresponding to ways of interpreting the
         files parameter.
         """

--- a/Modules/Scripted/DICOMPlugins/DICOMImageSequencePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMImageSequencePlugin.py
@@ -334,8 +334,7 @@ class DICOMImageSequencePluginClass(DICOMPlugin):
         return outputSequenceNode, playbackRateFps
 
     def load(self, loadable):
-        """Load the selection
-        """
+        """Load the selection"""
 
         outputSequenceNodes = []
 

--- a/Modules/Scripted/DICOMPlugins/DICOMImageSequencePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMImageSequencePlugin.py
@@ -18,7 +18,7 @@ from DICOMLib import DICOMLoadable
 #
 
 class DICOMImageSequencePluginClass(DICOMPlugin):
-    """ 2D image sequence loader plugin.
+    """2D image sequence loader plugin.
     It supports X-ray angiography and ultrasound images.
     The main difference compared to plain scalar volume plugin is that it
     loads frames as a single-slice-volume sequence (and not as a 3D volume),
@@ -44,7 +44,7 @@ class DICOMImageSequencePluginClass(DICOMPlugin):
         self.detailedLogging = False
 
     def examine(self, fileLists):
-        """ Returns a list of DICOMLoadable instances
+        """Returns a list of DICOMLoadable instances
         corresponding to ways of interpreting the
         fileLists parameter.
         """
@@ -55,7 +55,7 @@ class DICOMImageSequencePluginClass(DICOMPlugin):
         return loadables
 
     def examineFiles(self, files):
-        """ Returns a list of DICOMLoadable instances
+        """Returns a list of DICOMLoadable instances
         corresponding to ways of interpreting the
         files parameter.
         """

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -23,8 +23,7 @@ from DICOMLib import DICOMExportScalarVolume
 #
 
 class DICOMScalarVolumePluginClass(DICOMPlugin):
-    """ScalarVolume specific interpretation code
-    """
+    """ScalarVolume specific interpretation code"""
 
     def __init__(self, spacingEpsilon=1e-2, orientationEpsilon=1e-6):
         """
@@ -421,8 +420,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
         return volumesLogic.AddArchetypeScalarVolume(files[0], name, 0, fileList)
 
     def loadFilesWithSeriesReader(self, imageIOName, files, name, grayscale=True):
-        """Explicitly use the named imageIO to perform the loading
-        """
+        """Explicitly use the named imageIO to perform the loading"""
 
         if grayscale:
             reader = vtkITK.vtkITKArchetypeImageSeriesScalarReader()
@@ -548,8 +546,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
                 volumeNode.SetVoxelValueUnits(units)
 
     def loadWithMultipleLoaders(self, loadable):
-        """Load using multiple paths (for testing)
-        """
+        """Load using multiple paths (for testing)"""
         volumeNode = self.loadFilesWithArchetype(loadable.files, loadable.name + "-archetype")
         self.setVolumeNodeProperties(volumeNode, loadable)
         volumeNode = self.loadFilesWithSeriesReader("GDCM", loadable.files, loadable.name + "-gdcm", loadable.grayscale)
@@ -560,8 +557,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
         return volumeNode
 
     def load(self, loadable, readerApproach=None):
-        """Load the select as a scalar volume using desired approach
-        """
+        """Load the select as a scalar volume using desired approach"""
         # first, determine which reader approach the user prefers
         if not readerApproach:
             readerIndex = slicer.util.settingsValue("DICOM/ScalarVolume/ReaderApproach", 0, converter=int)
@@ -753,8 +749,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
             self.zeroEpsilon = zeroEpsilon
 
         def gridTransformFromCorners(self, volumeNode, sourceCorners, targetCorners):
-            """Create a grid transform that maps between the current and the desired corners.
-            """
+            """Create a grid transform that maps between the current and the desired corners."""
             # sanity check
             columns, rows, slices = volumeNode.GetImageData().GetDimensions()
             cornerShape = (slices, 2, 2, 3)

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -23,7 +23,7 @@ from DICOMLib import DICOMExportScalarVolume
 #
 
 class DICOMScalarVolumePluginClass(DICOMPlugin):
-    """ ScalarVolume specific interpretation code
+    """ScalarVolume specific interpretation code
     """
 
     def __init__(self, spacingEpsilon=1e-2, orientationEpsilon=1e-6):
@@ -153,7 +153,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
         return (int(settings.value("DICOM/ScalarVolume/AllowLoadingByTime", "0")) != 0)
 
     def examineForImport(self, fileLists):
-        """ Returns a sorted list of DICOMLoadable instances
+        """Returns a sorted list of DICOMLoadable instances
         corresponding to ways of interpreting the
         fileLists parameter (list of file lists).
         """
@@ -185,7 +185,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
         return numpy.array([float(element) for element in value.split("\\")])
 
     def examineFiles(self, files):
-        """ Returns a list of DICOMLoadable instances
+        """Returns a list of DICOMLoadable instances
         corresponding to ways of interpreting the
         files parameter.
         """
@@ -382,7 +382,9 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
         return loadables
 
     def seriesSorter(self, x, y):
-        """ returns -1, 0, 1 for sorting of strings like: "400: series description"
+        """
+        Returns -1, 0, 1 for sorting of strings like: "400: series description"
+
         Works for DICOMLoadable or other objects with name attribute
         """
         if not (hasattr(x, "name") and hasattr(y, "name")):
@@ -419,7 +421,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
         return volumesLogic.AddArchetypeScalarVolume(files[0], name, 0, fileList)
 
     def loadFilesWithSeriesReader(self, imageIOName, files, name, grayscale=True):
-        """ Explicitly use the named imageIO to perform the loading
+        """Explicitly use the named imageIO to perform the loading
         """
 
         if grayscale:

--- a/Modules/Scripted/DICOMPlugins/DICOMSlicerDataBundlePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMSlicerDataBundlePlugin.py
@@ -17,7 +17,7 @@ from DICOMLib import DICOMExportScene
 #
 
 class DICOMSlicerDataBundlePluginClass(DICOMPlugin):
-    """ DICOM import/export plugin for Slicer Scene Bundle
+    """DICOM import/export plugin for Slicer Scene Bundle
     (MRML scene file embedded in private tag of a DICOM file)
     """
 
@@ -30,7 +30,7 @@ class DICOMSlicerDataBundlePluginClass(DICOMPlugin):
         self.tags["zipData"] = "cadb,1010"
 
     def examineForImport(self, fileLists):
-        """ Returns a list of DICOMLoadable instances
+        """Returns a list of DICOMLoadable instances
         corresponding to ways of interpreting the
         fileLists parameter.
         """
@@ -46,7 +46,7 @@ class DICOMSlicerDataBundlePluginClass(DICOMPlugin):
         return loadables
 
     def examineFiles(self, files):
-        """ Returns a list of DICOMLoadable instances
+        """Returns a list of DICOMLoadable instances
         corresponding to ways of interpreting the
         files parameter.
         Look for the special private creator tags that indicate

--- a/Modules/Scripted/DICOMPlugins/DICOMVolumeSequencePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMVolumeSequencePlugin.py
@@ -16,7 +16,7 @@ from DICOMLib import DICOMExportScalarVolume
 #
 
 class DICOMVolumeSequencePluginClass(DICOMPlugin):
-    """ Volume sequence export plugin
+    """Volume sequence export plugin
     """
 
     def __init__(self):

--- a/Modules/Scripted/DICOMPlugins/DICOMVolumeSequencePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMVolumeSequencePlugin.py
@@ -16,8 +16,7 @@ from DICOMLib import DICOMExportScalarVolume
 #
 
 class DICOMVolumeSequencePluginClass(DICOMPlugin):
-    """Volume sequence export plugin
-    """
+    """Volume sequence export plugin"""
 
     def __init__(self):
         super().__init__()

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -592,13 +592,11 @@ class DataProbeTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         pass
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_DataProbe1()
 

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -592,7 +592,7 @@ class DataProbeTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         pass
 
@@ -603,7 +603,7 @@ class DataProbeTest(ScriptedLoadableModuleTest):
         self.test_DataProbe1()
 
     def test_DataProbe1(self):
-        """ Ideally you should have several levels of tests.  At the lowest level
+        """Ideally you should have several levels of tests.  At the lowest level
         tests should exercise the functionality of the logic with different inputs
         (both valid and invalid).  At higher levels your tests should emulate the
         way the user would interact with your code and confirm that it still works

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -125,7 +125,8 @@ class DataProbeInfoWidget:
 
     def getPixelString(self, volumeNode, ijk):
         """Given a volume node, create a human readable
-        string describing the contents"""
+        string describing the contents
+        """
         # TODO: the volume nodes should have a way to generate
         # these strings in a generic way
         if not volumeNode:
@@ -400,7 +401,8 @@ class DataProbeInfoWidget:
 
     def _createSmall(self):
         """Make the internals of the widget to display in the
-        Data Probe frame (lower left of slicer main window by default)"""
+        Data Probe frame (lower left of slicer main window by default)
+        """
 
         # this method makes SliceView Annotation
         self.sliceAnnotations = DataProbeLib.SliceAnnotations()

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -11,8 +11,7 @@ from . import DataProbeUtil
 
 
 class SliceAnnotations(VTKObservationMixin):
-    """Implement the Qt window showing settings for Slice View Annotations
-    """
+    """Implement the Qt window showing settings for Slice View Annotations"""
 
     DEFAULTS = {
         "enabled": 1,

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -283,7 +283,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget):
         self.frameSlider.value = nextStep
 
     def flyTo(self, pathPointIndex):
-        """ Apply the pathPointIndex-th step in the path to the global camera"""
+        """Apply the pathPointIndex-th step in the path to the global camera"""
 
         if self.path is None:
             return
@@ -407,7 +407,7 @@ class EndoscopyComputePath:
         self.calculatePath()
 
     def calculatePath(self):
-        """ Generate a flight path for of steps of length dl """
+        """Generate a flight path for of steps of length dl"""
         #
         # calculate the actual path
         # - take steps of self.dl in world space
@@ -434,7 +434,7 @@ class EndoscopyComputePath:
                 self.h11(t) * self.m[segment + 1])
 
     def step(self, segment, t, dl):
-        """ Take a step of dl and return the path point and new t
+        """Take a step of dl and return the path point and new t
         return:
         t = new parametric coordinate after step
         p = point after step

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -185,7 +185,8 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget):
 
     def setCameraNode(self, newCameraNode):
         """Allow to set the current camera node.
-        Connected to signal 'currentNodeChanged()' emitted by camera node selector."""
+        Connected to signal 'currentNodeChanged()' emitted by camera node selector.
+        """
 
         #  Remove previous observer
         if self.cameraNode and self.cameraNodeObserverTag:
@@ -221,7 +222,8 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget):
 
     def enableOrDisableCreateButton(self):
         """Connected to both the fiducial and camera node selector. It allows to
-        enable or disable the 'create path' button."""
+        enable or disable the 'create path' button.
+        """
         self.createPathButton.enabled = (self.cameraNodeSelector.currentNode() is not None
                                          and self.inputFiducialsNodeSelector.currentNode() is not None
                                          and self.outputPathNodeSelector.currentNode() is not None)
@@ -229,7 +231,8 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget):
     def onCreatePathButtonClicked(self):
         """Connected to 'create path' button. It allows to:
         - compute the path
-        - create the associated model"""
+        - create the associated model
+        """
 
         fiducialsNode = self.inputFiducialsNodeSelector.currentNode()
         outputPathNode = self.outputPathNodeSelector.currentNode()

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -228,8 +228,8 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget):
 
     def onCreatePathButtonClicked(self):
         """Connected to 'create path' button. It allows to:
-          - compute the path
-          - create the associated model"""
+        - compute the path
+        - create the associated model"""
 
         fiducialsNode = self.inputFiducialsNodeSelector.currentNode()
         outputPathNode = self.outputPathNodeSelector.currentNode()
@@ -435,11 +435,11 @@ class EndoscopyComputePath:
 
     def step(self, segment, t, dl):
         """ Take a step of dl and return the path point and new t
-          return:
-          t = new parametric coordinate after step
-          p = point after step
-          remainder = if step results in parametric coordinate > 1.0, then
-            this is the amount of world space not covered by step
+        return:
+        t = new parametric coordinate after step
+        p = point after step
+        remainder = if step results in parametric coordinate > 1.0, then
+        this is the amount of world space not covered by step
         """
         import numpy.linalg
         p0 = self.path[self.path.__len__() - 1]  # last element in path
@@ -467,18 +467,18 @@ class EndoscopyComputePath:
 
 class EndoscopyPathModel:
     """Create a vtkPolyData for a polyline:
-         - Add one point per path point.
-         - Add a single polyline
+    - Add one point per path point.
+    - Add a single polyline
     """
 
     def __init__(self, path, fiducialListNode, outputPathNode=None, cursorType=None):
         """
-          :param path: path points as numpy array.
-          :param fiducialListNode: input node, just used for naming the output node.
-          :param outputPathNode: output model node that stores the path points.
-          :param cursorType: can be 'markups' or 'model'. Markups has a number of advantages (radius it is easier to change the size,
-            can jump to views by clicking on it, has more visualization options, can be scaled to fixed display size),
-            but if some applications relied on having a model node as cursor then this argument can be used to achieve that.
+        :param path: path points as numpy array.
+        :param fiducialListNode: input node, just used for naming the output node.
+        :param outputPathNode: output model node that stores the path points.
+        :param cursorType: can be 'markups' or 'model'. Markups has a number of advantages (radius it is easier to change the size,
+        can jump to views by clicking on it, has more visualization options, can be scaled to fixed display size),
+        but if some applications relied on having a model node as cursor then this argument can be used to achieve that.
         """
 
         fids = fiducialListNode

--- a/Modules/Scripted/PerformanceTests/PerformanceTests.py
+++ b/Modules/Scripted/PerformanceTests/PerformanceTests.py
@@ -86,8 +86,7 @@ class PerformanceTestsWidget(ScriptedLoadableModuleWidget):
         self.log.repaint()
 
     def reslicing(self, iters=100):
-        """go into a loop that stresses the reslice performance
-        """
+        """go into a loop that stresses the reslice performance"""
         import time
         import math
         import numpy as np
@@ -125,8 +124,7 @@ class PerformanceTestsWidget(ScriptedLoadableModuleWidget):
         self.log.repaint()
 
     def crosshairJump(self, iters=15):
-        """go into a loop that stresses jumping to slices by moving crosshair
-        """
+        """go into a loop that stresses jumping to slices by moving crosshair"""
         import time
         sliceNode = slicer.util.getNode("vtkMRMLSliceNodeRed")
         dims = sliceNode.GetDimensions()

--- a/Modules/Scripted/PerformanceTests/PerformanceTests.py
+++ b/Modules/Scripted/PerformanceTests/PerformanceTests.py
@@ -86,7 +86,7 @@ class PerformanceTestsWidget(ScriptedLoadableModuleWidget):
         self.log.repaint()
 
     def reslicing(self, iters=100):
-        """ go into a loop that stresses the reslice performance
+        """go into a loop that stresses the reslice performance
         """
         import time
         import math
@@ -125,7 +125,7 @@ class PerformanceTestsWidget(ScriptedLoadableModuleWidget):
         self.log.repaint()
 
     def crosshairJump(self, iters=15):
-        """ go into a loop that stresses jumping to slices by moving crosshair
+        """go into a loop that stresses jumping to slices by moving crosshair
         """
         import time
         sliceNode = slicer.util.getNode("vtkMRMLSliceNodeRed")

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -280,8 +280,7 @@ class SampleDataWidget(ScriptedLoadableModuleWidget):
 
     @staticmethod
     def removeCategories(categoryLayout):
-        """Remove all categories from the given category layout.
-        """
+        """Remove all categories from the given category layout."""
         while categoryLayout.count() > 0:
             frame = categoryLayout.itemAt(0).widget()
             frame.visible = False
@@ -490,8 +489,7 @@ class SampleDataLogic:
 
     @staticmethod
     def isSampleDataSourceRegistered(category, sampleDataSource):
-        """Returns True if the sampleDataSource is registered with the category.
-        """
+        """Returns True if the sampleDataSource is registered with the category."""
         try:
             slicer.modules.sampleDataSources
         except AttributeError:
@@ -735,8 +733,7 @@ class SampleDataLogic:
         return None
 
     def categoryForSource(self, a_source):
-        """For a given SampleDataSource return the associated category name.
-        """
+        """For a given SampleDataSource return the associated category name."""
         for category in slicer.modules.sampleDataSources.keys():
             for source in slicer.modules.sampleDataSources[category]:
                 if a_source == source:

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -833,7 +833,7 @@ class SampleDataLogic:
         return self.downloadSamples("MRUSProstate")
 
     def humanFormatSize(self, size):
-        """ from https://stackoverflow.com/questions/1094841/reusable-library-to-get-human-readable-version-of-file-size"""
+        """from https://stackoverflow.com/questions/1094841/reusable-library-to-get-human-readable-version-of-file-size"""
         for x in ["bytes", "KB", "MB", "GB"]:
             if size < 1024.0 and size > -1024.0:
                 return f"{size:3.1f} {x}"

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -48,13 +48,15 @@ def downloadFromURL(uris=None, fileNames=None, nodeNames=None, checksums=None, l
 
 def downloadSample(sampleName):
     """For a given sample name this will search the available sources
-    and load it if it is available.  Returns the first loaded node."""
+    and load it if it is available.  Returns the first loaded node.
+    """
     return SampleDataLogic().downloadSamples(sampleName)[0]
 
 
 def downloadSamples(sampleName):
     """For a given sample name this will search the available sources
-    and load it if it is available.  Returns the loaded nodes."""
+    and load it if it is available.  Returns the loaded nodes.
+    """
     return SampleDataLogic().downloadSamples(sampleName)
 
 
@@ -619,7 +621,8 @@ class SampleDataLogic:
 
     def downloadFileIntoCache(self, uri, name, checksum=None):
         """Given a uri and and a filename, download the data into
-        a file of the given name in the scene's cache"""
+        a file of the given name in the scene's cache
+        """
         destFolderPath = slicer.mrmlScene.GetCacheManager().GetRemoteCacheDirectory()
 
         if not os.access(destFolderPath, os.W_OK):
@@ -633,7 +636,8 @@ class SampleDataLogic:
 
     def downloadSourceIntoCache(self, source):
         """Download all files for the given source and return a
-        list of file paths for the results"""
+        list of file paths for the results
+        """
         filePaths = []
         for uri, fileName, checksum in zip(source.uris, source.fileNames, source.checksums):
             filePaths.append(self.downloadFileIntoCache(uri, fileName, checksum))
@@ -725,7 +729,8 @@ class SampleDataLogic:
 
     def sourceForSampleName(self, sampleName):
         """For a given sample name this will search the available sources.
-        Returns SampleDataSource instance."""
+        Returns SampleDataSource instance.
+        """
         for category in slicer.modules.sampleDataSources.keys():
             for source in slicer.modules.sampleDataSources[category]:
                 if sampleName == source.sampleName:
@@ -774,12 +779,14 @@ class SampleDataLogic:
 
     def downloadSample(self, sampleName):
         """For a given sample name this will search the available sources
-        and load it if it is available.  Returns the first loaded node."""
+        and load it if it is available.  Returns the first loaded node.
+        """
         return self.downloadSamples(sampleName)[0]
 
     def downloadSamples(self, sampleName):
         """For a given sample name this will search the available sources
-        and load it if it is available.  Returns the loaded nodes."""
+        and load it if it is available.  Returns the loaded nodes.
+        """
         source = self.sourceForSampleName(sampleName)
         nodes = []
         if source:

--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -508,8 +508,7 @@ class ScreenCaptureWidget(ScriptedLoadableModuleWidget):
             return None
 
     def addLog(self, text):
-        """Append text to log window
-        """
+        """Append text to log window"""
         self.statusLabel.appendPlainText(text)
         self.statusLabel.ensureCursorVisible()
         slicer.app.processEvents()  # force update
@@ -1282,9 +1281,7 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
 
     def capture3dViewRotation(self, viewNode, startRotation, endRotation, numberOfImages, rotationAxis,
                               outputDir, outputFilenamePattern, captureAllViews=None, transparentBackground=False):
-        """
-        Acquire a set of screenshots of the 3D view while rotating it.
-        """
+        """Acquire a set of screenshots of the 3D view while rotating it."""
 
         self.cancelRequested = False
 
@@ -1344,9 +1341,7 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
     def captureSequence(self, viewNode, sequenceBrowserNode, sequenceStartIndex,
                         sequenceEndIndex, numberOfImages, outputDir, outputFilenamePattern,
                         captureAllViews=None, transparentBackground=False):
-        """
-        Acquire a set of screenshots of a view while iterating through a sequence.
-        """
+        """Acquire a set of screenshots of a view while iterating through a sequence."""
 
         self.cancelRequested = False
 
@@ -1450,9 +1445,7 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
             logging.debug("ffmpeg error output: " + stderr.decode())
 
     def deleteTemporaryFiles(self, outputDir, imageFileNamePattern, numberOfImages):
-        """
-        Delete files after a video has been created from them.
-        """
+        """Delete files after a video has been created from them."""
         import os
         filePathPattern = os.path.join(outputDir, imageFileNamePattern)
         for imageIndex in range(numberOfImages):
@@ -1461,9 +1454,7 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
             os.remove(filename)
 
     def getNextAvailableFileName(self, outputDir, outputFilenamePattern, snapshotIndex):
-        """
-        Find a file index that does not overwrite any existing file.
-        """
+        """Find a file index that does not overwrite any existing file."""
         if not os.path.exists(outputDir):
             os.makedirs(outputDir)
         filePathPattern = os.path.join(outputDir, outputFilenamePattern)
@@ -1485,8 +1476,7 @@ class ScreenCaptureTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
         import SampleData
         self.image1 = SampleData.downloadSample("MRBrainTumor1")
@@ -1522,8 +1512,7 @@ class ScreenCaptureTest(ScriptedLoadableModuleTest):
             self.assertFalse(os.path.exists(filename))
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_SliceSweep()
         self.test_SliceFade()

--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -1485,7 +1485,7 @@ class ScreenCaptureTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
         import SampleData

--- a/Modules/Scripted/SegmentEditor/SegmentEditor.py
+++ b/Modules/Scripted/SegmentEditor/SegmentEditor.py
@@ -164,7 +164,7 @@ class SegmentEditorTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Modules/Scripted/SegmentEditor/SegmentEditor.py
+++ b/Modules/Scripted/SegmentEditor/SegmentEditor.py
@@ -110,8 +110,7 @@ class SegmentEditorWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         return firstForegroundVolumeID
 
     def enter(self):
-        """Runs whenever the module is reopened
-        """
+        """Runs whenever the module is reopened"""
         if self.editor.turnOffLightboxes():
             slicer.util.warningDisplay(_("Segment Editor is not compatible with slice viewers in light box mode."
                                          "Views are being reset."), windowTitle=_("Segment Editor"))
@@ -159,23 +158,18 @@ class SegmentEditorWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
 
 class SegmentEditorTest(ScriptedLoadableModuleTest):
-    """
-    This is the test case for your scripted module.
-    """
+    """This is the test case for your scripted module."""
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Currently no testing functionality.
-        """
+        """Currently no testing functionality."""
         self.setUp()
         self.test_SegmentEditor1()
 
     def test_SegmentEditor1(self):
-        """Add test here later.
-        """
+        """Add test here later."""
         self.delayDisplay("Starting the test")
         self.delayDisplay("Test passed!")

--- a/Modules/Scripted/SegmentEditor/SubjectHierarchyPlugins/SegmentEditorSubjectHierarchyPlugin.py
+++ b/Modules/Scripted/SegmentEditor/SubjectHierarchyPlugins/SegmentEditorSubjectHierarchyPlugin.py
@@ -10,7 +10,7 @@ from AbstractScriptedSubjectHierarchyPlugin import *
 
 
 class SegmentEditorSubjectHierarchyPlugin(AbstractScriptedSubjectHierarchyPlugin):
-    """ Scripted subject hierarchy plugin for the Segment Editor module.
+    """Scripted subject hierarchy plugin for the Segment Editor module.
 
     This is also an example for scripted plugins, so includes all possible methods.
     The methods that are not needed (i.e. the default implementation in

--- a/Modules/Scripted/SegmentEditor/SubjectHierarchyPlugins/SegmentEditorSubjectHierarchyPlugin.py
+++ b/Modules/Scripted/SegmentEditor/SubjectHierarchyPlugins/SegmentEditorSubjectHierarchyPlugin.py
@@ -12,10 +12,10 @@ from AbstractScriptedSubjectHierarchyPlugin import *
 class SegmentEditorSubjectHierarchyPlugin(AbstractScriptedSubjectHierarchyPlugin):
     """ Scripted subject hierarchy plugin for the Segment Editor module.
 
-        This is also an example for scripted plugins, so includes all possible methods.
-        The methods that are not needed (i.e. the default implementation in
-        qSlicerSubjectHierarchyAbstractPlugin is satisfactory) can simply be
-        omitted in plugins created based on this one.
+    This is also an example for scripted plugins, so includes all possible methods.
+    The methods that are not needed (i.e. the default implementation in
+    qSlicerSubjectHierarchyAbstractPlugin is satisfactory) can simply be
+    omitted in plugins created based on this one.
     """
 
     # Necessary static member to be able to set python source to scripted subject hierarchy plugin

--- a/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
@@ -165,8 +165,7 @@ class SegmentStatisticsWidget(ScriptedLoadableModuleWidget):
         self.onParameterSetSelected()
 
     def enter(self):
-        """Runs whenever the module is reopened
-        """
+        """Runs whenever the module is reopened"""
         if self.parameterNodeSelector.currentNode() is None:
             parameterNode = self.logic.getParameterNode()
             slicer.mrmlScene.AddNode(parameterNode)
@@ -186,8 +185,7 @@ class SegmentStatisticsWidget(ScriptedLoadableModuleWidget):
             self.outputTableSelector.baseName = self.segmentationSelector.currentNode().GetName() + " statistics"
 
     def onApply(self):
-        """Calculate the label statistics
-        """
+        """Calculate the label statistics"""
 
         with slicer.util.tryWithErrorDisplay(_("Failed to compute results."), waitCursor=True):
             if not self.outputTableSelector.currentNode():
@@ -572,9 +570,7 @@ class SegmentStatisticsLogic(ScriptedLoadableModuleLogic):
         return headerNames, uniqueHeaderNames
 
     def exportToTable(self, table, nonEmptyKeysOnly=True):
-        """
-        Export statistics to table node
-        """
+        """Export statistics to table node"""
         tableWasModified = table.StartModify()
         table.RemoveAllColumns()
 
@@ -655,9 +651,7 @@ class SegmentStatisticsLogic(ScriptedLoadableModuleLogic):
         table.EndModify(tableWasModified)
 
     def showTable(self, table):
-        """
-        Switch to a layout where tables are visible and show the selected table
-        """
+        """Switch to a layout where tables are visible and show the selected table"""
         currentLayout = slicer.app.layoutManager().layout
         layoutWithTable = slicer.modules.tables.logic().GetLayoutWithTable(currentLayout)
         slicer.app.layoutManager().setLayout(layoutWithTable)
@@ -665,9 +659,7 @@ class SegmentStatisticsLogic(ScriptedLoadableModuleLogic):
         slicer.app.applicationLogic().PropagateTableSelection()
 
     def exportToString(self, nonEmptyKeysOnly=True):
-        """
-        Returns string with comma separated values, with header keys in quotes.
-        """
+        """Returns string with comma separated values, with header keys in quotes."""
         keys = self.getNonEmptyKeys() if nonEmptyKeysOnly else self.keys
         # Header
         csv = '"' + '","'.join(keys) + '"'
@@ -696,13 +688,11 @@ class SegmentStatisticsTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self, scenario=None):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_SegmentStatisticsBasic()
 
@@ -710,9 +700,7 @@ class SegmentStatisticsTest(ScriptedLoadableModuleTest):
         self.test_SegmentStatisticsPlugins()
 
     def test_SegmentStatisticsBasic(self):
-        """
-        This tests some aspects of the label statistics
-        """
+        """This tests some aspects of the label statistics"""
 
         self.delayDisplay("Starting test_SegmentStatisticsBasic")
 
@@ -767,9 +755,7 @@ class SegmentStatisticsTest(ScriptedLoadableModuleTest):
         self.delayDisplay("test_SegmentStatisticsBasic passed!")
 
     def test_SegmentStatisticsPlugins(self):
-        """
-        This tests some aspects of the segment statistics plugins
-        """
+        """This tests some aspects of the segment statistics plugins"""
 
         self.delayDisplay("Starting test_SegmentStatisticsPlugins")
 
@@ -963,8 +949,7 @@ class Slicelet:
 
 
 class SegmentStatisticsSlicelet(Slicelet):
-    """Creates the interface when module is run as a stand alone gui app.
-    """
+    """Creates the interface when module is run as a stand alone gui app."""
 
     def __init__(self):
         super().__init__(SegmentStatisticsWidget)

--- a/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
@@ -696,7 +696,7 @@ class SegmentStatisticsTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 
@@ -963,7 +963,7 @@ class Slicelet:
 
 
 class SegmentStatisticsSlicelet(Slicelet):
-    """ Creates the interface when module is run as a stand alone gui app.
+    """Creates the interface when module is run as a stand alone gui app.
     """
 
     def __init__(self):

--- a/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
@@ -359,6 +359,7 @@ class SegmentStatisticsLogic(ScriptedLoadableModuleLogic):
     Uses ScriptedLoadableModuleLogic base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
+
     registeredPlugins = [LabelmapSegmentStatisticsPlugin, ScalarVolumeSegmentStatisticsPlugin,
                          ClosedSurfaceSegmentStatisticsPlugin]
 
@@ -936,6 +937,7 @@ class Slicelet:
     implemented as a python class.
     This class provides common wrapper functionality used by all slicer modlets.
     """
+
     # TODO: put this in a SliceletLib
     # TODO: parse command line args
 

--- a/Modules/Scripted/SegmentStatistics/SubjectHierarchyPlugins/SegmentStatisticsSubjectHierarchyPlugin.py
+++ b/Modules/Scripted/SegmentStatistics/SubjectHierarchyPlugins/SegmentStatisticsSubjectHierarchyPlugin.py
@@ -9,7 +9,7 @@ from AbstractScriptedSubjectHierarchyPlugin import *
 
 
 class SegmentStatisticsSubjectHierarchyPlugin(AbstractScriptedSubjectHierarchyPlugin):
-    """ Scripted subject hierarchy plugin for the Segment Statistics module.
+    """Scripted subject hierarchy plugin for the Segment Statistics module.
 
     This is also an example for scripted plugins, so includes all possible methods.
     The methods that are not needed (i.e. the default implementation in

--- a/Modules/Scripted/SegmentStatistics/SubjectHierarchyPlugins/SegmentStatisticsSubjectHierarchyPlugin.py
+++ b/Modules/Scripted/SegmentStatistics/SubjectHierarchyPlugins/SegmentStatisticsSubjectHierarchyPlugin.py
@@ -11,10 +11,10 @@ from AbstractScriptedSubjectHierarchyPlugin import *
 class SegmentStatisticsSubjectHierarchyPlugin(AbstractScriptedSubjectHierarchyPlugin):
     """ Scripted subject hierarchy plugin for the Segment Statistics module.
 
-        This is also an example for scripted plugins, so includes all possible methods.
-        The methods that are not needed (i.e. the default implementation in
-        qSlicerSubjectHierarchyAbstractPlugin is satisfactory) can simply be
-        omitted in plugins created based on this one.
+    This is also an example for scripted plugins, so includes all possible methods.
+    The methods that are not needed (i.e. the default implementation in
+    qSlicerSubjectHierarchyAbstractPlugin is satisfactory) can simply be
+    omitted in plugins created based on this one.
     """
 
     # Necessary static member to be able to set python source to scripted subject hierarchy plugin

--- a/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
+++ b/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
@@ -116,9 +116,7 @@ class VectorToScalarVolumeWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     _parameterNode: Optional[VectorToScalarVolumeParameterNode]
 
     def __init__(self, parent=None):
-        """
-        Called when the user opens the module the first time and the widget is initialized.
-        """
+        """Called when the user opens the module the first time and the widget is initialized."""
         ScriptedLoadableModuleWidget.__init__(self, parent)
         VTKObservationMixin.__init__(self)  # needed for parameter node observation
         self.logic = None
@@ -126,9 +124,7 @@ class VectorToScalarVolumeWidget(ScriptedLoadableModuleWidget, VTKObservationMix
         self._updatingGUIFromParameterNode = False
 
     def setup(self):
-        """
-        Called when the user opens the module the first time and the widget is initialized.
-        """
+        """Called when the user opens the module the first time and the widget is initialized."""
         ScriptedLoadableModuleWidget.setup(self)
 
         # Load widget from .ui file (created by Qt Designer).
@@ -172,44 +168,32 @@ class VectorToScalarVolumeWidget(ScriptedLoadableModuleWidget, VTKObservationMix
         self.initializeParameterNode()
 
     def cleanup(self):
-        """
-        Called when the application closes and the module widget is destroyed.
-        """
+        """Called when the application closes and the module widget is destroyed."""
         self.removeObservers()
 
     def enter(self):
-        """
-        Called each time the user opens this module.
-        """
+        """Called each time the user opens this module."""
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
 
     def exit(self):
-        """
-        Called each time the user opens a different module.
-        """
+        """Called each time the user opens a different module."""
         # Do not react to parameter node changes (GUI wlil be updated when the user enters into the module)
         self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
 
     def onSceneStartClose(self, caller, event):
-        """
-        Called just before the scene is closed.
-        """
+        """Called just before the scene is closed."""
         # Parameter node will be reset, do not use it anymore
         self.setParameterNode(None)
 
     def onSceneEndClose(self, caller, event):
-        """
-        Called just after the scene is closed.
-        """
+        """Called just after the scene is closed."""
         # If this module is shown while the scene is closed then recreate a new parameter node immediately
         if self.parent.isEntered:
             self.initializeParameterNode()
 
     def initializeParameterNode(self):
-        """
-        Ensure parameter node exists and observed.
-        """
+        """Ensure parameter node exists and observed."""
         # Parameter node stores all user choices in parameter values, node selections, etc.
         # so that when the scene is saved and reloaded, these settings are restored.
 
@@ -295,9 +279,7 @@ class VectorToScalarVolumeWidget(ScriptedLoadableModuleWidget, VTKObservationMix
             self._parameterNode.ComponentToExtract = self.ui.componentsSpinBox.value
 
     def onApplyButton(self):
-        """
-        Run processing when user clicks "Apply" button.
-        """
+        """Run processing when user clicks "Apply" button."""
         with slicer.util.tryWithErrorDisplay(_("Failed to compute results."), waitCursor=True):
 
             # Compute output
@@ -320,9 +302,7 @@ class VectorToScalarVolumeLogic(ScriptedLoadableModuleLogic):
     """
 
     def __init__(self):
-        """
-        Called when the logic class is instantiated. Can be used for initializing member variables.
-        """
+        """Called when the logic class is instantiated. Can be used for initializing member variables."""
         ScriptedLoadableModuleLogic.__init__(self)
 
     @staticmethod
@@ -379,9 +359,7 @@ class VectorToScalarVolumeLogic(ScriptedLoadableModuleLogic):
         return True, None
 
     def run(self, parameterNode):
-        """
-        Run the conversion with given parameterNode.
-        """
+        """Run the conversion with given parameterNode."""
         if parameterNode is None:
             raise ValueError(_t("Invalid Parameter Node: None"))
 
@@ -507,13 +485,11 @@ class VectorToScalarVolumeTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear()
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_VectorToScalarVolume1()
 

--- a/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
+++ b/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
@@ -15,7 +15,7 @@ from slicer.parameterNodeWrapper import parameterNodeWrapper
 
 @contextmanager
 def MyScopedQtPropertySetter(qobject, properties):
-    """ Context manager to set/reset properties"""
+    """Context manager to set/reset properties"""
     # TODO: Move it to slicer.utils and delete it here.
     previousValues = {}
     for propertyName, propertyValue in properties.items():
@@ -413,7 +413,7 @@ class VectorToScalarVolumeLogic(ScriptedLoadableModuleLogic):
             self.runConversionMethodAverage(inputVolumeNode, outputVolumeNode)
 
     def runWithVariables(self, inputVolumeNode, outputVolumeNode, conversionMethod, componentToExtract=0):
-        """ Convenience method to run with variables, it creates a new parameterNode with these values. """
+        """Convenience method to run with variables, it creates a new parameterNode with these values."""
 
         parameterNode = VectorToScalarVolumeParameterNode(self.getParameterNode())
         parameterNode.InputVolume = inputVolumeNode
@@ -507,7 +507,7 @@ class VectorToScalarVolumeTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear()
 
@@ -518,7 +518,7 @@ class VectorToScalarVolumeTest(ScriptedLoadableModuleTest):
         self.test_VectorToScalarVolume1()
 
     def test_VectorToScalarVolume1(self):
-        """ Ideally you should have several levels of tests.  At the lowest level
+        """Ideally you should have several levels of tests.  At the lowest level
         tests should exercise the functionality of the logic with different inputs
         (both valid and invalid).  At higher levels your tests should emulate the
         way the user would interact with your code and confirm that it still works

--- a/Modules/Scripted/WebServer/WebServer.py
+++ b/Modules/Scripted/WebServer/WebServer.py
@@ -269,6 +269,7 @@ class SlicerHTTPServer(HTTPServer):
     This web server is configured to integrate with the Qt main loop
     by listening activity on the fileno of the servers socket.
     """
+
     # TODO: set header so client knows that image refreshes are needed (avoid
     # using the &time=xxx trick)
     def __init__(self,
@@ -314,6 +315,7 @@ class SlicerHTTPServer(HTTPServer):
         This class handles event driven chunking of the communication.
         .. note:: this is an internal class of the web server
         """
+
         def __init__(self,
                      connectionSocket:socket.socket,
                      requestHandlers:list[BaseRequestHandler],
@@ -557,6 +559,7 @@ class WebServerLogic:
     Exec interface is enabled if enableExec and enableSlicer are both set to True
     (enableExec is set to False by default for improved security).
     """
+
     def __init__(self,
                  port:Optional[int]=None,
                  enableSlicer:bool=True,

--- a/Modules/Scripted/WebServer/WebServerLib/BaseRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/BaseRequestHandler.py
@@ -1,6 +1,4 @@
-"""
-Base interface(s) for the Slicer WebServer module.
-"""
+"""Base interface(s) for the Slicer WebServer module."""
 
 import abc
 from typing import Callable, Optional

--- a/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
@@ -120,9 +120,7 @@ class SlicerRequestHandler(BaseRequestHandler):
         return contentType, responseBody
 
     def exec(self, request, requestBody):
-        """
-        Handle requests with path: /exec
-        """
+        """Handle requests with path: /exec"""
         self.logMessage("exec with body %s" % requestBody)
         p = urllib.parse.urlparse(request.decode())
         q = urllib.parse.parse_qs(p.query)
@@ -179,9 +177,7 @@ class SlicerRequestHandler(BaseRequestHandler):
                 self.trackingDevice.SetAndObserveTransformNodeID(self.tracker.GetID())
 
     def tracking(self, request):
-        """
-        Handle requests with path: /tracking
-        """
+        """Handle requests with path: /tracking"""
         p = urllib.parse.urlparse(request.decode())
         q = urllib.parse.parse_qs(p.query)
         self.logMessage(q)
@@ -231,9 +227,7 @@ class SlicerRequestHandler(BaseRequestHandler):
         return (f"Set matrix".encode()), b"text/plain"
 
     def sampleData(self, request):
-        """
-        Handle requests with path: /sampledata
-        """
+        """Handle requests with path: /sampledata"""
         p = urllib.parse.urlparse(request.decode())
         q = urllib.parse.parse_qs(p.query)
         self.logMessage(f"SampleData request: {repr(request)}")
@@ -510,8 +504,7 @@ space origin: %%origin%%
         return nrrdData, b"application/octet-stream"
 
     def getTransformNRRD(self, transformID):
-        """Return a nrrd binary blob with contents of the transform node
-        """
+        """Return a nrrd binary blob with contents of the transform node"""
         transformNode = slicer.util.getNode(transformID)
         transformArray = slicer.util.array(transformID)
 
@@ -721,9 +714,7 @@ space origin: %%origin%%
         return nodes
 
     def mrml(self, method, request):
-        """
-        Handle requests with path: /mrml
-        """
+        """Handle requests with path: /mrml"""
         import json
         p = urllib.parse.urlparse(request.decode())
         q = urllib.parse.parse_qs(p.query)
@@ -791,9 +782,7 @@ space origin: %%origin%%
             return b'{"success": true}', b"application/json"
 
     def system(self, method, request):
-        """
-        Handle requests with path: /system
-        """
+        """Handle requests with path: /system"""
         p = urllib.parse.urlparse(request.decode())
         q = urllib.parse.parse_qs(p.query)
 
@@ -828,9 +817,7 @@ space origin: %%origin%%
             return json.dumps(response).encode(), b"application/json"
 
     def screenshot(self, request):
-        """
-        Returns screenshot of the application main window.
-        """
+        """Returns screenshot of the application main window."""
         slicer.app.processEvents()
         slicer.util.forceRenderAllViews()
         screenshot = slicer.util.mainWindow().grab()
@@ -854,9 +841,7 @@ space origin: %%origin%%
         raise RuntimeError("Unknown layout name: " + layoutName)
 
     def gui(self, method, request):
-        """
-        Handle requests with path: /gui
-        """
+        """Handle requests with path: /gui"""
 
         p = urllib.parse.urlparse(request.decode())
         q = urllib.parse.parse_qs(p.query)

--- a/Utilities/Scripts/SEMToMediaWiki.py
+++ b/Utilities/Scripts/SEMToMediaWiki.py
@@ -13,9 +13,7 @@ import xml.dom.minidom
 
 
 def getTextValuesFromNode(nodelist):
-    r"""
-    Get this nodes text information.
-    """
+    r"""Get this nodes text information."""
     rc = []
     for node in nodelist:
         if node.nodeType == node.TEXT_NODE:
@@ -24,9 +22,7 @@ def getTextValuesFromNode(nodelist):
 
 
 def getThisNodesInfoAsText(currentNode, label):
-    r"""
-    Only get the text info for the matching label at this level of the tree
-    """
+    r"""Only get the text info for the matching label at this level of the tree"""
     labelNodeList = [node for node in
                      currentNode.childNodes if node.nodeName == label]
 
@@ -37,9 +33,7 @@ def getThisNodesInfoAsText(currentNode, label):
 
 
 def getLongFlagDefinition(currentNode):
-    r"""
-    Extract the long flag, and color the text string
-    """
+    r"""Extract the long flag, and color the text string"""
     labelNodeList = currentNode.getElementsByTagName("longflag")
     if labelNodeList.length > 0:
         labelNode = labelNodeList[0]  # Only get the first one
@@ -49,9 +43,7 @@ def getLongFlagDefinition(currentNode):
 
 
 def getFlagDefinition(currentNode):
-    r"""
-    Extract the (short) flag, and color the text string
-    """
+    r"""Extract the (short) flag, and color the text string"""
     labelNodeList = currentNode.getElementsByTagName("flag")
     if labelNodeList.length > 0:
         labelNode = labelNodeList[0]  # Only get the first one
@@ -61,9 +53,7 @@ def getFlagDefinition(currentNode):
 
 
 def getLabelDefinition(currentNode):
-    r"""
-    Extract the nodes label, and color the text string
-    """
+    r"""Extract the nodes label, and color the text string"""
     labelNodeList = currentNode.getElementsByTagName("label")
     if labelNodeList.length > 0:
         labelNode = labelNodeList[0]  # Only get the first one
@@ -73,9 +63,7 @@ def getLabelDefinition(currentNode):
 
 
 def getDefaultValueDefinition(currentNode):
-    r"""
-    Extract the default value
-    """
+    r"""Extract the default value"""
     labelNodeList = currentNode.getElementsByTagName("default")
     if labelNodeList.length > 0:
         labelNode = labelNodeList[0]  # Only get the first one
@@ -97,9 +85,7 @@ def GetSEMDoc(filename):
 
 
 def DumpSEMMediaWikiHeader(executableNode):
-    r"""
-    Just dump the header section of the MediaWikiPage
-    """
+    r"""Just dump the header section of the MediaWikiPage"""
 
     outputRegionTemplate = """
 __NOTOC__

--- a/Utilities/Scripts/SlicerWizard/Utilities.py
+++ b/Utilities/Scripts/SlicerWizard/Utilities.py
@@ -358,6 +358,7 @@ class SourceTreeDirectory:
 
       The relative path to the source directory.
     """
+
     # ---------------------------------------------------------------------------
 
     def __init__(self, root, relative_directory):

--- a/Utilities/Scripts/python_package_updater.py
+++ b/Utilities/Scripts/python_package_updater.py
@@ -48,16 +48,14 @@ def parse_pip_list_output(packages_to_update):
 
 
 def external_project_filepaths(directory):
-    """Yield a generator of external project filepaths found in ``directory``.
-    """
+    """Yield a generator of external project filepaths found in ``directory``."""
     for dirpath, _, filenames, in os.walk(directory):
         for filename in filenames:
             yield os.path.join(dirpath, filename)
 
 
 def hint_validation_mismatch_summary(mismatches):
-    """Format list of hint validation mismatches for display purpose.
-    """
+    """Format list of hint validation mismatches for display purpose."""
     return "\n".join([f"{filepath}\n  {first} != {second}" for filepath, first, second in mismatches])
 
 

--- a/Utilities/Scripts/update_translations.py
+++ b/Utilities/Scripts/update_translations.py
@@ -141,8 +141,7 @@ def restore_patched_python_files(source_files, root_dir):
 
 
 def get_lupdate_version(lupdate_path):
-    """Get version of lupdate. There are significant differences between lupdate capabilities in Qt5 and Qt6.
-    """
+    """Get version of lupdate. There are significant differences between lupdate capabilities in Qt5 and Qt6."""
     output = subprocess.check_output([lupdate_path, "-version"]).decode()  # returns 'lupdate version 5.15.2\r'
     m = re.match(r"lupdate version ([0-9]+)\.([0-9]+)\.([0-9]+).*", output)
     return [int(m.groups()[0]), int(m.groups()[1]), int(m.groups()[2])]

--- a/Utilities/Templates/Modules/Scripted/TemplateKey.py
+++ b/Utilities/Templates/Modules/Scripted/TemplateKey.py
@@ -114,6 +114,7 @@ class TemplateKeyParameterNode:
     thresholdedVolume - The output volume that will contain the thresholded volume.
     invertedVolume - The output volume that will contain the inverted thresholded volume.
     """
+
     inputVolume: vtkMRMLScalarVolumeNode
     imageThreshold: Annotated[float, WithinRange(-100, 500)] = 100
     invertThreshold: bool = False

--- a/Utilities/Templates/Modules/Scripted/TemplateKey.py
+++ b/Utilities/Templates/Modules/Scripted/TemplateKey.py
@@ -342,7 +342,7 @@ class TemplateKeyTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear()
 
@@ -353,7 +353,7 @@ class TemplateKeyTest(ScriptedLoadableModuleTest):
         self.test_TemplateKey1()
 
     def test_TemplateKey1(self):
-        """ Ideally you should have several levels of tests.  At the lowest level
+        """Ideally you should have several levels of tests.  At the lowest level
         tests should exercise the functionality of the logic with different inputs
         (both valid and invalid).  At higher levels your tests should emulate the
         way the user would interact with your code and confirm that it still works

--- a/Utilities/Templates/Modules/Scripted/TemplateKey.py
+++ b/Utilities/Templates/Modules/Scripted/TemplateKey.py
@@ -54,9 +54,7 @@ and Steve Pieper, Isomics, Inc. and was partially funded by NIH grant 3P41RR0132
 #
 
 def registerSampleData():
-    """
-    Add data sets to Sample Data module.
-    """
+    """Add data sets to Sample Data module."""
     # It is always recommended to provide sample data for users to make it easy to try the module,
     # but if no sample data is available then this method (and associated startupCompeted signal connection) can be removed.
 
@@ -132,9 +130,7 @@ class TemplateKeyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """
 
     def __init__(self, parent=None) -> None:
-        """
-        Called when the user opens the module the first time and the widget is initialized.
-        """
+        """Called when the user opens the module the first time and the widget is initialized."""
         ScriptedLoadableModuleWidget.__init__(self, parent)
         VTKObservationMixin.__init__(self)  # needed for parameter node observation
         self.logic = None
@@ -142,9 +138,7 @@ class TemplateKeyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self._parameterNodeGuiTag = None
 
     def setup(self) -> None:
-        """
-        Called when the user opens the module the first time and the widget is initialized.
-        """
+        """Called when the user opens the module the first time and the widget is initialized."""
         ScriptedLoadableModuleWidget.setup(self)
 
         # Load widget from .ui file (created by Qt Designer).
@@ -175,22 +169,16 @@ class TemplateKeyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.initializeParameterNode()
 
     def cleanup(self) -> None:
-        """
-        Called when the application closes and the module widget is destroyed.
-        """
+        """Called when the application closes and the module widget is destroyed."""
         self.removeObservers()
 
     def enter(self) -> None:
-        """
-        Called each time the user opens this module.
-        """
+        """Called each time the user opens this module."""
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
 
     def exit(self) -> None:
-        """
-        Called each time the user opens a different module.
-        """
+        """Called each time the user opens a different module."""
         # Do not react to parameter node changes (GUI will be updated when the user enters into the module)
         if self._parameterNode:
             self._parameterNode.disconnectGui(self._parameterNodeGuiTag)
@@ -198,24 +186,18 @@ class TemplateKeyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self._checkCanApply)
 
     def onSceneStartClose(self, caller, event) -> None:
-        """
-        Called just before the scene is closed.
-        """
+        """Called just before the scene is closed."""
         # Parameter node will be reset, do not use it anymore
         self.setParameterNode(None)
 
     def onSceneEndClose(self, caller, event) -> None:
-        """
-        Called just after the scene is closed.
-        """
+        """Called just after the scene is closed."""
         # If this module is shown while the scene is closed then recreate a new parameter node immediately
         if self.parent.isEntered:
             self.initializeParameterNode()
 
     def initializeParameterNode(self) -> None:
-        """
-        Ensure parameter node exists and observed.
-        """
+        """Ensure parameter node exists and observed."""
         # Parameter node stores all user choices in parameter values, node selections, etc.
         # so that when the scene is saved and reloaded, these settings are restored.
 
@@ -253,9 +235,7 @@ class TemplateKeyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.ui.applyButton.enabled = False
 
     def onApplyButton(self) -> None:
-        """
-        Run processing when user clicks "Apply" button.
-        """
+        """Run processing when user clicks "Apply" button."""
         with slicer.util.tryWithErrorDisplay(_("Failed to compute results."), waitCursor=True):
 
             # Compute output
@@ -284,9 +264,7 @@ class TemplateKeyLogic(ScriptedLoadableModuleLogic):
     """
 
     def __init__(self) -> None:
-        """
-        Called when the logic class is instantiated. Can be used for initializing member variables.
-        """
+        """Called when the logic class is instantiated. Can be used for initializing member variables."""
         ScriptedLoadableModuleLogic.__init__(self)
 
     def getParameterNode(self):
@@ -342,13 +320,11 @@ class TemplateKeyTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear()
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_TemplateKey1()
 

--- a/Utilities/Templates/Modules/ScriptedSegmentEditorEffect/SegmentEditorTemplateKey.py
+++ b/Utilities/Templates/Modules/ScriptedSegmentEditorEffect/SegmentEditorTemplateKey.py
@@ -40,7 +40,7 @@ class SegmentEditorTemplateKeyTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """Do whatever is needed to reset the state - typically a scene clear will be enough.
         """
         slicer.mrmlScene.Clear(0)
 

--- a/Utilities/Templates/Modules/ScriptedSegmentEditorEffect/SegmentEditorTemplateKey.py
+++ b/Utilities/Templates/Modules/ScriptedSegmentEditorEffect/SegmentEditorTemplateKey.py
@@ -40,13 +40,11 @@ class SegmentEditorTemplateKeyTest(ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough.
-        """
+        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
-        """Run as few or as many tests as needed here.
-        """
+        """Run as few or as many tests as needed here."""
         self.setUp()
         self.test_TemplateKey1()
 


### PR DESCRIPTION
These changes are steps toward minimizing the differences between the Slicer python sources and output of formatter like "ruff" or "black".

Once integrated, the commits prefixed with `STYLE: ` will be added to the `.git-blame-ignore-revs`[^1] file.

This pull request should be rebased after integrating:
* https://github.com/Slicer/Slicer/pull/7383
* https://github.com/Slicer/Slicer/pull/7384
* https://github.com/Slicer/Slicer/pull/7385
* https://github.com/Slicer/Slicer/pull/7386

[^1]: https://github.com/Slicer/Slicer/blob/main/.git-blame-ignore-revs