### PR TITLE
BUG: Fix meta-object system registration of qSlicerIO::fileType return type

### DIFF
--- a/Base/QTCore/qSlicerIO.h
+++ b/Base/QTCore/qSlicerIO.h
@@ -56,7 +56,7 @@ public:
   Q_INVOKABLE virtual QString description()const = 0;
 
   /// Multiple readers can share the same file type
-  Q_INVOKABLE virtual IOFileType fileType()const = 0;
+  Q_INVOKABLE virtual qSlicerIO::IOFileType fileType()const = 0;
 
   /// Returns a list of options for the reader. qSlicerIOOptions can be
   /// derived and have a UI associated to it (i.e. qSlicerIOOptionsWidget).


### PR DESCRIPTION
To ensure correct lookup of the return type of the `fileType` function registered with the meta-object system (MOC), this commit updates the function signature. Previously, it was registered as "IOFileType," and this caused issues with PythonQt, which expected "qSlicerIO::IOFileType" for proper identification.

This change eliminates the need to separately register the unqualified and potentially conflicting shorter version:

```cpp
qRegisterMetaType<qSlicerIO::IOFileType>("IOFileType");
```

It also fixes the following error:

```python
reader = slicer.qSlicerSceneBundleReader()
reader.fileType()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
ValueError: Called fileType() -> IOFileType, return type 'IOFileType' is ignored because it is unknown to PythonQt. Probably you should register it using qRegisterMetaType() or add a default constructor decorator to the class.
```

References:
* https://doc.qt.io/qt-6/signalsandslots-syntaxes.html