### PR TITLE
[5.6] BUG: Fix temporary folder containing special characters

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2850,7 +2850,10 @@ def tempDirectory(key="__SlicerTemp__", tempDir=None, includeDateTime=True):
     if not tempDir:
         tempDir = qt.QDir(slicer.app.temporaryPath)
     if includeDateTime:
-        tempDirName = key + qt.QDateTime().currentDateTime().toString("yyyy-MM-dd_hh+mm+ss.zzz")
+        # Force using en-US locale, otherwise for example on a computer with
+        # Egyptian Arabic (ar-EG) locale, Arabic numerals may be used.
+        enUsLocale = qt.QLocale(qt.QLocale.English, qt.QLocale.UnitedStates)
+        tempDirName = key + enUsLocale.toString(qt.QDateTime.currentDateTime(), "yyyy-MM-dd_hh+mm+ss.zzz")
     else:
         tempDirName = key
     fileInfo = qt.QFileInfo(qt.QDir(tempDir), tempDirName)

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -1017,12 +1017,15 @@ void qSlicerApplication::setupFileLogging()
 
   // Add new log file path for the current session
   QString tempDir = this->temporaryPath();
+  // Force using en-US locale, otherwise for example on a computer with
+  // Egyptian Arabic (ar-EG) locale, Arabic numerals may be used.
+  QLocale enUsLocale = QLocale(QLocale::English, QLocale::UnitedStates);
   QString currentLogFilePath = QString("%1/%2_%3_%4_%5_%6.log")
     .arg(tempDir)
     .arg(this->applicationName())
     .arg(qSlicerApplication::application()->applicationVersion())
     .arg(qSlicerApplication::application()->mainApplicationRevision())
-    .arg(QDateTime::currentDateTime().toString("yyyyMMdd_hhmmss"))
+    .arg(enUsLocale.toString(QDateTime::currentDateTime(), "yyyyMMdd_hhmmss"))
     .arg(QRandomGenerator::global()->generate() % 1000, 3, 10, QLatin1Char('0'));
   logFilePaths.prepend(currentLogFilePath);
 
@@ -1117,9 +1120,12 @@ void qSlicerApplication::logApplicationInformation() const
 
   int titleIndex = 0;
   // Session start time
+  // Force using en-US locale, otherwise for example on a computer with
+  // Egyptian Arabic (ar-EG) locale, Arabic numerals may be used.
+  QLocale enUsLocale = QLocale(QLocale::English, QLocale::UnitedStates);
   qDebug("%s: %s",
          qPrintable(titles.at(titleIndex++).leftJustified(titleWidth, '.')),
-         qPrintable(QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss")));
+         qPrintable(enUsLocale.toString(QDateTime::currentDateTime(), "yyyyMMdd_hhmmss")));
 
   // Slicer version
   qDebug("%s: %s (revision %s / %s) %s - %s %s",

--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -972,7 +972,10 @@ def importFromDICOMWeb(
                 outputDirectoryBase = slicer.dicomDatabase.databaseDirectory + "/DICOMweb"
                 if not os.access(outputDirectoryBase, os.F_OK):
                     os.makedirs(outputDirectoryBase)
-                outputDirectoryBase += "/" + qt.QDateTime.currentDateTime().toString("yyyyMMdd-hhmmss")
+                # Force using en-US locale, otherwise for example on a computer with
+                # Egyptian Arabic (ar-EG) locale, Arabic numerals may be used.
+                enUsLocale = qt.QLocale(qt.QLocale.English, qt.QLocale.UnitedStates)
+                outputDirectoryBase += "/" + enUsLocale.toString(qt.QDateTime.currentDateTime(), "yyyyMMdd-hhmmss")
                 outputDirectory = qt.QTemporaryDir(outputDirectoryBase)  # Add unique substring to directory
                 outputDirectory.setAutoRemove(False)
                 outputDirectoryPath = outputDirectory.path()

--- a/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMExportDialog.cxx
+++ b/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMExportDialog.cxx
@@ -415,7 +415,12 @@ void qSlicerDICOMExportDialog::onExport()
     {
     // Save to temporary folder and store files in database directory when adding
     outputFolder.setPath(qSlicerApplication::application()->temporaryPath());
-    QString tempSubDirName = QString("DICOMExportTemp_%1").arg(QDateTime::currentDateTime().toString("yyyyMMdd_hhmmss"));
+
+    // Force using en-US locale, otherwise for example on a computer with
+    // Egyptian Arabic (ar-EG) locale, Arabic numerals may be used.
+    QLocale enUsLocale = QLocale(QLocale::English, QLocale::UnitedStates);
+    QString tempSubDirName = QString("DICOMExportTemp_%1").arg(enUsLocale.toString(QDateTime::currentDateTime(), "yyyyMMdd_hhmmss"));
+
     outputFolder.mkdir(tempSubDirName);
     outputFolder.cd(tempSubDirName);
     }


### PR DESCRIPTION
Backports changes originally contributed to `main` through the following pull requests:
* https://github.com/Slicer/Slicer/pull/7430

---------

qt.QDateTime().currentDateTime().toString(...) may use Arabic numerals on an operating system set to Arabic language. Always specify en-US locale when using when using date in file/folder names to avoid having to work with paths that may contain unicode characters (such paths may cause problems on certain file systems and it may not be always possible to pass them as command-line arguments).

Fixes problem originally reported at:
https://discourse.slicer.org/t/i-tried-everything-to-run-totalsegmentator-pls-help/33023/3

(cherry picked from commit eccb98ce1f58b19d0a429981cc8e3cf131bcf3d5)