### PR TITLE
ENH: Update CTK to backport PythonQt fixes & restore script compilation to pyc

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "888cdd92b7d5d465ed7e6b378deb99e10a801588"
+    "4aba4e20341c7111f5637337952a089464dc15db"
     QUIET
     )
 


### PR DESCRIPTION
Related pull requests:
* https://github.com/commontk/CTK/pull/1189
* https://github.com/commontk/CTK/pull/1188

List of CTK changes:

```
$ git shortlog 888cdd92b..4aba4e20 --group=author --group=trailer:co-authored-by --no-merges
James Butler (1):
      ENH: Update PythonQt backporting recent changes from MeVisLab/pythonqt

Jean-Christophe Fillion-Robin (2):
      ENH: Update PythonQt backporting recent changes from MeVisLab/pythonqt
      ENH: Always compile python scripts as legacy .pyc files
```