### PR TITLE
ENH: Disable pip version check

### DIFF
--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -44,6 +44,30 @@ if(NOT Slicer_USE_SYSTEM_${proj})
       ${${proj}_DEPENDENCIES}
     )
 
+  #-----------------------------------------------------------------------------
+  # Slicer Launcher setting specific to build tree
+
+  # environment variables
+  set(${proj}_ENVVARS_LAUNCHER_BUILD
+    "PIP_DISABLE_PIP_VERSION_CHECK=1"
+    )
+  mark_as_superbuild(
+    VARS ${proj}_ENVVARS_LAUNCHER_BUILD
+    LABELS "ENVVARS_LAUNCHER_BUILD"
+    )
+
+  #-----------------------------------------------------------------------------
+  # Slicer Launcher setting specific to install tree
+
+  # environment variables
+  set(${proj}_ENVVARS_LAUNCHER_INSTALLED
+    "PIP_DISABLE_PIP_VERSION_CHECK=1"
+    )
+  mark_as_superbuild(
+    VARS ${proj}_ENVVARS_LAUNCHER_INSTALLED
+    LABELS "ENVVARS_LAUNCHER_INSTALLED"
+    )
+
 else()
   ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDENCIES})
 endif()


### PR DESCRIPTION
This commit addresses the quarterly update cycle of python packages bundled into Slicer. To mitigate unnecessary console clutter caused by the pip version check, the variable `PIP_DISABLE_PIP_VERSION_CHECK` is set, suppressing warnings such as:

```bash
$ PythonSlicer -m pip list
[...]
[notice] A new release of pip is available: X.Y.Z -> Z'.Y'.Z'
[notice] To update, run: pip install --upgrade pip
```

To ensure that `the PIP_DISABLE_PIP_VERSION_CHECK` environment variable is undefined when Slicer is built against a system or external Python installation, this variable is set only in the pip external project.

This also addresses an issue introduced in 028fb31 (COMP: Update python packages to latest) where the pip version was updated from `23.1.2` to `23.3`. This resulted in the following warning message instead of the expected update notification:

```bash
WARNING: There was an error checking the latest version of pip.
```

For additional details about `PIP_DISABLE_PIP_VERSION_CHECK`:
* https://pip.pypa.io/en/stable/cli/pip/#cmdoption-disable-pip-version-check
* https://pip.pypa.io/en/stable/topics/configuration/#environment-variables
