### PR TITLE
ENH: Make sequence item creating strategy configurable

### DIFF
--- a/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.h
+++ b/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.h
@@ -48,7 +48,8 @@ public:
   enum
   {
     ProxyNodeModifiedEvent = 21001,
-    IndexDisplayFormatModifiedEvent
+    IndexDisplayFormatModifiedEvent,
+    SequenceNodeModifiedEvent
   };
 
   /// Modes for determining recording frame rate.
@@ -59,6 +60,17 @@ public:
     SamplingAll = 0,
     SamplingLimitedToPlaybackFrameRate,
     NumberOfRecordingSamplingModes // this line must be the last one
+  };
+
+  /// Specify what happens when during sequence browsing if a sequence does not contain an item for the
+  /// current index.
+  enum MissingItemModeType
+  {
+    MissingItemInvalid = -1, ///< mode is invalid
+    MissingItemCreateFromPrevious = 0, ///< previous item is used for initializing the new item (this is the default mode)
+    MissingItemCreateFromDefault, ///< the new item is created from the default node (typically an empty node)
+    MissingItemSetToDefault, ///< the proxy node is set to the default (empty) node; new item is not created
+    NumberOfMissingItemModes // this line must be the last one
   };
 
   /// Modes displaying index for the user
@@ -105,9 +117,11 @@ public:
   /// Remove all sequence nodes (including the master sequence node)
   void RemoveAllSequenceNodes();
 
+  //@{
   /// Returns all synchronized sequence nodes (does not include the master sequence node)
   void GetSynchronizedSequenceNodes(std::vector< vtkMRMLSequenceNode* > &synchronizedDataNodes, bool includeMasterNode=false);
   void GetSynchronizedSequenceNodes(vtkCollection* synchronizedDataNodes, bool includeMasterNode=false);
+  //@}
 
   /// Returns number of synchronized sequence nodes
   int GetNumberOfSynchronizedSequenceNodes(bool includeMasterNode = false);
@@ -115,78 +129,111 @@ public:
   /// Deprecated. Use IsSynchronizedSequenceNodeID instead.
   bool IsSynchronizedSequenceNode(const char* sequenceNodeId, bool includeMasterNode = false);
 
+  //@{
   /// Returns true if the node is selected for synchronized browsing
   bool IsSynchronizedSequenceNodeID(const char* sequenceNodeId, bool includeMasterNode = false);
   bool IsSynchronizedSequenceNode(vtkMRMLSequenceNode* sequenceNode, bool includeMasterNode = false);
+  //@}
 
+  //@{
   /// Get/Set automatic playback (automatic continuous changing of selected sequence nodes)
   vtkGetMacro(PlaybackActive, bool);
   vtkSetMacro(PlaybackActive, bool);
   vtkBooleanMacro(PlaybackActive, bool);
+  //@}
 
+  //@{
   /// Get/Set playback rate in fps (frames per second)
   vtkGetMacro(PlaybackRateFps, double);
   vtkSetMacro(PlaybackRateFps, double);
+  //@}
 
+  //@{
   /// Skipping items if necessary to reach requested playback rate. Enabled by default.
   vtkGetMacro(PlaybackItemSkippingEnabled, bool);
   vtkSetMacro(PlaybackItemSkippingEnabled, bool);
   vtkBooleanMacro(PlaybackItemSkippingEnabled, bool);
+  //@}
 
+  //@{
   /// Get/Set playback looping (restart from the first sequence node when reached the last one)
   vtkGetMacro(PlaybackLooped, bool);
   vtkSetMacro(PlaybackLooped, bool);
   vtkBooleanMacro(PlaybackLooped, bool);
+  //@}
 
+  //@{
   /// Get/Set selected bundle index
   vtkGetMacro(SelectedItemNumber, int);
   vtkSetMacro(SelectedItemNumber, int);
+  //@}
 
