### PR TITLE
BUG: Support checking if IO registration from python without registered IOs

### DIFF
--- a/Base/QTCore/qSlicerCoreIOManager.cxx
+++ b/Base/QTCore/qSlicerCoreIOManager.cxx
@@ -211,6 +211,11 @@ qSlicerCoreIOManager::qSlicerCoreIOManager(QObject* _parent)
   :QObject(_parent)
   , d_ptr(new qSlicerCoreIOManagerPrivate)
 {
+  // To ensure that these types are known before any qSlicerIO instance is created,
+  // they are registered here. This complements the registration in the `qSlicerIO::qSlicerIO`
+  // constructor.
+  qRegisterMetaType<qSlicerIO::IOFileType>("qSlicerIO::IOFileType");
+  qRegisterMetaType<qSlicerIO::IOProperties>("qSlicerIO::IOProperties");
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This ensures the `IOFileType` type associated with the `fileType` parameter of the functions used to check if a particular reader or writer is registered as a metatype without having any `qSlicerIO` instance already created.

The relevant `qSlicerCoreIOManager` functions are the following:

```
int registeredFileReaderCount(const qSlicerIO::IOFileType& fileType) const;
int registeredFileWriterCount(const qSlicerIO::IOFileType& fileType) const;
```

For example, this addresses the following error where executing python code through the `-c` option (equivalent to passing `--disable-modules`):

```bash
./Slicer -c "import slicer;print(slicer.app.ioManager().registeredFileReaderCount('VolumeFile'));slicer.app.quit()"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ValueError: Called registeredFileReaderCount(qSlicerIO::IOFileType fileType) -> int with wrong arguments: ('VolumeFile',)
```

Related pull request:
* https://github.com/Slicer/Slicer/pull/7552
