### PR TITLE
COMP: Fix reporting of -Wunused-function related to qSlicerApplicationHelper

### DIFF
--- a/Base/QTApp/qSlicerApplicationHelper.txx
+++ b/Base/QTApp/qSlicerApplicationHelper.txx
@@ -80,6 +80,17 @@ int qSlicerApplicationHelper::postInitializeApplication(
     QScopedPointer<SlicerMainWindowType>& window
     )
 {
+
+#if defined(Q_CC_GNU) && Q_CC_GNU <= 703
+  // The lines below are needed for suppressing "-Wunused-function" warnings
+  // reported when using GCC<=7.3 to build translation units not making use
+  // of the "qSlicerApplicationHelper::postInitializeApplication" function.
+# ifdef Slicer_USE_QtTesting
+  (void)setEnableQtTesting; // Fix -Wunused-function warning
+# endif
+  (void)splashMessage; // Fix -Wunused-function warning
+#endif
+
   if (app.style())
     {
     app.installEventFilter(app.style());


### PR DESCRIPTION
Workaround the reporting of -Wunused-function warnings when using
GCC <= 7.3 to build translation units not making use of the
"qSlicerApplicationHelper::postInitializeApplication" function.

This was verified with the following self-contained example
compiled using the "https://godbolt.org/" platform specifying the
-Wunused-function flag and toggling between "x86-64 gcc 7.3" and
"x86-64 gcc 7.4".

```
#include <iostream>

namespace
{
void setEnableQtTesting()
{
  std::cout << "setEnableQtTesting" << std::endl;
}
} // end of anonymous namespace

template<typename SlicerMainWindowType>
void postInitializeApplication()
{
  setEnableQtTesting();
}
int main(int, char*[])
{
  std::cout << "Hello" << std::endl;
  return 0;
}
```

Fixes:
```
In file included from /work/Stable/Slicer-0/Base/QTApp/qSlicerApplicationHelper.h:77:0,
                 from inner-build/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleGenericTest.cxx:38:
/work/Stable/Slicer-0/Base/QTApp/qSlicerApplicationHelper.txx:64:6:
 warning: ‘void {anonymous}::splashMessage(QScopedPointer<QSplashScreen>&, const QString&)’ defined but not used [-Wunused-function]
 void splashMessage(QScopedPointer<QSplashScreen>& splashScreen, const QString& message)
      ^~~~~~~~~~~~~
```

and
```
/work/Stable/Slicer-0/Base/QTApp/qSlicerApplicationHelper.txx:53:6:
 warning: ‘void {anonymous}::setEnableQtTesting()’ defined but not used [-Wunused-function]
 void setEnableQtTesting()
      ^~~~~~~~~~~~~~~~~~
```

raised for the SlicerDMRI extenstion build in:
https://slicer.cdash.org/viewBuildError.php?type=1&buildid=3210886