### PR TITLE
STYLE: Add recent formatting changes to ignored list for git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -342,3 +342,7 @@ db4bcddcaca1c9277dcb46e8a787043e43ad8b6e
 6a545c3917ae6c284570593d444136df8ac270f4
 # STYLE: Align Python scripts with "ruff" formatting adjusting quotes
 b19d02ac2119b7457c2341e995ad6353235bbbb4
+# STYLE: Align Python scripts with "ruff" formatting updating argument parser
+90164ec63b891a0d9ee89b06af68ba8d9a29dfb6
+# STYLE: Align Python scripts with "ruff" formatting updating if expressions
+830c33a34ca6d33dc70a4004f674ed640337eee7


### PR DESCRIPTION
This adds recent formatting commits to the git blame ignore list.

For convenience, here is the list of commit added to the `.git-blame-ignore-revs` file. While reviewing this pull request, consider (un)checking if any of these should be added/removed or commenting if I missed any.

* [x] 90164ec63b891a0d9ee89b06af68ba8d9a29dfb6 `STYLE: Align Python scripts with "ruff" formatting updating argument parser`
* [x] 830c33a34ca6d33dc70a4004f674ed640337eee7 `STYLE: Align Python scripts with "ruff" formatting updating if expressions`