### PR TITLE
ENH: Update VTK backporting VR and OpenXR improvements

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "2f050efc87d34eb296b72f17c3b8039ad9c54f9c") # slicer-v9.2.20230607-1ff325c54-2
+    set(_git_tag "b9aae674d7d024396189ce44a0ddd49c7c47446a") # slicer-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
Updates VTK to support integration of the OpenXR runtime into the SlicerVirtualReality extension.

The following merge requests, including the backported commits referenced below, have been submitted to upstream VTK for reference

* `VR: Declare AddAction() functions as virtual` See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10785

* `VR: Resolve "Not rendered" warnings after XR RenderWindow Initialization` See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10794

Additionally this commit also adds the OpenXR bindings for the oculus touch controller copied from kitware/paraview@ec4111e7c. See `Plugins/XRInterface/Plugin/pv_openxr_binding_oculus_touch_controller.json`.

List of VTK changes:

```
$ git shortlog 2f050efc8..b9aae674d --no-merges
Jean-Christophe Fillion-Robin (5):
      Revert "[Backport MR-10785] VR: Declare AddAction() functions as virtual"
      [Backport MR-10785] VR: Improve consistency in OpenVR interactor AddAction()
      [Backport MR-10785] VR: Declare AddAction() functions as virtual
      [Backport MR-10794] VR: Resolve "Not rendered" warnings after XR RenderWindow Initialization
      [SlicerVirtualReality] ENH: Add OpenXR bindings for oculus_touch
```