### PR TITLE
ENH: Update VTK backporting OpenXR-SDK improvements to streamline integration

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "b9aae674d7d024396189ce44a0ddd49c7c47446a") # slicer-v9.2.20230607-1ff325c54-2
+    set(_git_tag "211f2b71a5c448c4c2f9fa33414adc7b8ad13f44") # slicer-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
Updates VTK to support finding OpenXR-SDK using the `OpenXRConfig.cmake` file provided in the OpenXR-SDK project itself.

List of VTK changes:

```
$ git shortlog b9aae674d..211f2b71a --no-merges
Sankhesh Jhaveri (1):
      [Backport MR-10792] OpenXR: Use the OpenXRConfig.cmake files provided by OpenXR-SDK

Software Solution Team (1):
      [Backport] improve FindOpenXR.cmake for windows platform
```