### PR TITLE
Update Ruff configuration checking trailing commas

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -7,6 +7,7 @@ select = [
 #  "ANN",         # flake8-annotations
   "B",           # flake8-bugbear
   "C4",          # flake8-comprehensions
+  "COM",         # flake8-commas
   "E", "F", "W", # flake8
   "D",           # pydocstyle
 #  "EXE",         # flake8-executable

--- a/Applications/SlicerApp/Testing/Python/BRAINSFitRigidRegistrationCrashIssue4139.py
+++ b/Applications/SlicerApp/Testing/Python/BRAINSFitRigidRegistrationCrashIssue4139.py
@@ -125,7 +125,7 @@ class BRAINSFitRigidRegistrationCrashIssue4139Test(ScriptedLoadableModuleTest):
             "movingVolume": moving,
             "linearTransform": outputTransform,
             "outputVolume": outputVolume,
-            "useRigid": True
+            "useRigid": True,
         }
         cmdLineNode = slicer.cli.runSync(slicer.modules.brainsfit, parameters=parameters)
         self.assertIsNotNone(cmdLineNode)

--- a/Applications/SlicerApp/Testing/Python/CLISerializationTest.py
+++ b/Applications/SlicerApp/Testing/Python/CLISerializationTest.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
         "--enumeration", "Bill",
         "--boolean1",
         "--seed", "1.0,0.0,-1.0",
-        "--seedsOutFile", serializeSeedsOutFile
+        "--seedsOutFile", serializeSeedsOutFile,
     ]
     parameters = serialize_options
     parameters.extend(required_inputs)
@@ -117,11 +117,11 @@ if __name__ == "__main__":
             {
                 "boolean1": True,
                 "boolean2": False,
-                "boolean3": False
+                "boolean3": False,
             },
             "Enumeration Parameters":
             {
-                "stringChoice": "Bill"
+                "stringChoice": "Bill",
             },
             "File, Directory and Image Parameters":
             {
@@ -130,28 +130,28 @@ if __name__ == "__main__":
                 "files": ["1.does", "2.not", "3.matter"],
                 "image1": "",
                 "image2": "",
-                "outputFile1": ""
+                "outputFile1": "",
             },
             "Generic Tables":
             {
                 "inputDT": "",
-                "outputDT": ""
+                "outputDT": "",
             },
             "Geometry Parameters":
             {
                 "InputModel": "",
                 "ModelSceneFile": [],
-                "OutputModel": ""
+                "OutputModel": "",
             },
             "Index Parameters":
             {
                 "arg0": mrHeadResampled,
-                "arg1": ctHeadAxial
+                "arg1": ctHeadAxial,
             },
             "Measurements":
             {
                 "inputFA": "",
-                "outputFA": ""
+                "outputFA": "",
             },
             "Point Parameters":
             {
@@ -161,12 +161,12 @@ if __name__ == "__main__":
             },
             "Regions of interest":
             {
-                "regions": []
+                "regions": [],
             },
             "Scalar Parameters (\u00e1rv\u00edzt\u0171r\u0151 t\u00fck\u00f6rf\u00far\u00f3g\u00e9p)":
             {
                 "doubleVariable": 30,
-                "integerVariable": 30
+                "integerVariable": 30,
             },
             "Simple return types":
             {
@@ -176,7 +176,7 @@ if __name__ == "__main__":
                 "anintegerreturn": 5,
                 "anintegervectorreturn": [],
                 "astringchoicereturn": "Bill",
-                "astringreturn": "Hello"
+                "astringreturn": "Hello",
             },
             "Transform Parameters":
             {
@@ -187,14 +187,14 @@ if __name__ == "__main__":
                 "transformInputNonlinear": "",
                 "transformOutput": "",
                 "transformOutputBspline": "",
-                "transformOutputNonlinear": ""
+                "transformOutputNonlinear": "",
             },
             "Vector Parameters":
             {
                 "floatVector": [1.2999999523162842, 2, -14],
-                "stringVector": ["foo", "bar", "foobar"]
-            }
-        }
+                "stringVector": ["foo", "bar", "foobar"],
+            },
+        },
     }
 
     with open(json_file, encoding="utf8") as file:
@@ -213,7 +213,7 @@ if __name__ == "__main__":
 
     # Now try to deserialize the CLI.
     parameters = [
-        "--seedsOutFile", deserializeSeedsOutFile
+        "--seedsOutFile", deserializeSeedsOutFile,
     ]
     (returncode, deserializeErr, deserializeOut) = EMTSerializer.deserializeCLI(CLIName, json_file, parameters)
     if returncode != EXIT_SUCCESS:

--- a/Applications/SlicerApp/Testing/Python/DICOMReaders.py
+++ b/Applications/SlicerApp/Testing/Python/DICOMReaders.py
@@ -75,7 +75,7 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
              # DCMTK reads it but then ITK rejects loading the image with 0 spacing.
              "expectedFailures": ["GDCM", "Archetype", "DCMTK", "GDCM with DCMTK fallback"],
              "voxelValueQuantity": '(110852, DCM, "MR signal intensity")',
-             "voxelValueUnits": '(1, UCUM, "no units")'
+             "voxelValueUnits": '(1, UCUM, "no units")',
              },
             {"url": TESTING_DATA_URL + "SHA256/899f3f8617ca53bad7dca0b2908478319e708b48ff41dfa64b6bac1d76529928",
                 "checksum": "SHA256:899f3f8617ca53bad7dca0b2908478319e708b48ff41dfa64b6bac1d76529928",
@@ -84,8 +84,8 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
                 "seriesUID": "1.3.6.1.4.1.5962.99.1.3814087073.479799962.1489872804257.270.0",
                 "expectedFailures": [],
                 "voxelValueQuantity": '(110852, DCM, "MR signal intensity")',
-                "voxelValueUnits": '(1, UCUM, "no units")'
-             }
+                "voxelValueUnits": '(1, UCUM, "no units")',
+             },
         ]
 
         # another dataset that could be added in the future - currently fails for all readers

--- a/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
+++ b/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
@@ -53,7 +53,7 @@ class JRC2013VisWidget(ScriptedLoadableModuleWidget):
         formLayout = qt.QFormLayout(testsCollapsibleButton)
 
         # test buttons
-        tests = (("Part 1: DICOM", self.onPart1DICOM), ("Part 2: Head", self.onPart2Head), ("Part 3: Liver", self.onPart3Liver), ("Part 4: Lung", self.onPart4Lung),)
+        tests = (("Part 1: DICOM", self.onPart1DICOM), ("Part 2: Head", self.onPart2Head), ("Part 3: Liver", self.onPart3Liver), ("Part 4: Lung", self.onPart4Lung))
         for text, slot in tests:
             testButton = qt.QPushButton(text)
             testButton.toolTip = "Run the test."
@@ -111,7 +111,7 @@ class JRC2013VisWidget(ScriptedLoadableModuleWidget):
                 "/../DCMTK-build/bin/Release"
                 "/../DCMTK-build/bin/Debug"
                 "/../DCMTK-build/bin/RelWithDebInfo"
-                "/../DCMTK-build/bin/MinSizeRel"
+                "/../DCMTK-build/bin/MinSizeRel",
             )
 
             dcmqrscpExePath = None
@@ -204,7 +204,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
                 "/../DCMTK-build/bin/Release",
                 "/../DCMTK-build/bin/Debug",
                 "/../DCMTK-build/bin/RelWithDebInfo"
-                "/../DCMTK-build/bin/MinSizeRel"
+                "/../DCMTK-build/bin/MinSizeRel",
             )
 
             dcmqrscpExePath = None
@@ -427,7 +427,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
                 modelNode.GetDisplayNode().SetVisibility(0)
 
             segmentVII = slicer.util.getNode("LiverSegment_II")
-            transparentNodes = ("MiddleHepaticVein_and_Branches", "LiverSegment_IVb", "LiverSegmentV",)
+            transparentNodes = ("MiddleHepaticVein_and_Branches", "LiverSegment_IVb", "LiverSegmentV")
             for nodeName in transparentNodes:
                 modelNode = slicer.util.getNode(nodeName)
                 modelNode.GetDisplayNode().SetOpacity(0.5)

