### PR TITLE
[5.6] Streamline Endoscopy UX removing "Use this curve" button

### DIFF
--- a/Docs/user_guide/modules/endoscopy.md
+++ b/Docs/user_guide/modules/endoscopy.md
@@ -15,7 +15,6 @@ Selects the camera and curve to be manipulated.
 
 - **Camera**: The camera used for the flythrough.
 - **Curve to modify**: The curve defining the flythrough path control points.
-- **Use this curve**: Press to indicate that the camera and curve have been selected.
 
 ### Flythrough
 

--- a/Docs/user_guide/modules/endoscopy.md
+++ b/Docs/user_guide/modules/endoscopy.md
@@ -15,7 +15,7 @@ Selects the camera and curve to be manipulated.
 
 - **Camera**: The camera used for the flythrough.
 - **Curve to modify**: The curve defining the flythrough path control points.
-- **Create flythrough path**: Press to generate the flythrough path corresponding to the selected curve and camera.
+- **Use this curve**: Press to indicate that the camera and curve have been selected.
 
 ### Flythrough
 
@@ -28,7 +28,7 @@ Controls the animation.
 - **View Angle**: Field of view of the camera.  The default value of 30 degrees approximates normal camera lenses.  Larger numbers, such as 110 or 120 degrees approximate the wide angle lenses often used in endoscopy viewing systems.
 - **Save keyframe orientation** / **Update keyframe orientation**: Press to indicate that a flythrough frame is a keyframe and that you have selected your desired camera orientation for this keyframe in the first-person, 3D viewing pane.  If you wish to update the orientation for a keyframe, use the Frame, First, Back, Next, or Last buttons to go to the frame, adjust the camera orientation, and hit this button again.
 - **Delete keyframe orientation**: Discard the camera orientation associated with the selected keyframe.
-- **First**: PRess to go to the lowest-numbered keyframe.
+- **First**: Press to go to the lowest-numbered keyframe.
 - **Back**: Press to move backwards through the flythrough to the nearest keyframe.
 - **Next**: Press to move forwards through the flythrough to the nearest keyframe.
 - **Last**: Press to go to the highest-numbered keyframe

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -193,6 +193,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         viewAngleSlider.decimals = 0
         viewAngleSlider.minimum = 30
         viewAngleSlider.maximum = 180
+        viewAngleSlider.suffix = " \N{DEGREE SIGN}"
         viewAngleSlider.connect("valueChanged(double)", self.viewAngleSliderValueChanged)
         flythroughFormLayout.addRow(_("View Angle:"), viewAngleSlider)
         self.viewAngleSlider = viewAngleSlider

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -797,9 +797,9 @@ class EndoscopyLogic:
         quaternionInterpolator = vtk.vtkQuaternionInterpolator()
         quaternionInterpolator.SetSearchMethod(0)  # binary search
 
-        # # Using a modified Kochanek basis
-        # quaternionInterpolator.SetInterpolationTypeToSpline()
-        # Using linear spherical interpolation
+        # Use the "linear spherical interpolation" rather than the "cubic spline interpolation" (using a modified
+        # Kochanek basis) because the latter seems to use the supplied quaternions as guide points, but doesn't
+        # necessarily take a path through them.
         quaternionInterpolator.SetInterpolationTypeToLinear()
 
         resampledCurveLength = self.resampledCurve.GetCurveLengthWorld()

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -917,12 +917,6 @@ class EndoscopyLogic:
         return orientation
 
     @staticmethod
-    def matrix3x3ToQuaternion(matrix3x3):
-        quaternion = np.zeros((4,))
-        vtk.vtkMath.matrix3x3ToQuaternion(matrix3x3, quaternion)
-        return quaternion
-
-    @staticmethod
     def orientationToMatrix3x3(orientation):
         matrix3x3 = np.zeros((3, 3))
         vtkQ = vtk.vtkQuaternion[np.float64]()
@@ -937,12 +931,6 @@ class EndoscopyLogic:
         vtkQ.SetRotationAngleAndAxis(*orientation)
         vtkQ.Get(quaternion)
         return quaternion
-
-    @staticmethod
-    def quaternionToMatrix3x3(quaternion):
-        matrix3x3 = np.zeros((3, 3))
-        vtk.vtkMath.quaternionToMatrix3x3(quaternion, matrix3x3)
-        return matrix3x3
 
     @staticmethod
     def quaternionToOrientation(quaternion):

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -722,7 +722,7 @@ class EndoscopyLogic:
         self.cameraOrientations = None
         self.cameraOrientationResampledCurveIndices = None
 
