### PR TITLE
COMP: Fix generation of additional launcher settings for list-based settings

### DIFF
--- a/Extensions/CMake/SlicerBlockAdditionalLauncherSettings.cmake
+++ b/Extensions/CMake/SlicerBlockAdditionalLauncherSettings.cmake
@@ -92,14 +92,15 @@ if(NOT TARGET ConfigureAdditionalLauncherSettings AND _configure_additional_laun
   # External projects - library paths
   foreach(varname IN LISTS ${SUPERBUILD_TOPLEVEL_PROJECT}_EP_LABEL_LIBRARY_PATHS_LAUNCHER_BUILD)
     set(value ${${varname}})
-    string(REPLACE "<CMAKE_CFG_INTDIR>" "\${CMAKE_CFG_INTDIR}" value ${value})
+    list(TRANSFORM value REPLACE "<CMAKE_CFG_INTDIR>" "\${CMAKE_CFG_INTDIR}")
     list(APPEND EXTENSION_LIBRARY_PATHS_BUILD ${value})
   endforeach()
 
   # Extension dependencies - library paths
   foreach(dep ${EXTENSION_DEPENDS})
-    string(REPLACE "\$(Configuration)" "\${CMAKE_CFG_INTDIR}" path "${${dep}_LIBRARY_PATHS_LAUNCHER_BUILD}")
-    list(APPEND EXTENSION_LIBRARY_PATHS_BUILD ${path})
+    set(paths ${${dep}_LIBRARY_PATHS_LAUNCHER_BUILD})
+    list(TRANSFORM paths REPLACE "\$(Configuration)" "\${CMAKE_CFG_INTDIR}")
+    list(APPEND EXTENSION_LIBRARY_PATHS_BUILD ${paths})
   endforeach()
 
   #-----------------------------------------------------------------------------
@@ -120,14 +121,15 @@ if(NOT TARGET ConfigureAdditionalLauncherSettings AND _configure_additional_laun
   # External projects - paths
   foreach(varname IN LISTS ${SUPERBUILD_TOPLEVEL_PROJECT}_EP_LABEL_PATHS_LAUNCHER_BUILD)
     set(value ${${varname}})
-    string(REPLACE "<CMAKE_CFG_INTDIR>" "\${CMAKE_CFG_INTDIR}" value ${value})
+    list(TRANSFORM value REPLACE "<CMAKE_CFG_INTDIR>" "\${CMAKE_CFG_INTDIR}")
     list(APPEND EXTENSION_PATHS_BUILD ${value})
   endforeach()
 
   # Extension dependencies - paths
   foreach(dep ${EXTENSION_DEPENDS})
-    string(REPLACE "\$(Configuration)" "\${CMAKE_CFG_INTDIR}" path "${${dep}_PATHS_LAUNCHER_BUILD}")
-    list(APPEND EXTENSION_PATHS_BUILD ${path})
+    set(paths ${${dep}_PATHS_LAUNCHER_BUILD})
+    list(TRANSFORM paths REPLACE "\$(Configuration)" "\${CMAKE_CFG_INTDIR}")
+    list(APPEND EXTENSION_PATHS_BUILD ${paths})
   endforeach()
 
   #-----------------------------------------------------------------------------
@@ -139,14 +141,15 @@ if(NOT TARGET ConfigureAdditionalLauncherSettings AND _configure_additional_laun
   # External projects - environment variables
   foreach(varname IN LISTS ${SUPERBUILD_TOPLEVEL_PROJECT}_EP_LABEL_ENVVARS_LAUNCHER_BUILD)
     set(value ${${varname}})
-    string(REPLACE "<CMAKE_CFG_INTDIR>" "\${CMAKE_CFG_INTDIR}" value ${value})
+    list(TRANSFORM value REPLACE "<CMAKE_CFG_INTDIR>" "\${CMAKE_CFG_INTDIR}")
     list(APPEND EXTENSION_LAUNCHER_SETTINGS_ENVVARS ${value})
   endforeach()
 
   # Extension dependencies - environment variables
   foreach(dep ${EXTENSION_DEPENDS})
-    string(REPLACE "\$(Configuration)" "\${CMAKE_CFG_INTDIR}" path "${${dep}_ENVVARS_LAUNCHER_BUILD}")
-    list(APPEND EXTENSION_LAUNCHER_SETTINGS_ENVVARS ${path})
+    set(paths ${${dep}_ENVVARS_LAUNCHER_BUILD})
+    list(TRANSFORM paths REPLACE "\$(Configuration)" "\${CMAKE_CFG_INTDIR}")
+    list(APPEND EXTENSION_LAUNCHER_SETTINGS_ENVVARS ${paths})
   endforeach()
 
   #-----------------------------------------------------------------------------
@@ -167,13 +170,16 @@ if(NOT TARGET ConfigureAdditionalLauncherSettings AND _configure_additional_laun
 
   # External projects - pythonpath
   foreach(varname IN LISTS ${SUPERBUILD_TOPLEVEL_PROJECT}_EP_LABEL_PYTHONPATH_LAUNCHER_BUILD)
-    list(APPEND EXTENSION_PYTHONPATH_BUILD ${${varname}})
+    set(value ${${varname}})
+    list(TRANSFORM value REPLACE "<CMAKE_CFG_INTDIR>" "\${CMAKE_CFG_INTDIR}")
+    list(APPEND EXTENSION_PYTHONPATH_BUILD ${value})
   endforeach()
 
   # Extension dependencies - pythonpath
   foreach(dep ${EXTENSION_DEPENDS})
-    string(REPLACE "\$(Configuration)" "\${CMAKE_CFG_INTDIR}" path "${${dep}_PYTHONPATH_LAUNCHER_BUILD}")
-    list(APPEND EXTENSION_PYTHONPATH_BUILD ${path})
+    set(paths ${${dep}_PYTHONPATH_LAUNCHER_BUILD})
+    list(TRANSFORM paths REPLACE "\$(Configuration)" "\${CMAKE_CFG_INTDIR}")
+    list(APPEND EXTENSION_PYTHONPATH_BUILD ${paths})
   endforeach()
 
   set(EXTENSION_PATH_ENVVARS_BUILD

--- a/Extensions/CMake/SlicerBlockAdditionalLauncherSettings.cmake
+++ b/Extensions/CMake/SlicerBlockAdditionalLauncherSettings.cmake
@@ -99,7 +99,7 @@ if(NOT TARGET ConfigureAdditionalLauncherSettings AND _configure_additional_laun
   # Extension dependencies - library paths
   foreach(dep ${EXTENSION_DEPENDS})
     set(paths ${${dep}_LIBRARY_PATHS_LAUNCHER_BUILD})
-    list(TRANSFORM paths REPLACE "\$(Configuration)" "\${CMAKE_CFG_INTDIR}")
+    list(TRANSFORM paths REPLACE "\\$\\(Configuration\\)" "\${CMAKE_CFG_INTDIR}")
     list(APPEND EXTENSION_LIBRARY_PATHS_BUILD ${paths})
   endforeach()
 
@@ -128,7 +128,7 @@ if(NOT TARGET ConfigureAdditionalLauncherSettings AND _configure_additional_laun
   # Extension dependencies - paths
   foreach(dep ${EXTENSION_DEPENDS})
     set(paths ${${dep}_PATHS_LAUNCHER_BUILD})
-    list(TRANSFORM paths REPLACE "\$(Configuration)" "\${CMAKE_CFG_INTDIR}")
+    list(TRANSFORM paths REPLACE "\\$\\(Configuration\\)" "\${CMAKE_CFG_INTDIR}")
     list(APPEND EXTENSION_PATHS_BUILD ${paths})
   endforeach()
 
@@ -148,7 +148,7 @@ if(NOT TARGET ConfigureAdditionalLauncherSettings AND _configure_additional_laun
   # Extension dependencies - environment variables
   foreach(dep ${EXTENSION_DEPENDS})
     set(paths ${${dep}_ENVVARS_LAUNCHER_BUILD})
-    list(TRANSFORM paths REPLACE "\$(Configuration)" "\${CMAKE_CFG_INTDIR}")
+    list(TRANSFORM paths REPLACE "\\$\\(Configuration\\)" "\${CMAKE_CFG_INTDIR}")
     list(APPEND EXTENSION_LAUNCHER_SETTINGS_ENVVARS ${paths})
   endforeach()
 
@@ -178,7 +178,7 @@ if(NOT TARGET ConfigureAdditionalLauncherSettings AND _configure_additional_laun
   # Extension dependencies - pythonpath
   foreach(dep ${EXTENSION_DEPENDS})
     set(paths ${${dep}_PYTHONPATH_LAUNCHER_BUILD})
-    list(TRANSFORM paths REPLACE "\$(Configuration)" "\${CMAKE_CFG_INTDIR}")
+    list(TRANSFORM paths REPLACE "\\$\\(Configuration\\)" "\${CMAKE_CFG_INTDIR}")
     list(APPEND EXTENSION_PYTHONPATH_BUILD ${paths})
   endforeach()
 


### PR DESCRIPTION
This commit addresses two issues:

## Use of `string(REPLACE ...)`

The use of the `string(REPLACE ...)` command introduced in commits e9f28d6c8  and b1efab8a6 led caused input variable representing a list to be concatenated as a single string. This commit addresses this by transitioning to the `TRANSFORM` action allowing to replace values individually within a list.

Also addresses the missing replacement of `<CMAKE_CFG_INTDIR>` associated with the `PYTHONPATH_LAUNCHER_BUILD` settings.

| Before & After |
|---|
| ![image](https://github.com/Slicer/Slicer/assets/219043/f844319a-b5b9-4aba-a88e-4422198d915e) |

## Use of incorrect regular expression to replace `$(Configuration)`

Fixes the regular expression used for replacing `$(Configuration)` with `${CMAKE_CFG_INTDIR}` so that the placeholder variable is ultimately replaced through the execution of the custom command associated with the `ConfigureAdditionalLauncherSettings` custom target.

| Before | After |
|--|--|
| ![image](https://github.com/Slicer/Slicer/assets/219043/0223dd9f-71d8-4c43-baca-46f0f6b31234) | ![image](https://github.com/Slicer/Slicer/assets/219043/6b3655eb-90f2-4e6e-9092-15213e74f160) |
| ![image](https://github.com/Slicer/Slicer/assets/219043/bee03143-e610-434b-be90-d984f0218cbe) | ![image](https://github.com/Slicer/Slicer/assets/219043/460368e1-7487-4b67-929a-676dc3a770c2) |

