### PR TITLE
BUG: Update VTK to to fix vtkSMPToolsAPI static initialization order issue

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "4bfb0f049af04aec4177182b8b774b605c04fdbe") # slicer-v9.2.20230607-1ff325c54-2
+    set(_git_tag "46201478cdf2dc1e5dda260ba61505195bbcc932") # slicer-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
This addresses a crash related to the static initialization order 'fiasco' in `vtkSMPToolsAPI`. It ensures proper deletion of the `vtkSMPToolsAPI` singleton once the last translation unit referencing it has been unloaded.

This update ensures that the SMP backend is cleaned up at the appropriate time, fixing the following macOS tests that started to fail following commit 28dca75dc (ENH: Enable TBB as the default VTK SMP implementation on all platforms):
* `py_nomainwindow_SegmentationWidgetsTest1`
* `py_sceneImport2428`
* `py_SegmentStatistics`
* `py_UtilTest`

List of changes:

```
$ git shortlog  4bfb0f049a..d1727b8ce6 --no-merges Jean-Christophe Fillion-Robin (2):
      [Backport MR-10751] BUG: Resolve crash by fixing vtkSMPToolsAPI static initialization order issue
      [Backport MR-10751] ENH: Simplify vtkSMPToolsAPIInitialize managing pointer and counter locally
```

## Related

* https://github.com/Slicer/Slicer/issues/7449
* https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10751