### PR TITLE
BUG: Update VTK backporting OpenVR rendering fix when HMD inside the volume

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "c69cf77a685e27c73f75e2972ad607bb6ec690d0") # slicer-v9.2.20230607-1ff325c54-2
+    set(_git_tag "7767cabe4b4d8d792d5a3cb3670286326459f58b") # slicer-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
This addresses proper rendering, particularly by `vtkOpenGLGPUVolumeRaycastMapper`, when the head-mounted display (HMD) is positioned inside the volume. The issue is resolved by ensuring correct computation of the plane frustum when the camera is tracking the HMD and is positioned inside the volume.

The changes listed below impact the following VTK modules:
* `Rendering/VR`
* `Rendering/OpenVR`
* `Rendering/OpenXR`

Fixes:
* https://github.com/KitwareMedical/SlicerVirtualReality/issues/125

For more details:
* https://github.com/Slicer/VTK/pull/48
* [VTK issue 19123](https://gitlab.kitware.com/vtk/vtk/-/issues/19123): `OpenXR: Fix near plane clipping with camera inside volume`
* [VTK merge request #10783](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10783): `VR: Accommodate separate eye transforms`

List of VTK changes:

```
$ git shortlog c69cf77a6..7767cabe4 --no-merges
Sankhesh Jhaveri (3):
      [Backport MR-10783] VR: Move the TrackHMD flag to the camera
      [Backport MR-10783] VR: Deprecate vtkVRRenderWindow::TrackHMD
      [Backport MR-10783] VR: Provide stereo projection transforms for rendering
```

cc: @sankhesh @LucasGandel 