### PR TITLE
COMP: Call c_str() to get const char* for property comparison tests

### DIFF
--- a/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h
+++ b/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h
@@ -325,30 +325,36 @@
 /// test a string variable on the object by calling Set/Get
 #define TEST_SET_GET_STRING( object, variable ) \
   { \
-  const char * originalStringPointer = object->Get##variable(); \
+  std::string tmpString = std::string(object->Get##variable()); \
+  const char * originalStringPointer = tmpString.c_str(); \
   std::string originalString; \
   if( originalStringPointer != nullptr ) \
     { \
     originalString = originalStringPointer; \
     } \
   object->Set##variable( "testing with a const char");                  \
-  if( strcmp(object->Get##variable(), "testing with a const char") != 0) \
+  tmpString = std::string(object->Get##variable());                     \
+  if( strcmp(tmpString.c_str(), "testing with a const char") != 0) \
     {                                                                   \
     std::cerr << "Error in Set/Get"#variable << " with a string literal" << std::endl; \
     return EXIT_FAILURE;                                                \
     }                                                                   \
   std::string string1 = "testingIsGood"; \
   object->Set##variable( string1.c_str() ); \
-  if( object->Get##variable() != string1 ) \
+  tmpString = std::string(object->Get##variable()); \
+  if( tmpString != string1 ) \
     {   \
-    std::cerr << "Error in Set/Get"#variable << ", tried to set to " << string1.c_str() << " but got " << (object->Get##variable() ? object->Get##variable() : "null") << std::endl; \
+    std::cerr << "Error in Set/Get"#variable \
+      << ", tried to set to " << string1.c_str() << " but got " << (tmpString.c_str() ? tmpString.c_str() : "null") << std::endl; \
     return EXIT_FAILURE; \
     } \
   std::string string2 = "moreTestingIsBetter"; \
   object->Set##variable( string2.c_str() ); \
+  tmpString = std::string(object->Get##variable()); \
   if( object->Get##variable() != string2 ) \
     {   \
-    std::cerr << "Error in Set/Get"#variable << ", tried to set to " << string2.c_str() << " but got " << (object->Get##variable() ? object->Get##variable() : "null") << std::endl; \
+    std::cerr << "Error in Set/Get"#variable \
+      << ", tried to set to " << string2.c_str() << " but got " << (tmpString.c_str() ? tmpString.c_str() : "null") << std::endl; \
     return EXIT_FAILURE; \
     } \
   if( originalStringPointer != nullptr ) \


### PR DESCRIPTION
Call `c_str()` to get `const char*` types for object property comparison tests.

Fixes:
```
Slicer/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeTest1.cxx:
 In function ‘int vtkMRMLSceneViewNodeTest1(int, char**)’:
Slicer/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h:328:62:
 warning: ‘vtkStdString::operator const char*()’ is deprecated: Call `.c_str()` explicitly [-Wdeprecated-declarations]
   const char * originalStringPointer = object->Get##variable(); \
```

and similar errors.

raised for example in:
https://github.com/Slicer/Slicer/actions/runs/6885650499/job/18730113110#step:4:3460
