### PR TITLE
COMP: Fix -Wnonnull warnings in MRML Annotation nodes

### DIFF
--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationControlPointsStorageNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationControlPointsStorageNode.cxx
@@ -238,7 +238,7 @@ int vtkMRMLAnnotationControlPointsStorageNode::ReadAnnotation(vtkMRMLAnnotationC
 
   if (refNode == nullptr)
     {
-      vtkErrorMacro("ReadAnnotation: unable to cast input node " << refNode->GetID() << " to an annotation node");
+      vtkErrorMacro("ReadAnnotation: unable to cast input node (nullptr) to an annotation node");
       return 0;
     }
 

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLinesStorageNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLinesStorageNode.cxx
@@ -228,7 +228,7 @@ int vtkMRMLAnnotationLinesStorageNode::ReadAnnotation(vtkMRMLAnnotationLinesNode
 
   if (refNode == nullptr)
     {
-      vtkErrorMacro("ReadAnnotation: unable to cast input node " << refNode->GetID() << " to an annotation node");
+      vtkErrorMacro("ReadAnnotation: unable to cast input node (nullptr) to an annotation node");
       return 0;
     }
 

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerStorageNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerStorageNode.cxx
@@ -200,7 +200,7 @@ int vtkMRMLAnnotationRulerStorageNode::ReadAnnotation(vtkMRMLAnnotationRulerNode
 
   if (refNode == nullptr)
     {
-    vtkErrorMacro("ReadAnnotation: unable to cast input node " << refNode->GetID() << " to an annotation node");
+    vtkErrorMacro("ReadAnnotation: unable to cast input node (nullptr) to an annotation node");
     return 0;
     }
 


### PR DESCRIPTION
Fix null pointer property query warnings.

Fixes:
```
slicer/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationControlPointsStorageNode.cxx:
 In member function ‘int vtkMRMLAnnotationControlPointsStorageNode::ReadAnnotation(vtkMRMLAnnotationControlPointsNode*)’:
slicer/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationControlPointsStorageNode.cxx:241:83:
 warning: ‘this’ pointer is null [-Wnonnull]
  241 |       vtkErrorMacro("ReadAnnotation: unable to cast input node " << refNode->GetID() << " to a annotation node");
      |                                                                     ~~~~~~~~~~~~~~^~
licer/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLinesStorageNode.cxx:
 In member function ‘int vtkMRMLAnnotationLinesStorageNode::ReadAnnotation(vtkMRMLAnnotationLinesNode*)’:
slicer/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLinesStorageNode.cxx:231:83:
 warning: ‘this’ pointer is null [-Wnonnull]
  231 |       vtkErrorMacro("ReadAnnotation: unable to cast input node " << refNode->GetID() << " to a annotation node");
      |                                                                     ~~~~~~~~~~~~~~^~
slicer/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerStorageNode.cxx:
 In member function ‘int vtkMRMLAnnotationRulerStorageNode::ReadAnnotation(vtkMRMLAnnotationRulerNode*)’:
slicer/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerStorageNode.cxx:203:81:
 warning: ‘this’ pointer is null [-Wnonnull]
  203 |     vtkErrorMacro("ReadAnnotation: unable to cast input node " << refNode->GetID() << " to a annotation node");
      |                                                                   ~~~~~~~~~~~~~~^~
```

raised when compiling 3D Slicer locally on an Ubuntu 22.04 machine with gcc-11.