### PR TITLE
Simplify Endoscopy API relelated to quaternion

### DIFF
--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -822,8 +822,12 @@ class EndoscopyLogic:
                 )
                 quaternion = np.zeros((4,))
                 quaternionInterpolator.InterpolateQuaternion(distanceAlongResampledCurve, quaternion)
+
                 relativeOrientation = EndoscopyLogic.quaternionToOrientation(quaternion)
-                self.setRelativeOrientation(self.resampledCurve, resampledCurvePointIndex, relativeOrientation)
+
+                worldOrientation = self.relativeOrientationToWorld(self.resampledCurve, resampledCurvePointIndex, relativeOrientation)
+
+                self.resampledCurve.SetNthControlPointOrientation(resampledCurvePointIndex, worldOrientation)
 
     def getDefaultOrientation(self, curve, curveControlPointIndex):
         numberOfCurveControlPoints = curve.GetNumberOfControlPoints()
@@ -850,19 +854,6 @@ class EndoscopyLogic:
         worldOrientation = EndoscopyLogic.matrix3x3ToOrientation(matrix3x3)
 
         return worldOrientation
-
-    @staticmethod
-    def setWorldOrientation(curve, curveControlPointIndex, worldOrientation):
-        curve.SetNthControlPointOrientation(curveControlPointIndex, worldOrientation)
-
-    def getRelativeOrientation(self, curve, curveControlPointIndex):
-        worldOrientation = np.zeros((4,))
-        curve.GetNthControlPointOrientation(curveControlPointIndex, worldOrientation)
-        return self.worldOrientationToRelative(curve, curveControlPointIndex, worldOrientation)
-
-    def setRelativeOrientation(self, curve, curveControlPointIndex, relativeOrientation):
-        worldOrientation = self.relativeOrientationToWorld(curve, curveControlPointIndex, relativeOrientation)
-        EndoscopyLogic.setWorldOrientation(curve, curveControlPointIndex, worldOrientation)
 
     def relativeOrientationToWorld(self, curve, curveControlPointIndex, relativeOrientation):
         defaultOrientation = self.getDefaultOrientation(curve, curveControlPointIndex)

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -886,7 +886,7 @@ class EndoscopyLogic:
     @staticmethod
     def matrix3x3ToOrientation(matrix3x3):
         orientation = np.zeros((4,))
-        vtkQ = vtk.vtkQuaternion[np.float64]()
+        vtkQ = vtk.vtkQuaterniond()
         vtkQ.FromMatrix3x3(matrix3x3)
         orientation[0] = vtkQ.GetRotationAngleAndAxis(orientation[1:4])
         return orientation
@@ -894,7 +894,7 @@ class EndoscopyLogic:
     @staticmethod
     def orientationToMatrix3x3(orientation):
         matrix3x3 = np.zeros((3, 3))
-        vtkQ = vtk.vtkQuaternion[np.float64]()
+        vtkQ = vtk.vtkQuaterniond()
         vtkQ.SetRotationAngleAndAxis(*orientation)
         vtkQ.ToMatrix3x3(matrix3x3)
         return matrix3x3
@@ -902,7 +902,7 @@ class EndoscopyLogic:
     @staticmethod
     def orientationToQuaternion(orientation):
         quaternion = np.zeros((4,))
-        vtkQ = vtk.vtkQuaternion[np.float64]()
+        vtkQ = vtk.vtkQuaterniond()
         vtkQ.SetRotationAngleAndAxis(*orientation)
         vtkQ.Get(quaternion)
         return quaternion
@@ -910,8 +910,7 @@ class EndoscopyLogic:
     @staticmethod
     def quaternionToOrientation(quaternion):
         orientation = np.zeros((4,))
-        vtkQ = vtk.vtkQuaternion[np.float64]()
-        vtkQ.Set(*quaternion)
+        vtkQ = vtk.vtkQuaterniond(*quaternion)
         orientation[0] = vtkQ.GetRotationAngleAndAxis(orientation[1:4])
         return orientation
 

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -901,12 +901,6 @@ class EndoscopyLogic:
         return orientation
 
     @staticmethod
-    def matrix3x3ToQuaternion(matrix3x3):
-        quaternion = np.zeros((4,))
-        vtk.vtkMath.matrix3x3ToQuaternion(matrix3x3, quaternion)
-        return quaternion
-
-    @staticmethod
     def orientationToMatrix3x3(orientation):
         matrix3x3 = np.zeros((3, 3))
         vtkQ = vtk.vtkQuaternion[np.float64]()
@@ -921,12 +915,6 @@ class EndoscopyLogic:
         vtkQ.SetRotationAngleAndAxis(*orientation)
         vtkQ.Get(quaternion)
         return quaternion
-
-    @staticmethod
-    def quaternionToMatrix3x3(quaternion):
-        matrix3x3 = np.zeros((3, 3))
-        vtk.vtkMath.quaternionToMatrix3x3(quaternion, matrix3x3)
-        return matrix3x3
 
     @staticmethod
     def quaternionToOrientation(quaternion):


### PR DESCRIPTION
This is a follow-up of commit 717fd6f2b (ENH: Add support for managing orientation keyframe in Endoscopy) introduced through https://github.com/Slicer/Slicer/pull/7165

The set of commits aims to simplify the Endoscopy API (removing <s>~60</s> ~30 lines):

- Simplifies math helper functions API supporting only "return by value": Supporting both "return by value" and "pass mutable object as argument" API is error-prone.
- Removes unnecessary wrapping of relative orientation functions.
- Directly utilizes `vtkMRMLMarkupsNode::SetNthControlPointOrientation`.
- <s>Directly employs VTK's math functions for converting between matrices and quaternions.</s>
- <s>Streamlines interpolation by eliminating unnecessary functions: `orientationToQuaternion` and `quaternionToOrientation` are converting to/from the same object.</s>
- Remove unused functions: 
   - `getRelativeOrientation`
   - `matrix3x3ToQuaternion` and `quaternionToMatrix3x3` (these were also not working)