### PR TITLE
Ensure selected item number in Sequence browser remains valid

### DIFF
--- a/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.cxx
+++ b/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.cxx
@@ -983,7 +983,7 @@ void vtkMRMLSequenceBrowserNode::SetRecordingActive(bool recording)
 //---------------------------------------------------------------------------
 int vtkMRMLSequenceBrowserNode::SelectFirstItem()
 {
-  int selectedItemNumber = (this->GetNumberOfItems() > 0)  ? 0 :- 1;
+  int selectedItemNumber = (this->GetNumberOfItems() > 0)  ? 0 : -1;
   this->SetSelectedItemNumber(selectedItemNumber);
   return selectedItemNumber;
 }
@@ -1005,11 +1005,11 @@ int vtkMRMLSequenceBrowserNode::SelectNextItem(int selectionIncrement/*=1*/)
     // nothing to replay
     return -1;
     }
-  int selectedItemNumber=this->GetSelectedItemNumber();
+  int selectedItemNumber = this->GetSelectedItemNumber();
   MRMLNodeModifyBlocker blocker(this); // invoke modification event once all the modifications has been completed
-  if (selectedItemNumber<0)
+  if (selectedItemNumber < 0)
     {
-    selectedItemNumber=0;
+    selectedItemNumber = 0;
     }
   else
     {
@@ -1023,8 +1023,10 @@ int vtkMRMLSequenceBrowserNode::SelectNextItem(int selectionIncrement/*=1*/)
         }
       else
         {
+        // auto-rewind to the first item and stop replay
+        // (this allows playing the sequence by one click)
         this->SetPlaybackActive(false);
-        selectedItemNumber=0;
+        selectedItemNumber = 0;
         }
       }
     else if (selectedItemNumber<0)
@@ -1032,10 +1034,13 @@ int vtkMRMLSequenceBrowserNode::SelectNextItem(int selectionIncrement/*=1*/)
       if (this->GetPlaybackLooped())
         {
         // wrap around and keep playback going
-        selectedItemNumber = (selectedItemNumber % numberOfItems) + numberOfItems;
+        // (need to compute the modulo twice: first to handle negative numbers, the second to actually compute the wraparound)
+        selectedItemNumber = ((selectedItemNumber % numberOfItems) + numberOfItems) % numberOfItems;
         }
       else
         {
+        // auto-rewind to the last item and stop replay
+        // (this allows playing the sequence in reverse direction by one click)
         this->SetPlaybackActive(false);
         selectedItemNumber = numberOfItems - 1;
         }
@@ -1089,8 +1094,8 @@ void vtkMRMLSequenceBrowserNode::ProcessMRMLEvents(vtkObject* caller, unsigned l
   else if (vtkMRMLSequenceNode::SafeDownCast(modifiedNode))
     {
     this->InvokeCustomModifiedEvent(SequenceNodeModifiedEvent, modifiedNode);
+      }
     }
-}
 
 //---------------------------------------------------------------------------
 void vtkMRMLSequenceBrowserNode::SaveProxyNodesState()

--- a/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.h
+++ b/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.h
@@ -163,7 +163,7 @@ public:
   //@}
 
   //@{
-  /// Get/Set selected bundle index
+  /// Get/Set selected item number. Item number is an integer between 0 and (NumberOfItems - 1).
   vtkGetMacro(SelectedItemNumber, int);
   vtkSetMacro(SelectedItemNumber, int);
   //@}

--- a/Modules/Loadable/Sequences/Testing/Python/SequencesSelfTest.py
+++ b/Modules/Loadable/Sequences/Testing/Python/SequencesSelfTest.py
@@ -122,6 +122,10 @@ class SequencesSelfTestTest(ScriptedLoadableModuleTest):
         self.delayDisplay("Test browsing of sequence")
         checkSequenceItems(browserNode, sequenceNode)
 
+        # Set selected item, to be tested later after loading the scene
+        lastSelectedItem = 12
+        browserNode.SetSelectedItemNumber(lastSelectedItem)
+
         # Test saving and loading of sequence
         savedSceneDir = os.path.join(self.sequencesSelfTestDir, "savedscene")
         clearSavedSceneFolder(savedSceneDir)
@@ -138,6 +142,9 @@ class SequencesSelfTestTest(ScriptedLoadableModuleTest):
         slicer.util.loadScene(os.path.join(savedSceneDir, "savedscene.mrml"))
         # Remove temporary folder to not pollute the file system
         clearSavedSceneFolder(savedSceneDir)
+
+        # Test selected item index
+        self.assertEqual(browserNode.GetSelectedItemNumber(), lastSelectedItem)
 
         self.delayDisplay("Test browsing of loaded sequence")
         browserNode = slicer.util.getFirstNodeByClassByName("vtkMRMLSequenceBrowserNode", "CTPCardioSeq browser")

--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserSeekWidget.cxx
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserSeekWidget.cxx
@@ -90,6 +90,9 @@ void qMRMLSequenceBrowserSeekWidget::setMRMLSequenceBrowserNode(vtkMRMLSequenceB
     this, SLOT(onIndexDisplayFormatModified()));
   qvtkReconnect(d->SequenceBrowserNode, browserNode, vtkCommand::ModifiedEvent,
     this, SLOT(updateWidgetFromMRML()));
+  // Update slider when a new item is added to a sequence
+  qvtkReconnect(d->SequenceBrowserNode, browserNode, vtkMRMLSequenceBrowserNode::SequenceNodeModifiedEvent,
+    this, SLOT(updateWidgetFromMRML()));
 
   d->SequenceBrowserNode = browserNode;
   this->onIndexDisplayFormatModified();
@@ -164,7 +167,7 @@ void qMRMLSequenceBrowserSeekWidget::updateWidgetFromMRML()
   d->slider_IndexValue->blockSignals(sliderBlockSignals);
 
   int selectedItemNumber = d->SequenceBrowserNode->GetSelectedItemNumber();
-  if (selectedItemNumber > 0 && selectedItemNumber < numberOfDataNodes)
+  if (selectedItemNumber >= 0 && selectedItemNumber < numberOfDataNodes)
     {
     QString indexValue;
     QString indexUnit;
@@ -172,7 +175,7 @@ void qMRMLSequenceBrowserSeekWidget::updateWidgetFromMRML()
     if (d->SequenceBrowserNode->GetIndexDisplayMode() == vtkMRMLSequenceBrowserNode::IndexDisplayAsIndexValue)
       {
       // display as formatted index value (12.34sec)
-      indexValue = QString::fromStdString(d->SequenceBrowserNode->GetFormattedIndexValue(d->SequenceBrowserNode->GetSelectedItemNumber()));
+      indexValue = QString::fromStdString(d->SequenceBrowserNode->GetFormattedIndexValue(selectedItemNumber));
       indexUnit = QString::fromStdString(sequenceNode->GetIndexUnit());
       if (indexValue.length() == 0)
         {


### PR DESCRIPTION
Two small fixes in keeping selected item number in sequence browser valid when browsing/adding/deleting items in the master sequence node.

These are not critical fixes, not required to be included in 5.6.1 patch release.