--- a/Applications/SlicerApp/Testing/Python/MeasureStartupTimes.py
+++ b/Applications/SlicerApp/Testing/Python/MeasureStartupTimes.py
@@ -72,7 +72,7 @@ def collect_startup_times_overall(output_file, drop_cache=False, display_output=
         ["--disable-builtin-loadable-modules"],
         ["--disable-builtin-scripted-loadable-modules"],
         ["--disable-builtin-cli-modules", "--disable-builtin-scripted-loadable-modules"],
-        ["--disable-modules"]
+        ["--disable-modules"],
     ]
 
     for test in tests:
@@ -141,7 +141,7 @@ with open("{0}", 'w') as output:
 def slicerRevision():
     (returnCode, stdout, stderr) = runSlicerAndExit(slicer_executable, [
         "--no-main-window", "--ignore-slicerrc", "--disable-modules",
-        "--python-code", "print(slicer.app.repositoryRevision)"
+        "--python-code", "print(slicer.app.repositoryRevision)",
     ])
     assert returnCode == EXIT_SUCCESS
     return stdout.split()[0]
@@ -258,7 +258,7 @@ if __name__ == "__main__":
 
     common_kwargs = {
         "display_output": args.display_slicer_output,
-        "drop_cache": args.drop_cache
+        "drop_cache": args.drop_cache,
     }
 
     # Since the "normal" experiment is included in the "overall" one,

--- a/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
@@ -52,7 +52,7 @@ class RSNAVisTutorialWidget(ScriptedLoadableModuleWidget):
         formLayout = qt.QFormLayout(testsCollapsibleButton)
 
         # test buttons
-        tests = (("Part 1: DICOM", self.onPart1DICOM), ("Part 2: Head", self.onPart2Head), ("Part 3: Liver", self.onPart3Liver), ("Part 4: Lung", self.onPart4Lung),)
+        tests = (("Part 1: DICOM", self.onPart1DICOM), ("Part 2: Head", self.onPart2Head), ("Part 3: Liver", self.onPart3Liver), ("Part 4: Lung", self.onPart4Lung))
         for text, slot in tests:
             testButton = qt.QPushButton(text)
             testButton.toolTip = "Run the test."
@@ -446,7 +446,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
             for modelNode in models.values():
                 modelNode.GetDisplayNode().SetVisibility(0)
 
-            transparentNodes = ("MiddleHepaticVein_and_Branches", "LiverSegment_IVb", "LiverSegmentV",)
+            transparentNodes = ("MiddleHepaticVein_and_Branches", "LiverSegment_IVb", "LiverSegmentV")
             for nodeName in transparentNodes:
                 modelNode = slicer.util.getNode(nodeName)
                 modelNode.GetDisplayNode().SetOpacity(0.5)

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleCleanupTest.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleCleanupTest.py
@@ -59,7 +59,7 @@ def check_exit_code(slicer_executable, testing_enabled=True, debug=False):
             "--no-splash",
             "--disable-builtin-modules",
             "--additional-module-path", temporaryModuleDirPath,
-            "--python-code", 'slicer.util.selectModule("ModuleCleanup")'
+            "--python-code", 'slicer.util.selectModule("ModuleCleanup")',
         ]
 
         test_output_file = temporaryModuleDirPath + "/ModuleCleanupTest.out"

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleCleanupTestHelperModule.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleCleanupTestHelperModule.py
@@ -8,7 +8,7 @@ class ModuleCleanup(ScriptedLoadableModule):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = "Module for cleanup test"
         self.parent.categories = ["ModuleCleanup"]  # Explicitly add a category to work around issue #4698
