### PR TITLE
ENH: Update SimpleITK from 2.2.0rc2 to 2.2.1 to support TotalSegmentator v2

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -140,7 +140,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" \"-m\" \"pi
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "ca0c09386219dfff61975437b7ea32b246adb724"  # slicer-v2.2.0-2022-08-30-1c0cf5de
+    "6a057bdf8e8fdae4f7b39265f445759e0b577eb0"  # slicer-v2.2.1-2022-12-01-f95590f7
     QUIET
     )
 


### PR DESCRIPTION
List of changes:

```
$ git shortlog 1c0cf5de..v2.2.1 --no-merges
Bradley Lowekamp (17):
      Fix numpy character dtype conversion warning
      Update ITK Superbuild version
      UpdateLabelOverlapMeasures with ITK 5.3 changes
      Use ITK GTest already defined
      Use system python executable
      Update AZP Mac package utility python version to 3.9
      Fix GHA trigger for Package workflows
      Preserve SWIG PCRE file timestamps
      CircleCI install "file" executable depedency
      Correct DOWNLOAD_EXTRACT_TIMESTAMP value
      Update ITK to 5.3.0 tagged release
      Fix CircleCI Python 3.8 build
      Update actions to fix warning
      Make Image valid after move
      Add testing for valid image after move
      Adding cp311 to GHA Package workflow
      Update version to 2.2.1
```