### PR TITLE
BUG: Update VTK to backport vtkSSAOPass fixes

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "a7235af9dc7faff4601a622e0c45d72c36690e69") # slicer-v9.2.20230607-1ff325c54-2
+    set(_git_tag "4308220744e4848b91f3434476eabc9df8daa279") # slicer-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
This update addresses an issue (#7518) related to the orientation marker collapsing when shadow visibility is enabled in `vtkSSAOPass`.

Fixes https://github.com/Slicer/Slicer/issues/7518

List of VTK changes:

```
Andras Lasso (2):
      [Backport] Reset DepthMaskOverride before checking the property keys of the volume
      [Backport] Fix initialization of the depth test state with QVTKOpenGLNativeWidget

Lucas Gandel (3):
      [Backport] Do not always clear the renderer in vtkSSAOPass
      [Backport] Reset DepthMaskOverride before checking the property keys of the volume
      [Backport] Fix initialization of the depth test state with QVTKOpenGLNativeWidget
```

> [!NOTE]
> The listing above was manually updated based on the output of the command below to properly account for authorship that is incorrectly reported due to invalid "Co-authored-by:" trailers:
>
>
> ```
> $ git shortlog --group=author --group=trailer:co-authored-by a7235af9d..430822074
> ```

cc: @LucasGandel @lassoan 