### PR TITLE
Docstring fix escape sequence issues

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -48,7 +48,6 @@ extend-ignore = [
   "D10",     # undocumented-public-*
   "D202",    # No blank lines allowed after function docstring"
   "D205",    # 1 blank line required between summary line and description
-  "D301",    # escape-sequence-in-docstring
   "D4",
 
   "E401",    # Multiple imports on one line

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -3797,10 +3797,10 @@ def pip_uninstall(requirements):
 
 
 def longPath(path):
-    """Make long paths work on Windows, where the maximum path length is 260 characters.
+    r"""Make long paths work on Windows, where the maximum path length is 260 characters.
 
     For example, the files in the DICOM database may have paths longer than this limit.
-    Accessing these can be made safe by prefixing it with the UNC prefix ('\\?\').
+    Accessing these can be made safe by prefixing it with the UNC prefix ('\\\\?\\').
 
     :param string path: Path to be made safe if too long
 

--- a/Utilities/Scripts/SEMToMediaWiki.py
+++ b/Utilities/Scripts/SEMToMediaWiki.py
@@ -13,7 +13,7 @@ import xml.dom.minidom
 
 
 def getTextValuesFromNode(nodelist):
-    r"""Get this nodes text information."""
+    """Get this nodes text information."""
     rc = []
     for node in nodelist:
         if node.nodeType == node.TEXT_NODE:
@@ -22,7 +22,7 @@ def getTextValuesFromNode(nodelist):
 
 
 def getThisNodesInfoAsText(currentNode, label):
-    r"""Only get the text info for the matching label at this level of the tree"""
+    """Only get the text info for the matching label at this level of the tree"""
     labelNodeList = [node for node in
                      currentNode.childNodes if node.nodeName == label]
 
@@ -33,7 +33,7 @@ def getThisNodesInfoAsText(currentNode, label):
 
 
 def getLongFlagDefinition(currentNode):
-    r"""Extract the long flag, and color the text string"""
+    """Extract the long flag, and color the text string"""
     labelNodeList = currentNode.getElementsByTagName("longflag")
     if labelNodeList.length > 0:
         labelNode = labelNodeList[0]  # Only get the first one
@@ -43,7 +43,7 @@ def getLongFlagDefinition(currentNode):
 
 
 def getFlagDefinition(currentNode):
-    r"""Extract the (short) flag, and color the text string"""
+    """Extract the (short) flag, and color the text string"""
     labelNodeList = currentNode.getElementsByTagName("flag")
     if labelNodeList.length > 0:
         labelNode = labelNodeList[0]  # Only get the first one
@@ -53,7 +53,7 @@ def getFlagDefinition(currentNode):
 
 
 def getLabelDefinition(currentNode):
-    r"""Extract the nodes label, and color the text string"""
+    """Extract the nodes label, and color the text string"""
     labelNodeList = currentNode.getElementsByTagName("label")
     if labelNodeList.length > 0:
         labelNode = labelNodeList[0]  # Only get the first one
@@ -63,7 +63,7 @@ def getLabelDefinition(currentNode):
 
 
 def getDefaultValueDefinition(currentNode):
-    r"""Extract the default value"""
+    """Extract the default value"""
     labelNodeList = currentNode.getElementsByTagName("default")
     if labelNodeList.length > 0:
         labelNode = labelNodeList[0]  # Only get the first one
@@ -85,7 +85,7 @@ def GetSEMDoc(filename):
 
 
 def DumpSEMMediaWikiHeader(executableNode):
-    r"""Just dump the header section of the MediaWikiPage"""
+    """Just dump the header section of the MediaWikiPage"""
 
     outputRegionTemplate = """
 __NOTOC__

--- a/Utilities/Scripts/SlicerWizard/ExtensionProject.py
+++ b/Utilities/Scripts/SlicerWizard/ExtensionProject.py
@@ -129,7 +129,6 @@ class ExtensionProject:
         the project instance was created. If the encoding cannot be determined, the
         property will have the value ``None``.
 
-        .. 'note' directive needs '\' to span multiple lines!
         .. note:: If ``encoding`` is ``None``, the project information is stored \
                   as raw bytes using :class:`str`. In such case, passing a \
                   non-ASCII :class:`unicode` to  any method or property \
@@ -261,8 +260,8 @@ class ExtensionProject:
         .. note::
 
           Variables set using a nested reference are not supported.
-          For example, if the underlying CMake code is ``set(foo \"world\")``
-          and ``set(hello_${foo} \"earth\")``. Occurrences of
+          For example, if the underlying CMake code is ``set(foo "world")``
+          and ``set(hello_${foo} "earth")``. Occurrences of
           '``${hello_${foo}}``' will be replaced by '``hello_world-NOTFOUND``'
 
         .. seealso:: :func:`.substituteVariableReferences`

--- a/Utilities/Scripts/SlicerWizard/ExtensionWizard.py
+++ b/Utilities/Scripts/SlicerWizard/ExtensionWizard.py
@@ -62,7 +62,6 @@ class ExtensionWizard:
     Interaction with `GitHub <https://github.com>`_ uses
     :func:`.GithubHelper.logIn` to authenticate.
 
-    .. 'note' directive needs '\' to span multiple lines!
     .. note:: Most methods will signal the application to exit if \
               something goes wrong. This behavior is hidden by the \
               :meth:`~ExtensionWizard.execute` method when  passing \

--- a/Utilities/Scripts/SlicerWizard/TemplateManager.py
+++ b/Utilities/Scripts/SlicerWizard/TemplateManager.py
@@ -236,7 +236,6 @@ class TemplateManager:
 
         This sets the template key for ``name`` to ``key``.
 
-        .. 'note' directive needs '\' to span multiple lines!
         .. note:: Template keys depend only on the template name, and not the \
                   template category. As a result, two templates with the same name \
                   in different categories will use the same key.
@@ -322,7 +321,6 @@ class TemplateManager:
         This adds |CLI| arguments to the specified ``parser`` that may be used to
         interact with the template collection.
 
-        .. 'note' directive needs '\' to span multiple lines!
         .. note:: The arguments use ``'<'`` and ``'>'`` to annotate optional \
                   values. It is recommended to use :class:`.WizardHelpFormatter` \
                   with the parser so that these will be displayed using the \

--- a/Utilities/Scripts/SlicerWizard/__init__.py
+++ b/Utilities/Scripts/SlicerWizard/__init__.py
@@ -3,7 +3,6 @@
 This package provides a suite of tools to help automate certain tasks that are
 often performed when developing code and extensions for Slicer.
 
-.. 'note' directive needs '\' to span multiple lines!
 .. note:: This documentation is intended for developers working \
           on such tools. Users of the same should refer to the \
           :wikidoc:`Developers/ExtensionWizard Extension Wizard` \


### PR DESCRIPTION
Fix scripts and update Ruff configuration checking if docstrings require raw string prefix

For reference:

> In Python, backslashes are typically used to escape characters in strings. In raw strings (those prefixed with an r), however, backslashes are treated as literal characters.
>
> PEP 257 recommends the use of raw strings (i.e., r"""raw triple double quotes""") for docstrings that include backslashes. The use of a raw string ensures that any backslashes are treated as literal characters, and not as escape sequences, which avoids confusion.

Copied from https://docs.astral.sh/ruff/rules/escape-sequence-in-docstring/

### Documentation of `slicer.util.longPath`

| Context | Illustration |
|--|--|
| Before| ![image](https://github.com/Slicer/Slicer/assets/219043/d698002d-bbf6-4ff2-98f9-b8b00c413537) | 
| After|![image](https://github.com/Slicer/Slicer/assets/219043/2a4443f5-4982-445e-b34d-17f600523d57) |
