### PR TITLE
BUG: Fix crash when module category name matches a module name

### DIFF
--- a/Base/QTGUI/qSlicerModulesMenu.cxx
+++ b/Base/QTGUI/qSlicerModulesMenu.cxx
@@ -327,7 +327,13 @@ QMenu* qSlicerModulesMenuPrivate::menu(QMenu* menu, QStringList subCategories, b
     {
     if (action->text() == category)
       {
-      return this->menu(action->menu(), subCategories);
+      QMenu* submenu = action->menu();
+      if (!submenu)
+        {
+        // This action is a module (it does not have a menu)
+        return nullptr;
+        }
+      return this->menu(submenu, subCategories);
       }
     }
   // if we are here that means the category has not been found, create it.
@@ -556,6 +562,11 @@ void qSlicerModulesMenu::addModule(qSlicerAbstractCoreModule* moduleToAdd)
   foreach(const QString& category, module->categories())
     {
     QMenu* menu = d->menu(this, category.split('.'), module->isBuiltIn());
+    if (!menu)
+      {
+      qWarning() << "Failed to add module" << module->name() << "to the menu" << category << "because this string is already used as module name.";
+      menu = this;
+      }
     d->addModuleAction(menu, moduleAction, true, module->isBuiltIn());
     }
 


### PR DESCRIPTION
In one of the language translations, "Segmentation" module category name was translated with the same word as "Segmentations" module name, which caused Slicer to crash. Added a check to log a warning if such name conflict occurs and put the module in the top-level category.

fixes #7523