### PR TITLE
COMP: Update VTK to fix preprocessor expression in vtkOpenGLRenderWindow

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "08161371c282cd7eb8ce3058882e6ffa846fac67") # slicer-v9.2.20230607-1ff325c54-2
+    set(_git_tag "c69cf77a685e27c73f75e2972ad607bb6ec690d0") # slicer-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
Fixes a regression introduced through commit
Slicer/VTK@b4fa8ba5d2 (`[Backport] ReadPixels: Check for errors only when VTK is configured to report errors`)

List of VTK changes:

```
$ git shortlog 08161371c..c69cf77a6 --no-merges
Jaswant Panchumarti (1):
      OpenGL2: Use #ifdef instead of #if to fix compiler error
```