### PR TITLE
BUG: Workaround for Slicer hang on scipy.linalg import on Windows 11

### DIFF
--- a/Base/Python/slicer/__init__.py
+++ b/Base/Python/slicer/__init__.py
@@ -212,6 +212,7 @@ if not standalone_python:
     try:
         import numpy  # noqa: F401
         import scipy  # noqa: F401
+        import scipy.linalg  # noqa: F401
     except ImportError as detail:
         print(detail)
 


### PR DESCRIPTION
The GPA and QuickAlign modules in the SlicerMorph extension were causing the Slicer application to hang during module instantiation on Windows 11. This issue mirrors the previous errors encountered during the import of `numpy` and `scipy`, both of which were addressed in commits 542f53c5b and ad5d20d1a, respectively.

This commit adds `scipy.linalg` to the list of pre-imported packages, preventing the hang during the application start.