+  /// Set selected item by index value.
+  /// If exact match is not required and index is numeric then the best matching data node is returned.
+  /// Returns true if the index value is found.
+  /// \sa GetItemNumberFromIndexValue
+  bool SetSelectedItemByIndexValue(const std::string& indexValue, bool exactMatchRequired = true);
+
+  //@{
   /// Get/set recording of proxy nodes
   vtkGetMacro(RecordingActive, bool);
   void SetRecordingActive(bool recording);
   vtkBooleanMacro(RecordingActive, bool);
+  //@}
 
+  //@{
   /// Get/set whether to only record when the master node is modified (or emits an observed event)
   vtkGetMacro(RecordMasterOnly, bool);
   vtkSetMacro(RecordMasterOnly, bool);
   vtkBooleanMacro(RecordMasterOnly, bool);
+  //@}
 
-  /// Set the recording sampling mode
+  //@{
+  /// Get/set the recording sampling mode
   vtkSetMacro(RecordingSamplingMode, int);
   void SetRecordingSamplingModeFromString(const char *recordingSamplingModeString);
-  /// Get the recording sampling mode
   vtkGetMacro(RecordingSamplingMode, int);
   virtual std::string GetRecordingSamplingModeAsString();
+  //@}
 
+  //@{
   /// Helper functions for converting between string and code representation of recording sampling modes
   static std::string GetRecordingSamplingModeAsString(int recordingSamplingMode);
   static int GetRecordingSamplingModeFromString(const std::string &recordingSamplingModeString);
+  //@}
 
-  /// Set index display mode
+  //@{
+  /// Helper functions for converting between string and code representation of recording sampling modes
+  static std::string GetMissingItemModeAsString(int missingItemMode);
+  static MissingItemModeType GetMissingItemModeFromString(const std::string& missingItemModeString);
+  //@}
+
+  //@{
+  /// Get/set index display mode
   vtkSetMacro(IndexDisplayMode, int);
   void SetIndexDisplayModeFromString(const char *indexDisplayModeString);
-  /// Get index display mode
   vtkGetMacro(IndexDisplayMode, int);
   virtual std::string GetIndexDisplayModeAsString();
+  //@}
 
-  /// Set format of index value display (used if index type is numeric)
+  //@{
+  /// Get/set format of index value display (used if index type is numeric)
   void SetIndexDisplayFormat(std::string displayFormat);
-  /// Get format of index value display (used if index type is numeric)
   vtkGetMacro(IndexDisplayFormat, std::string);
+  //@}
 
+  //@{
   /// Helper functions for converting between string and code representation of index display modes
   static std::string GetIndexDisplayModeAsString(int indexDisplayMode);
   static int GetIndexDisplayModeFromString(const std::string &indexDisplayModeString);
+  //@}
 
-  /// Selects the next sequence item for display, returns current selected item number
+  //@{
+  /// Selects a sequence item for display, returns current selected item number.
   int SelectNextItem(int selectionIncrement=1);
-
-  /// Selects first sequence item for display, returns current selected item number
   int SelectFirstItem();
-
-  /// Selects last sequence item for display, returns current selected item number
   int SelectLastItem();
+  //@}
 
   /// Returns number of items in the sequence (number of data nodes in master sequence node)
   int GetNumberOfItems();
@@ -240,7 +287,6 @@ public:
   void GetAllProxyNodes(std::vector< vtkMRMLNode* > &nodes);
   void GetAllProxyNodes(vtkCollection* nodes);
 
