### PR TITLE
ENH: Update VTK backporting support for Holographic.Remoting.OpenXr >= 2.9.3

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "211f2b71a5c448c4c2f9fa33414adc7b8ad13f44") # slicer-v9.2.20230607-1ff325c54-2
+    set(_git_tag "a7235af9dc7faff4601a622e0c45d72c36690e69") # slicer-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
This will allow to build SlicerVirtualReality extension against the latest version of `Microsoft.Holographic.Remoting.OpenXr` matching the version of the "Holographic Remoting Player" directly available in the Microsoft store.

List of VTK changes:

```
$ git shortlog 211f2b71a..a7235af9d --no-merges
Jean-Christophe Fillion-Robin (1):
      [Backport MR-10814] OpenXRRemoting: Support building against Holographic.Remoting.OpenXr >= 2.9.3
```