### PR TITLE
COMP: Fix `-Wimplicit-fallthrough` warnings in qSlicerStyle

### DIFF
--- a/Base/QTGUI/qSlicerStyle.cxx
+++ b/Base/QTGUI/qSlicerStyle.cxx
@@ -179,6 +179,7 @@ QRect qSlicerStyle::subControlRect(ComplexControl control, const QStyleOptionCom
             }
           }
         // </HACK>
+        Q_FALLTHROUGH();
 #endif // QT_NO_SLIDER
     default:
       rect = Superclass::subControlRect(control, option, subControl, widget);
@@ -289,6 +290,7 @@ int qSlicerStyle::styleHint(StyleHint hint, const QStyleOption *opt, const QWidg
         res = widget->property("SH_ItemView_ActivateItemOnSingleClick").toBool();
         break;
         }
+      Q_FALLTHROUGH();
     // Overload the SH_ComboBox_Popup option to prevent issue with checkable
     // combobox. For more details see: https://bugreports.qt.io/browse/QTBUG-19683
     case QStyle::SH_ComboBox_Popup:


### PR DESCRIPTION
Fixes:
```
slicer/Base/QTGUI/qSlicerStyle.cxx:
 In member function ‘virtual QRect qSlicerStyle::subControlRect(QStyle::ComplexControl, const QStyleOptionComplex*, QStyle::SubControl, const QWidget*) const’:
slicer/Base/QTGUI/qSlicerStyle.cxx:180:11:
 warning: this statement may fall through [-Wimplicit-fallthrough=]
  180 |           }
      |           ^
slicer/Base/QTGUI/qSlicerStyle.cxx:183:5: note: here
  183 |     default:
      |     ^~~~~~~
```
and

```
slicer/Base/QTGUI/qSlicerStyle.cxx:
 In member function ‘virtual int qSlicerStyle::styleHint(QStyle::StyleHint, const QStyleOption*, const QWidget*, QStyleHintReturn*) const’:
slicer/Base/QTGUI/qSlicerStyle.cxx:287:7:
 warning: this statement may fall through [-Wimplicit-fallthrough=]
  287 |       if (widget && widget->property("SH_ItemView_ActivateItemOnSingleClick").isValid())
      |       ^~
slicer/Base/QTGUI/qSlicerStyle.cxx:294:5: note: here
  294 |     case QStyle::SH_ComboBox_Popup:
      |     ^~~~
```

raised when compiling 3D Slicer locally on an Ubuntu 22.04 machine with gcc-11.