### PR TITLE
COMP: Update VTK backporting deprecation macro update

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "7767cabe4b4d8d792d5a3cb3670286326459f58b") # slicer-v9.2.20230607-1ff325c54-2
+    set(_git_tag "573f18292ff92ce9f28f2c08e9ea4d68d9e2c7da") # slicer-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
This follows up on commit a0d5883544 ([Backport MR-10783] VR: Deprecate vtkVRRenderWindow::TrackHMD) adding missing deprecation macro required to successfully build. 

Related:
* https://github.com/Slicer/Slicer/pull/7507

List of VTK changes:

```
$ git shortlog 7767cabe4..573f18292 --no-merges
willdunklin (1):
      [Backport] vtkDeprecation: add VTK_DEPRECATED_IN_9_4_0 macro
```