### PR TITLE
COMP: Re-generate additional launcher settings if settings are updated

### DIFF
--- a/Extensions/CMake/SlicerBlockAdditionalLauncherSettings.cmake
+++ b/Extensions/CMake/SlicerBlockAdditionalLauncherSettings.cmake
@@ -238,6 +238,7 @@ ${EXTENSION_LAUNCHER_SETTINGS_ADDITIONAL_PATH_ENVVARS}
   add_custom_command(
     DEPENDS
       ${CMAKE_CURRENT_LIST_FILE}
+      ${_additional_settings_configure_script}
     OUTPUT
       ${Slicer_ADDITIONAL_LAUNCHER_SETTINGS_FILE}
     COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
This commit ensures that the custom command responsible for generating `AdditionalLauncherSettings.ini` is rerun whenever the project is re-configured with different options. This is important to account for changes in the set of paths associated with the launcher settings.