### PR TITLE
ENH: Update CTK

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "84187713304e4ed5a457ee9758de1af4a22d8dbd"
+    "b83ff7a54addd489764da9c607ef0f53374751fd"
     QUIET
     )
 


### PR DESCRIPTION
This updates removes Python 2.x support, streamline test execution setting launch environment and fixes tests while addressing minor issues.

Highlights:
* Convert `ctkDoubleRangeSlider::setRange` to a slot to expose to Python
* Fix `applySettings()` to emit `settingChanged()` only if needed
* Fix segfault in `ctkFileDialog::selectionMode()` with native dialogs

List of CTK changes:

```
$ git shortlog 841877133..b83ff7a54 --group=author --group=trailer:co-authored-by --no-merges
Andras Lasso (1):
      BUG: Fix connection with "dicomserver.co.uk" server using port 104 as default

Davide Punzo (4):
      BUG: Fix connection with "dicomserver.co.uk" server using port 104 as default
      BUG: Fix segfault in ctkDICOMAppWidget support use of native file dialog
      BUG: Fix support of interactive mode in ctkDICOMAppWidgetTest1
      BUG: Fix ctkDICOMBrowserTester checking for use of native file dialog

Jean-Christophe Fillion-Robin (35):
      COMP: Remove Python 2.x support from PythonCore and PythonWidget libraries
      STYLE: Fix indent in PythonQt library wrapper files
      COMP: Remove support for building VTK with Python 2.x support enabled
      STYLE: Fix indent in VTK external project
      ENH: Remove python 2.7 support from ctk_compile_file helper function
      ENH: Convert ctkDoubleRangeSlider::setRange to a slot to expose to Python
      BUG: Fix ctkDICOMDatabaseTest2 comparing upper-cased tag
      BUG: Ensure ctkFileDialog respects application attribute AA_DontUseNativeDialogs
      BUG: Fix segfault in ctkDICOMAppWidget support use of native file dialog
      BUG: Fix support of interactive mode in ctkDICOMAppWidgetTest1
      BUG: Fix ctkDICOMBrowserTester checking for use of native file dialog
      COMP: Simplify ctkDICOMHost test removing duplicated SIMPLE_TEST CMake macro
      ENH: Support running ctkDICOMHostTest1 without having to install CTK
      ENH: Update ctkDICOMTester to lookup DCMTK executables in build tree
      ENH: Support running ctkDICOMDatabase tests in parallel using QTemporaryDir
      ENH: Streamline test execution setting launch environment (#1168)
      BUG: Fix lookup of DCMTK binaries in ctkDICOMTester for multi-config build tree
      COMP: Fix lookup of DCMTK binaries for ctkDICOMApplicationTest1 on Windows
      COMP: Fix ctkDICOMApplicationTest1 setting launch environment
      DOC: Update paths in ctkDICOMApplicationTest1 and ctkDICOMTester examples
      BUG: Resolve invocation error in ctkDICOMApplicationTest1 for ctkDICOMRetrieve
      ENH: Improve ctkDICOMApplicationTest1 output formatting
      ENH: Improve error reporting in ctkDICOMApplicationTest1
      BUG: Fix ctkDICOMApplicationTest1 on Windows configuring hostname in dcmqrscp.cfg
      ENH: Add GitHub Actions workflow for running "pre-commit"
      STYLE: Trim trailing whitespaces
      ENH: Update pre-commit config to include "trailing-whitespace"
      BUG: Fix ctkUtilsCopyDirRecursivelyTest on windows creating hidden files
      BUG: Fix segfault in ctkFileDialog::selectionMode() with native dialogs
      ENH: Update "simple_test" macro to allow specifying different test names & args
      ENH: Update ctkFileDialogTest1 to check Use & DoNotUse of NativeDialogs
      DOC: Update ctkFileDialog docstring to describe behavior as native dialog
      BUG: Fix ctkCoreSettingsTest testMultiplePaths on Windows
      BUG: Fix ctkSettingsPanelTest reading settings file as text
      BUG: Fix applySettings() to emit "settingChanged()" only if needed
```