### PR TITLE
BUG: Update VTK backporting fix for OpenVR gesture recognition

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "d5d688b473f45355d7ad290fb2d68de5cf4ddd0b") # slicer-v9.2.20230607-1ff325c54-2
+    set(_git_tag "08161371c282cd7eb8ce3058882e6ffa846fac67") # slicer-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
This includes a workaround to recognize OpenVR gesture where buttons are pressed consecutively.

Corresponding changes have been contributed to upstream VTK as [MR-10771][1] and [MR-10778][2]

[1]: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10771
[2]: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10778

List of VTK changes:

```
$ git shortlog d5d688b47..08161371c2 --no-merges
Jean-Christophe Fillion-Robin (2):
      [Backport MR-10771] BUG: Add missing Elevation3DEvent to vtkCommand::EventHasData()
      [Backport MR-10778] BUG: Recognize OpenVR gesture where buttons are pressed consecutively
```