### PR TITLE
[5.6] Update GitHub CI workflow to be release specific

### DIFF
--- a/.github/actions/slicer-build/Dockerfile
+++ b/.github/actions/slicer-build/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM slicer/slicer-base
+FROM slicer/slicer-base:5.6
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   # Triggers the workflow on push or pull request events
   push:
     branches:
-      - "main"
+      - "5.6"
   pull_request:
     branches:
       - "*"


### PR DESCRIPTION
### Summary
* Update slicer-build GitHub action to use `5.6` docker image
* Update CI GitHub workflow to test `5.6` branch instead of `main`

### Notes

The `slicer-base` image was manually tagged and published on the `metroplex` factory using the following commands:

```
docker tag slicer/slicer-base:latest slicer/slicer-base:5.6
docker push slicer/slicer-base:5.6
```

Since it is based on the `latest` version, it includes external project specific changes associated with this pull-request:
* https://github.com/Slicer/Slicer/pull/7451
* https://github.com/Slicer/Slicer/pull/7453