### PR TITLE
COMP: Fix `-Wstringop-truncation` GCC warning in vtkMRMLROIListNode 

### DIFF
--- a/Libs/MRML/Core/vtkMRMLROIListNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLROIListNode.cxx
@@ -196,7 +196,7 @@ void vtkMRMLROIListNode::ReadXMLAttributes(const char** atts)
         if (IDPtr != nullptr)
           {
           // replace the space with a carriage return
-          IDPtr = strncpy(IDPtr, "\n", 1);
+          IDPtr[0] = '\n';
           }
         }
       // now parse the string into tokens by the newline


### PR DESCRIPTION
Fixes:

```
In function ‘char* strncpy(char*, const char*, size_t)’,
    inlined from ‘virtual void vtkMRMLROIListNode::ReadXMLAttributes(const char**)’ at slicer/Libs/MRML/Core/vtkMRMLROIListNode.cxx:199:26:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:34: warning: ‘char* __builtin_strncpy(char*, const char*, long unsigned int)’ output truncated before terminating nul copying 1 byte from a string of the same length [-Wstringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
```

raised when compiling on an Ubuntu 22.04 machine with gcc-11.