### PR TITLE
[5.6] BUG: Restore maximization of view on double click event

### DIFF
--- a/Docs/developer_guide/mrml_overview.md
+++ b/Docs/developer_guide/mrml_overview.md
@@ -69,9 +69,9 @@ For more details, see [this page](https://www.slicer.org/wiki/Documentation/Nigh
 - Using the `AddObserver()`/`RemoveObserver()` methods is tedious and error-prone, therefore it is recommended to instead use [EventBroker](https://www.slicer.org/wiki/Slicer3:EventBroker) and the vtkObserverManager helper class, macros, and callback methods.
   - MRML observer macros are defined in Libs/MRML/vtkMRMLNode.h
   - vtkSetMRMLObjectMacro - registers a MRML node with another VTK object (another MRML node, Logic or GUI). No observers are added.
-  - vtkSetAndObserveMRMLObjectMacro - registers a MRML node and adds an observer for vtkCommand::ModifyEvent.
+  - vtkSetAndObserveMRMLObjectMacro - registers a MRML node and adds an observer for vtkCommand::ModifiedEvent.
   - vtkSetAndObserveMRMLObjectEventsMacro - registers a MRML node and adds an observer for a specified set of events.
-  - The `SetAndObserveMRMLScene()` and `SetAndObserveMRMLSceneEvents()` methods are used in GUI and Logic objects to observe Modify, NewScene, NodeAdded, etc. events.
+  - The `SetAndObserveMRMLScene()` and `SetAndObserveMRMLSceneEvents()` methods are used in GUI and Logic objects to observe Modified, NewScene, NodeAdded, etc. events.
   - The `ProcessMRMLEvents()` method should be implemented in MRML nodes, Logic, and GUI classes in order to process events from the observed nodes.
 
 ## Advanced topics

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
@@ -101,6 +101,12 @@ void vtkMRMLViewInteractorStyle::OnMouseMove()
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::OnRightButtonDoubleClick()
+{
+  this->GetInteractorStyle()->OnRightButtonDoubleClick();
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnRightButtonDown()
 {
   this->MouseMovedSinceButtonDown = false;
@@ -114,6 +120,12 @@ void vtkMRMLViewInteractorStyle::OnRightButtonUp()
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::OnMiddleButtonDoubleClick()
+{
+  this->GetInteractorStyle()->OnMiddleButtonDoubleClick();
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnMiddleButtonDown()
 {
   this->MouseMovedSinceButtonDown = false;
@@ -124,6 +136,12 @@ void vtkMRMLViewInteractorStyle::OnMiddleButtonDown()
 void vtkMRMLViewInteractorStyle::OnMiddleButtonUp()
 {
   this->GetInteractorStyle()->OnMiddleButtonUp();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::OnLeftButtonDoubleClick()
+{
+  this->GetInteractorStyle()->OnLeftButtonDoubleClick();
 }
 
 //----------------------------------------------------------------------------
@@ -414,17 +432,26 @@ void vtkMRMLViewInteractorStyle::ProcessEvents(vtkObject* vtkNotUsed(object),
     case vtkCommand::MouseMoveEvent:
       self->OnMouseMove();
       break;
+    case vtkCommand::RightButtonDoubleClickEvent:
+      self->OnRightButtonDoubleClick();
+      break;
     case vtkCommand::RightButtonPressEvent:
       self->OnRightButtonDown();
       break;
     case vtkCommand::RightButtonReleaseEvent:
       self->OnRightButtonUp();
       break;
+    case vtkCommand::MiddleButtonDoubleClickEvent:
+      self->OnMiddleButtonDoubleClick();
+      break;
     case vtkCommand::MiddleButtonPressEvent:
       self->OnMiddleButtonDown();
       break;
     case vtkCommand::MiddleButtonReleaseEvent:
       self->OnMiddleButtonUp();
+      break;
+    case vtkCommand::LeftButtonDoubleClickEvent:
+      self->OnLeftButtonDoubleClick();
       break;
     case vtkCommand::LeftButtonPressEvent:
       self->OnLeftButtonDown();
@@ -513,10 +540,13 @@ void vtkMRMLViewInteractorStyle::SetInteractor(vtkRenderWindowInteractor *intera
 
     // Mouse
     interactor->AddObserver(vtkCommand::MouseMoveEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::RightButtonDoubleClickEvent, this->EventCallbackCommand, priority);
     interactor->AddObserver(vtkCommand::RightButtonPressEvent, this->EventCallbackCommand, priority);
     interactor->AddObserver(vtkCommand::RightButtonReleaseEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::MiddleButtonDoubleClickEvent, this->EventCallbackCommand, priority);
     interactor->AddObserver(vtkCommand::MiddleButtonPressEvent, this->EventCallbackCommand, priority);
     interactor->AddObserver(vtkCommand::MiddleButtonReleaseEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::LeftButtonDoubleClickEvent, this->EventCallbackCommand, priority);
     interactor->AddObserver(vtkCommand::LeftButtonPressEvent, this->EventCallbackCommand, priority);
     interactor->AddObserver(vtkCommand::LeftButtonReleaseEvent, this->EventCallbackCommand, priority);
     interactor->AddObserver(vtkCommand::EnterEvent, this->EventCallbackCommand, priority);

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
@@ -206,9 +206,27 @@ void vtkMRMLViewInteractorStyle::OnConfigure()
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::OnStartPinch()
+{
+  this->GetInteractorStyle()->OnStartPinch();
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnPinch()
 {
   this->GetInteractorStyle()->OnPinch();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::OnEndPinch()
+{
+  this->GetInteractorStyle()->OnEndPinch();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::OnStartRotate()
+{
+  this->GetInteractorStyle()->OnStartRotate();
 }
 
 //----------------------------------------------------------------------------
@@ -218,9 +236,27 @@ void vtkMRMLViewInteractorStyle::OnRotate()
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::OnEndRotate()
+{
+  this->GetInteractorStyle()->OnEndRotate();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::OnStartPan()
+{
+  this->GetInteractorStyle()->OnStartPan();
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnPan()
 {
   this->GetInteractorStyle()->OnPan();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::OnEndPan()
+{
+  this->GetInteractorStyle()->OnEndPan();
 }
 
 //----------------------------------------------------------------------------
@@ -473,14 +509,32 @@ void vtkMRMLViewInteractorStyle::ProcessEvents(vtkObject* vtkNotUsed(object),
       break;
 
     // Touch gesture interaction events
+    case vtkCommand::StartPinchEvent:
+      self->OnStartPinch();
+      break;
     case vtkCommand::PinchEvent:
       self->OnPinch();
+      break;
+    case vtkCommand::EndPinchEvent:
+      self->OnEndPinch();
+      break;
+    case vtkCommand::StartRotateEvent:
+      self->OnStartRotate();
       break;
     case vtkCommand::RotateEvent:
       self->OnRotate();
       break;
+    case vtkCommand::EndRotateEvent:
+      self->OnEndRotate();
+      break;
+    case vtkCommand::StartPanEvent:
+      self->OnStartPan();
+      break;
     case vtkCommand::PanEvent:
       self->OnPan();
+      break;
+    case vtkCommand::EndPanEvent:
+      self->OnEndPan();
       break;
     case vtkCommand::TapEvent:
       self->OnTap();
@@ -555,9 +609,15 @@ void vtkMRMLViewInteractorStyle::SetInteractor(vtkRenderWindowInteractor *intera
     interactor->AddObserver(vtkCommand::MouseWheelBackwardEvent, this->EventCallbackCommand, priority);
 
     // Touch gesture
+    interactor->AddObserver(vtkCommand::StartPinchEvent, this->EventCallbackCommand, priority);
     interactor->AddObserver(vtkCommand::PinchEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::EndPinchEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::StartRotateEvent, this->EventCallbackCommand, priority);
     interactor->AddObserver(vtkCommand::RotateEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::EndRotateEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::StartPanEvent, this->EventCallbackCommand, priority);
     interactor->AddObserver(vtkCommand::PanEvent, this->EventCallbackCommand, priority);
+    interactor->AddObserver(vtkCommand::EndPanEvent, this->EventCallbackCommand, priority);
     interactor->AddObserver(vtkCommand::TapEvent, this->EventCallbackCommand, priority);
     interactor->AddObserver(vtkCommand::LongTapEvent, this->EventCallbackCommand, priority);
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.h
@@ -64,9 +64,15 @@ public:
   virtual void OnMouseWheelBackward();
 
   // Touch gesture interaction events
+  virtual void OnStartPinch();
   virtual void OnPinch();
+  virtual void OnEndPinch();
+  virtual void OnStartRotate();
   virtual void OnRotate();
+  virtual void OnEndRotate();
+  virtual void OnStartPan();
   virtual void OnPan();
+  virtual void OnEndPan();
   virtual void OnTap();
   virtual void OnLongTap();
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.h
@@ -51,10 +51,13 @@ public:
   virtual void OnMouseMove();
   virtual void OnEnter();
   virtual void OnLeave();
+  virtual void OnLeftButtonDoubleClick();
   virtual void OnLeftButtonDown();
   virtual void OnLeftButtonUp();
+  virtual void OnMiddleButtonDoubleClick();
   virtual void OnMiddleButtonDown();
   virtual void OnMiddleButtonUp();
+  virtual void OnRightButtonDoubleClick();
   virtual void OnRightButtonDown();
   virtual void OnRightButtonUp();
   virtual void OnMouseWheelForward();


### PR DESCRIPTION
Backports changes originally contributed to `main` through the following pull requests:
* https://github.com/Slicer/Slicer/pull/7442