### PR TITLE
ENH: Update CTK DICOM Database version from 0.7.0 to 0.8.0

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "f53820a4e6ebfc9649897577a6157d94833e9699"
+    "84187713304e4ed5a457ee9758de1af4a22d8dbd"
     QUIET
     )
 


### PR DESCRIPTION
The `ctkDICOMDatabase` update allows handling DICOM files with both file paths and URLs. The SQLite database schema now includes a `URL` field. Entries in the `Images` table can have a `URL`, a `fileName`, or both. The schema version is updated from `0.7.0` to `0.8.0`.

The `ctkDICOMTagCache` is also improved to store tags as uppercase hex, ensuring consistency and optimizing storage and performance.

For more details, refer to https://github.com/commontk/CTK/pull/1154

List of CTK changes:

```
$ git shortlog f53820a4e..841877133 --no-merges 
Steve Pieper (1):
      ENH: Update DICOM Database with URL Support and Tag Cache Optimization
```