-        self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)", ]
+        self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)" ]
         self.parent.helpText = """
     This module allows to test that exception raised during module cleanup
     sets exit code.

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleA.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleA.py
@@ -9,7 +9,7 @@ class ModuleA(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = "Module A"
-        self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)", ]
+        self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)" ]
         self.parent.helpText = """
     This module allows to test the scripted module import.
     """

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleB.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleB.py
@@ -7,7 +7,7 @@ class ModuleB(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = "Module B"
-        self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)", ]
+        self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)" ]
         self.parent.helpText = """
     This module allows to test the scripted module import.
     """

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleC_WithoutWidget.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleC_WithoutWidget.py
@@ -7,7 +7,7 @@ class ModuleC_WithoutWidget(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = "Module A"
-        self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)", ]
+        self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)" ]
         self.parent.helpText = """
     This module allows to test the scripted module import.
     """

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleD_WithFileDialog_WithoutWidget.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleD_WithFileDialog_WithoutWidget.py
@@ -8,7 +8,7 @@ class ModuleD_WithFileDialog_WithoutWidget(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = "Module D"
-        self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)", ]
+        self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)" ]
         self.parent.helpText = """
     This module allows to test the scripted module import.
     """

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleE_WithFileWriter_WithoutWidget.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleE_WithFileWriter_WithoutWidget.py
@@ -7,7 +7,7 @@ class ModuleE_WithFileWriter_WithoutWidget(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = "Module E"
-        self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)", ]
+        self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)" ]
         self.parent.helpText = """
     This module allows to test the scripted module import.
     """

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleF_WithFileReader_WithoutWidget.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleF_WithFileReader_WithoutWidget.py
@@ -7,7 +7,7 @@ class ModuleF_WithFileReader_WithoutWidget(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = "Module F"
-        self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)", ]
+        self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)" ]
         self.parent.helpText = """
     This module allows to test the scripted module import.
     """

--- a/Applications/SlicerApp/Testing/Python/ShaderProperties.py
+++ b/Applications/SlicerApp/Testing/Python/ShaderProperties.py
@@ -114,7 +114,7 @@ class ShaderPropertiesTest(ScriptedLoadableModuleTest):
             fn = slicer.util.getNode("vtkMRMLMarkupsLineNode1")
             endpoints = []
             for n in range(2):
-                endpoints.append([0, ] * 3)
+                endpoints.append([0 ] * 3)
                 fn.GetNthControlPointPosition(n, endpoints[n])
             return endpoints
 

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreLoopTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreLoopTest.py
@@ -115,7 +115,7 @@ class SlicerMRBMultipleSaveRestoreLoop(ScriptedLoadableModuleTest):
             self.delayDisplay("Saving mrb to: %s" % mrbFilePath)
             screenShot = ctk.ctkWidgetsUtils.grabWidget(widget)
             self.assertTrue(
-                ioManager.saveScene(mrbFilePath, screenShot)
+                ioManager.saveScene(mrbFilePath, screenShot),
             )
             self.delayDisplay("Finished saving MRB %s" % i)
 

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
@@ -122,11 +122,11 @@ class SlicerMRBMultipleSaveRestore(ScriptedLoadableModuleTest):
         mrbFilePath = slicer.util.tempDirectory("__mrb__") + "/SlicerMRBMultipleSaveRestore-1.mrb"
         self.delayDisplay("Saving scene to: %s\n" % sceneSaveDirectory + "Saving mrb to: %s" % mrbFilePath)
         self.assertTrue(
-            applicationLogic.SaveSceneToSlicerDataBundleDirectory(sceneSaveDirectory, None)
+            applicationLogic.SaveSceneToSlicerDataBundleDirectory(sceneSaveDirectory, None),
         )
         self.delayDisplay("Finished saving scene")
         self.assertTrue(
-            applicationLogic.Zip(mrbFilePath, sceneSaveDirectory)
+            applicationLogic.Zip(mrbFilePath, sceneSaveDirectory),
         )
         self.delayDisplay("Finished saving MRB")
         self.delayDisplay("Slicer mrml scene root dir after first save = %s" % slicer.mrmlScene.GetRootDirectory())
@@ -173,11 +173,11 @@ class SlicerMRBMultipleSaveRestore(ScriptedLoadableModuleTest):
         mrbFilePath = slicer.util.tempDirectory("__mrb__") + "/SlicerMRBMultipleSaveRestore-2.mrb"
         self.delayDisplay("Saving scene to: %s\n" % sceneSaveDirectory + "Saving mrb to: %s" % mrbFilePath)
         self.assertTrue(
-            applicationLogic.SaveSceneToSlicerDataBundleDirectory(sceneSaveDirectory, None)
+            applicationLogic.SaveSceneToSlicerDataBundleDirectory(sceneSaveDirectory, None),
         )
         self.delayDisplay("Finished saving scene after restoring a scene view")
         self.assertTrue(
-            applicationLogic.Zip(mrbFilePath, sceneSaveDirectory)
+            applicationLogic.Zip(mrbFilePath, sceneSaveDirectory),
         )
         self.delayDisplay("Finished saving MRB after restoring a scene view")
 

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBSaveRestoreCheckPathsTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBSaveRestoreCheckPathsTest.py
@@ -202,7 +202,7 @@ class SlicerMRBSaveRestoreCheckPaths(ScriptedLoadableModuleTest):
         mrbFilePath = slicer.util.tempDirectory("__mrb__") + "/SlicerMRBSaveRestoreCheckPaths-1.mrb"
         slicer.util.delayDisplay("\n\n\nSaving mrb to: %s" % mrbFilePath)
         self.assertTrue(
-            ioManager.saveScene(mrbFilePath, screenShot)
+            ioManager.saveScene(mrbFilePath, screenShot),
         )
         slicer.util.delayDisplay("Finished saving mrb\n\n\n")
 
@@ -232,7 +232,7 @@ class SlicerMRBSaveRestoreCheckPaths(ScriptedLoadableModuleTest):
         mrbFilePath = slicer.util.tempDirectory("__mrb__") + "/SlicerMRBSaveRestoreCheckPaths-2.mrb"
         slicer.util.delayDisplay("Saving second mrb to: %s\n\n\n\n" % mrbFilePath)
         self.assertTrue(
-            ioManager.saveScene(mrbFilePath, screenShot)
+            ioManager.saveScene(mrbFilePath, screenShot),
         )
         slicer.util.delayDisplay("\n\n\nFinished second saving mrb %s" % mrbFilePath)
 

--- a/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest1.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest1.py
@@ -234,7 +234,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
             defaultPlusMoveTransform[2],  # [0.0, 0.0, 100.0, 0.2]
             defaultPlusMoveTransform[0],  # [100.0, 0.0, 0.0, -42.0]
             defaultPlusMoveTransform[1],  # [0.0, 100.0, 0.0, 52.0]
-            defaultPlusMoveTransform[3]  # [0.0, 0.0, 0.0, 1.0],
+            defaultPlusMoveTransform[3],  # [0.0, 0.0, 0.0, 1.0],
         ]
         representation.GetTransform(transform)
         self.assertTransform(transform, defaultPlusMovePlusRotationTransform)
@@ -244,7 +244,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
             volumePlusMoveTransform[2],
             volumePlusMoveTransform[0],
             volumePlusMoveTransform[1],
-            volumePlusMoveTransform[3]
+            volumePlusMoveTransform[3],
         ]
 
         volume.SetAndObserveTransformNodeID(tNode.GetID())

--- a/Applications/SlicerApp/Testing/Python/UtilTest.py
+++ b/Applications/SlicerApp/Testing/Python/UtilTest.py
@@ -118,7 +118,7 @@ class UtilTestTest(ScriptedLoadableModuleTest):
             foreground=foregroundNode,
             label=labelmapNode,
             foregroundOpacity=0.5,
-            labelOpacity=0.1
+            labelOpacity=0.1,
         )
         self.assertEqual(redSliceCompositeNode.GetBackgroundVolumeID(), backgroundNode.GetID())
         self.assertEqual(redSliceCompositeNode.GetForegroundVolumeID(), foregroundNode.GetID())
@@ -139,7 +139,7 @@ class UtilTestTest(ScriptedLoadableModuleTest):
             foreground=otherForegroundNode.GetID(),
             label=otherLabelmapNode.GetID(),
             foregroundOpacity=0.0,
-            labelOpacity=1.0
+            labelOpacity=1.0,
         )
         self.assertEqual(redSliceCompositeNode.GetBackgroundVolumeID(), otherBackgroundNode.GetID())
         self.assertEqual(redSliceCompositeNode.GetForegroundVolumeID(), otherForegroundNode.GetID())

--- a/Applications/SlicerApp/Testing/Python/WebEngine.py
+++ b/Applications/SlicerApp/Testing/Python/WebEngine.py
@@ -57,22 +57,22 @@ class WebEngineWidget(ScriptedLoadableModuleWidget):
         buttons = []
         self.sites = [
             {
-                "label": "Web Console", "url": "http://localhost:1337"
+                "label": "Web Console", "url": "http://localhost:1337",
             },
             {
-                "label": "Crowds Cure Cancer", "url": "http://cancer.crowds-cure.org"
+                "label": "Crowds Cure Cancer", "url": "http://cancer.crowds-cure.org",
             },
             {
-                "label": "Slicer Home Page", "url": "https://slicer.org"
+                "label": "Slicer Home Page", "url": "https://slicer.org",
             },
             {
-                "label": "MorphoSource", "url": "https://www.morphosource.org"
+                "label": "MorphoSource", "url": "https://www.morphosource.org",
             },
             {
-                "label": "Slicer SampleData", "url": "https://www.slicer.org/wiki/SampleData"
+                "label": "Slicer SampleData", "url": "https://www.slicer.org/wiki/SampleData",
             },
             {
-                "label": "SlicerMorph", "url": "https://slicermorph.github.io"
+                "label": "SlicerMorph", "url": "https://slicermorph.github.io",
             },
         ]
         for site in self.sites:

--- a/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
@@ -286,7 +286,7 @@ class QDoubleSpinBoxCtkSliderWidgetToFloatConnector(GuiConnector):
     @staticmethod
     def canRepresent(widget, datatype) -> bool:
         return unannotatedType(datatype) == float and type(widget) in (
-            qt.QDoubleSpinBox, ctk.ctkSliderWidget, slicer.qMRMLSliderWidget
+            qt.QDoubleSpinBox, ctk.ctkSliderWidget, slicer.qMRMLSliderWidget,
         )
 
     @staticmethod
@@ -351,7 +351,7 @@ class QComboBoxToStringableConnector(GuiConnector):
     @staticmethod
     def canRepresent(widget, datatype) -> bool:
         return type(widget) == qt.QComboBox and unannotatedType(datatype) in (
-            int, float, str, bool
+            int, float, str, bool,
         )
 
     @staticmethod

--- a/Base/Python/slicer/parameterNodeWrapper/parameterPack.py
+++ b/Base/Python/slicer/parameterNodeWrapper/parameterPack.py
@@ -55,7 +55,7 @@ def _writeValue(self, name: str, value) -> None:
 def _makeConcreteProperty(name: str):
     return property(
         lambda self: _readValue(self, name),
-        lambda self, value: _writeValue(self, name, value)
+        lambda self, value: _writeValue(self, name, value),
     )
 
 

--- a/Base/Python/slicer/parameterNodeWrapper/serializers.py
+++ b/Base/Python/slicer/parameterNodeWrapper/serializers.py
@@ -509,7 +509,7 @@ class ObservedList(collections.abc.MutableSequence):
         self._saveList()
         return val
 
-    def clear(self, ) -> None:
+    def clear(self ) -> None:
         self._list.clear()
         self._saveList()
 
@@ -1008,7 +1008,7 @@ class EnumSerializer(Serializer):
             return self.enum[key]
         except KeyError as ex:
             raise ValueError(
-                f"Found {key!r} in parameter node but it is not a name in {self.enum!r}"
+                f"Found {key!r} in parameter node but it is not a name in {self.enum!r}",
             ) from ex
 
     def remove(self, parameterNode, name: str) -> None:

--- a/Base/Python/slicer/parameterNodeWrapper/validators.py
+++ b/Base/Python/slicer/parameterNodeWrapper/validators.py
@@ -39,7 +39,7 @@ def extractValidators(annotations):
 
     return (
         [x for x in annotations if isValidator(x)],
-        [x for x in annotations if not isValidator(x)]
+        [x for x in annotations if not isValidator(x)],
     )
 
 

--- a/Base/Python/slicer/parameterNodeWrapper/wrapper.py
+++ b/Base/Python/slicer/parameterNodeWrapper/wrapper.py
@@ -123,7 +123,7 @@ class _CachedParameterWrapper(_ParameterWrapper):
 def _makeProperty(name: str):
     return property(
         lambda self: getattr(self, f"_{name}_impl").read(),
-        lambda self, value: getattr(self, f"_{name}_impl").write(value)
+        lambda self, value: getattr(self, f"_{name}_impl").write(value),
     )
 
 

--- a/Base/Python/slicer/release/wiki.py
+++ b/Base/Python/slicer/release/wiki.py
@@ -152,7 +152,7 @@ class Wiki:
     VERSION_INFO_PAGES = {
         "previous": "Template:Documentation/prevversion",
         "current": "Template:Documentation/currentversion",
-        "next": "Template:Documentation/nextversion"
+        "next": "Template:Documentation/nextversion",
     }
 
     def version_info(self, page_name):
@@ -175,7 +175,7 @@ class Wiki:
         return {
             "previous": self.current_version(),
             "current": target_release_version,
-            "next": "%d.%d" % (target_major, target_minor + 2)
+            "next": "%d.%d" % (target_major, target_minor + 2),
         }
 
     def update_version_info_pages(self, release_version):
@@ -249,7 +249,7 @@ class Wiki:
         "Documentation/Release/Report a problem",
         "Documentation/UserTraining",
         "Documentation/UserFeedback",
-        "Documentation/Release/SlicerApplication/HardwareConfiguration"
+        "Documentation/Release/SlicerApplication/HardwareConfiguration",
     ]
 
     def redirect_page_version(self, page_name):
@@ -304,7 +304,7 @@ class Wiki:
         # update page
         content = content.replace(
             marker,
-            marker + "\n" + template.format(version=release_version)
+            marker + "\n" + template.format(version=release_version),
         )
         summary = "Add %s" % release_version
         self.set_page_content(page_name, content, summary)
@@ -422,7 +422,7 @@ def main():
     parser.add_argument(
         "--password", type=str, default=os.environ.get("SLICER_WIKI_UPDATEBOT_PWD"),
         help="password for 'UpdateBot' user. By default, try to get password from "
-        "'SLICER_WIKI_UPDATEBOT_PWD' environment variable."
+        "'SLICER_WIKI_UPDATEBOT_PWD' environment variable.",
     )
 
     subparsers = parser.add_subparsers(
@@ -435,27 +435,27 @@ def main():
     parser_query.add_argument(
         "--version-info", action="store_true",
         help="display the version associated with pages %s" % ", ".join(
-            ["%s" % page_name for page_name in Wiki.VERSION_INFO_PAGES.values()])
+            ["%s" % page_name for page_name in Wiki.VERSION_INFO_PAGES.values()]),
     )
     parser_query.add_argument(
         "--next-version-info", action="store_true",
         help="display what would be the *next* version associated "
         "with pages %s" % ", ".join(
-            ["%s" % page_name for page_name in Wiki.VERSION_INFO_PAGES.values()])
+            ["%s" % page_name for page_name in Wiki.VERSION_INFO_PAGES.values()]),
     )
     parser_query.add_argument(
         "--version-list", action="store_true",
         help="display the versions associated with page "
-        "'Template::Documentation/versionlist'"
+        "'Template::Documentation/versionlist'",
     )
     parser_query.add_argument(
         "--acknowledgments-main-version", action="store_true",
         help="display the version associated with page "
-        "'Template:Documentation/acknowledgments-versionlist'"
+        "'Template:Documentation/acknowledgments-versionlist'",
     )
     parser_query.add_argument(
         "--redirect-pages-version", action="store_true",
-        help="display the version associated with pages with redirect"
+        help="display the version associated with pages with redirect",
     )
 
     # sub-command parser
@@ -463,7 +463,7 @@ def main():
         "copy", help="copy Nightly pages into RELEASE_VERSION namespace")
     parser_copy.add_argument(
         "release_version", type=str, metavar="RELEASE_VERSION",
-        help="the release version where Nightly pages will be copied into"
+        help="the release version where Nightly pages will be copied into",
     )
 
     # sub-command parser
@@ -472,30 +472,30 @@ def main():
 
     parser_update.add_argument(
         "release_version", type=str, metavar="RELEASE_VERSION",
-        help="the release version used to update permanent pages"
+        help="the release version used to update permanent pages",
     )
     parser_update.add_argument(
         "--version-info-pages", action="store_true",
         help="update the version associated with pages %s" % ", ".join(
-            ["%s" % page_name for page_name in Wiki.VERSION_INFO_PAGES.values()])
+            ["%s" % page_name for page_name in Wiki.VERSION_INFO_PAGES.values()]),
     )
     parser_update.add_argument(
         "--redirect-pages", action="store_true",
-        help="update the version associated with redirect pages"
+        help="update the version associated with redirect pages",
     )
     parser_update.add_argument(
         "--version-list", action="store_true",
         help="add RELEASE_VERSION to page "
-        "'Template::Documentation/versionlist'"
+        "'Template::Documentation/versionlist'",
     )
     parser_update.add_argument(
         "--acknowledgments-main-version", action="store_true",
         help="add RELEASE_VERSION to page "
-        "'Template:Documentation/acknowledgments-versionlist'"
+        "'Template:Documentation/acknowledgments-versionlist'",
     )
     parser_update.add_argument(
         "--top-level-documentation-page", action="store_true",
-        help="add RELEASE_VERSION to page 'Documentation'"
+        help="add RELEASE_VERSION to page 'Documentation'",
     )
 
     args = parser.parse_args()

--- a/Base/Python/slicer/tests/test_slicer_parameter_pack.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_pack.py
@@ -298,11 +298,11 @@ class TypedParameterNodeTest(unittest.TestCase):
 
         param.nodes.append(ModelInfo(
             slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", "n1"),
-            True
+            True,
         ))
         param.nodes.append(ModelInfo(
             slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", "n2"),
-            False
+            False,
         ))
 
         self.assertEqual(param.nodes[0].model.GetName(), "n1")

--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -200,7 +200,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     (master_doc, "3Dslicer", "3D Slicer Documentation",
-     [author], 1)
+     [author], 1),
 ]
 
 

--- a/Libs/vtkITK/Testing/vtkITKArchetypeDiffusionTensorReaderFile.py
+++ b/Libs/vtkITK/Testing/vtkITKArchetypeDiffusionTensorReaderFile.py
@@ -39,8 +39,8 @@ class vtkITKReaderAgainstNRRDReader(unittest.TestCase):
         self.assertTrue(
             compare_vtk_matrix(
                 self.ritk.GetMeasurementFrameMatrix(),
-                self.rnrrd.GetMeasurementFrameMatrix()
-            )
+                self.rnrrd.GetMeasurementFrameMatrix(),
+            ),
         )
 
     def test_ras_to_ijk(self):
@@ -52,8 +52,8 @@ class vtkITKReaderAgainstNRRDReader(unittest.TestCase):
         self.assertTrue(
             compare_vtk_matrix(
                 self.ritk.GetRasToIjkMatrix(),
-                self.rnrrd.GetRasToIjkMatrix()
-            )
+                self.rnrrd.GetRasToIjkMatrix(),
+            ),
         )
 
     def test_pointdata(self):

--- a/Libs/vtkITK/Testing/vtkITKArchetypeScalarReaderFile.py
+++ b/Libs/vtkITK/Testing/vtkITKArchetypeScalarReaderFile.py
@@ -37,8 +37,8 @@ class vtkITKReaderAgainstNRRDReader(unittest.TestCase):
         self.assertTrue(
             compare_vtk_matrix(
                 self.ritk.GetRasToIjkMatrix(),
-                self.rnrrd.GetRasToIjkMatrix()
-            )
+                self.rnrrd.GetRasToIjkMatrix(),
+            ),
         )
 
     def test_pointdata(self):

--- a/Modules/Loadable/Colors/Testing/Python/ColorLegendSelfTest.py
+++ b/Modules/Loadable/Colors/Testing/Python/ColorLegendSelfTest.py
@@ -152,7 +152,7 @@ class ColorLegendSelfTestTest(ScriptedLoadableModuleTest):
         sliceNameColor = {
             "Red": [1., 0., 0.],
             "Green": [0., 1., 0.],
-            "Yellow": [1., 1., 0.]
+            "Yellow": [1., 1., 0.],
         }
         for sliceName, titleColor in sliceNameColor.items():
             self.delayDisplay("Test color legend on the " + sliceName + " slice view", self.delayMs)

--- a/Modules/Loadable/Markups/Testing/Python/PluggableMarkupsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/PluggableMarkupsSelfTest.py
@@ -128,7 +128,7 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
             slicer.vtkMRMLMarkupsLineNode(): slicer.vtkSlicerLineWidget(),
             slicer.vtkMRMLMarkupsPlaneNode(): slicer.vtkSlicerPlaneWidget(),
             slicer.vtkMRMLMarkupsROINode(): slicer.vtkSlicerROIWidget(),
-            slicer.vtkMRMLMarkupsTestLineNode(): slicer.vtkSlicerTestLineWidget()
+            slicer.vtkMRMLMarkupsTestLineNode(): slicer.vtkSlicerTestLineWidget(),
         }
 
     def additionalOptionsWidgets(self):
@@ -137,7 +137,7 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
             slicer.qMRMLMarkupsAngleMeasurementsWidget(),
             slicer.qMRMLMarkupsPlaneWidget(),
             slicer.qMRMLMarkupsROIWidget(),
-            slicer.qMRMLMarkupsTestLineWidget()
+            slicer.qMRMLMarkupsTestLineWidget(),
         ]
 
     def test_unregister_existing_markups(self):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorLogicalEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorLogicalEffect.py
@@ -228,7 +228,7 @@ segment list in effect options - below.
                 vtkSegmentationCore.vtkOrientedImageDataResample.ResampleOrientedImageToReferenceOrientedImage(
                     modifierSegmentLabelmap, commonGeometryImage, modifierSegmentLabelmap_CommonGeometry,
                     False,  # nearest neighbor interpolation,
-                    True  # make sure resampled modifier segment is not cropped
+                    True,  # make sure resampled modifier segment is not cropped
                 )
                 modifierSegmentLabelmap = modifierSegmentLabelmap_CommonGeometry
 

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/__init__.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/__init__.py
@@ -31,7 +31,7 @@ editorEffectNames = [
     "SegmentEditorMarginEffect",
     "SegmentEditorMaskVolumeEffect",
     "SegmentEditorSmoothingEffect",
-    "SegmentEditorThresholdEffect"
+    "SegmentEditorThresholdEffect",
 ]
 
 

--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -362,17 +362,17 @@ class DICOMPlugin:
         MRname2UID = {
             "MR Image Storage": "1.2.840.10008.5.1.4.1.1.4",
             "Enhanced MR Image Storage": "1.2.840.10008.5.1.4.1.1.4.1",
-            "Legacy Converted Enhanced MR Image Storage": "1.2.840.10008.5.1.4.1.1.4.4"
+            "Legacy Converted Enhanced MR Image Storage": "1.2.840.10008.5.1.4.1.1.4.4",
         }
         CTname2UID = {
             "CT Image Storage": "1.2.840.10008.5.1.4.1.1.2",
             "Enhanced CT Image Storage": "1.2.840.10008.5.1.4.1.1.2.1",
-            "Legacy Converted Enhanced CT Image Storage": "1.2.840.10008.5.1.4.1.1.2.2"
+            "Legacy Converted Enhanced CT Image Storage": "1.2.840.10008.5.1.4.1.1.2.2",
         }
         PETname2UID = {
             "Positron Emission Tomography Image Storage": "1.2.840.10008.5.1.4.1.1.128",
             "Enhanced PET Image Storage": "1.2.840.10008.5.1.4.1.1.130",
-            "Legacy Converted Enhanced PET Image Storage": "1.2.840.10008.5.1.4.1.1.128.1"
+            "Legacy Converted Enhanced PET Image Storage": "1.2.840.10008.5.1.4.1.1.128.1",
         }
 
         if sopClassUID in MRname2UID.values():

--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -47,14 +47,14 @@ class DICOMProcess:
         "/../DCMTK-build/bin/MinSizeRel",
         "/../DCMTK-build/bin",
         "/../CTK-build/CMakeExternals/Install/bin",
-        "/bin"
+        "/bin",
     ]
-    PROCESS_STATE_NAMES = {0: "NotRunning", 1: "Starting", 2: "Running", }
+    PROCESS_STATE_NAMES = {0: "NotRunning", 1: "Starting", 2: "Running" }
 
     @classmethod
     def getDCMTKToolsPath(
         cls,
-        additionalPaths: list[str] = []
+        additionalPaths: list[str] = [],
     ) -> str:
         """
         Get the first candidate directory that may contain DCMTK tools
