### PR TITLE
BUG: Can load removed data from database

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMBrowser.py
+++ b/Modules/Scripted/DICOMLib/DICOMBrowser.py
@@ -316,6 +316,7 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
         self.loadableTable.setLoadables([])
         self.fileLists = self.getFileListsForRole(seriesUIDList, "SeriesUIDList")
         self.updateButtonStates()
+        self.fileLists = []
 
     def getFileListsForRole(self, uidArgument, role):
         fileLists = []


### PR DESCRIPTION
Load button from show DICOM browser can load a deleted data. To solve the bug, remove signals have been created in CTK to be able to connect in slicer. See CTK pull request:

https://github.com/commontk/CTK/pull/1164

This issue is described here: https://github.com/Slicer/Slicer/issues/7290
