### PR TITLE
COMP: Fix ITK's threading-related method name deprecation warnings

### DIFF
--- a/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx
+++ b/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx
@@ -922,7 +922,7 @@ int Do( parameters list )
         }
       if( list.numberOfThread )
         {
-        transformDeformationFieldFilter->SetNumberOfThreads( list.numberOfThread );
+        transformDeformationFieldFilter->SetNumberOfWorkUnits( list.numberOfThread );
         }
       transformDeformationFieldFilter->SetInput( field );
       transformDeformationFieldFilter->SetTransform( transform->GetTransform() );
@@ -1000,7 +1000,7 @@ int Do( parameters list )
     resampler->SetInput( image );
     if( list.numberOfThread )
       {
-      resampler->SetNumberOfThreads( list.numberOfThread );
+      resampler->SetNumberOfWorkUnits( list.numberOfThread );
       }
     resampler->SetInterpolator( interpol );
     itk::Matrix<double, 3, 3> outputImageDirection ;
@@ -1030,7 +1030,7 @@ int Do( parameters list )
     zeroFilter->SetInput( image );
     if( list.numberOfThread )
       {
-      zeroFilter->SetNumberOfThreads( list.numberOfThread );
+      zeroFilter->SetNumberOfWorkUnits( list.numberOfThread );
       }
     zeroFilter->Update();
     image = zeroFilter->GetOutput();
@@ -1043,7 +1043,7 @@ int Do( parameters list )
     absFilter->SetInput( image );
     if( list.numberOfThread )
       {
-      absFilter->SetNumberOfThreads( list.numberOfThread );
+      absFilter->SetNumberOfWorkUnits( list.numberOfThread );
       }
     absFilter->Update();
     image = absFilter->GetOutput();
@@ -1056,7 +1056,7 @@ int Do( parameters list )
     nearestFilter->SetInput( image );
     if( list.numberOfThread )
       {
-      nearestFilter->SetNumberOfThreads( list.numberOfThread );
+      nearestFilter->SetNumberOfWorkUnits( list.numberOfThread );
       }
     nearestFilter->Update();
     image = nearestFilter->GetOutput();

