### PR TITLE
Streamline Endoscopy UX removing "Use this curve" button

### DIFF
--- a/Docs/user_guide/modules/endoscopy.md
+++ b/Docs/user_guide/modules/endoscopy.md
@@ -15,7 +15,6 @@ Selects the camera and curve to be manipulated.
 
 - **Camera**: The camera used for the flythrough.
 - **Curve to modify**: The curve defining the flythrough path control points.
-- **Use this curve**: Press to indicate that the camera and curve have been selected.
 
 ### Flythrough
 

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -797,9 +797,9 @@ class EndoscopyLogic:
         quaternionInterpolator = vtk.vtkQuaternionInterpolator()
         quaternionInterpolator.SetSearchMethod(0)  # binary search
 
-        # # Using a modified Kochanek basis
-        # quaternionInterpolator.SetInterpolationTypeToSpline()
-        # Using linear spherical interpolation
+        # Use the "linear spherical interpolation" rather than the "cubic spline interpolation" (using a modified
+        # Kochanek basis) because the latter seems to use the supplied quaternions as guide points, but doesn't
+        # necessarily take a path through them.
         quaternionInterpolator.SetInterpolationTypeToLinear()
 
         resampledCurveLength = self.resampledCurve.GetCurveLengthWorld()

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -722,7 +722,7 @@ class EndoscopyLogic:
         self.cameraOrientations = None
         self.cameraOrientationResampledCurveIndices = None
 
