### PR TITLE
COMP: Use `Qt::SkipEmptyParts` instead of deprecated `QString::SkipEmptyParts`

### DIFF
--- a/Base/QTApp/qSlicerErrorReportDialog.cxx
+++ b/Base/QTApp/qSlicerErrorReportDialog.cxx
@@ -81,7 +81,11 @@ qSlicerErrorReportDialog::qSlicerErrorReportDialog(QWidget* parentWidget)
     QVariant fileString(path);
     QFileInfo fi(path);
     QString fileName = fi.fileName();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QStringList stringList = fileName.split("_", Qt::SkipEmptyParts);
+#else
     QStringList stringList = fileName.split("_", QString::SkipEmptyParts);
+#endif
     itemApp->setText(stringList.at(0));
     itemApp->setData(Qt::UserRole, fileString);
     if (stringList.size() >= 6) // compatibility for log files with and without app version in filename


### PR DESCRIPTION
Use `Qt::SkipEmptyParts` instead of deprecated `QString::SkipEmptyParts`
applying fix similar to 94f644676

Note that the version check test for Qt 5.14 because the Qt enum was effectively introduced in Qt 5.14. See https://github.com/qt/qtbase/commit/26a0db4b441a74cb65410635c3e8608a6360c793


Fixes:
```
slicer/Base/QTApp/qSlicerErrorReportDialog.cxx:84:44:
 warning: ‘QStringList QString::split(const QString&, QString::SplitBehavior, Qt::CaseSensitivity) const’ is deprecated:
  Use Qt::SplitBehavior variant instead [-Wdeprecated-declarations]
   84 |     QStringList stringList = fileName.split("_", QString::SkipEmptyParts);
      |                              ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sdks/qt/5.15.2/gcc_64/include/QtCore/qstring.h:609:17: note: declared here
  609 |     QStringList split(const QString &sep, SplitBehavior behavior,
      |                 ^~~~~
```

raised when compiling 3D Slicer locally on an Ubuntu 22.04 machine with gcc-11 and using Qt 5.15.2.

Documentation:
https://doc.qt.io/qt-5/qstring-obsolete.html#SplitBehavior-enum