@@ -473,7 +473,7 @@ class DICOMSender:
         self.progressCallback = progressCallback or self._defaultProgressCallback
         if self.protocol.upper() == "DIMSE" and auth:
             logging.warning(
-                f"Authentication is not currently supported for {self.protocol} protocol."
+                f"Authentication is not currently supported for {self.protocol} protocol.",
             )
         self.auth = auth or getGlobalDICOMAuth()
 
@@ -488,7 +488,7 @@ class DICOMSender:
     def send(self) -> None:
         """Sends DICOM files to a remote server. Called on instance initialization."""
         self.progressCallback(
-            f"Starting send to {self.destinationUrl.toString()} using {self.protocol} protocol"
+            f"Starting send to {self.destinationUrl.toString()} using {self.protocol} protocol",
         )
 
         if self.protocol.lower() == "dicomweb":
@@ -506,7 +506,7 @@ class DICOMSender:
         for file in self.files:
             self._sendOneFileWithDIMSE(file)
             if not self.progressCallback(
-                f"Sent {file} to {self.destinationUrl.host()}:{self.destinationUrl.port()}"
+                f"Sent {file} to {self.destinationUrl.host()}:{self.destinationUrl.port()}",
             ):
                 raise UserWarning("Sending was cancelled, upload is incomplete.")
 