-    def setControlPoints(self, inputCurve: slicer.vtkMRMLMarkupsCurveNode) -> bool:
+    def setControlPoints(self, inputCurve: slicer.vtkMRMLMarkupsCurveNode) -> None:
         expectedType = slicer.vtkMRMLMarkupsCurveNode
         if not isinstance(inputCurve, expectedType):
             raise TypeError(

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -218,24 +218,28 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         firstOrientationButton.enabled = True
         firstOrientationButton.connect("clicked()", self.onFirstOrientationButtonClicked)
         flythroughOrientationLayout.addWidget(firstOrientationButton)
+        self.firstOrientationButton = firstOrientationButton
 
         backOrientationButton = qt.QPushButton(_("Back"))
         backOrientationButton.toolTip = _("Go to the previous user-supplied keyframe.")
         backOrientationButton.enabled = True
         backOrientationButton.connect("clicked()", self.onBackOrientationButtonClicked)
         flythroughOrientationLayout.addWidget(backOrientationButton)
+        self.backOrientationButton = backOrientationButton
 
         nextOrientationButton = qt.QPushButton(_("Next"))
         nextOrientationButton.toolTip = _("Go to the next user-supplied keyframe.")
         nextOrientationButton.enabled = True
         nextOrientationButton.connect("clicked()", self.onNextOrientationButtonClicked)
         flythroughOrientationLayout.addWidget(nextOrientationButton)
+        self.nextOrientationButton = nextOrientationButton
 
         lastOrientationButton = qt.QPushButton(_("Last"))
         lastOrientationButton.toolTip = _("Go to the last user-supplied keyframe.")
         lastOrientationButton.enabled = True
         lastOrientationButton.connect("clicked()", self.onLastOrientationButtonClicked)
         flythroughOrientationLayout.addWidget(lastOrientationButton)
+        self.lastOrientationButton = lastOrientationButton
 
         flythroughFormLayout.addRow(flythroughOrientationLayout)
 
@@ -350,6 +354,21 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.deleteOrientationButton.enabled = deletable
         self.saveOrientationButton.text = (
             _("Update Keyframe Orientation") if deletable else _("Save Keyframe Orientation")
+        )
+
+        # Update keyframe navigation buttons
+        firstResampledCurvePointIndex = self.logic.getFirstControlPointIndex()
+        lastResampledCurvePointIndex = self.logic.getLastControlPointIndex()
+        (
+            self.firstOrientationButton.enabled,
+            self.backOrientationButton.enabled,
+            self.nextOrientationButton.enabled,
+            self.lastOrientationButton.enabled,
+        ) = (
+            firstResampledCurvePointIndex is not None and firstResampledCurvePointIndex != resampledCurvePointIndex,
+            self.logic.getPreviousControlPointIndex(resampledCurvePointIndex) is not None,
+            self.logic.getNextControlPointIndex(resampledCurvePointIndex) is not None,
+            lastResampledCurvePointIndex is not None and lastResampledCurvePointIndex != resampledCurvePointIndex,
         )
 
         # If there is no input curve available (e.g scene close), stop playblack

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -435,10 +435,8 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         resampledCurvePointIndex = int(self.frameSlider.value)
 
         self.ignoreInputCurveModified += 1
-        cameraOrientations = self.logic.saveOrientationAtIndex(resampledCurvePointIndex, self.cameraNode)
+        self.logic.saveOrientationAtIndex(resampledCurvePointIndex, self.cameraNode)
         self.ignoreInputCurveModified -= 1
-
-        self.logic.interpolateOrientationsForControlPoints(cameraOrientations)
 
         self.flyTo(resampledCurvePointIndex)
 
@@ -447,10 +445,8 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         resampledCurvePointIndexToDelete = int(self.frameSlider.value)
 
         self.ignoreInputCurveModified += 1
-        cameraOrientations = self.logic.removeOrientationAtIndex(resampledCurvePointIndexToDelete)
+        self.logic.removeOrientationAtIndex(resampledCurvePointIndexToDelete)
         self.ignoreInputCurveModified -= 1
-
-        self.logic.interpolateOrientationsForControlPoints(cameraOrientations)
 
         self.flyTo(resampledCurvePointIndexToDelete)
 
@@ -713,6 +709,7 @@ class EndoscopyLogic:
         cameraOrientations[distanceAlongResampledCurve] = worldOrientation
 
         EndoscopyLogic.setInputCurveCameraOrientations(inputCurve, cameraOrientations)
+        self.interpolateOrientationsForControlPoints(cameraOrientations)
 
         return cameraOrientations
 
@@ -738,6 +735,7 @@ class EndoscopyLogic:
                 break
 
         EndoscopyLogic.setInputCurveCameraOrientations(inputCurve, cameraOrientations)
+        self.interpolateOrientationsForControlPoints(cameraOrientations)
 
         return cameraOrientations
 

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -411,34 +411,16 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.flyTo(resampledCurvePointIndexToDelete)
 
     def onFirstOrientationButtonClicked(self):
-        allIndices = self.logic.cameraOrientationResampledCurveIndices
-        if not allIndices:
-            return
-        whereTo = min(allIndices, default=self.frameSlider.minimum)
-        self.frameSlider.value = whereTo
+        self.frameSlider.value = self.logic.getFirstControlPointIndex()
 
     def onBackOrientationButtonClicked(self):
-        allIndices = self.logic.cameraOrientationResampledCurveIndices
-        allIndices = [x for x in allIndices if x < self.frameSlider.value]
-        if not allIndices:
-            return
-        whereTo = max(allIndices)
-        self.frameSlider.value = whereTo
+        self.frameSlider.value = self.logic.getPreviousControlPointIndex(self.frameSlider.value)
 
     def onNextOrientationButtonClicked(self):
-        allIndices = self.logic.cameraOrientationResampledCurveIndices
-        allIndices = [x for x in allIndices if x > self.frameSlider.value]
-        if not allIndices:
-            return
-        whereTo = min(allIndices)
-        self.frameSlider.value = whereTo
+        self.frameSlider.value = self.logic.getNextControlPointIndex(self.frameSlider.value)
 
     def onLastOrientationButtonClicked(self):
-        allIndices = self.logic.cameraOrientationResampledCurveIndices
-        if not allIndices:
-            return
-        whereTo = max(allIndices)
-        self.frameSlider.value = whereTo
+        self.frameSlider.value = self.logic.getLastControlPointIndex()
 
     def onSaveExportModelButtonClicked(self):
         logging.debug("Create Model...")
@@ -602,6 +584,24 @@ class EndoscopyLogic:
 
     def getNumberOfControlPoints(self):
         return self.resampledCurve.GetNumberOfControlPoints()
+
+    def getFirstControlPointIndex(self):
+        allIndices = self.cameraOrientationResampledCurveIndices
+        return min(allIndices, default=None)
+
+    def getPreviousControlPointIndex(self, currentResampledCurvePointIndex):
+        allIndices = self.cameraOrientationResampledCurveIndices
+        allIndices = [x for x in allIndices if x < currentResampledCurvePointIndex]
+        return max(allIndices, default=None)
+
+    def getNextControlPointIndex(self, currentResampledCurvePointIndex):
+        allIndices = self.cameraOrientationResampledCurveIndices
+        allIndices = [x for x in allIndices if x > currentResampledCurvePointIndex]
+        return min(allIndices, default=None)
+
+    def getLastControlPointIndex(self):
+        allIndices = self.cameraOrientationResampledCurveIndices
+        return max(allIndices, default=None)
 
     def setControlPointsByResamplingAndInterpolationFromInputCurve(self, inputCurve) -> None:
         if inputCurve is None:

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -412,24 +412,32 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def onFirstOrientationButtonClicked(self):
         allIndices = self.logic.cameraOrientationResampledCurveIndices
+        if not allIndices:
+            return
         whereTo = min(allIndices, default=self.frameSlider.minimum)
         self.frameSlider.value = whereTo
 
     def onBackOrientationButtonClicked(self):
         allIndices = self.logic.cameraOrientationResampledCurveIndices
         allIndices = [x for x in allIndices if x < self.frameSlider.value]
-        whereTo = max(allIndices, default=self.frameSlider.minimum)
+        if not allIndices:
+            return
+        whereTo = max(allIndices)
         self.frameSlider.value = whereTo
 
     def onNextOrientationButtonClicked(self):
         allIndices = self.logic.cameraOrientationResampledCurveIndices
         allIndices = [x for x in allIndices if x > self.frameSlider.value]
-        whereTo = min(allIndices, default=self.frameSlider.maximum)
+        if not allIndices:
+            return
+        whereTo = min(allIndices)
         self.frameSlider.value = whereTo
 
     def onLastOrientationButtonClicked(self):
         allIndices = self.logic.cameraOrientationResampledCurveIndices
-        whereTo = max(allIndices, default=self.frameSlider.maximum)
+        if not allIndices:
+            return
+        whereTo = max(allIndices)
         self.frameSlider.value = whereTo
 
     def onSaveExportModelButtonClicked(self):

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -565,7 +565,7 @@ class EndoscopyLogic:
     def __init__(self, inputCurve, dl=0.5):
         self.cleanup()
         self.dl = dl  # desired world space step size (in mm)
-        self.setControlPoints(inputCurve)
+        self.setControlPointsByResamplingAndInterpolationFromInputCurve(inputCurve)
 
     def cleanup(self):
         # Whether we're about to construct or delete, free all resources and initialize class members to None.
@@ -578,7 +578,7 @@ class EndoscopyLogic:
     def getNumberOfControlPoints(self):
         return self.resampledCurve.GetNumberOfControlPoints()
 
-    def setControlPoints(self, inputCurve: slicer.vtkMRMLMarkupsCurveNode) -> None:
+    def setControlPointsByResamplingAndInterpolationFromInputCurve(self, inputCurve: slicer.vtkMRMLMarkupsCurveNode) -> None:
         expectedType = slicer.vtkMRMLMarkupsCurveNode
         if not isinstance(inputCurve, expectedType):
             raise TypeError(

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -283,16 +283,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def setCameraNode(self, newCameraNode):
         """Allow to set the current camera node."""
-
-        # Remove previous observer
-        cameraNode = EndoscopyLogic.getCameraFromInputCurve(self.inputCurve)
-        if cameraNode is not None:
-            self.removeObserver(cameraNode, vtk.vtkCommand.ModifiedEvent, self.updateWidgetFromMRML)
-
         EndoscopyLogic.setInputCurveCamera(self.inputCurve, newCameraNode)
-
-        if newCameraNode is not None:
-            self.addObserver(newCameraNode, vtk.vtkCommand.ModifiedEvent, self.updateWidgetFromMRML)
 
         # Update UI
         self.updateWidgetFromMRML()
@@ -322,9 +313,6 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Update UI
         self.updateWidgetFromMRML()
-
-        # Initialize to the start of the path
-        self.flyTo(0)
 
     def updateWidgetFromMRML(self, *_unused):
         # Create a cursor and associated transform so that the user can see where the flythrough is progressing.
@@ -473,6 +461,9 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def flyTo(self, resampledCurvePointIndex):
         """Apply the resampledCurvePointIndex-th step in the path to the global camera"""
         self.logic.updateCameraFromOrientationAtIndex(resampledCurvePointIndex)
+
+        # Update UI
+        self.updateWidgetFromMRML()
 
     @staticmethod
     def _viewNodeIDFromCameraNode(cameraNode):

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -73,7 +73,6 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         self.transform = None
         self.cursor = None
-        self.model = None
         self.skip = 0
         self.logic = None
         self.timer = qt.QTimer()
@@ -394,7 +393,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Hide the cursor, model and inputCurve from the main 3D view
         EndoscopyWidget._hideOnlyInView(
             EndoscopyWidget._viewNodeIDFromCameraNode(self.cameraNode),
-            [self.cursor, self.model, self.inputCurve],
+            [self.cursor, inputCurve],
         )
 
         # Update flythrough variables
@@ -491,12 +490,10 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if self.transform:
             model.model.SetNodeReferenceID("CameraTransform", self.transform.GetID())
 
-        self.model = model.model
-
         # Hide the model from the main 3D view
         EndoscopyWidget._hideOnlyInView(
             EndoscopyWidget._viewNodeIDFromCameraNode(self.cameraNode),
-            [self.model],
+            [model.model],
         )
         logging.debug("-> Model created")
 

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -438,7 +438,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         cameraOrientations = self.logic.saveOrientationAtIndex(resampledCurvePointIndex, self.cameraNode)
         self.ignoreInputCurveModified -= 1
 
-        self.logic.interpolateOrientations(cameraOrientations)
+        self.logic.interpolateOrientationsForControlPoints(cameraOrientations)
 
         self.flyTo(resampledCurvePointIndex)
 
@@ -450,7 +450,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         cameraOrientations = self.logic.removeOrientationAtIndex(resampledCurvePointIndexToDelete)
         self.ignoreInputCurveModified -= 1
 
-        self.logic.interpolateOrientations(cameraOrientations)
+        self.logic.interpolateOrientationsForControlPoints(cameraOrientations)
 
         self.flyTo(resampledCurvePointIndexToDelete)
 
@@ -639,9 +639,9 @@ class EndoscopyLogic:
 
         cameraOrientations = EndoscopyLogic.getCameraOrientationsFromInputCurve(inputCurve)
 
-        self.interpolateOrientations(cameraOrientations)
+        self.interpolateOrientationsForControlPoints(cameraOrientations)
 
-    def interpolateOrientations(self, cameraOrientations):
+    def interpolateOrientationsForControlPoints(self, cameraOrientations):
 
         # Configure a vtkQuaternionInterpolator using the user's supplied orientations.
         # Note that all distances are as measured along resampledCurve rather than along inputCurve.

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -370,7 +370,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         self.setInputCurve(inputCurve)
 
-        numberOfControlPoints = self.logic.resampledCurve.GetNumberOfControlPoints()
+        numberOfControlPoints = self.logic.getNumberOfControlPoints()
 
         # Update frame slider range
         self.frameSlider.maximum = max(0, numberOfControlPoints - 2)
@@ -495,7 +495,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def flyToNext(self):
         currentStep = int(self.frameSlider.value)
         nextStep = currentStep + self.skip + 1
-        if nextStep > self.logic.resampledCurve.GetNumberOfControlPoints() - 2:
+        if nextStep > self.logic.getNumberOfControlPoints() - 2:
             nextStep = 0
         self.frameSlider.value = nextStep
 
@@ -504,7 +504,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         if (
             self.logic.resampledCurve is None
-            or not 0 <= resampledCurvePointIndex < self.logic.resampledCurve.GetNumberOfControlPoints()
+            or not 0 <= resampledCurvePointIndex < self.logic.getNumberOfControlPoints()
         ):
             return
 
@@ -620,7 +620,7 @@ class EndoscopyLogic:
 
     Example:
       logic = EndoscopyLogic(inputCurve)
-      print(f"computed path has {logic.resampledCurve.GetNumberOfControlPoints()} elements")
+      print(f"computed path has {logic.getNumberOfControlPoints()} elements")
 
     Notes:
     * `orientation` = (angle, *axis), where angle is in radians and axis is the unit 3D-vector for the axis
@@ -643,6 +643,9 @@ class EndoscopyLogic:
         self.resampledCurve = None
         self.planeNormal = None
         self.cameraOrientationResampledCurveIndices = None
+
+    def getNumberOfControlPoints(self):
+        return self.resampledCurve.GetNumberOfControlPoints()
 
     def setControlPoints(self, inputCurve: slicer.vtkMRMLMarkupsCurveNode) -> None:
         expectedType = slicer.vtkMRMLMarkupsCurveNode


### PR DESCRIPTION
Selecting the curve is now sufficient to work with the associated flythrough path. Also listen to the more specific `PointEndInteractionEvent` to only update the curve after user is done updating the curve.

Instantiate one EndoscopyLogic and simplify its API 

... introducing:
* `updateCameraFromOrientationAtIndex()`
* `getNumberOfControlPoints()`
* `saveOrientationAtIndex()`
* `removeOrientationAtIndex()`
* `createTransformFromInputCurve()` / `getTransformFromInputCurve()` / `setInputCurveTransform()`
* `createCursorFromInputCurve()` / `getCursorFromInputCurve()` / `setInputCurveCursor()`

... renaming:
* `setControlPoints` to `setControlPointsByResamplingAndInterpolationFromInputCurve`
* `interpolateOrientations` to `interpolateOrientationsForControlPoints`
* `loadCameraOrientations()` to `getCameraOrientationsFromInputCurve()`
* `saveCameraOrientations()` to `setInputCurveCameraOrientations()`
* `onPlayButtonToggled()` to `setPlaybackEnabled()` (to allow programmatic start/stop of playback)

... updating:

* `interpolateOrientationsForControlPoints()` to require a `cameraOrientations` parameter. This allows to remove the need for maintaining a dedicated `cameraOrientations` instance variable

.. removing:
* `createCursor()`

It also revisits how camera, camera transform ad camera cursor are referenced. These are now directly referenced from the input curve using `Camera`, `CameraTransform` and `CameraCursor` reference role.

Other changes:
* convert relative orientation API to staticmethod
* remove unneeded instance variable related to Endoscopy model export
* consolidate all widget update into `updateWidgetFromMRML()`
* remove `ignoreInputCurveModified` instance variable and instead introduce a `updatingControlPoints` variable to guard `setControlPoints()`
* allow to set and get the input curve `CameraOrientations` independently of the `EndoscopyWidget`. This is done through `getCameraOrientationsFromInputCurve()` and `setInputCurveCameraOrientations()`