--- a/Modules/CLI/ResampleDTIVolume/Testing/itkDifferenceDiffusionTensor3DImageFilter.txx
+++ b/Modules/CLI/ResampleDTIVolume/Testing/itkDifferenceDiffusionTensor3DImageFilter.txx
@@ -132,7 +132,7 @@ void
 DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
 ::BeforeThreadedGenerateData()
 {
-  int numberOfThreads = this->GetNumberOfThreads();
+  int numberOfThreads = this->GetNumberOfWorkUnits();
 
   // Initialize statistics about difference image.
   m_MeanDifference = NumericTraits<RealType>::ZeroValue();
@@ -325,7 +325,7 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
 ::AfterThreadedGenerateData()
 {
   // Set statistics about difference image.
-  int numberOfThreads = this->GetNumberOfThreads();
+  int numberOfThreads = this->GetNumberOfWorkUnits();
 
   for( int i = 0; i < numberOfThreads; ++i )
     {

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.txx
@@ -40,7 +40,7 @@ DiffusionTensor3DInterpolateImageFunctionReimplementation<TData, TCoordRep>
   typedef SeparateComponentsOfADiffusionTensorImage<TData, TData> SeparateType;
   typename SeparateType::Pointer separateFilter = SeparateType::New();
   separateFilter->SetInput( inputImage );
-  separateFilter->SetNumberOfThreads( this->m_NumberOfThreads );
+  separateFilter->SetNumberOfWorkUnits( this->m_NumberOfThreads );
   separateFilter->Update();
   AllocateInterpolator();
   for( int i = 0; i < 6; i++ )

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DRead.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DRead.txx
@@ -53,7 +53,7 @@ DiffusionTensor3DRead<TData>
     {
     m_Reader = FileReaderType::New();
     m_Reader->SetFileName( input );
-    m_Reader->SetNumberOfThreads(m_NumberOfThreads);
+    m_Reader->SetNumberOfWorkUnits(m_NumberOfThreads);
     m_Reader->Update();
     const DictionaryType &        dictionary = m_Reader->GetMetaDataDictionary();
     DictionaryType::ConstIterator itr = dictionary.Begin();

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.txx
@@ -115,7 +115,7 @@ DiffusionTensor3DWrite<TData>
   writer->SetInput( m_Input );
   writer->SetFileName( output );
   writer->UseCompressionOn();
-  writer->SetNumberOfThreads(m_NumberOfThreads);
+  writer->SetNumberOfWorkUnits(m_NumberOfThreads);
   try
     {
     writer->Update();

--- a/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
+++ b/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
@@ -589,7 +589,7 @@ SetAllTransform( parameters & list,
         }
       if( list.numberOfThread )
         {
-        transformDeformationFieldFilter->SetNumberOfThreads( list.numberOfThread );
+        transformDeformationFieldFilter->SetNumberOfWorkUnits( list.numberOfThread );
         }
       transformDeformationFieldFilter->SetInput( field );
       transformDeformationFieldFilter->SetTransform( transform );


### PR DESCRIPTION
Fix ITK's threading-related method name deprecation warnings.

Fixes:
```
Slicer/Modules/CLI/ResampleDTIVolume/Testing/itkDifferenceDiffusionTensor3DImageFilter.txx:135:7:
 warning: ‘slicer_itk::ThreadIdType slicer_itk::ProcessObject::GetNumberOfThreads() const’ is deprecated [-Wdeprecated-declarations]
   int numberOfThreads = this->GetNumberOfThreads();
       ^~~~~~~~~~~~~~~
In file included from /usr/src/Slicer-build/ITK/Modules/Core/Common/include/itkLightObject.h:21:0,
                 from /usr/src/Slicer-build/ITK/Modules/Core/Common/include/itkObject.h:31,
                 from /usr/src/Slicer-build/ITK/Modules/Core/Common/include/itkMultiThreaderBase.h:31,
                 from /usr/src/Slicer-build/ITK/Modules/Compatibility/Deprecated/include/itkMultiThreader.h:23,
                 from /usr/src/Slicer/Modules/CLI/ResampleDTIVolume/Testing/itkTestMainExtended.h:41,
                 from /usr/src/Slicer/Modules/CLI/ResampleDTIVolume/Testing/ResampleDTIVolumeTest.cxx:9:
Slicer-build/ITK/Modules/Core/Common/include/itkProcessObject.h:499:31: note: declared here
   itkLegacyMacro(ThreadIdType GetNumberOfThreads() const) { return this->GetNumberOfWorkUnits(); }
                               ^
```

and
```
Slicer/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx:925:60:
 warning: ‘void slicer_itk::ProcessObject::SetNumberOfThreads(slicer_itk::ThreadIdType)’ is deprecated [-Wdeprecated-declarations]
         transformDeformationFieldFilter->SetNumberOfThreads( list.numberOfThread );
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/src/Slicer-build/ITK/Modules/Core/Common/include/itkLightObject.h:21:0,
                 from /usr/src/Slicer-build/ITK/Modules/Core/Common/include/itkObject.h:31,
                 from /usr/src/Slicer/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DResample.h:17,
                 from /usr/src/Slicer/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx:15:
Slicer-build/ITK/Modules/Core/Common/include/itkProcessObject.h:497:23: note: declared here
   itkLegacyMacro(void SetNumberOfThreads(ThreadIdType count)) { this->SetNumberOfWorkUnits(count); }
                       ^
```

raised for example in:
https://github.com/Slicer/Slicer/actions/runs/6885650499/job/18730113110#step:4:3902 and
https://github.com/Slicer/Slicer/actions/runs/6885650499/job/18730113110#step:4:3942