@@ -539,7 +539,7 @@ class DICOMSender:
         try:
             for file in self.files:
                 if not self.progressCallback(
-                    f"Sending {file} to {self.destinationUrl.toString()} using {self.protocol}"
+                    f"Sending {file} to {self.destinationUrl.toString()} using {self.protocol}",
                 ):
                     raise UserWarning("Sending was cancelled, upload is incomplete.")
                 self._sendOneFileWithDICOMWeb(file, client)
@@ -588,7 +588,7 @@ class DICOMSender:
 
         # Terminate transfer and notify user of failure
         if self._dicomSendSCU(
-            file, config=os.path.join(RESOURCE_ROOT, self.extended_dicom_config_path)
+            file, config=os.path.join(RESOURCE_ROOT, self.extended_dicom_config_path),
         ):
             # success
             return True
@@ -597,7 +597,7 @@ class DICOMSender:
         raise UserWarning(userMsg)
 
     def _sendOneFileWithDICOMWeb(
-        self, file: str, client: dicomweb_client.DICOMwebClient
+        self, file: str, client: dicomweb_client.DICOMwebClient,
     ) -> None:
         """
         Do the actual work of transmitting one DICOM file to a remote server
@@ -614,7 +614,7 @@ class DICOMSender:
         client.store_instances(datasets=[dataset])
 
     def _parseKheopsView(
-        self, destinationURL: qt.QUrl
+        self, destinationURL: qt.QUrl,
     ) -> Optional[tuple[qt.QUrl, HTTPBasicAuth]]:
         """
         Parse parameters for specific Kheops server implementation.