-
   /// Deprecated method!
   void GetAllVirtualOutputDataNodes(vtkCollection* nodes)
     {
@@ -268,23 +314,41 @@ public:
   /// Returns true if any of the sequence node is allowed to record
   bool IsAnySequenceNodeRecording();
 
-  /// Get the synchronization properties for the given sequence/proxy tuple
-  bool GetRecording(vtkMRMLSequenceNode* sequenceNode);
+  //@{
+  /// Update the proxy node with the content of the sequence.
   bool GetPlayback(vtkMRMLSequenceNode* sequenceNode);
-  /// Overwrite proxy node name with name automatically generated from sequence base name and current item index.
-  bool GetOverwriteProxyName(vtkMRMLSequenceNode* sequenceNode);
+  void SetPlayback(vtkMRMLSequenceNode* sequenceNode, bool playback);
+  //@}
+
+  //@{
+  /// Add new items to the sequence when sequence recording is activated.
+  bool GetRecording(vtkMRMLSequenceNode* sequenceNode);
+  void SetRecording(vtkMRMLSequenceNode* sequenceNode, bool recording);
+  //@}
+
+  //@{
   /// Enable saving of current proxy node state into the sequence.
   /// If saving is enabled then data is copied from the sequence to into the proxy node using shallow-copy,
   /// which is faster than deep-copy (that is used when save changes disabled).
   /// However, if save changes enabled, proxy node changes are stored in the sequence, therefore users
   /// may accidentally change sequence node content by modifying proxy nodes.
   bool GetSaveChanges(vtkMRMLSequenceNode* sequenceNode);
-
-  /// Set the synchronization properties for the given sequence/proxy tuple
-  void SetRecording(vtkMRMLSequenceNode* sequenceNode, bool recording);
-  void SetPlayback(vtkMRMLSequenceNode* sequenceNode, bool playback);
-  void SetOverwriteProxyName(vtkMRMLSequenceNode* sequenceNode, bool overwrite);
   void SetSaveChanges(vtkMRMLSequenceNode* sequenceNode, bool save);
+  //@}
+
+  //@{
+  /// Overwrite proxy node name with name automatically generated from sequence base name and current item index.
+  bool GetOverwriteProxyName(vtkMRMLSequenceNode* sequenceNode);
+  void SetOverwriteProxyName(vtkMRMLSequenceNode* sequenceNode, bool overwrite);
+  //@}
+
+  //@{
+  /// Specify what happens when during sequence browsing if a sequence does not contain an item for the
+  /// current index.
+  /// \sa MissingItemMode
+  MissingItemModeType GetMissingItemMode(vtkMRMLSequenceNode* sequenceNode);
+  void SetMissingItemMode(vtkMRMLSequenceNode* sequenceNode, MissingItemModeType missingItemMode);
+  //@}
 
   /// Process MRML node events for recording of the proxy nodes
   void ProcessMRMLEvents( vtkObject *caller, unsigned long event, void *callData ) override;

--- a/Modules/Loadable/Sequences/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Sequences/Testing/Cxx/CMakeLists.txt
@@ -4,6 +4,7 @@ set(KIT qSlicer${MODULE_NAME}Module)
 set(KIT_TEST_SRCS
   vtkMRMLSequenceBrowserNodeTest1.cxx
   vtkMRMLSequenceNodeTest1.cxx
+  vtkSlicerSequencesLogicTest1.cxx
   vtkMRMLSequenceStorageNodeTest1.cxx
   )
 
@@ -19,4 +20,5 @@ set(TEMP "${CMAKE_BINARY_DIR}/Testing/Temporary")
 #-----------------------------------------------------------------------------
 simple_test(vtkMRMLSequenceBrowserNodeTest1)
 simple_test(vtkMRMLSequenceNodeTest1)
+simple_test(vtkSlicerSequencesLogicTest1)
 simple_test(vtkMRMLSequenceStorageNodeTest1 ${TEMP})

--- a/Modules/Loadable/Sequences/Testing/Cxx/vtkSlicerSequencesLogicTest1.cxx
+++ b/Modules/Loadable/Sequences/Testing/Cxx/vtkSlicerSequencesLogicTest1.cxx
@@ -1,0 +1,281 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// MRML includes
+#include "vtkMRMLApplicationLogic.h"
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLScene.h"
+#include "vtkMRMLSequenceNode.h"
+#include "vtkMRMLSequenceBrowserNode.h"
+#include "vtkMRMLTextNode.h"
+#include "vtkSlicerSequencesLogic.h"
+// VTK includes
+#include <vtkNew.h>
+#include <vtkTestingOutputWindow.h>
+
+namespace
+{
+  int TestLogicWithoutScene()
+  {
+    // Testing sequences logic without setting a scene.
+    // Errors are be returned but there should be no crash.
+
+    vtkSmartPointer<vtkMRMLScene> scene = vtkSmartPointer<vtkMRMLScene>::New();
+
+    vtkNew<vtkSlicerSequencesLogic> sequencesLogic;
+    vtkNew<vtkMRMLSequenceBrowserNode> browserNode;
+    vtkNew<vtkMRMLSequenceNode> sequenceNode;
+    vtkNew<vtkMRMLTextNode> proxyNode;
+    vtkNew<vtkMRMLSequenceNode> sequenceNode2;
+
+    CHECK_NULL(sequencesLogic->AddSequence(nullptr/*filename*/));
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_NULL(sequencesLogic->AddSynchronizedNode(nullptr, proxyNode, browserNode));
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_NOT_NULL(sequencesLogic->AddSynchronizedNode(sequenceNode, proxyNode, browserNode));
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    sequencesLogic->UpdateProxyNodesFromSequences(browserNode);
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    sequencesLogic->UpdateSequencesFromProxyNodes(browserNode, proxyNode);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    sequencesLogic->UpdateAllProxyNodes();
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    vtkNew<vtkCollection> compatibleNodes;
+    sequencesLogic->GetCompatibleNodesFromScene(compatibleNodes, sequenceNode);
+    CHECK_INT(compatibleNodes->GetNumberOfItems(), 0);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    CHECK_BOOL(vtkSlicerSequencesLogic::IsNodeCompatibleForBrowsing(sequenceNode, sequenceNode2), true);
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    vtkNew<vtkCollection> foundBrowserNodes;
+    sequencesLogic->GetBrowserNodesForSequenceNode(sequenceNode, foundBrowserNodes);
+    CHECK_INT(foundBrowserNodes->GetNumberOfItems(), 0);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_NULL(sequencesLogic->GetFirstBrowserNodeForSequenceNode(sequenceNode));
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    foundBrowserNodes->RemoveAllItems();
+    sequencesLogic->GetBrowserNodesForProxyNode(proxyNode, foundBrowserNodes);
+    CHECK_INT(foundBrowserNodes->GetNumberOfItems(), 0);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_NULL(sequencesLogic->GetFirstBrowserNodeForProxyNode(proxyNode));
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    return EXIT_SUCCESS;
+  }
+
+  int TestAddSequence()
+  {
+    // Basic test of creating and browsing a sequence
+
+    vtkSmartPointer<vtkMRMLScene> scene = vtkSmartPointer<vtkMRMLScene>::New();
+    vtkNew<vtkSlicerSequencesLogic> sequencesLogic;
+    sequencesLogic->SetMRMLScene(scene);
+
+    vtkMRMLSequenceBrowserNode* browserNode = vtkMRMLSequenceBrowserNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLSequenceBrowserNode"));
+    vtkMRMLTextNode* proxyNode = vtkMRMLTextNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLTextNode"));
+
+    vtkMRMLSequenceNode* sequenceNode = sequencesLogic->AddSynchronizedNode(nullptr, proxyNode, browserNode);
+    CHECK_NOT_NULL(sequenceNode);
+    CHECK_INT(sequenceNode->GetNumberOfDataNodes(), 0);
+
+    // Add some nodes to the sequence
+    vtkNew<vtkMRMLTextNode> proxyNode2;
+    proxyNode2->SetText("Zero");
+    sequenceNode->SetDataNodeAtValue(proxyNode2, "0");
+    proxyNode2->SetText("One");
+    sequenceNode->SetDataNodeAtValue(proxyNode2, "1");
+    proxyNode2->SetText("Two");
+    sequenceNode->SetDataNodeAtValue(proxyNode2, "2");
+
+    // Browse the sequence
+    CHECK_INT(browserNode->GetSelectedItemNumber(), 0); // first item is selected by default
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("0"), true);
+    CHECK_STD_STRING(proxyNode->GetText(), "Zero");
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("1"), true);
+    CHECK_STD_STRING(proxyNode->GetText(), "One");
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("2"), true);
+    CHECK_STD_STRING(proxyNode->GetText(), "Two");
+
+    return EXIT_SUCCESS;
+  }
+
+  int TestSparseSequence()
+  {
+    // Test sparse sequences, where not all sequences have items for all index values
+
+    vtkSmartPointer<vtkMRMLScene> scene = vtkSmartPointer<vtkMRMLScene>::New();
+    vtkNew<vtkSlicerSequencesLogic> sequencesLogic;
+    sequencesLogic->SetMRMLScene(scene);
+
+    // Create browser node
+    vtkMRMLSequenceBrowserNode* browserNode = vtkMRMLSequenceBrowserNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLSequenceBrowserNode"));
+
+    vtkNew<vtkMRMLTextNode> proxyNodeTemp;
+
+    // Add some nodes to the master sequence
+    vtkMRMLTextNode* masterProxyNode = vtkMRMLTextNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLTextNode"));
+    vtkMRMLSequenceNode* masterSequenceNode = sequencesLogic->AddSynchronizedNode(nullptr, masterProxyNode, browserNode);
+    proxyNodeTemp->SetText("ZeroM");
+    masterSequenceNode->SetDataNodeAtValue(proxyNodeTemp, "0");
+    proxyNodeTemp->SetText("OneM");
+    masterSequenceNode->SetDataNodeAtValue(proxyNodeTemp, "1");
+    proxyNodeTemp->SetText("TwoM");
+    masterSequenceNode->SetDataNodeAtValue(proxyNodeTemp, "2");
+    proxyNodeTemp->SetText("ThreeM");
+    masterSequenceNode->SetDataNodeAtValue(proxyNodeTemp, "3");
+    proxyNodeTemp->SetText("FourM");
+    masterSequenceNode->SetDataNodeAtValue(proxyNodeTemp, "4");
+
+    // Add some nodes to a synchronized sequence
+    vtkMRMLTextNode* synchronizedProxyNode1 = vtkMRMLTextNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLTextNode"));
+    vtkMRMLSequenceNode* synchronizedSequenceNode1 = sequencesLogic->AddSynchronizedNode(nullptr, synchronizedProxyNode1, browserNode);
+    proxyNodeTemp->SetText("ZeroS1");
+    synchronizedSequenceNode1->SetDataNodeAtValue(proxyNodeTemp, "0");
+    proxyNodeTemp->SetText("OneS1");
+    synchronizedSequenceNode1->SetDataNodeAtValue(proxyNodeTemp, "1");
+    proxyNodeTemp->SetText("FourS1");
+    synchronizedSequenceNode1->SetDataNodeAtValue(proxyNodeTemp, "4");
+
+    // Browse the sequence and check how missing items are handled.
+
+    // Check defaults
+    CHECK_INT(browserNode->GetMissingItemMode(synchronizedSequenceNode1), vtkMRMLSequenceBrowserNode::MissingItemCreateFromPrevious);
+    CHECK_BOOL(browserNode->GetSaveChanges(synchronizedSequenceNode1), false);
+
+    // 1. MissingItemCreateFromPrevious
+
+    browserNode->SetMissingItemMode(synchronizedSequenceNode1, vtkMRMLSequenceBrowserNode::MissingItemCreateFromPrevious);
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("0"), true);
+    CHECK_NOT_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("0"));
+    CHECK_STD_STRING(synchronizedProxyNode1->GetText(), "ZeroS1");
+
+    CHECK_NOT_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("1"));
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("1"), true);
+    CHECK_STD_STRING(synchronizedProxyNode1->GetText(), "OneS1");
+
+    CHECK_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("3")); // the item is missing
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("3"), true);
+    CHECK_STD_STRING(synchronizedProxyNode1->GetText(), "OneS1"); // previous value is copied
+    CHECK_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("3")); // the item is still missing because save mode is not enabled
+
+    CHECK_NOT_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("4"));
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("4"), true);
+    CHECK_STD_STRING(synchronizedProxyNode1->GetText(), "FourS1");
+
+    // Check if missing item is created if "save changes" is enabled
+    browserNode->SetSaveChanges(synchronizedSequenceNode1, true);
+
+    CHECK_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("3")); // the item is missing
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("3"), true);
+    CHECK_STD_STRING(synchronizedProxyNode1->GetText(), "OneS1"); // previous value is copied
+    CHECK_NOT_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("3")); // the item is now created
+
+    // Remove the created missing item and reset "save changes" to false
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("0"), true);
+    synchronizedSequenceNode1->RemoveDataNodeAtValue("3");
+    browserNode->SetSaveChanges(synchronizedSequenceNode1, false);
+
+    // 2. MissingItemCreateFromDefault
+
+    browserNode->SetMissingItemMode(synchronizedSequenceNode1, vtkMRMLSequenceBrowserNode::MissingItemCreateFromDefault);
+
+    CHECK_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("3")); // the item is missing
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("3"), true);
+    CHECK_STD_STRING(synchronizedProxyNode1->GetText(), ""); // default value is used
+    CHECK_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("3")); // the item is still missing because save mode is not enabled
+
+    CHECK_NOT_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("0")); // the item is present
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("0"), true);
+    CHECK_STD_STRING(synchronizedProxyNode1->GetText(), "ZeroS1"); // default value is used
+    CHECK_NOT_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("0")); // the item is still present
+
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("4"), true);
+
+    // Check if missing item is created if "save changes" is enabled
+    browserNode->SetSaveChanges(synchronizedSequenceNode1, true);
+
+    CHECK_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("3")); // the item is missing
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("3"), true);
+    CHECK_STD_STRING(synchronizedProxyNode1->GetText(), ""); // default value is used
+    CHECK_NOT_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("3")); // the item is now created
+
+    CHECK_NOT_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("0")); // the item is present
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("0"), true);
+    CHECK_STD_STRING(synchronizedProxyNode1->GetText(), "ZeroS1"); // default value is used
+    CHECK_NOT_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("0")); // the item is still present
+
+    // Remove the created missing item and reset "save changes" to false
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("0"), true);
+    synchronizedSequenceNode1->RemoveDataNodeAtValue("3");
+    browserNode->SetSaveChanges(synchronizedSequenceNode1, false);
+
+    // 3. MissingItemSetToDefault
+
+    browserNode->SetMissingItemMode(synchronizedSequenceNode1, vtkMRMLSequenceBrowserNode::MissingItemSetToDefault);
+
+    CHECK_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("3")); // the item is missing
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("3"), true);
+    CHECK_STD_STRING(synchronizedProxyNode1->GetText(), ""); // default value is used
+    CHECK_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("3")); // the item is still missing because save mode is not enabled
+
+    CHECK_NOT_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("0")); // the item is present
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("0"), true);
+    CHECK_STD_STRING(synchronizedProxyNode1->GetText(), "ZeroS1"); // default value is used
+    CHECK_NOT_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("0")); // the item is still present
+
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("4"), true);
+
+    // Check if missing item is created if "save changes" is enabled
+    browserNode->SetSaveChanges(synchronizedSequenceNode1, true);
+
+    CHECK_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("3")); // the item is missing
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("3"), true);
+    CHECK_STD_STRING(synchronizedProxyNode1->GetText(), ""); // default value is used
+    CHECK_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("3")); // the item is still missing because MissingItemSetToDefault
+
+    CHECK_NOT_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("0")); // the item is present
+    CHECK_BOOL(browserNode->SetSelectedItemByIndexValue("0"), true);
+    CHECK_STD_STRING(synchronizedProxyNode1->GetText(), "ZeroS1"); // default value is used
+    CHECK_NOT_NULL(synchronizedSequenceNode1->GetDataNodeAtValue("0")); // the item is still present
+
+    return EXIT_SUCCESS;
+  }
+}
+
+int vtkSlicerSequencesLogicTest1(int , char * [] )
+{
+  CHECK_EXIT_SUCCESS(TestLogicWithoutScene());
+  CHECK_EXIT_SUCCESS(TestAddSequence());
+  CHECK_EXIT_SUCCESS(TestSparseSequence());
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
It is now possible to represent non-existing items in a sequence as an empty node. It is also possible to enable saving of modifications while avoid creating missing items during sequence browsing.

Additional small fixes and improvements:
- added a test for Sequences module logic and added a few fixes in sequence node observations (so that proxy node is automatically updated if a sequence node is changed)
- added convenience API to browser node to allow selecting item by index value
- i18n: allow translation of sequence node name suffix