### PR TITLE
BUG: Ensure packaging of the latest d3dcompiler_47.dll for SlicerVirtualReality

### DIFF
--- a/CMake/SlicerBlockInstallQt.cmake
+++ b/CMake/SlicerBlockInstallQt.cmake
@@ -172,8 +172,33 @@ set(QT_INSTALL_LIB_DIR ${Slicer_INSTALL_LIB_DIR})
 
     set(executable "${Slicer_MAIN_PROJECT_APPLICATION_NAME}App-real.exe")
 
+    # Setting the "WindowsSdkDir" env. variable before building the PACKAGE target ensures
+    # that the "windeployqt" tool can lookup the path of a recent version of the "d3dcompiler_47.dll"
+    # library in the directory "%WindowsSdkDir%/Redist/D3D/x64"
+
+    if(CMAKE_WINDOWS_KITS_10_DIR)
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION.html
+      # and https://cmake.org/cmake/help/latest/module/InstallRequiredSystemLibraries.html
+      set(windows_kits_dir "${CMAKE_WINDOWS_KITS_10_DIR}")
+    elseif(ENV{WindowsSdkDir})
+      # If building from an environments established by vcvarsall.bat or similar scripts.
+      set(windows_kits_dir "$ENV{WindowsSdkDir}")
+    else()
+      # Default to registry value
+      # Copied from CMake/Modules/InstallRequiredSystemLibraries.cmake
+      get_filename_component(windows_kits_dir
+        "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]" ABSOLUTE)
+    endif()
+    if(NOT windows_kits_dir)
+      message(WARNING "Failed to lookup Windows SDK directory required to package Qt libraries")
+    endif()
     install(
       CODE "
+        set(windows_kits_dir \"${windows_kits_dir}\")
+        set(ENV{WindowsSdkDir} \${windows_kits_dir})
+        if(\"\$ENV{WindowsSdkDir}\" STREQUAL \"\")
+          message(FATAL_ERROR \"Setting WindowsSdkDir env. variable is required to ensure windeployqt can install the most recent version of d3dcompiler_47.dll\")
+        endif()
         set(ENV{PATH} \"${QT_BINARY_DIR};\$ENV{PATH}\")
         execute_process(COMMAND \"${windeployqt}\" ${_args} \"\${CMAKE_INSTALL_PREFIX}/bin/${executable}\")
       "


### PR DESCRIPTION
This commit focuses on updating the Qt install rules to ensure the packaging of the latest version of `d3dcompiler_47.dll`. The proper functioning of "Microsoft.Holographic.Remoting.OpenXr" within the SlicerVirtualReality extension with OpenXR remoting enabled relies on this update for successful scene rendering.

By setting the `WindowsSdkDir` environment variable, the "windeployqt" tool is instructed to look up and deploy the library available on the system. This action prevents the deployment of an older version that may be installed alongside Qt 5.15.2 libraries when Qt is installed using the installer.

For future reference, here are links related to the `windeployqt` tool

* For Qt 5.15.2 (source managed in the `qttools` project)
  * https://github.com/qt/qttools/blob/v5.15.2/src/windeployqt/main.cpp#L1469-L1478
  * https://github.com/qt/qttools/blob/v5.15.2/src/shared/winutils/utils.cpp#L928-L948
* For Qt 6 (sources managed in the `qtbase` project)
  * https://github.com/qt/qtbase/blob/6.7/src/tools/windeployqt/main.cpp#L1576-L1599
  * https://github.com/qt/qtbase/blob/6.7/src/tools/windeployqt/utils.cpp#L835-L879