-    def setControlPoints(self, inputCurve: slicer.vtkMRMLMarkupsCurveNode) -> bool:
+    def setControlPoints(self, inputCurve: slicer.vtkMRMLMarkupsCurveNode) -> None:
         expectedType = slicer.vtkMRMLMarkupsCurveNode
         if not isinstance(inputCurve, expectedType):
             raise TypeError(

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -218,24 +218,28 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         firstOrientationButton.enabled = True
         firstOrientationButton.connect("clicked()", self.onFirstOrientationButtonClicked)
         flythroughOrientationLayout.addWidget(firstOrientationButton)
+        self.firstOrientationButton = firstOrientationButton
 
         backOrientationButton = qt.QPushButton(_("Back"))
         backOrientationButton.toolTip = _("Go to the previous user-supplied keyframe.")
         backOrientationButton.enabled = True
         backOrientationButton.connect("clicked()", self.onBackOrientationButtonClicked)
         flythroughOrientationLayout.addWidget(backOrientationButton)
+        self.backOrientationButton = backOrientationButton
 
         nextOrientationButton = qt.QPushButton(_("Next"))
         nextOrientationButton.toolTip = _("Go to the next user-supplied keyframe.")
         nextOrientationButton.enabled = True
         nextOrientationButton.connect("clicked()", self.onNextOrientationButtonClicked)
         flythroughOrientationLayout.addWidget(nextOrientationButton)
+        self.nextOrientationButton = nextOrientationButton
 
         lastOrientationButton = qt.QPushButton(_("Last"))
         lastOrientationButton.toolTip = _("Go to the last user-supplied keyframe.")
         lastOrientationButton.enabled = True
         lastOrientationButton.connect("clicked()", self.onLastOrientationButtonClicked)
         flythroughOrientationLayout.addWidget(lastOrientationButton)
+        self.lastOrientationButton = lastOrientationButton
 
         flythroughFormLayout.addRow(flythroughOrientationLayout)
 
@@ -350,6 +354,21 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.deleteOrientationButton.enabled = deletable
         self.saveOrientationButton.text = (
             _("Update Keyframe Orientation") if deletable else _("Save Keyframe Orientation")
+        )
+
+        # Update keyframe navigation buttons
+        firstResampledCurvePointIndex = self.logic.getFirstControlPointIndex()
+        lastResampledCurvePointIndex = self.logic.getLastControlPointIndex()
+        (
+            self.firstOrientationButton.enabled,
+            self.backOrientationButton.enabled,
+            self.nextOrientationButton.enabled,
+            self.lastOrientationButton.enabled,
+        ) = (
+            firstResampledCurvePointIndex is not None and firstResampledCurvePointIndex != resampledCurvePointIndex,
+            self.logic.getPreviousControlPointIndex(resampledCurvePointIndex) is not None,
+            self.logic.getNextControlPointIndex(resampledCurvePointIndex) is not None,
+            lastResampledCurvePointIndex is not None and lastResampledCurvePointIndex != resampledCurvePointIndex,
         )
 
         # If there is no input curve available (e.g scene close), stop playblack

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -435,10 +435,8 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         resampledCurvePointIndex = int(self.frameSlider.value)
 
         self.ignoreInputCurveModified += 1
-        cameraOrientations = self.logic.saveOrientationAtIndex(resampledCurvePointIndex, self.cameraNode)
+        self.logic.saveOrientationAtIndex(resampledCurvePointIndex, self.cameraNode)
         self.ignoreInputCurveModified -= 1
-
-        self.logic.interpolateOrientationsForControlPoints(cameraOrientations)
 
         self.flyTo(resampledCurvePointIndex)
 
@@ -447,10 +445,8 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         resampledCurvePointIndexToDelete = int(self.frameSlider.value)
 
         self.ignoreInputCurveModified += 1
-        cameraOrientations = self.logic.removeOrientationAtIndex(resampledCurvePointIndexToDelete)
+        self.logic.removeOrientationAtIndex(resampledCurvePointIndexToDelete)
         self.ignoreInputCurveModified -= 1
-
-        self.logic.interpolateOrientationsForControlPoints(cameraOrientations)
 
         self.flyTo(resampledCurvePointIndexToDelete)
 
@@ -713,6 +709,7 @@ class EndoscopyLogic:
         cameraOrientations[distanceAlongResampledCurve] = worldOrientation
 
         EndoscopyLogic.setInputCurveCameraOrientations(inputCurve, cameraOrientations)
+        self.interpolateOrientationsForControlPoints(cameraOrientations)
 
         return cameraOrientations
 
@@ -738,6 +735,7 @@ class EndoscopyLogic:
                 break
 
         EndoscopyLogic.setInputCurveCameraOrientations(inputCurve, cameraOrientations)
+        self.interpolateOrientationsForControlPoints(cameraOrientations)
 
         return cameraOrientations
 

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -411,34 +411,16 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.flyTo(resampledCurvePointIndexToDelete)
 
     def onFirstOrientationButtonClicked(self):
-        allIndices = self.logic.cameraOrientationResampledCurveIndices
-        if not allIndices:
-            return
-        whereTo = min(allIndices, default=self.frameSlider.minimum)
-        self.frameSlider.value = whereTo
+        self.frameSlider.value = self.logic.getFirstControlPointIndex()
 
     def onBackOrientationButtonClicked(self):
-        allIndices = self.logic.cameraOrientationResampledCurveIndices
-        allIndices = [x for x in allIndices if x < self.frameSlider.value]
-        if not allIndices:
-            return
-        whereTo = max(allIndices)
-        self.frameSlider.value = whereTo
+        self.frameSlider.value = self.logic.getPreviousControlPointIndex(self.frameSlider.value)
 
     def onNextOrientationButtonClicked(self):
-        allIndices = self.logic.cameraOrientationResampledCurveIndices
-        allIndices = [x for x in allIndices if x > self.frameSlider.value]
-        if not allIndices:
-            return
-        whereTo = min(allIndices)
-        self.frameSlider.value = whereTo
+        self.frameSlider.value = self.logic.getNextControlPointIndex(self.frameSlider.value)
 
     def onLastOrientationButtonClicked(self):
-        allIndices = self.logic.cameraOrientationResampledCurveIndices
-        if not allIndices:
-            return
-        whereTo = max(allIndices)
-        self.frameSlider.value = whereTo
+        self.frameSlider.value = self.logic.getLastControlPointIndex()
 
     def onSaveExportModelButtonClicked(self):
         logging.debug("Create Model...")
@@ -602,6 +584,24 @@ class EndoscopyLogic:
 
     def getNumberOfControlPoints(self):
         return self.resampledCurve.GetNumberOfControlPoints()
+
+    def getFirstControlPointIndex(self):
+        allIndices = self.cameraOrientationResampledCurveIndices
+        return min(allIndices, default=None)
+
+    def getPreviousControlPointIndex(self, currentResampledCurvePointIndex):
+        allIndices = self.cameraOrientationResampledCurveIndices
+        allIndices = [x for x in allIndices if x < currentResampledCurvePointIndex]
+        return max(allIndices, default=None)
+
+    def getNextControlPointIndex(self, currentResampledCurvePointIndex):
+        allIndices = self.cameraOrientationResampledCurveIndices
+        allIndices = [x for x in allIndices if x > currentResampledCurvePointIndex]
+        return min(allIndices, default=None)
+
+    def getLastControlPointIndex(self):
+        allIndices = self.cameraOrientationResampledCurveIndices
+        return max(allIndices, default=None)
 
     def setControlPointsByResamplingAndInterpolationFromInputCurve(self, inputCurve) -> None:
         if inputCurve is None:

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -412,24 +412,32 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def onFirstOrientationButtonClicked(self):
         allIndices = self.logic.cameraOrientationResampledCurveIndices
+        if not allIndices:
+            return
         whereTo = min(allIndices, default=self.frameSlider.minimum)
         self.frameSlider.value = whereTo
 
     def onBackOrientationButtonClicked(self):
         allIndices = self.logic.cameraOrientationResampledCurveIndices
         allIndices = [x for x in allIndices if x < self.frameSlider.value]
-        whereTo = max(allIndices, default=self.frameSlider.minimum)
+        if not allIndices:
+            return
+        whereTo = max(allIndices)
         self.frameSlider.value = whereTo
 
     def onNextOrientationButtonClicked(self):
         allIndices = self.logic.cameraOrientationResampledCurveIndices
         allIndices = [x for x in allIndices if x > self.frameSlider.value]
-        whereTo = min(allIndices, default=self.frameSlider.maximum)
+        if not allIndices:
+            return
+        whereTo = min(allIndices)
         self.frameSlider.value = whereTo
 
     def onLastOrientationButtonClicked(self):
         allIndices = self.logic.cameraOrientationResampledCurveIndices
-        whereTo = max(allIndices, default=self.frameSlider.maximum)
+        if not allIndices:
+            return
+        whereTo = max(allIndices)
         self.frameSlider.value = whereTo
 
     def onSaveExportModelButtonClicked(self):

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -153,7 +153,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Play button
         playButton = qt.QPushButton(_("Play flythrough"))
-        playButton.toolTip = _("Fly through curve.")
+        playButton.toolTip = _("Start or stop the flythrough animation.")
         playButton.checkable = True
         playButton.connect("toggled(bool)", self.onPlayButtonToggled)
         flythroughFormLayout.addRow(playButton)
@@ -161,6 +161,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Frame slider
         frameSlider = ctk.ctkSliderWidget()
+        frameSlider.toolTip = _("The current frame along the path.")
         frameSlider.decimals = 0
         frameSlider.connect("valueChanged(double)", self.frameSliderValueChanged)
         flythroughFormLayout.addRow(_("Frame:"), frameSlider)
@@ -168,6 +169,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Frame skip slider
         frameSkipSlider = ctk.ctkSliderWidget()
+        frameSkipSlider.toolTip = _("Number of frames to skip.")
         frameSkipSlider.decimals = 0
         frameSkipSlider.minimum = 0
         frameSkipSlider.maximum = 50
@@ -176,6 +178,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Frame delay slider
         frameDelaySlider = ctk.ctkSliderWidget()
+        frameDelaySlider.toolTip = _("Time delay between animation frames.")
         frameDelaySlider.decimals = 0
         frameDelaySlider.minimum = 5
         frameDelaySlider.maximum = 100
@@ -186,6 +189,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # View angle slider
         viewAngleSlider = ctk.ctkSliderWidget()
+        viewAngleSlider.toolTip = _("Field of view of the camera in degrees.")
         viewAngleSlider.decimals = 0
         viewAngleSlider.minimum = 30
         viewAngleSlider.maximum = 180
@@ -197,7 +201,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Button for saving the camera orientation of a location
         saveOrientationButton = qt.QPushButton(_("Save Keyframe Orientation"))
-        saveOrientationButton.toolTip = _("Save the camera orientation for this frame")
+        saveOrientationButton.toolTip = _("Save the camera orientation for this frame.")
         saveOrientationButton.enabled = False
         saveOrientationButton.connect("clicked()", self.onSaveOrientationButtonClicked)
         keyframeOrientationLayout.addWidget(saveOrientationButton)
@@ -205,7 +209,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Button for deleting the camera orientation of a location
         deleteOrientationButton = qt.QPushButton(_("Delete Keyframe Orientation"))
-        deleteOrientationButton.toolTip = _("Delete the camera orientation for this frame")
+        deleteOrientationButton.toolTip = _("Delete the saved camera orientation for this frame.")
         deleteOrientationButton.enabled = False
         deleteOrientationButton.connect("clicked()", self.onDeleteOrientationButtonClicked)
         keyframeOrientationLayout.addWidget(deleteOrientationButton)
@@ -216,25 +220,25 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         flythroughOrientationLayout = qt.QHBoxLayout()
 
         firstOrientationButton = qt.QPushButton(_("First"))
-        firstOrientationButton.toolTip = _("Go to the first user-supplied keyframe")
+        firstOrientationButton.toolTip = _("Go to the first user-supplied keyframe.")
         firstOrientationButton.enabled = True
         firstOrientationButton.connect("clicked()", self.onFirstOrientationButtonClicked)
         flythroughOrientationLayout.addWidget(firstOrientationButton)
 
         backOrientationButton = qt.QPushButton(_("Back"))
-        backOrientationButton.toolTip = _("Go to the previous user-supplied keyframe")
+        backOrientationButton.toolTip = _("Go to the previous user-supplied keyframe.")
         backOrientationButton.enabled = True
         backOrientationButton.connect("clicked()", self.onBackOrientationButtonClicked)
         flythroughOrientationLayout.addWidget(backOrientationButton)
 
         nextOrientationButton = qt.QPushButton(_("Next"))
-        nextOrientationButton.toolTip = _("Go to the next user-supplied keyframe")
+        nextOrientationButton.toolTip = _("Go to the next user-supplied keyframe.")
         nextOrientationButton.enabled = True
         nextOrientationButton.connect("clicked()", self.onNextOrientationButtonClicked)
         flythroughOrientationLayout.addWidget(nextOrientationButton)
 
         lastOrientationButton = qt.QPushButton(_("Last"))
-        lastOrientationButton.toolTip = _("Go to the last user-supplied keyframe")
+        lastOrientationButton.toolTip = _("Go to the last user-supplied keyframe.")
         lastOrientationButton.enabled = True
         lastOrientationButton.connect("clicked()", self.onLastOrientationButtonClicked)
         flythroughOrientationLayout.addWidget(lastOrientationButton)
@@ -256,7 +260,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Select name for output model
         outputPathNodeSelector = slicer.qMRMLNodeComboBox()
         outputPathNodeSelector.objectName = "outputPathNodeSelector"
-        outputPathNodeSelector.toolTip = _("Create a model node.")
+        outputPathNodeSelector.toolTip = _("Select or create the destination model for exporting the flythrough path.")
         outputPathNodeSelector.nodeTypes = ["vtkMRMLModelNode"]
         outputPathNodeSelector.noneEnabled = False
         outputPathNodeSelector.addEnabled = True
@@ -268,7 +272,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Button for exporting a model
         saveExportModelButton = qt.QPushButton(_("Export as model"))
-        saveExportModelButton.toolTip = _("Export as model")
+        saveExportModelButton.toolTip = _("Export the current flythrough path as a model.")
         saveExportModelButton.enabled = False
         saveExportModelButton.connect("clicked()", self.onSaveExportModelButtonClicked)
         advancedFormLayout.addRow(saveExportModelButton)

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -565,7 +565,7 @@ class EndoscopyLogic:
     def __init__(self, inputCurve, dl=0.5):
         self.cleanup()
         self.dl = dl  # desired world space step size (in mm)
-        self.setControlPoints(inputCurve)
+        self.setControlPointsByResamplingAndInterpolationFromInputCurve(inputCurve)
 
     def cleanup(self):
         # Whether we're about to construct or delete, free all resources and initialize class members to None.
@@ -578,7 +578,7 @@ class EndoscopyLogic:
     def getNumberOfControlPoints(self):
         return self.resampledCurve.GetNumberOfControlPoints()
 
-    def setControlPoints(self, inputCurve: slicer.vtkMRMLMarkupsCurveNode) -> None:
+    def setControlPointsByResamplingAndInterpolationFromInputCurve(self, inputCurve: slicer.vtkMRMLMarkupsCurveNode) -> None:
         expectedType = slicer.vtkMRMLMarkupsCurveNode
         if not isinstance(inputCurve, expectedType):
             raise TypeError(

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -283,16 +283,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def setCameraNode(self, newCameraNode):
         """Allow to set the current camera node."""
-
-        # Remove previous observer
-        cameraNode = EndoscopyLogic.getCameraFromInputCurve(self.inputCurve)
-        if cameraNode is not None:
-            self.removeObserver(cameraNode, vtk.vtkCommand.ModifiedEvent, self.updateWidgetFromMRML)
-
         EndoscopyLogic.setInputCurveCamera(self.inputCurve, newCameraNode)
-
-        if newCameraNode is not None:
-            self.addObserver(newCameraNode, vtk.vtkCommand.ModifiedEvent, self.updateWidgetFromMRML)
 
         # Update UI
         self.updateWidgetFromMRML()
@@ -322,9 +313,6 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Update UI
         self.updateWidgetFromMRML()
-
-        # Initialize to the start of the path
-        self.flyTo(0)
 
     def updateWidgetFromMRML(self, *_unused):
         # Create a cursor and associated transform so that the user can see where the flythrough is progressing.
@@ -473,6 +461,9 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def flyTo(self, resampledCurvePointIndex):
         """Apply the resampledCurvePointIndex-th step in the path to the global camera"""
         self.logic.updateCameraFromOrientationAtIndex(resampledCurvePointIndex)
+
+        # Update UI
+        self.updateWidgetFromMRML()
 
     @staticmethod
     def _viewNodeIDFromCameraNode(cameraNode):

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -42,7 +42,7 @@ class Endoscopy(ScriptedLoadableModule):
 Create or import a markups curve.
 Pick the Camera to use for either playing the flythrough or editing associated keyframes.
 Select the Camera to use for playing the flythrough.
-Clicking "Create flythrough path" will make a flythrough curve and enable the flythrough panel.
+Clicking "Use this curve" will make a flythrough curve and enable the flythrough panel.
 You can manually scroll through the path with the Frame slider.
 The Play/Pause button toggles animated flythrough.
 The Frame Skip slider speeds up the animation by skipping points on the path.
@@ -132,7 +132,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.inputCurveSelector = inputCurveSelector
 
         # CreatePath button
-        createPathButton = qt.QPushButton(_("Create flythrough path"))
+        createPathButton = qt.QPushButton(_("Use this curve"))
         createPathButton.toolTip = _("Base the flythrough on the selected input curve.")
         createPathButton.enabled = False
         createPathButton.connect("clicked()", self.onCreatePathButtonClicked)
@@ -152,7 +152,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Play button
         playButton = qt.QPushButton(_("Play flythrough"))
-        playButton.toolTip = _("Fly through path.")
+        playButton.toolTip = _("Fly through curve.")
         playButton.checkable = True
         playButton.connect("toggled(bool)", self.onPlayButtonToggled)
         flythroughFormLayout.addRow(playButton)
@@ -344,7 +344,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         pass
 
     def onCreatePathButtonClicked(self):
-        """Connected to `createPath` button.  It allows to:
+        """Connected to 'Use this curve'` button.  It allows to:
         - compute the path
         - create cursor
         - ensure cursor, model and input curve are not visible in the endoscopy view

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -841,8 +841,7 @@ class EndoscopyLogic:
                 relativeOrientation = EndoscopyLogic.quaternionToOrientation(quaternion)
                 self.setRelativeOrientation(self.resampledCurve, resampledCurvePointIndex, relativeOrientation)
 
-    def getDefaultOrientation(self, curve, curveControlPointIndex, worldOrientation=None):
-        worldOrientation = worldOrientation if worldOrientation is not None else np.zeros((4,))
+    def getDefaultOrientation(self, curve, curveControlPointIndex):
         numberOfCurveControlPoints = curve.GetNumberOfControlPoints()
         # If the curve is not closed then the last control point has the same orientation as its previous control point.
         # Get its forward direction by looking at the previous control point.
@@ -864,7 +863,7 @@ class EndoscopyLogic:
             focalPoint += increment
 
         matrix3x3 = EndoscopyLogic.buildCameraMatrix3x3(cameraPosition, focalPoint, self.planeNormal)
-        EndoscopyLogic.matrix3x3ToOrientation(matrix3x3, worldOrientation)
+        worldOrientation = EndoscopyLogic.matrix3x3ToOrientation(matrix3x3)
 
         return worldOrientation
 
@@ -872,32 +871,24 @@ class EndoscopyLogic:
     def setWorldOrientation(curve, curveControlPointIndex, worldOrientation):
         curve.SetNthControlPointOrientation(curveControlPointIndex, worldOrientation)
 
-    def getRelativeOrientation(self, curve, curveControlPointIndex, relativeOrientation=None):
-        relativeOrientation = relativeOrientation if relativeOrientation is not None else np.zeros((4,))
-
+    def getRelativeOrientation(self, curve, curveControlPointIndex):
         worldOrientation = np.zeros((4,))
         curve.GetNthControlPointOrientation(curveControlPointIndex, worldOrientation)
-
-        self.worldOrientationToRelative(curve, curveControlPointIndex, worldOrientation, relativeOrientation)
-        return relativeOrientation
+        return self.worldOrientationToRelative(curve, curveControlPointIndex, worldOrientation)
 
     def setRelativeOrientation(self, curve, curveControlPointIndex, relativeOrientation):
         worldOrientation = self.relativeOrientationToWorld(curve, curveControlPointIndex, relativeOrientation)
         EndoscopyLogic.setWorldOrientation(curve, curveControlPointIndex, worldOrientation)
 
-    def relativeOrientationToWorld(self, curve, curveControlPointIndex, relativeOrientation, worldOrientation=None):
-        worldOrientation = worldOrientation if worldOrientation is not None else np.zeros((4,))
+    def relativeOrientationToWorld(self, curve, curveControlPointIndex, relativeOrientation):
         defaultOrientation = self.getDefaultOrientation(curve, curveControlPointIndex)
-        EndoscopyLogic.multiplyOrientations(relativeOrientation, defaultOrientation, worldOrientation)
-        return worldOrientation
+        return EndoscopyLogic.multiplyOrientations(relativeOrientation, defaultOrientation)
 
-    def worldOrientationToRelative(self, curve, curveControlPointIndex, worldOrientation, relativeOrientation=None):
-        relativeOrientation = relativeOrientation if relativeOrientation is not None else np.zeros((4,))
+    def worldOrientationToRelative(self, curve, curveControlPointIndex, worldOrientation):
         inverseDefaultOrientation = self.getDefaultOrientation(curve, curveControlPointIndex)
         # Convert defaultOrientation to its inverse by negating the angle of rotation
         inverseDefaultOrientation[0] *= -1.0
-        EndoscopyLogic.multiplyOrientations(worldOrientation, inverseDefaultOrientation, relativeOrientation)
-        return relativeOrientation
+        return EndoscopyLogic.multiplyOrientations(worldOrientation, inverseDefaultOrientation)
 
     @staticmethod
     def distanceAlongCurveOfNthControlPoint(curve, indexOfControlPoint):
@@ -918,58 +909,56 @@ class EndoscopyLogic:
         return indexOfControlPoint
 
     @staticmethod
-    def matrix3x3ToOrientation(matrix3x3, orientation=None):
-        orientation = orientation if orientation is not None else np.zeros((4,))
+    def matrix3x3ToOrientation(matrix3x3):
+        orientation = np.zeros((4,))
         vtkQ = vtk.vtkQuaternion[np.float64]()
         vtkQ.FromMatrix3x3(matrix3x3)
         orientation[0] = vtkQ.GetRotationAngleAndAxis(orientation[1:4])
         return orientation
 
     @staticmethod
-    def matrix3x3ToQuaternion(matrix3x3, quaternion=None):
-        quaternion = quaternion if quaternion is not None else np.zeros((4,))
+    def matrix3x3ToQuaternion(matrix3x3):
+        quaternion = np.zeros((4,))
         vtk.vtkMath.matrix3x3ToQuaternion(matrix3x3, quaternion)
         return quaternion
 
     @staticmethod
-    def orientationToMatrix3x3(orientation, matrix3x3=None):
-        matrix3x3 = matrix3x3 if matrix3x3 is not None else np.zeros((3, 3))
+    def orientationToMatrix3x3(orientation):
+        matrix3x3 = np.zeros((3, 3))
         vtkQ = vtk.vtkQuaternion[np.float64]()
         vtkQ.SetRotationAngleAndAxis(*orientation)
         vtkQ.ToMatrix3x3(matrix3x3)
         return matrix3x3
 
     @staticmethod
-    def orientationToQuaternion(orientation, quaternion=None):
-        quaternion = quaternion if quaternion is not None else np.zeros((4,))
+    def orientationToQuaternion(orientation):
+        quaternion = np.zeros((4,))
         vtkQ = vtk.vtkQuaternion[np.float64]()
         vtkQ.SetRotationAngleAndAxis(*orientation)
         vtkQ.Get(quaternion)
         return quaternion
 
     @staticmethod
-    def quaternionToMatrix3x3(quaternion, matrix3x3=None):
-        matrix3x3 = matrix3x3 if matrix3x3 is not None else np.zeros((3, 3))
+    def quaternionToMatrix3x3(quaternion):
+        matrix3x3 = np.zeros((3, 3))
         vtk.vtkMath.quaternionToMatrix3x3(quaternion, matrix3x3)
         return matrix3x3
 
     @staticmethod
-    def quaternionToOrientation(quaternion, orientation=None):
-        orientation = orientation if orientation is not None else np.zeros((4,))
+    def quaternionToOrientation(quaternion):
+        orientation = np.zeros((4,))
         vtkQ = vtk.vtkQuaternion[np.float64]()
         vtkQ.Set(*quaternion)
         orientation[0] = vtkQ.GetRotationAngleAndAxis(orientation[1:4])
         return orientation
 
     @staticmethod
-    def multiplyOrientations(leftOrientation, rightOrientation, resultOrientation=None):
-        resultOrientation = resultOrientation if resultOrientation is not None else np.zeros((4,))
+    def multiplyOrientations(leftOrientation, rightOrientation):
         return EndoscopyLogic.matrix3x3ToOrientation(
             np.matmul(
                 EndoscopyLogic.orientationToMatrix3x3(leftOrientation),
                 EndoscopyLogic.orientationToMatrix3x3(rightOrientation),
             ),
-            resultOrientation,
         )
 
     @staticmethod
@@ -997,8 +986,8 @@ class EndoscopyLogic:
         return p, n
 
     @staticmethod
-    def buildCameraMatrix3x3(cameraPosition, focalPoint, viewUp, outputMatrix3x3=None):
-        outputMatrix3x3 = outputMatrix3x3 if outputMatrix3x3 is not None else np.zeros((3, 3))
+    def buildCameraMatrix3x3(cameraPosition, focalPoint, viewUp):
+        outputMatrix3x3 = np.zeros((3, 3))
         # Note that viewUp might be supplied as planeNormal, which might not be orthogonal to (focalPoint -
         # cameraPosition), so this mathematics is careful to handle that case too.
 
@@ -1014,8 +1003,8 @@ class EndoscopyLogic:
         return outputMatrix3x3
 
     @staticmethod
-    def buildCameraMatrix4x4(cameraPosition, inputMatrix3x3, outputMatrix4x4=None):
-        outputMatrix4x4 = outputMatrix4x4 if outputMatrix4x4 is not None else vtk.vtkMatrix4x4()
+    def buildCameraMatrix4x4(cameraPosition, inputMatrix3x3):
+        outputMatrix4x4 = vtk.vtkMatrix4x4()
         outputMatrix4x4.SetElement(3, 3, 1.0)
         for col in range(3):
             for row in range(3):

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -73,7 +73,6 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         self.transform = None
         self.cursor = None
-        self.model = None
         self.skip = 0
         self.logic = None
         self.timer = qt.QTimer()
@@ -394,7 +393,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Hide the cursor, model and inputCurve from the main 3D view
         EndoscopyWidget._hideOnlyInView(
             EndoscopyWidget._viewNodeIDFromCameraNode(self.cameraNode),
-            [self.cursor, self.model, self.inputCurve],
+            [self.cursor, inputCurve],
         )
 
         # Update flythrough variables
@@ -491,12 +490,10 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if self.transform:
             model.model.SetNodeReferenceID("CameraTransform", self.transform.GetID())
 
-        self.model = model.model
-
         # Hide the model from the main 3D view
         EndoscopyWidget._hideOnlyInView(
             EndoscopyWidget._viewNodeIDFromCameraNode(self.cameraNode),
-            [self.model],
+            [model.model],
         )
         logging.debug("-> Model created")
 

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -438,7 +438,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         cameraOrientations = self.logic.saveOrientationAtIndex(resampledCurvePointIndex, self.cameraNode)
         self.ignoreInputCurveModified -= 1
 
-        self.logic.interpolateOrientations(cameraOrientations)
+        self.logic.interpolateOrientationsForControlPoints(cameraOrientations)
 
         self.flyTo(resampledCurvePointIndex)
 
@@ -450,7 +450,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         cameraOrientations = self.logic.removeOrientationAtIndex(resampledCurvePointIndexToDelete)
         self.ignoreInputCurveModified -= 1
 
-        self.logic.interpolateOrientations(cameraOrientations)
+        self.logic.interpolateOrientationsForControlPoints(cameraOrientations)
 
         self.flyTo(resampledCurvePointIndexToDelete)
 
@@ -639,9 +639,9 @@ class EndoscopyLogic:
 
         cameraOrientations = EndoscopyLogic.getCameraOrientationsFromInputCurve(inputCurve)
 
-        self.interpolateOrientations(cameraOrientations)
+        self.interpolateOrientationsForControlPoints(cameraOrientations)
 
-    def interpolateOrientations(self, cameraOrientations):
+    def interpolateOrientationsForControlPoints(self, cameraOrientations):
 
         # Configure a vtkQuaternionInterpolator using the user's supplied orientations.
         # Note that all distances are as measured along resampledCurve rather than along inputCurve.

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -838,8 +838,12 @@ class EndoscopyLogic:
                 )
                 quaternion = np.zeros((4,))
                 quaternionInterpolator.InterpolateQuaternion(distanceAlongResampledCurve, quaternion)
+
                 relativeOrientation = EndoscopyLogic.quaternionToOrientation(quaternion)
-                self.setRelativeOrientation(self.resampledCurve, resampledCurvePointIndex, relativeOrientation)
+
+                worldOrientation = self.relativeOrientationToWorld(self.resampledCurve, resampledCurvePointIndex, relativeOrientation)
+
+                self.resampledCurve.SetNthControlPointOrientation(resampledCurvePointIndex, worldOrientation)
 
     def getDefaultOrientation(self, curve, curveControlPointIndex):
         numberOfCurveControlPoints = curve.GetNumberOfControlPoints()
@@ -866,19 +870,6 @@ class EndoscopyLogic:
         worldOrientation = EndoscopyLogic.matrix3x3ToOrientation(matrix3x3)
 
         return worldOrientation
-
-    @staticmethod
-    def setWorldOrientation(curve, curveControlPointIndex, worldOrientation):
-        curve.SetNthControlPointOrientation(curveControlPointIndex, worldOrientation)
-
-    def getRelativeOrientation(self, curve, curveControlPointIndex):
-        worldOrientation = np.zeros((4,))
-        curve.GetNthControlPointOrientation(curveControlPointIndex, worldOrientation)
-        return self.worldOrientationToRelative(curve, curveControlPointIndex, worldOrientation)
-
-    def setRelativeOrientation(self, curve, curveControlPointIndex, relativeOrientation):
-        worldOrientation = self.relativeOrientationToWorld(curve, curveControlPointIndex, relativeOrientation)
-        EndoscopyLogic.setWorldOrientation(curve, curveControlPointIndex, worldOrientation)
 
     def relativeOrientationToWorld(self, curve, curveControlPointIndex, relativeOrientation):
         defaultOrientation = self.getDefaultOrientation(curve, curveControlPointIndex)

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -902,7 +902,7 @@ class EndoscopyLogic:
     @staticmethod
     def matrix3x3ToOrientation(matrix3x3):
         orientation = np.zeros((4,))
-        vtkQ = vtk.vtkQuaternion[np.float64]()
+        vtkQ = vtk.vtkQuaterniond()
         vtkQ.FromMatrix3x3(matrix3x3)
         orientation[0] = vtkQ.GetRotationAngleAndAxis(orientation[1:4])
         return orientation
@@ -910,7 +910,7 @@ class EndoscopyLogic:
     @staticmethod
     def orientationToMatrix3x3(orientation):
         matrix3x3 = np.zeros((3, 3))
-        vtkQ = vtk.vtkQuaternion[np.float64]()
+        vtkQ = vtk.vtkQuaterniond()
         vtkQ.SetRotationAngleAndAxis(*orientation)
         vtkQ.ToMatrix3x3(matrix3x3)
         return matrix3x3
@@ -918,7 +918,7 @@ class EndoscopyLogic:
     @staticmethod
     def orientationToQuaternion(orientation):
         quaternion = np.zeros((4,))
-        vtkQ = vtk.vtkQuaternion[np.float64]()
+        vtkQ = vtk.vtkQuaterniond()
         vtkQ.SetRotationAngleAndAxis(*orientation)
         vtkQ.Get(quaternion)
         return quaternion
@@ -926,8 +926,7 @@ class EndoscopyLogic:
     @staticmethod
     def quaternionToOrientation(quaternion):
         orientation = np.zeros((4,))
-        vtkQ = vtk.vtkQuaternion[np.float64]()
-        vtkQ.Set(*quaternion)
+        vtkQ = vtk.vtkQuaterniond(*quaternion)
         orientation[0] = vtkQ.GetRotationAngleAndAxis(orientation[1:4])
         return orientation
 

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -370,7 +370,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         self.setInputCurve(inputCurve)
 
-        numberOfControlPoints = self.logic.resampledCurve.GetNumberOfControlPoints()
+        numberOfControlPoints = self.logic.getNumberOfControlPoints()
 
         # Update frame slider range
         self.frameSlider.maximum = max(0, numberOfControlPoints - 2)
@@ -495,7 +495,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def flyToNext(self):
         currentStep = int(self.frameSlider.value)
         nextStep = currentStep + self.skip + 1
-        if nextStep > self.logic.resampledCurve.GetNumberOfControlPoints() - 2:
+        if nextStep > self.logic.getNumberOfControlPoints() - 2:
             nextStep = 0
         self.frameSlider.value = nextStep
 
@@ -504,7 +504,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         if (
             self.logic.resampledCurve is None
-            or not 0 <= resampledCurvePointIndex < self.logic.resampledCurve.GetNumberOfControlPoints()
+            or not 0 <= resampledCurvePointIndex < self.logic.getNumberOfControlPoints()
         ):
             return
 
@@ -620,7 +620,7 @@ class EndoscopyLogic:
 
     Example:
       logic = EndoscopyLogic(inputCurve)
-      print(f"computed path has {logic.resampledCurve.GetNumberOfControlPoints()} elements")
+      print(f"computed path has {logic.getNumberOfControlPoints()} elements")
 
     Notes:
     * `orientation` = (angle, *axis), where angle is in radians and axis is the unit 3D-vector for the axis
@@ -643,6 +643,9 @@ class EndoscopyLogic:
         self.resampledCurve = None
         self.planeNormal = None
         self.cameraOrientationResampledCurveIndices = None
+
+    def getNumberOfControlPoints(self):
+        return self.resampledCurve.GetNumberOfControlPoints()
 
     def setControlPoints(self, inputCurve: slicer.vtkMRMLMarkupsCurveNode) -> None:
         expectedType = slicer.vtkMRMLMarkupsCurveNode


### PR DESCRIPTION
Backports changes originally contributed to `main` through the following pull requests:
- https://github.com/Slicer/Slicer/pull/7435
- https://github.com/Slicer/Slicer/pull/7431
- https://github.com/Slicer/Slicer/pull/7433
- https://github.com/Slicer/Slicer/pull/7436
- https://github.com/Slicer/Slicer/pull/7437
- https://github.com/Slicer/Slicer/pull/7439

Verified that the `Endoscopy.py` file associated with the `5.6` branch includes all changes from the one of the `main` branch (as of https://github.com/Slicer/Slicer/commit/7bd7cd0f596a73dce4201d05cb6aa9836f5b51bd) expect the one introduced through https://github.com/Slicer/Slicer/pull/7446