### PR TITLE
ENH: Update CTK adding removePatient/Series/Study signals to DICOM database

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "b83ff7a54addd489764da9c607ef0f53374751fd"
+    "45f33c81d8f60d2ac4b749cb21828974a73a4f76"
     QUIET
     )
 


### PR DESCRIPTION
This updates adds the signals `patientRemoved(QString)`, `studyRemoved(QString)` and `seriesRemoved(QString)` to the DICOM database (see `ctkDICOMDatabase`).

It also improves the CTK continuous integration and DICOM testing infrastructure.

Highlights:
* Add removePatient/Series/Study signals to DICOM database
* Fix and update DICOM tests to support running all of them in ~7s
* Update pre-commit config to include "end-of-file-fixer" and "mixed-line-ending"


List of CTK changes:

```
$ git shortlog b83ff7a54..45f33c81 --group=author --group=trailer:co-authored-by --no-merges
Andras Lasso (1):
      ENH: Add removePatient/Series/Study signals to DICOM database

Davide Punzo (4):
      ENH: Refine order of ctkErrorLogLevel enum values
      ENH: Update ctkLogger adding support for log level
      BUG: Fix argument processing and usage message in ctkDICOM tests
      ENH: Add removePatient/Series/Study signals to DICOM database

Jean-Christophe Fillion-Robin (12):
      ENH: Refine order of ctkErrorLogLevel enum values
      ENH: Update ctkLogger adding support for log level
      ENH: Update ctkLoggerTest1 to check logging using a Qt message handler.
      ENH: Update ctkDICOMDatabaseTest2 to test use of lower and upper case tags
      BUG: Fix argument processing and usage message in ctkDICOM tests
      BUG: Set test resource lock on all tests using "dcmqrscp" executable
      BUG: Ensure DICOM tests all read/write from different sqlite database
      BUG: Update ctkDICOMTester to always kill "storescp" process on destruction
      ENH: Add removePatient/Series/Study signals to DICOM database
      STYLE: Update files to end with only one newline
      ENH: Update pre-commit config to include "end-of-file-fixer"
      ENH: Update pre-commit config to include "mixed-line-ending"

cpoette (1):
      ENH: Add removePatient/Series/Study signals to DICOM database
```