### PR TITLE
COMP: Fix -Wunused-function warning in qMRMLLayoutManagerTest1

### DIFF
--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest1.cxx
@@ -106,6 +106,8 @@ bool testLayoutManagerViewWidgetForThreeD(int line, qMRMLLayoutManager* layoutMa
 //------------------------------------------------------------------------------
 int qMRMLLayoutManagerTest1(int argc, char * argv[] )
 {
+  (void)checkViewArrangement; // Fix -Wunused-function warning
+
   qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
   qMRMLWidget::postInitializeApplication();


### PR DESCRIPTION
This commit re-introduces the marking of "checkViewArrangement" as unused that was inadvertently removed as part of 3ce46788 (`ENH: Add check for available application updates`) and originally introduced in 53fea52c1 (`COMP: Fix -Wunused-function warnings in qMRMLLayoutManager tests`)

It fixes the following warning:

```
/path/to/Slicer/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTestHelper.cxx:13:6: warning: ‘bool {anonymous}::checkViewArrangement(int, qMRMLLayoutManager*, vtkMRMLLayoutNode*, int)’ defined but not used [-Wunused-function]
 bool checkViewArrangement(int line, qMRMLLayoutManager* layoutManager,
      ^~~~~~~~~~~~~~~~~~~~
```


This warning may be reproduced using the following self-contained example compiled using the "https://godbolt.org/" platform specifying the `-Wunused-function` flag and using any of "x86-64 gcc" compilers:

```cpp

#include <iostream>

namespace
{
void checkViewArrangement()
{
  std::cout << "setEnableQtTesting" << std::endl;
}

int safeApplicationQuit()
{
  std::cout << "safeApplicationQuit" << std::endl;
  return 0;
}
} // end of anonymous namespace

// qMRMLLayoutManagerTest1
int main(int, char*[])
{
  std::cout << "Hello" << std::endl;
  return safeApplicationQuit();
}
```

