### PR TITLE
ENH: Use "Use this curve" instead of "Create flythrough path" as button text

### DIFF
--- a/Docs/user_guide/modules/endoscopy.md
+++ b/Docs/user_guide/modules/endoscopy.md
@@ -15,7 +15,7 @@ Selects the camera and curve to be manipulated.
 
 - **Camera**: The camera used for the flythrough.
 - **Curve to modify**: The curve defining the flythrough path control points.
-- **Create flythrough path**: Press to generate the flythrough path corresponding to the selected curve and camera.
+- **Use this curve**: Press to indicate that the camera and curve have been selected.
 
 ### Flythrough
 
@@ -28,7 +28,7 @@ Controls the animation.
 - **View Angle**: Field of view of the camera.  The default value of 30 degrees approximates normal camera lenses.  Larger numbers, such as 110 or 120 degrees approximate the wide angle lenses often used in endoscopy viewing systems.
 - **Save keyframe orientation** / **Update keyframe orientation**: Press to indicate that a flythrough frame is a keyframe and that you have selected your desired camera orientation for this keyframe in the first-person, 3D viewing pane.  If you wish to update the orientation for a keyframe, use the Frame, First, Back, Next, or Last buttons to go to the frame, adjust the camera orientation, and hit this button again.
 - **Delete keyframe orientation**: Discard the camera orientation associated with the selected keyframe.
-- **First**: PRess to go to the lowest-numbered keyframe.
+- **First**: Press to go to the lowest-numbered keyframe.
 - **Back**: Press to move backwards through the flythrough to the nearest keyframe.
 - **Next**: Press to move forwards through the flythrough to the nearest keyframe.
 - **Last**: Press to go to the highest-numbered keyframe

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -42,7 +42,7 @@ class Endoscopy(ScriptedLoadableModule):
 Create or import a markups curve.
 Pick the Camera to use for either playing the flythrough or editing associated keyframes.
 Select the Camera to use for playing the flythrough.
-Clicking "Create flythrough path" will make a flythrough curve and enable the flythrough panel.
+Clicking "Use this curve" will make a flythrough curve and enable the flythrough panel.
 You can manually scroll through the path with the Frame slider.
 The Play/Pause button toggles animated flythrough.
 The Frame Skip slider speeds up the animation by skipping points on the path.
@@ -132,7 +132,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.inputCurveSelector = inputCurveSelector
 
         # CreatePath button
-        createPathButton = qt.QPushButton(_("Create flythrough path"))
+        createPathButton = qt.QPushButton(_("Use this curve"))
         createPathButton.toolTip = _("Base the flythrough on the selected input curve.")
         createPathButton.enabled = False
         createPathButton.connect("clicked()", self.onCreatePathButtonClicked)
@@ -152,7 +152,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Play button
         playButton = qt.QPushButton(_("Play flythrough"))
-        playButton.toolTip = _("Fly through path.")
+        playButton.toolTip = _("Fly through curve.")
         playButton.checkable = True
         playButton.connect("toggled(bool)", self.onPlayButtonToggled)
         flythroughFormLayout.addRow(playButton)
@@ -344,7 +344,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         pass
 
     def onCreatePathButtonClicked(self):
-        """Connected to `createPath` button.  It allows to:
+        """Connected to 'Use this curve'` button.  It allows to:
         - compute the path
         - create cursor
         - ensure cursor, model and input curve are not visible in the endoscopy view


### PR DESCRIPTION
This reflects that the purpose of the button is to indicate to the Endoscopy module which curve the flythrough should be along.  Although the button does also trigger computations for the flythrough this is a behind-the-scenes decision that could later be changed.  In particular, modifications of the curve cause re-calculations as necessary without the user having to click the button again.