### PR TITLE
COMP: Support using Slicer_INSTALL_* vars in external project exporting config

### DIFF
--- a/CMake/SlicerConfig.cmake.in
+++ b/CMake/SlicerConfig.cmake.in
@@ -368,6 +368,15 @@ set(Slicer_INSTALL_THIRDPARTY_BIN_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXT
 set(Slicer_INSTALL_THIRDPARTY_LIB_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_THIRDPARTY_LIB_DIR}")
 set(Slicer_INSTALL_THIRDPARTY_SHARE_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_THIRDPARTY_SHARE_DIR}")
 
+# Strip "./" to workaround CMake issue #23312
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/23312
+foreach(varname IN ITEMS
+  Slicer_INSTALL_THIRDPARTY_BIN_DIR
+  Slicer_INSTALL_THIRDPARTY_LIB_DIR
+  )
+  string(REGEX REPLACE "^\.\/(.*)" "\\1" ${varname} ${${varname}})
+endforeach()
+
 # The Slicer install prefix (*not* defined in the install tree)
 set(Slicer_INSTALL_PREFIX  "@CMAKE_INSTALL_PREFIX@")
 

--- a/CMake/SlicerDirectories.cmake
+++ b/CMake/SlicerDirectories.cmake
@@ -85,6 +85,14 @@ set(Slicer_INSTALL_LIBEXEC_DIR "${Slicer_INSTALL_ROOT}${Slicer_LIBEXEC_DIR}")
 set(Slicer_INSTALL_ITKFACTORIES_DIR "${Slicer_INSTALL_LIB_DIR}/ITKFactories")
 set(Slicer_INSTALL_QM_DIR "${Slicer_INSTALL_ROOT}${Slicer_QM_DIR}")
 
+# Strip "./" to workaround CMake issue #23312
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/23312
+foreach(varname IN ITEMS
+  Slicer_INSTALL_BIN_DIR
+  Slicer_INSTALL_LIB_DIR
+  )
+  string(REGEX REPLACE "^\.\/(.*)" "\\1" ${varname} ${${varname}})
+endforeach()
 
 #-----------------------------------------------------------------------------
 # Slicer CLI relative directories
@@ -105,6 +113,14 @@ set(Slicer_INSTALL_CLIMODULES_BIN_DIR "${Slicer_INSTALL_ROOT}${Slicer_CLIMODULES
 set(Slicer_INSTALL_CLIMODULES_LIB_DIR "${Slicer_INSTALL_ROOT}${Slicer_CLIMODULES_LIB_DIR}")
 set(Slicer_INSTALL_CLIMODULES_SHARE_DIR "${Slicer_INSTALL_ROOT}${Slicer_CLIMODULES_SHARE_DIR}")
 
+# Strip "./" to workaround CMake issue #23312
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/23312
+foreach(varname IN ITEMS
+  Slicer_INSTALL_CLIMODULES_BIN_DIR
+  Slicer_INSTALL_CLIMODULES_LIB_DIR
+  )
+  string(REGEX REPLACE "^\.\/(.*)" "\\1" ${varname} ${${varname}})
+endforeach()
 
 #-----------------------------------------------------------------------------
 # Qt Loadable Modules relative directories
@@ -129,6 +145,15 @@ set(Slicer_INSTALL_QTLOADABLEMODULES_PYTHON_LIB_DIR "${Slicer_INSTALL_ROOT}${Sli
 set(Slicer_INSTALL_QTLOADABLEMODULES_INCLUDE_DIR "${Slicer_INSTALL_ROOT}${Slicer_QTLOADABLEMODULES_INCLUDE_DIR}")
 set(Slicer_INSTALL_QTLOADABLEMODULES_SHARE_DIR "${Slicer_INSTALL_ROOT}${Slicer_QTLOADABLEMODULES_SHARE_DIR}")
 
+# Strip "./" to workaround CMake issue #23312
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/23312
+foreach(varname IN ITEMS
+  Slicer_INSTALL_QTLOADABLEMODULES_BIN_DIR
+  Slicer_INSTALL_QTLOADABLEMODULES_LIB_DIR
+  Slicer_INSTALL_QTLOADABLEMODULES_PYTHON_LIB_DIR
+  )
+  string(REGEX REPLACE "^\.\/(.*)" "\\1" ${varname} ${${varname}})
+endforeach()
 
 #-----------------------------------------------------------------------------
 # Scripted Modules relative directories
@@ -151,6 +176,14 @@ set(Slicer_INSTALL_QTSCRIPTEDMODULES_LIB_DIR "${Slicer_INSTALL_ROOT}${Slicer_QTS
 set(Slicer_INSTALL_QTSCRIPTEDMODULES_INCLUDE_DIR "${Slicer_INSTALL_ROOT}${Slicer_QTSCRIPTEDMODULES_INCLUDE_DIR}")
 set(Slicer_INSTALL_QTSCRIPTEDMODULES_SHARE_DIR "${Slicer_INSTALL_ROOT}${Slicer_QTSCRIPTEDMODULES_SHARE_DIR}")
 
+# Strip "./" to workaround CMake issue #23312
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/23312
+foreach(varname IN ITEMS
+  Slicer_INSTALL_QTSCRIPTEDMODULES_BIN_DIR
+  Slicer_INSTALL_QTSCRIPTEDMODULES_LIB_DIR
+  )
+  string(REGEX REPLACE "^\.\/(.*)" "\\1" ${varname} ${${varname}})
+endforeach()
 
 # --------------------------------------------------------------------------
 # ThirdParty: Used to superbuild projects built in Slicer extension.
@@ -171,3 +204,12 @@ set(Slicer_THIRDPARTY_SHARE_DIR ${Slicer_SHARE_DIR})
 set(Slicer_INSTALL_THIRDPARTY_BIN_DIR "${Slicer_INSTALL_ROOT}${Slicer_THIRDPARTY_BIN_DIR}")
 set(Slicer_INSTALL_THIRDPARTY_LIB_DIR "${Slicer_INSTALL_ROOT}${Slicer_THIRDPARTY_LIB_DIR}")
 set(Slicer_INSTALL_THIRDPARTY_SHARE_DIR "${Slicer_INSTALL_ROOT}${Slicer_THIRDPARTY_SHARE_DIR}")
+
+# Strip "./" to workaround CMake issue #23312
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/23312
+foreach(varname IN ITEMS
+  Slicer_INSTALL_THIRDPARTY_BIN_DIR
+  Slicer_INSTALL_THIRDPARTY_LIB_DIR
+  )
+  string(REGEX REPLACE "^\.\/(.*)" "\\1" ${varname} ${${varname}})
+endforeach()

--- a/CMake/UseSlicer.cmake.in
+++ b/CMake/UseSlicer.cmake.in
@@ -323,6 +323,15 @@ if(Slicer_BUILD_CLI_SUPPORT)
   set(Slicer_INSTALL_CLIMODULES_BIN_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_CLIMODULES_BIN_DIR}")
   set(Slicer_INSTALL_CLIMODULES_LIB_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_CLIMODULES_LIB_DIR}")
   set(Slicer_INSTALL_CLIMODULES_SHARE_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_CLIMODULES_SHARE_DIR}")
+  # Strip "./" to workaround CMake issue #23312
+  # See https://gitlab.kitware.com/cmake/cmake/-/issues/23312
+  foreach(varname IN ITEMS
+    Slicer_INSTALL_CLIMODULES_BIN_DIR
+    Slicer_INSTALL_CLIMODULES_LIB_DIR
+    )
+    string(REGEX REPLACE "^\.\/(.*)" "\\1" ${varname} ${${varname}})
+  endforeach()
+
   if(APPLE)
     set(SlicerExecutionModel_DEFAULT_CLI_INSTALL_RUNTIME_DESTINATION "${Slicer_INSTALL_CLIMODULES_BIN_DIR}")
     set(SlicerExecutionModel_DEFAULT_CLI_INSTALL_LIBRARY_DESTINATION "${Slicer_INSTALL_CLIMODULES_LIB_DIR}")
@@ -339,12 +348,29 @@ set(Slicer_INSTALL_QTLOADABLEMODULES_LIB_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUN
 set(Slicer_INSTALL_QTLOADABLEMODULES_PYTHON_LIB_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_QTLOADABLEMODULES_PYTHON_LIB_DIR}")
 set(Slicer_INSTALL_QTLOADABLEMODULES_INCLUDE_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_QTLOADABLEMODULES_INCLUDE_DIR}")
 set(Slicer_INSTALL_QTLOADABLEMODULES_SHARE_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_QTLOADABLEMODULES_SHARE_DIR}")
+# Strip "./" to workaround CMake issue #23312
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/23312
+foreach(varname IN ITEMS
+  Slicer_INSTALL_QTLOADABLEMODULES_BIN_DIR
+  Slicer_INSTALL_QTLOADABLEMODULES_LIB_DIR
+  Slicer_INSTALL_QTLOADABLEMODULES_PYTHON_LIB_DIR
+  )
+  string(REGEX REPLACE "^\.\/(.*)" "\\1" ${varname} ${${varname}})
+endforeach()
 
 if(Slicer_USE_PYTHONQT)
   set(Slicer_INSTALL_QTSCRIPTEDMODULES_BIN_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_QTSCRIPTEDMODULES_BIN_DIR}")
   set(Slicer_INSTALL_QTSCRIPTEDMODULES_LIB_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_QTSCRIPTEDMODULES_LIB_DIR}")
   set(Slicer_INSTALL_QTSCRIPTEDMODULES_INCLUDE_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_QTSCRIPTEDMODULES_INCLUDE_DIR}")
   set(Slicer_INSTALL_QTSCRIPTEDMODULES_SHARE_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_QTSCRIPTEDMODULES_SHARE_DIR}")
+  # Strip "./" to workaround CMake issue #23312
+  # See https://gitlab.kitware.com/cmake/cmake/-/issues/23312
+  foreach(varname IN ITEMS
+    Slicer_INSTALL_QTSCRIPTEDMODULES_BIN_DIR
+    Slicer_INSTALL_QTSCRIPTEDMODULES_LIB_DIR
+    )
+    string(REGEX REPLACE "^\.\/(.*)" "\\1" ${varname} ${${varname}})
+  endforeach()
 endif()
 
 # These variables can be used when configuring extension external projects in
@@ -355,6 +381,14 @@ endif()
 set(Slicer_INSTALL_THIRDPARTY_BIN_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_THIRDPARTY_BIN_DIR}")
 set(Slicer_INSTALL_THIRDPARTY_LIB_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_THIRDPARTY_LIB_DIR}")
 set(Slicer_INSTALL_THIRDPARTY_SHARE_DIR "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_THIRDPARTY_SHARE_DIR}")
+# Strip "./" to workaround CMake issue #23312
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/23312
+foreach(varname IN ITEMS
+  Slicer_INSTALL_THIRDPARTY_BIN_DIR
+  Slicer_INSTALL_THIRDPARTY_LIB_DIR
+  )
+  string(REGEX REPLACE "^\.\/(.*)" "\\1" ${varname} ${${varname}})
+endforeach()
 
 set(Slicer_INSTALL_THIRDPARTY_EXECUTABLE_LINK_FLAGS "")
 set(Slicer_INSTALL_THIRDPARTY_LIBRARY_LINK_FLAGS "")


### PR DESCRIPTION
Workaround CMake issue 23312 by ensuring `Slicer_INSTALL_*` variables do no starts with "./". This ensures that on Linux and Windows, external projects in SuperBuild extensions setting variable `CMAKE_INSTALL_LIBDIR` like with value of `Slicer_INSTALL_THIRDPARTY_LIB_DIR` can generate a valid target file with the variable `_IMPORT_PREFIX` properly computed.