### PR TITLE
ENH: Add experimental visual DICOM browser

### DIFF
--- a/Modules/Scripted/DICOM/Resources/UI/DICOM.ui
+++ b/Modules/Scripted/DICOM/Resources/UI/DICOM.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>372</width>
+    <width>622</width>
     <height>663</height>
    </rect>
   </property>
@@ -46,9 +46,9 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="showBrowserButton">
+      <widget class="ctkMenuButton" name="showBrowserButton">
        <property name="toolTip">
-        <string>Show DICOM database browser window</string>
+        <string>Import files into DICOM database</string>
        </property>
        <property name="text">
         <string>    Show DICOM database</string>
@@ -59,7 +59,7 @@
        </property>
        <property name="iconSize">
         <size>
-         <width>32</width>
+         <width>64</width>
          <height>32</height>
         </size>
        </property>

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "45f33c81d8f60d2ac4b749cb21828974a73a4f76"
+    "88ff72b9c2b1e57cf4f822ea2e547be5b9a32b98"
     QUIET
     )
 


### PR DESCRIPTION
**:zap: Updated[^1] Description: :zap:**

[^1]: _The description has been updated by @jcfr on 2024.01.19 based on the consolidated list of commits integrating the CTK changes merged through https://github.com/commontk/CTK/pull/1165_


This enhancement includes an update to CTK and introduces the `ctkDICOMVisualBrowserWidget` to augment DICOM exploration, query, and retrieval capabilities within the DICOM module. The widget is seamlessly integrated into the Slicer DICOM module and is labeled as experimental.

For a comprehensive overview and future plans, refer to the roadmap at:
* https://github.com/commontk/CTK/issues/1162.

By default, the widget is disabled, and users can access the familiar `ctkDICOMBrowser` when opening the `DICOM` module. To enable the experimental feature, users can toggle the option in the dropdown menu of the `Show DICOM database` pushbutton in the `DICOM` module UI.

In `SlicerDICOMBrowser`, this introduces an instance of `ctkDICOMVisualBrowserWidget` alongside the existing `ctkDICOMBrowser` instance. When users activate the experimental feature, widget visibilities are adjusted accordingly. Both widgets share the same DICOM folder set in the DICOM settings.

List of CTK changes:

```
$ git shortlog 45f33c81..88ff72b9 --group=author --group=trailer:co-authored-by --no-merges
Andras Lasso (1):
      ENH: Add Visual DICOM Browser (#1165)

Davide Punzo (1):
      ENH: Add Visual DICOM Browser (#1165)

Jean-Christophe Fillion-Robin (1):
      ENH: Add Visual DICOM Browser (#1165)
```

-----------------

**Original Description:**

@lassoan @pieper @jcfr 
This PR adds the visual DICOM browser widget. CTK reference PR https://github.com/commontk/CTK/pull/1142
For more info see CTK PR [overview](https://github.com/commontk/CTK/pull/1142#issuecomment-1759806374) .

We tested the widget on Linux and Windows on multiple servers (e.g. Orthanc and [www.dicomserver.co.uk](http://www.dicomserver.co.uk/)), but we are flagging this feature as experimental.

The developement is still ongoing (see https://github.com/commontk/CTK/issues/1162). However, I would like to start getting feedback and if anyone can test on MacOS or different server configurations would be highly welcome.

In default I have set the widget hidden and the user has to click the advanced menu for accessing it. See below:
[Screencast from 2024-01-09 14-28-57.webm](https://github.com/Slicer/Slicer/assets/7985338/b1df0862-cc29-42b4-85dc-f9bec2da189a)

