### PR TITLE
ENH: Simplify logic in `vtkMRMLViewInteractorStyle::CustomProcessEvents`

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
@@ -445,10 +445,9 @@ void vtkMRMLViewInteractorStyle::CustomProcessEvents(vtkObject* object,
 
   // Displayable managers add interactor style observers and those observers
   // replace callback method calls. We make sure here that displayable managers
-  // get the chance to process the events first (except when we are in an
-  // interaction state - such as zooming, panning, etc).
+  // get the chance to process the events first.
 
-  if (/*self->GetInteractorStyle()->GetState() != VTKIS_NONE || */!self->DelegateInteractionEventToDisplayableManagers(event) || self->GetInteractorStyle()->GetState() != VTKIS_NONE)
+  if (!self->DelegateInteractionEventToDisplayableManagers(event))
     {
     // Displayable managers did not processed it
     vtkMRMLViewInteractorStyle::ProcessEvents(object, event, clientdata, calldata);


### PR DESCRIPTION
Considering that:
1. we always have to first attempt to delegate to our displayable managers, and then call the "regular" interactor style processing only if these are not "delegated", checking for the interaction state is not needed.
2. we are not observing events like InteractionEvent, StartInteractionEvent or EndInteractionEvent currently used to process interaction state in regular VTK widgets.

... we remove the check of the interaction state.

For reference,this logic was initially introduced in 364ff7b6d (`ENH: Use common interactor style for slice and 3D views`). At the time of that commit[^1], the function `DelegateInteractionEventToDisplayableManagers` was invoked once at the beginning of `CustomProcessEvents` for each events only if "state" was not VTKIS_NONE. It was also systematically invoked in the overridden `OnXXX()` functions, called as a side effect of `Superclass::ProcessEvents`.

Following the refactoring introduced in commit 1cc3b2c62 (`ENH: Improve Event Delegation in qMRMLThreeDView and qMRMLSliceView`), the function `DelegateInteractionEventToDisplayableManagers` now ends up being called only once for all observed events and then the "original" interactor style function are called from `vtkMRMLViewInteractorStyle::ProcessEvents()`.

[^1]: https://github.com/Slicer/Slicer/blob/364ff7b6d4758629b8659712fdec990d8bddd81b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx#L351-L360