### PR TITLE
COMP: Prefer clearing CMAKE_INSTALL_NAME_TOOL on a per-project basis

### DIFF
--- a/CMake/UseSlicer.cmake.in
+++ b/CMake/UseSlicer.cmake.in
@@ -304,7 +304,10 @@ if(APPLE)
   set(Slicer_BUNDLE_EXTENSIONS_LOCATION "${Slicer_EXTENSIONS_DIRBASENAME}-${Slicer_REVISION}/${EXTENSION_NAME}/")
 
   set(CMAKE_INSTALL_NAME_TOOL "" CACHE FILEPATH "" FORCE)
-  mark_as_superbuild(VARS CMAKE_INSTALL_NAME_TOOL:FILEPATH ALL_PROJECTS)
+  # Due to the possibility of external projects (e.g., LibFFI) enabling languages (e.g., ASM)
+  # that necessitate `install_name_tool` via the "CMakeFindBinUtils" module, we opt to clear
+  # CMAKE_INSTALL_NAME_TOOL on a per-project basis.
+  # mark_as_superbuild(VARS CMAKE_INSTALL_NAME_TOOL:FILEPATH ALL_PROJECTS)
 
   set(CMAKE_MACOSX_RPATH 0 CACHE BOOL "" FORCE)
   mark_as_superbuild(VARS CMAKE_MACOSX_RPATH:BOOL ALL_PROJECTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,10 @@ if(APPLE)
     )
 
   set(CMAKE_INSTALL_NAME_TOOL "" CACHE FILEPATH "" FORCE)
-  mark_as_superbuild(VARS CMAKE_INSTALL_NAME_TOOL:FILEPATH ALL_PROJECTS)
+  # Due to the possibility of external projects (e.g., LibFFI) enabling languages (e.g., ASM)
+  # that necessitate `install_name_tool` via the "CMakeFindBinUtils" module, we opt to clear
+  # CMAKE_INSTALL_NAME_TOOL on a per-project basis.
+  # mark_as_superbuild(VARS CMAKE_INSTALL_NAME_TOOL:FILEPATH ALL_PROJECTS)
 
   set(CMAKE_MACOSX_RPATH 0)
   mark_as_superbuild(VARS CMAKE_MACOSX_RPATH:BOOL ALL_PROJECTS)


### PR DESCRIPTION
Follow-up of 52b238d0ec (`COMP: Ensure full path ID for macOS libraries installed for fix-up`) reverting the systematic clearing of `CMAKE_INSTALL_NAME_TOOL`.

Due to the possibility of external projects (e.g., LibFFI) enabling languages (e.g., ASM) that necessitate `install_name_tool` via the "CMakeFindBinUtils" module, we opt to clear `CMAKE_INSTALL_NAME_TOOL` on a per-project basis.

Related:
* https://github.com/Slicer/Slicer/pull/7537