### PR TITLE
BUG: Fix error string format in `DICOMScalarVolumePlugin` and `ImportItkSnapLabel`

### DIFF
--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -706,7 +706,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
 
             # Validate tags
             if tags["Modality"] == "":
-                error = _("Empty modality for series '{volumeName}'").format(volumeNode.GetName())
+                error = _("Empty modality for series '{volumeName}'").format(volumeName=volumeNode.GetName())
                 logging.error(error)
                 return error
 

--- a/Modules/Scripted/ImportItkSnapLabel/ImportItkSnapLabel.py
+++ b/Modules/Scripted/ImportItkSnapLabel/ImportItkSnapLabel.py
@@ -140,7 +140,7 @@ class ImportItkSnapLabelFileReader:
                              "name": fields[7]}
                     colors.append(color)
                     continue
-                raise ValueError(_("Syntax error in line {line}").format(lineIndex))
+                raise ValueError(_("Syntax error in line {line}").format(line=lineIndex))
 
         return colors
 


### PR DESCRIPTION


Fixes regressions introduced in the these commits

- 60c659f33 (`ENH: Add transformation step before strings extraction`) for `DICOMScalarVolumePlugin`

- d3f49ed35 (`BUG: Make more strings translatable`) for `ImportItkSnapLabel`