### PR TITLE
[5.6] BUG: Fix vtkQtTranslator leak on quick exit

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -380,8 +380,10 @@ void qSlicerCoreApplicationPrivate::init()
   }
 
   // Set up translation in MRML classes using Qt translator
-  vtkNew<vtkQtTranslator> mrmlTranslator;
-  vtkMRMLI18N::GetInstance()->SetTranslator(mrmlTranslator);
+  { // placed in a block to avoid memory leaks on quick exit at handlePreApplicationCommandLineArguments
+    vtkNew<vtkQtTranslator> mrmlTranslator;
+    vtkMRMLI18N::GetInstance()->SetTranslator(mrmlTranslator);
+  }
 
   // Ensure that temporary folder is writable
   {
@@ -600,6 +602,7 @@ void qSlicerCoreApplicationPrivate::quickExit(int exitCode)
   Q_Q(qSlicerCoreApplication);
 
   // Delete VTK objects to exit cleanly, without memory leaks
+  vtkMRMLI18N::GetInstance()->SetTranslator(nullptr);
   this->AppLogic = nullptr;
   this->MRMLRemoteIOLogic = nullptr;
   this->DataIOManagerLogic = nullptr;


### PR DESCRIPTION
Backports changes originally contributed to `main` through the following pull requests:
* https://github.com/Slicer/Slicer/pull/7447

-----------

Fix a regression introduced in db1d60134 (BUG: Enable language translation in MRML classes) ensuring the vtkQtTranslator instance is deleted in quickExit

(cherry picked from commit 3f0e381b67893e957ef7854c7642af0c19f12032)