### PR TITLE
BUG: Resolve del method override issue in AutoComplete segment editor effect

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -74,8 +74,6 @@ extend-ignore = [
   "PGH001",  # No builtin `eval()` allowed
   "PGH002",  # `warn` is deprecated in favor of `warning`
 
-  "PLE0302", # The special method `__del__` expects 1 parameter, 2 were given
-
   "PLR0912", # Too many branche
   "PLR0913", # Too many arguments in function definition
   "PLR0911", # Too many return statements

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/AbstractScriptedSegmentEditorAutoCompleteEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/AbstractScriptedSegmentEditorAutoCompleteEffect.py
@@ -61,8 +61,7 @@ class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEdi
 
         self.previewComputationInProgress = False
 
-    def __del__(self, scriptedEffect):
-        super(SegmentEditorAutoCompleteEffect, self).__del__()
+    def __del__(self):
         self.delayedAutoUpdateTimer.stop()
         self.observeSegmentation(False)
 


### PR DESCRIPTION
This commit rectifies the linter error concerning the `__del__` method in the AutoComplete segment editor effect. The specific issue was that the `__del__` method expects one parameter, but two were given. To resolve this, the call to the superclass `__del__` has been removed, as it is not implemented.

Note that while this correction resolves the immediate warning, there may still be issues with proper garbage collection for some effects.

A proposal to address the root cause is documented in:
* Slicer#7392

It also updates the Ruff configuration, re-enabling the PLE0302 rule to ensure that `__del__` functions are called with the expected number of parameters.