### PR TITLE
COMP: Fix unused parameter warnings in `vtkMRMLI18NTest1.cxx`

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLI18NTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLI18NTest1.cxx
@@ -28,7 +28,8 @@ namespace
     vtkTypeMacro(vtkTestTranslator, vtkMRMLTranslator);
 
     /// Translation method for testing that returns "translated-(context)(sourceText)" as translation
-    std::string Translate(const char* context, const char* sourceText, const char* disambiguation = nullptr, int n = -1) override
+    std::string Translate(const char* context, const char* sourceText,
+                          const char* vtkNotUsed(disambiguation) /*= nullptr*/, int vtkNotUsed(n) /*= -1*/) override
       {
       return std::string("translated-") + context + sourceText;
       }


### PR DESCRIPTION
Fix unused parameter warnings in `vtkMRMLI18NTest1.cxx`

Fixes:
```
/usr/src/Slicer/Libs/MRML/Core/Testing/vtkMRMLI18NTest1.cxx:
 In member function ‘virtual std::string {anonymous}::vtkTestTranslator::Translate(const char*, const char*, const char*, int)’:
/usr/src/Slicer/Libs/MRML/Core/Testing/vtkMRMLI18NTest1.cxx:31:101:
 warning: unused parameter ‘disambiguation’ [-Wunused-parameter]
     std::string Translate(const char* context, const char* sourceText, const char* disambiguation = nullptr, int n = -1) override
                                                                                                     ^~~~~~~
/usr/src/Slicer/Libs/MRML/Core/Testing/vtkMRMLI18NTest1.cxx:31:119:
 warning: unused parameter ‘n’ [-Wunused-parameter]
     std::string Translate(const char* context, const char* sourceText, const char* disambiguation = nullptr, int n = -1) override
                                                                                                                       ^
```

Raised for example at:
https://github.com/Slicer/Slicer/actions/runs/6950843491/job/18911721210#step:4:3066