### PR TITLE
ENH: Update VTK to backporting VR, OpenVR and OpenXR improvements

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "573f18292ff92ce9f28f2c08e9ea4d68d9e2c7da") # slicer-v9.2.20230607-1ff325c54-2
+    set(_git_tag "2f050efc87d34eb296b72f17c3b8039ad9c54f9c") # slicer-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
Updates VTK to support the integration of multiple runtime into the SlicerVirtualReality extension.

The following merge requests, including the backported commits referenced below, have been submitted to upstream VTK for reference

* `VR: Update interactor style API adding GetMappedAction()`.
  See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10784

* `VR: Declare AddAction() functions as virtual`.
  See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10785

* `VR: Update vtkVRRenderWindowInteractor marking ComplexGesture recognition functions as public`.
  See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10786

* `VR: Add SetInteractionState() API to VR interactor style`.
  See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10789


List of VTK changes:

```
$ git shortlog 573f18292..2f050efc8 --no-merges
Jean-Christophe Fillion-Robin (11):
      [Backport MR-10784] VR: Update interactor style API adding GetMappedAction()
      [Backport MR-10785] VR: Declare AddAction() functions as virtual
      [Backport MR-10786] VR: Mark ComplexGesture recognition functions as public
      [Backport MR-10786] VR: Add GetCurrentGesture() API for retrieving the gesture being recognized
      [Backport MR-10786] VR: Add SetCurrentGesture() API for setting the gesture being recognized
      [Backport MR-10786] VR: Add GetDeviceInputDownCount() API
      [Backport MR-10786] VR: Add SetDeviceInputDownCount() API
      [Backport MR-10786] VR: Add SetStartingPhysicalToWorldMatrix() API
      [Backport MR-10786] VR: Add SetStartingPhysicalEventPose() API
      [Backport MR-10789] VR: Add SetInteractionState() API to VR interactor style
      [Backport MR-10789] VR: Improve robustness of GetInteractionState() by checking input
```