--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -253,7 +253,7 @@ def loadByInstanceUID(instanceUID, messages=None, progressCallback=None):
     highestConfidence = {
         "confidence": 0,
         "plugin": None,
-        "loadable": None
+        "loadable": None,
     }
     for plugin in loadablesByPlugin.keys():
         for loadable in loadablesByPlugin[plugin]:
@@ -263,10 +263,10 @@ def loadByInstanceUID(instanceUID, messages=None, progressCallback=None):
                     highestConfidence = {
                         "confidence": loadable.confidence,
                         "plugin": plugin,
-                        "loadable": loadable
+                        "loadable": loadable,
                     }
     filteredLoadablesByPlugin = {}
-    filteredLoadablesByPlugin[highestConfidence["plugin"]] = [highestConfidence["loadable"], ]
+    filteredLoadablesByPlugin[highestConfidence["plugin"]] = [highestConfidence["loadable"] ]
     # load the results
     return loadLoadables(filteredLoadablesByPlugin)
 
@@ -895,11 +895,11 @@ def importFromDICOMWeb(
 
     if auth and accessToken:
         clientLogger.warning(
-            f"Received both AuthBase and accessToken for DICOM fetch, defaulting to AuthBase"
+            f"Received both AuthBase and accessToken for DICOM fetch, defaulting to AuthBase",
         )
 
     progressDialog = slicer.util.createProgressDialog(
-        parent=slicer.util.mainWindow(), value=0, maximum=100
+        parent=slicer.util.mainWindow(), value=0, maximum=100,
     )
     try:
         progressDialog.labelText = f"Retrieving series list..."

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -320,7 +320,7 @@ class DataProbeInfoWidget:
                     ras_y=abs(ras[1]),
                     ras_z=abs(ras[2]),
                     orient=sliceNode.GetOrientationString(),
-                    spacing=spacing
+                    spacing=spacing,
                     )
 
     def generateLayerName(self, slicerLayerLogic):

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -52,13 +52,13 @@ class SliceAnnotations(VTKObservationMixin):
         self.cornerTexts.append({
             "1-Label": {"text": "", "category": "A"},
             "2-Foreground": {"text": "", "category": "A"},
-            "3-Background": {"text": "", "category": "A"}
+            "3-Background": {"text": "", "category": "A"},
         })
         # Bottom Right Corner Text
         # Not used - orientation figure may be drawn there
         self.cornerTexts.append({
             "1-TR": {"text": "", "category": "A"},
-            "2-TE": {"text": "", "category": "A"}
+            "2-TE": {"text": "", "category": "A"},
         })
         # Top Left Corner Text
         self.cornerTexts.append({
@@ -70,7 +70,7 @@ class SliceAnnotations(VTKObservationMixin):
             "6-Bg-SeriesTime": {"text": "", "category": "C"},
             "7-Bg-SeriesTime": {"text": "", "category": "C"},
             "8-Bg-SeriesDescription": {"text": "", "category": "C"},
-            "9-Fg-SeriesDescription": {"text": "", "category": "C"}
+            "9-Fg-SeriesDescription": {"text": "", "category": "C"},
         })
         # Top Right Corner Text
         self.cornerTexts.append({
@@ -82,7 +82,7 @@ class SliceAnnotations(VTKObservationMixin):
             "6-TR": {"text": "", "category": "A"},
             "7-TE": {"text": "", "category": "A"},
             "8-SlabReconstructionThickness": {"text": "", "category": "A"},
-            "9-SlabReconstructionType": {"text": "", "category": "A"}
+            "9-SlabReconstructionType": {"text": "", "category": "A"},
         })
 
         #
@@ -700,7 +700,7 @@ class SliceAnnotations(VTKObservationMixin):
             "0010,1010": "Patient Age",
             "0018,5100": "Patient Position",
             "0018,0080": "Repetition Time",
-            "0018,0081": "Echo Time"
+            "0018,0081": "Echo Time",
         }
         for tag in tags.keys():
             value = slicer.dicomDatabase.instanceValue(uid, tag)

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -172,12 +172,12 @@ class SampleDataSource:
             if checksums is None:
                 checksums = [None] * len(uris)
         elif isinstance(uris, str):
-            uris = [uris, ]
-            fileNames = [fileNames, ]
-            nodeNames = [nodeNames, ]
-            loadFiles = [loadFiles, ]
-            loadFileType = [loadFileType, ]
-            checksums = [checksums, ]
+            uris = [uris ]
+            fileNames = [fileNames ]
+            nodeNames = [nodeNames ]
+            loadFiles = [loadFiles ]
+            loadFileType = [loadFileType ]
+            checksums = [checksums ]
 
         updatedFileType = []
         for fileName, nodeName, fileType in zip(fileNames, nodeNames, loadFileType):
@@ -215,7 +215,7 @@ class SampleDataSource:
                 f"  len(nodeNames)       : {len(nodeNames)}\n"
                 f"  len(loadFiles)       : {len(loadFiles)}\n"
                 f"  len(updatedFileType) : {len(updatedFileType)}\n"
-                f"  len(checksums)       : {len(checksums)}\n"
+                f"  len(checksums)       : {len(checksums)}\n",
             )
 
     def __eq__(self, other):
@@ -228,7 +228,7 @@ class SampleDataSource:
             "thumbnailFileName : %s" % self.thumbnailFileName,
             "loadFileProperties: %s" % self.loadFileProperties,
             "customDownloader  : %s" % self.customDownloader,
-            ""
+            "",
         ]
         for fileName, uri, nodeName, loadFile, fileType, checksum in zip(self.fileNames, self.uris, self.nodeNames, self.loadFiles, self.loadFileType, self.checksums):
             output.extend([
@@ -238,7 +238,7 @@ class SampleDataSource:
                 " nodeName    : %s" % nodeName,
                 " loadFile    : %s" % loadFile,
                 " loadFileType: %s" % fileType,
-                ""
+                "",
             ])
         return "\n".join(output)
 
@@ -539,7 +539,7 @@ class SampleDataLogic:
              "BaselineVolume.nrrd", "BaselineVolume", "SHA256:dff28a7711d20b6e16d5416535f6010eb99fd0c8468aaa39be4e39da78e93ec2"),
             ("DTIVolume", None,
              (TESTING_DATA_URL + "SHA256/d785837276758ddd9d21d76a3694e7fd866505a05bc305793517774c117cb38d",
-              TESTING_DATA_URL + "SHA256/67564aa42c7e2eec5c3fd68afb5a910e9eab837b61da780933716a3b922e50fe", ),
+              TESTING_DATA_URL + "SHA256/67564aa42c7e2eec5c3fd68afb5a910e9eab837b61da780933716a3b922e50fe" ),
              ("DTIVolume.raw.gz", "DTIVolume.nhdr"), (None, "DTIVolume"),
              ("SHA256:d785837276758ddd9d21d76a3694e7fd866505a05bc305793517774c117cb38d",
               "SHA256:67564aa42c7e2eec5c3fd68afb5a910e9eab837b61da780933716a3b922e50fe")),
