### PR TITLE
ENH: Improve handling of invalid input in MRMLViewInteractorStyle classes

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceViewInteractorStyle.cxx
@@ -94,6 +94,11 @@ bool vtkMRMLSliceViewInteractorStyle::DelegateInteractionEventToDisplayableManag
   // Get display and world position
   int* displayPositionInt = this->GetInteractor()->GetEventPosition();
   vtkRenderer* pokedRenderer = this->GetInteractor()->FindPokedRenderer(displayPositionInt[0], displayPositionInt[1]);
+  if (!pokedRenderer)
+    {
+    // can happen during application shutdown
+    return false;
+    }
   double displayPosition[4] =
     {
     static_cast<double>(displayPositionInt[0] - pokedRenderer->GetOrigin()[0]),

--- a/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewInteractorStyle.cxx
@@ -108,12 +108,16 @@ void vtkMRMLThreeDViewInteractorStyle::OnLeave()
 //----------------------------------------------------------------------------
 bool vtkMRMLThreeDViewInteractorStyle::DelegateInteractionEventToDisplayableManagers(vtkEventData* inputEventData)
 {
+  if (!inputEventData)
+    {
+    return false;
+    }
   // Get display and world position
   int* displayPositionInt = this->GetInteractor()->GetEventPosition();
   vtkRenderer* pokedRenderer = this->GetInteractor()->FindPokedRenderer(displayPositionInt[0], displayPositionInt[1]);
   vtkInteractorStyle* interactorStyle = vtkInteractorStyle::SafeDownCast(this->GetInteractor()->GetInteractorStyle());
   interactorStyle->SetCurrentRenderer(pokedRenderer);
-  if (!pokedRenderer || !inputEventData)
+  if (!pokedRenderer)
     {
     // can happen during application shutdown
     return false;

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
@@ -294,8 +294,17 @@ bool vtkMRMLViewInteractorStyle::DelegateInteractionEventToDisplayableManagers(u
 //----------------------------------------------------------------------------
 bool vtkMRMLViewInteractorStyle::DelegateInteractionEventToDisplayableManagers(vtkEventData* inputEventData)
 {
+  if (!inputEventData)
+    {
+    return false;
+    }
   int* displayPositionInt = this->GetInteractor()->GetEventPosition();
   vtkRenderer* pokedRenderer = this->GetInteractor()->FindPokedRenderer(displayPositionInt[0], displayPositionInt[1]);
+  if (!pokedRenderer)
+    {
+    // can happen during application shutdown
+    return false;
+    }
 
   vtkNew<vtkMRMLInteractionEventData> ed;
   ed->SetType(inputEventData ? inputEventData->GetType() : vtkCommand::NoEvent);


### PR DESCRIPTION
Within the `DelegateInteractionEventToDisplayableManagers` function:

- Introduce a check for `pokedRenderer`, mirroring the one initially incorporated in `vtkMRMLThreeDViewInteractorStyle` via commit 364ff7b6d (ENH: Use common interactor style for slice and 3D views).

- Introduce (or relocate) a check for `inputEventData` at the beginning of the `Delegate` function for consistency with the update to `vtkMRMLSliceViewInteractorStyle` in commit 731be146e (BUG: Fix crash when creating and showing qMRMLSliceWidget using Python). This adjustment also prevents the invocation of `FindPokedRenderer` when there is no `inputEventData`.