### PR TITLE
Fix scripted loadable module importing wrapped classes

### DIFF
--- a/Base/QTGUI/qSlicerLoadableModule.cxx
+++ b/Base/QTGUI/qSlicerLoadableModule.cxx
@@ -57,10 +57,10 @@ bool qSlicerLoadableModule::importModulePythonExtensions(
     const QString& intDir,const QString& modulePath,
     bool isEmbedded)
 {
-  Q_UNUSED(intDir);
 #ifdef Slicer_USE_PYTHONQT
   return qSlicerScriptedUtils::importModulePythonExtensions(pythonManager, intDir, modulePath, isEmbedded);
 #else
+  Q_UNUSED(intDir);
   Q_UNUSED(isEmbedded);
   Q_UNUSED(modulePath);
   Q_UNUSED(pythonManager);

--- a/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
@@ -190,28 +190,6 @@ bool qSlicerScriptedLoadableModule::setPythonSource(const QString& filePath)
 void qSlicerScriptedLoadableModule::setup()
 {
   Q_D(qSlicerScriptedLoadableModule);
-
-  qSlicerCoreApplication * app = qSlicerCoreApplication::application();
-  if (app)
-    {
-    // Set to /path/to/lib/Slicer-X.Y/qt-scripted-modules
-    QString modulePath = QFileInfo(this->path()).absolutePath();
-    // Set to /path/to/lib/Slicer-X.Y
-    modulePath = QFileInfo(modulePath).absolutePath();
-    // Set to /path/to/lib/Slicer-X.Y/qt-loadable-modules
-    modulePath = modulePath + "/" Slicer_QTLOADABLEMODULES_SUBDIR;
-
-    bool isEmbedded = app->isEmbeddedModule(this->path());
-    if (!isEmbedded)
-      {
-      if (!qSlicerLoadableModule::importModulePythonExtensions(
-            app->corePythonManager(), app->intDir(), modulePath, isEmbedded))
-        {
-        qWarning() << "qSlicerLoadableModule::setup - Failed to import module" << this->name() << "python extensions";
-        }
-      }
-    }
-
   this->registerFileDialog();
   this->registerIO();
   d->PythonCppAPI.callMethod(Pimpl::SetupMethod);

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -31,7 +31,7 @@ class Endoscopy(ScriptedLoadableModule):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = _("Endoscopy")
         self.parent.categories = [translate("qSlicerAbstractCoreModule", "Endoscopy")]
-        self.parent.dependencies = []
+        self.parent.dependencies = ["Markups"]
         self.parent.contributors = [
             "Steve Pieper (Isomics)",
             "Harald Scheirich (Kitware)",


### PR DESCRIPTION

1. Fixes Endoscopy module dependency by adding "Markups"

2. Ensure scripted modules can always import wrapped C++ classes even if loading of loadable module is disabled. It fixes the tests `py_nowarning_[no]mainwindow_[nocli_]noloadableTest`.

3. De-duplicate code in loadable module factory by reusing qSlicerScriptedUtils.