@@ -553,20 +553,20 @@ class SampleDataLogic:
              "Panoramix-cropped.nrrd", "Panoramix-cropped", "SHA256:146af87511520c500a3706b7b2bfb545f40d5d04dd180be3a7a2c6940e447433"),
             ("CBCTDentalSurgery", None,
              (TESTING_DATA_URL + "SHA256/7bfa16945629c319a439f414cfb7edddd2a97ba97753e12eede3b56a0eb09968",
-              TESTING_DATA_URL + "SHA256/4cdc3dc35519bb57daeef4e5df89c00849750e778809e94971d3876f95cc7bbd",),
+              TESTING_DATA_URL + "SHA256/4cdc3dc35519bb57daeef4e5df89c00849750e778809e94971d3876f95cc7bbd"),
              ("PreDentalSurgery.gipl.gz", "PostDentalSurgery.gipl.gz"), ("PreDentalSurgery", "PostDentalSurgery"),
              ("SHA256:7bfa16945629c319a439f414cfb7edddd2a97ba97753e12eede3b56a0eb09968",
               "SHA256:4cdc3dc35519bb57daeef4e5df89c00849750e778809e94971d3876f95cc7bbd")),
             ("MRUSProstate", "MR-US Prostate",
              (TESTING_DATA_URL + "SHA256/4843cdc9ea5d7bcce61650d1492ce01035727c892019339dca726380496896aa",
-              TESTING_DATA_URL + "SHA256/34decf58b1e6794069acbe947b460252262fe95b6858c5e320aeab03bc82ebb2",),
+              TESTING_DATA_URL + "SHA256/34decf58b1e6794069acbe947b460252262fe95b6858c5e320aeab03bc82ebb2"),
              ("Case10-MR.nrrd", "case10_US_resampled.nrrd"), ("MRProstate", "USProstate"),
              ("SHA256:4843cdc9ea5d7bcce61650d1492ce01035727c892019339dca726380496896aa",
               "SHA256:34decf58b1e6794069acbe947b460252262fe95b6858c5e320aeab03bc82ebb2")),
             ("CTMRBrain", "CT-MR Brain",
              (TESTING_DATA_URL + "SHA256/6a5b6caccb76576a863beb095e3bfb910c50ca78f4c9bf043aa42f976cfa53d1",
               TESTING_DATA_URL + "SHA256/2da3f655ed20356ee8cdf32aa0f8f9420385de4b6e407d28e67f9974d7ce1593",
-              TESTING_DATA_URL + "SHA256/fa1fe5910a69182f2b03c0150d8151ac6c75df986449fb5a6c5ae67141e0f5e7",),
+              TESTING_DATA_URL + "SHA256/fa1fe5910a69182f2b03c0150d8151ac6c75df986449fb5a6c5ae67141e0f5e7"),
              ("CT-brain.nrrd", "MR-brain-T1.nrrd", "MR-brain-T2.nrrd"),
              ("CTBrain", "MRBrainT1", "MRBrainT2"),
              ("SHA256:6a5b6caccb76576a863beb095e3bfb910c50ca78f4c9bf043aa42f976cfa53d1",
@@ -574,7 +574,7 @@ class SampleDataLogic:
               "SHA256:fa1fe5910a69182f2b03c0150d8151ac6c75df986449fb5a6c5ae67141e0f5e7")),
             ("CBCTMRHead", "CBCT-MR Head",
              (TESTING_DATA_URL + "SHA256/4ce7aa75278b5a7b757ed0c8d7a6b3caccfc3e2973b020532456dbc8f3def7db",
-              TESTING_DATA_URL + "SHA256/b5e9f8afac58d6eb0e0d63d059616c25a98e0beb80f3108410b15260a6817842",),
+              TESTING_DATA_URL + "SHA256/b5e9f8afac58d6eb0e0d63d059616c25a98e0beb80f3108410b15260a6817842"),
              ("DZ-CBCT.nrrd", "DZ-MR.nrrd"),
              ("DZ-CBCT", "DZ-MR"),
              ("SHA256:4ce7aa75278b5a7b757ed0c8d7a6b3caccfc3e2973b020532456dbc8f3def7db",
@@ -612,7 +612,7 @@ class SampleDataLogic:
             nodeNames=["TinyPatient_CT", "TinyPatient_Segments"],
             thumbnailFileName=os.path.join(iconPath, "TinyPatient.png"),
             loadFileType=["VolumeFile", "SegmentationFile"],
-            checksums=["SHA256:c0743772587e2dd4c97d4e894f5486f7a9a202049c8575e032114c0a5c935c3b", "SHA256:3243b62bde36b1db1cdbfe204785bd4bc1fbb772558d5f8cac964cda8385d470"]
+            checksums=["SHA256:c0743772587e2dd4c97d4e894f5486f7a9a202049c8575e032114c0a5c935c3b", "SHA256:3243b62bde36b1db1cdbfe204785bd4bc1fbb772558d5f8cac964cda8385d470"],
         )
 
     def registerTestingDataSources(self):
@@ -774,7 +774,7 @@ class SampleDataLogic:
         """
         return self.downloadFromSource(SampleDataSource(
             uris=uris, fileNames=fileNames, nodeNames=nodeNames, loadFiles=loadFiles,
-            loadFileType=loadFileTypes, loadFileProperties=loadFileProperties, checksums=checksums
+            loadFileType=loadFileTypes, loadFileProperties=loadFileProperties, checksums=checksums,
         ))
 
     def downloadSample(self, sampleName):
@@ -1169,7 +1169,7 @@ class SampleDataTest(ScriptedLoadableModuleTest):
         "sampleName": "customDownloader",
         "uris": "http://down.load/test",
         "fileNames": "cust.om",
-        "customDownloader": CustomDownloader()
+        "customDownloader": CustomDownloader(),
     }
 
     def test_customDownloader(self):

--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -883,7 +883,7 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
         # Try to find the executable at specific paths
         commonFfmpegPaths = [
             "/usr/local/bin/ffmpeg",
-            "/usr/bin/ffmpeg"
+            "/usr/bin/ffmpeg",
         ]
         for ffmpegPath in commonFfmpegPaths:
             if os.path.isfile(ffmpegPath):
@@ -892,7 +892,7 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
                 return True
         # Search for the executable in directories
         commonFfmpegDirs = [
-            self.getDownloadedFfmpegDirectory()
+            self.getDownloadedFfmpegDirectory(),
         ]
         for ffmpegDir in commonFfmpegDirs:
             if self.findFfmpegInDirectory(ffmpegDir):

--- a/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/SegmentStatisticsPluginBase.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/SegmentStatisticsPluginBase.py
@@ -24,7 +24,7 @@ class SegmentStatisticsPluginBase:
         info = {
             "name": name,
             "description": description,
-            "units": units
+            "units": units,
         }
         if componentNames:
             info["componentNames"] = componentNames

--- a/Modules/Scripted/SelfTests/SelfTests.py
+++ b/Modules/Scripted/SelfTests/SelfTests.py
@@ -115,7 +115,7 @@ class SelfTestsWidget(ScriptedLoadableModuleWidget):
         slicer.util.infoDisplay(self.logic, windowTitle="SelfTests")
 
     def onRun(self, test):
-        self.logic.run([test, ], continueCheck=self.continueCheck)
+        self.logic.run([test ], continueCheck=self.continueCheck)
         slicer.util.infoDisplay(self.logic, windowTitle="SelfTests")
 
     def continueCheck(self, logic):

--- a/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
+++ b/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
@@ -59,7 +59,7 @@ class VectorToScalarVolume(ScriptedLoadableModule):
         self.parent.dependencies = []
         self.parent.contributors = ["Steve Pieper (Isomics)",
                                     "Pablo Hernandez-Cerdan (Kitware)",
-                                    "Jean-Christophe Fillion-Robin (Kitware)", ]
+                                    "Jean-Christophe Fillion-Robin (Kitware)" ]
         self.parent.helpText = _("""
     <p>Make a scalar (1 component) volume from a vector volume.</p>
 

--- a/Modules/Scripted/WebServer/WebServerLib/BaseRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/BaseRequestHandler.py
@@ -50,7 +50,7 @@ class BaseRequestHandler(abc.ABC):
 
     @abc.abstractmethod
     def handleRequest(
-        self, method: str, uri: bytes, requestBody: bytes
+        self, method: str, uri: bytes, requestBody: bytes,
     ) -> tuple[bytes, bytes]:
         """
         Do the work of handling the incoming request.

--- a/Modules/Scripted/WebServer/WebServerLib/DICOMRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/DICOMRequestHandler.py
@@ -45,7 +45,7 @@ class DICOMRequestHandler(BaseRequestHandler):
         return 0.5 if parsedURL.path.startswith(b"/dicom") else 0.0
 
     def handleRequest(
-        self, uri: bytes, requestBody: bytes, **_kwargs
+        self, uri: bytes, requestBody: bytes, **_kwargs,
     ) -> tuple[bytes, bytes]:
         """
         Dispatches various dicom requests

