### PR TITLE
COMP: Update CTK with newer PythonQt version

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -65,13 +65,13 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/commontk/CTK.git"
+    "${EP_GIT_PROTOCOL}://github.com/jamesobutler/CTK.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "f53820a4e6ebfc9649897577a6157d94833e9699"
+    "updated-python-qt-dec-2023"
     QUIET
     )
 


### PR DESCRIPTION
This PR updates CTK with a newer PythonQt version that has generated Qt 5.15 headers. Currently building Slicer with Qt 5.15, will use Qt 5.11 generated headers. Updating the PythonQt version also serves to help with the starting point of testing latest Qt 6 support (next steps after this).

Reviewing https://doc.qt.io/qt-5/newclasses515.html#new-enum-types, this now allows me to use https://doc.qt.io/qt-5/qtabbar.html#setTabVisible which was specifically introduced in Qt 5.15. This usage has currently been unavailable in latest Slicer.

![image](https://github.com/Slicer/Slicer/assets/15837524/360ea094-d022-4b78-b53f-70573a1f77be)

I have run Slicer tests on the Windows platform and observed passing results like existing Slicer preview builds.

- [ ] https://github.com/commontk/CTK/pull/1159 should be integrated first
- [ ] Once the above is integrated, update this PR pointing to github.com/commontk/CTK with the integrated commit hash

```
CommonTK:
$ git shortlog f53820a..TBD
James Butler (1):
      COMP: Update PythonQt version with generated Qt 5.15 wrappers
```