### PR TITLE
BUG: Fix VTK-based object creation in PythonSlicer regardless of import order

### DIFF
--- a/Base/Python/mrml.py
+++ b/Base/Python/mrml.py
@@ -2,7 +2,15 @@
 namespace.
 """
 
+# Importing VTK is required for loading its Python modules and ensuring seamless instantiation
+# of VTK-based MRML or Slicer Python modules from code executed in both "PythonSlicer executable"
+# and the "Slicer Python Console" environments. For more details, see Base/Python/slicer/__init__.py
+import vtk  # noqa: F401
+
 from MRMLCLIPython import *
 from MRMLCorePython import *
 from MRMLDisplayableManagerPython import *
 from MRMLLogicPython import *
+
+# Cleanup: Removing things the user shouldn't have to see.
+del vtk

--- a/Base/Python/slicer/__init__.py
+++ b/Base/Python/slicer/__init__.py
@@ -154,6 +154,26 @@ For more details, see the generated Slicer API documentation.
 """)
 
 # -----------------------------------------------------------------------------
+# Importing VTK is required for loading its Python modules and ensuring seamless instantiation
+# of VTK-based MRML or Slicer Python modules from code executed in both "PythonSlicer executable"
+# and the "Slicer Python Console" environments.
+#
+# For example, regardless of the order of the imports, the following is now supported in
+# both environments:
+#
+#   import slicer
+#   import vtk
+#   object = slicer.vtkMRMLScene()
+#   assert isinstance(object, vtk.vtkObject)
+#
+# This is needed because the wrapping of the MRML or Slicer VTK-based C++ classes is done
+# through the vtkMacroKitPythonWrap (from vtkAddon) and the generated "vtk*PythonInitImpl.cxx"
+# files do not include the names of the dependent VTK modules in the list used with
+# "vtkPythonUtil::ImportModule".
+
+import vtk  # noqa: F401
+
+# -----------------------------------------------------------------------------
 # Load modules: Add VTK and PythonQt python module attributes into slicer namespace
 
 try:
@@ -199,3 +219,4 @@ if not standalone_python:
 del _createModule
 del available_kits
 del standalone_python
+del vtk

--- a/Base/Python/slicer/logic.py
+++ b/Base/Python/slicer/logic.py
@@ -2,4 +2,12 @@
 namespace.
 """
 
+# Importing VTK is required for loading its Python modules and ensuring seamless instantiation
+# of VTK-based MRML or Slicer Python modules from code executed in both "PythonSlicer executable"
+# and the "Slicer Python Console" environments. For more details, see Base/Python/slicer/__init__.py
+import vtk  # noqa: F401
+
 from SlicerBaseLogicPython import *
+
+# Cleanup: Removing things the user shouldn't have to see.
+del vtk

--- a/Base/Python/slicer/slicerqt.py
+++ b/Base/Python/slicer/slicerqt.py
@@ -1,7 +1,12 @@
 import logging
 
+# Importing ctk, qt, vtk, and slicer is necessary for subsequent use and to accommodate
+# legacy code in Slicer extensions relying on "from __main__ import vtk, qt, ctk, slicer".
 import ctk
 import qt
+
+# The vtk import is retained due to legacy code in Slicer extensions
+# that relies on "from __main__ import vtk, qt, ctk, slicer".
 import vtk  # noqa: F401
 
 import slicer

--- a/Base/Python/vtkAddon.py
+++ b/Base/Python/vtkAddon.py
@@ -2,4 +2,12 @@
 namespace.
 """
 
+# Importing VTK is required for loading its Python modules and ensuring seamless instantiation
+# of VTK-based MRML or Slicer Python modules from code executed in both "PythonSlicer executable"
+# and the "Slicer Python Console" environments. For more details, see Base/Python/slicer/__init__.py
+import vtk  # noqa: F401
+
 from vtkAddonPython import *
+
+# Cleanup: Removing things the user shouldn't have to see.
+del vtk

--- a/Base/Python/vtkITK.py
+++ b/Base/Python/vtkITK.py
@@ -2,4 +2,12 @@
 namespace.
 """
 
+# Importing VTK is required for loading its Python modules and ensuring seamless instantiation
+# of VTK-based MRML or Slicer Python modules from code executed in both "PythonSlicer executable"
+# and the "Slicer Python Console" environments. For more details, see Base/Python/slicer/__init__.py
+import vtk  # noqa: F401
+
 from vtkITKPython import *
+
+# Cleanup: Removing things the user shouldn't have to see.
+del vtk

--- a/Base/Python/vtkSegmentationCore.py
+++ b/Base/Python/vtkSegmentationCore.py
@@ -2,4 +2,12 @@
 namespace.
 """
 
+# Importing VTK is required for loading its Python modules and ensuring seamless instantiation
+# of VTK-based MRML or Slicer Python modules from code executed in both "PythonSlicer executable"
+# and the "Slicer Python Console" environments. For more details, see Base/Python/slicer/__init__.py
+import vtk  # noqa: F401
+
 from vtkSegmentationCorePython import *
+
+# Cleanup: Removing things the user shouldn't have to see.
+del vtk

--- a/Base/Python/vtkTeem.py
+++ b/Base/Python/vtkTeem.py
@@ -2,4 +2,12 @@
 namespace.
 """
 
+# Importing VTK is required for loading its Python modules and ensuring seamless instantiation
+# of VTK-based MRML or Slicer Python modules from code executed in both "PythonSlicer executable"
+# and the "Slicer Python Console" environments. For more details, see Base/Python/slicer/__init__.py
+import vtk  # noqa: F401
+
 from vtkTeemPython import *
+
+# Cleanup: Removing things the user shouldn't have to see.
+del vtk


### PR DESCRIPTION
This commit addresses an issue where the creation of VTK-based objects in script executed through the PythonSlicer executable was dependent on the order of module imports. The update ensures consistent and successful instantiation of associated objects, such as `vtkMRMLScene`, regardless of the import order.

For instance, the following code is now supported:

```py
import slicer
import vtk
object = slicer.vtkMRMLScene()
assert isinstance(object, vtk.vtkObject)
```

It doesn't require the developer to always import `vtk` before `slicer`.

The problem stemmed from the wrapping of MRML or Slicer VTK-based C++ classes through `vtkMacroKitPythonWrap` (from vtkAddon). The generated `vtk*PythonInitImpl.cxx` files do not include the names of dependent VTK modules in the list used with `vtkPythonUtil::ImportModule`.

Additionally, a comment is added to `slicerqt.py` to clarify that imports may be necessary to accommodate legacy code in Slicer extensions relying on `from main import vtk, qt, ctk, slicer`.