--- a/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
@@ -54,7 +54,7 @@ class SlicerRequestHandler(BaseRequestHandler):
         return 0.5 if route.startswith(b"/slicer") else 0.0
 
     def handleRequest(
-        self, method: str, uri: bytes, requestBody: bytes
+        self, method: str, uri: bytes, requestBody: bytes,
     ) -> tuple[bytes, bytes]:
         """Handle a slicer api request.
         TODO: better routing (add routing plugins)
@@ -461,8 +461,8 @@ class SlicerRequestHandler(BaseRequestHandler):
         sizes = imageData.GetDimensions()
         sizes = " ".join(list(map(str, sizes)))
 
-        originList = [0, ] * 3
-        directionLists = [[0, ] * 3, [0, ] * 3, [0, ] * 3]
+        originList = [0 ] * 3
+        directionLists = [[0 ] * 3, [0 ] * 3, [0 ] * 3]
         ijkToRAS = vtk.vtkMatrix4x4()
         volumeNode.GetIJKToRASMatrix(ijkToRAS)
         for row in range(3):
@@ -511,7 +511,7 @@ space origin: %%origin%%
         if transformNode is None or transformArray is None:
             self.logMessage("Could not find requested transform")
             return None
-        supportedNodes = ["vtkMRMLGridTransformNode", ]
+        supportedNodes = ["vtkMRMLGridTransformNode" ]
         if not transformNode.GetClassName() in supportedNodes:
             self.logMessage("Can only get grid transforms")
             return None
@@ -577,12 +577,12 @@ space origin: %%origin%%
             node["scale"] = displayNode.GetGlyphScale()
             node["markups"] = []
             for markupIndex in range(markupsNode.GetNumberOfControlPoints()):
-                position = [0, ] * 3
+                position = [0 ] * 3
                 markupsNode.GetNthControlPointPosition(markupIndex, position)
                 position
                 node["markups"].append({
                     "label": markupsNode.GetNthControlPointLabel(markupIndex),
-                    "position": position
+                    "position": position,
                 })
             fiducials[markupsNode.GetID()] = node
         return (json.dumps(fiducials).encode()), b"application/json"
@@ -921,7 +921,7 @@ space origin: %%origin%%
 
         if scrollTo:
             volumeNode = sliceLogic.GetBackgroundLayer().GetVolumeNode()
-            bounds = [0, ] * 6
+            bounds = [0 ] * 6
             sliceLogic.GetVolumeSliceBounds(volumeNode, bounds)
             sliceLogic.SetSliceOffset(bounds[4] + (scrollTo * (bounds[5] - bounds[4])))
         if offset:

--- a/Modules/Scripted/WebServer/WebServerLib/StaticPagesRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/StaticPagesRequestHandler.py
@@ -52,7 +52,7 @@ class StaticPagesRequestHandler(BaseRequestHandler):
         return 0.1
 
     def handleRequest(
-        self, method: str, uri: bytes, requestBody: bytes
+        self, method: str, uri: bytes, requestBody: bytes,
     ) -> tuple[bytes, bytes]:
         """Return directory listing or binary contents of files
         TODO: other header fields like modified time

--- a/Utilities/Scripts/SlicerWizard/ExtensionProject.py
+++ b/Utilities/Scripts/SlicerWizard/ExtensionProject.py
@@ -39,7 +39,7 @@ class ExtensionProject:
     _referencedVariables = re.compile(r"\$\{([\w_\/\.\+\-]+)\}")
 
     # ---------------------------------------------------------------------------
-    def __init__(self, path, encoding=None, filename="CMakeLists.txt", ):
+    def __init__(self, path, encoding=None, filename="CMakeLists.txt" ):
         """
         :param path: Top level directory of the extension project.
         :type path: :class:`str`

--- a/Utilities/Scripts/SlicerWizard/ExtensionWizard.py
+++ b/Utilities/Scripts/SlicerWizard/ExtensionWizard.py
@@ -684,7 +684,7 @@ class ExtensionWizard:
             os.path.join(scriptPath, "..", "..", "..", "Utilities", "Templates"),  # Run from source directory
             os.path.join(scriptPath, "..", "..", "..", "share",  # Run from install
                          "Slicer-%s.%s" % tuple(__version_info__[:2]),
-                         "Wizard", "Templates")
+                         "Wizard", "Templates"),
         ]
         descriptionFileTemplate = None
         for candidate in candidateBuiltInTemplatePaths:

--- a/Utilities/Scripts/SlicerWizard/__version__.py
+++ b/Utilities/Scripts/SlicerWizard/__version__.py
@@ -2,7 +2,7 @@ __version_info__ = (
     5,
     5,
     0,
-    "dev0"
+    "dev0",
 )
 
 __version__ = ".".join(map(str, __version_info__))

--- a/Utilities/Scripts/SlicerWizard/__version__.py.in
+++ b/Utilities/Scripts/SlicerWizard/__version__.py.in
@@ -2,7 +2,7 @@ __version_info__ = (
     @Slicer_VERSION_MAJOR@,
     @Slicer_VERSION_MINOR@,
     @Slicer_VERSION_PATCH@,
-    @Slicer_VERSION_TWEAK_OR_DEV@
+    @Slicer_VERSION_TWEAK_OR_DEV@,
 )
 
 __version__ = ".".join(map(str, __version_info__))

--- a/Utilities/Scripts/SlicerWizard/doc/conf.py
+++ b/Utilities/Scripts/SlicerWizard/doc/conf.py
@@ -284,7 +284,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ("index", "slicerwizard", "SlicerWizard Documentation",
-     [author], 1)
+     [author], 1),
 ]
 
 # If true, show URL addresses after external links.

--- a/Utilities/Templates/Modules/Scripted/TemplateKey.py
+++ b/Utilities/Templates/Modules/Scripted/TemplateKey.py
@@ -79,7 +79,7 @@ def registerSampleData():
         #  import hashlib; print(hashlib.sha256(open(filename, "rb").read()).hexdigest())
         checksums="SHA256:998cb522173839c78657f4bc0ea907cea09fd04e44601f17c82ea27927937b95",
         # This node name will be used when the data set is loaded
-        nodeNames="TemplateKey1"
+        nodeNames="TemplateKey1",
     )
 
     # TemplateKey2
@@ -93,7 +93,7 @@ def registerSampleData():
         fileNames="TemplateKey2.nrrd",
         checksums="SHA256:1a64f3f422eb3d1c9b093d1a18da354b13bcf307907c66317e2463ee530b7a97",
         # This node name will be used when the data set is loaded
-        nodeNames="TemplateKey2"
+        nodeNames="TemplateKey2",
     )
 
 
@@ -298,7 +298,7 @@ class TemplateKeyLogic(ScriptedLoadableModuleLogic):
             "InputVolume": inputVolume.GetID(),
             "OutputVolume": outputVolume.GetID(),
             "ThresholdValue": imageThreshold,
-            "ThresholdType": "Above" if invert else "Below"
+            "ThresholdType": "Above" if invert else "Below",
         }
         cliNode = slicer.cli.run(slicer.modules.thresholdscalarvolume, None, cliParams, wait_for_completion=True, update_display=showResult)
         # We don't need the CLI module node anymore, remove it to not clutter the scene with it


### PR DESCRIPTION
These changes are steps toward minimizing the differences between the Slicer python sources and output of formatter like "ruff" or "black".

**Rational:** The presence of a trailing comma can reduce diff size when parameters or elements are added or removed from function calls, function definitions, literals, etc.

See https://docs.astral.sh/ruff/rules/#flake8-commas-com


Once integrated, the commits prefixed with `STYLE: ` will be added to the `.git-blame-ignore-revs`[^1] file.

[^1]: https://github.com/Slicer/Slicer/blob/main/.git-blame-ignore-revs