### PR TITLE
ENH: Improve appearance of node information section in Data module

### DIFF
--- a/Libs/MRML/Widgets/Resources/UI/qMRMLNodeAttributeTableView.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLNodeAttributeTableView.ui
@@ -26,35 +26,19 @@
    <string>qMRMLNodeAttributeTableView</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item row="0" column="0">
-    <widget class="QLabel" name="AttributeTableMessageLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>13</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>No node selected</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
     <widget class="QTableWidget" name="NodeAttributesTable">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLNodeAttributeTableWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLNodeAttributeTableWidget.ui
@@ -14,75 +14,108 @@
    <string>qMRMLNodeAttributeTableWidget</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <property name="spacing">
     <number>4</number>
    </property>
    <item row="2" column="0">
-    <widget class="qMRMLNodeAttributeTableView" name="MRMLNodeAttributeTableView">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>1</verstretch>
-      </sizepolicy>
+    <widget class="ctkCollapsibleGroupBox" name="NodeAttributesGroupBox">
+     <property name="title">
+      <string>Attributes</string>
      </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="qMRMLNodeAttributeTableView" name="MRMLNodeAttributeTableView">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>1</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QPushButton" name="AddAttributeButton">
+          <property name="minimumSize">
+           <size>
+            <width>72</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Add blank row to the table. The attribute is added to the MRML node when the name and value is set</string>
+          </property>
+          <property name="text">
+           <string>Add</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="RemoveAttributeButton">
+          <property name="minimumSize">
+           <size>
+            <width>72</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Remove selected attribute(s)</string>
+          </property>
+          <property name="text">
+           <string>Remove</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="3" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="AddAttributeButton">
-       <property name="minimumSize">
-        <size>
-         <width>72</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Add blank row to the table. The attribute is added to the MRML node when the name and value is set</string>
-       </property>
-       <property name="text">
-        <string>Add</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="RemoveAttributeButton">
-       <property name="minimumSize">
-        <size>
-         <width>72</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Remove selected attribute(s)</string>
-       </property>
-       <property name="text">
-        <string>Remove</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item row="1" column="0">
-    <widget class="ctkCollapsibleGroupBox" name="NodeInformationGroupBox">
+    <widget class="ctkCollapsibleGroupBox" name="NodePropertiesGroupBox">
      <property name="title">
-      <string>Node information</string>
+      <string>Properties</string>
      </property>
      <property name="collapsed">
       <bool>true</bool>
@@ -91,13 +124,22 @@
       <property name="spacing">
        <number>0</number>
       </property>
-      <property name="margin">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
        <number>4</number>
       </property>
       <item>
        <widget class="QLabel" name="MRMLNodeInfoLabel">
         <property name="text">
-         <string>No node information is available.</string>
+         <string/>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -114,15 +156,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>qMRMLNodeAttributeTableView</class>
-   <extends>QWidget</extends>
-   <header>qMRMLNodeAttributeTableView.h</header>
-  </customwidget>
-  <customwidget>
    <class>ctkCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>ctkCollapsibleGroupBox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLNodeAttributeTableView</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeAttributeTableView.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/Libs/MRML/Widgets/qMRMLNodeAttributeTableView.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeAttributeTableView.cxx
@@ -191,14 +191,13 @@ void qMRMLNodeAttributeTableView::onAttributeChanged(QTableWidgetItem* changedIt
       changedItem->setText(attributeNameBeforeEditing);
       d->NodeAttributesTable->blockSignals(wasBlocked);
 
-      // Don't set if there is another attribute with the same name (would overwrite it),
-      // revert to the original value and display a message.
+      // Ensure the attribute name is unique; if not, avoid overwriting it by reverting
+      // to the original value and notify the user.
       d->MessageText = tr("There is already an attribute with the same name");
       QRect rect = d->NodeAttributesTable->visualItemRect(changedItem);
       d->MessagePosition = d->NodeAttributesTable->mapToGlobal(rect.bottomLeft());
-      // If we directly show the tooltip in this callback function now then the tooltip
-      // does not appear, therefore we trigger a timer to display it once the attribute change
-      // is fully completed.
+      // Due to limitations in displaying the tooltip immediately within this callback,
+      // a timer is used to delay its appearance until after the attribute change is fully processed.
       d->MessageDisplayTimer.start(0);
       }
     else

--- a/Libs/MRML/Widgets/qMRMLNodeAttributeTableView.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeAttributeTableView.cxx
@@ -22,6 +22,8 @@
 // Qt includes
 #include <QStringList>
 #include <QItemSelectionModel>
+#include <QTimer>
+#include <QToolTip>
 
 // qMRML includes
 #include "qMRMLNodeAttributeTableView.h"
@@ -43,16 +45,12 @@ public:
   qMRMLNodeAttributeTableViewPrivate(qMRMLNodeAttributeTableView& object);
   void init();
 
-  /// Sets table message and takes care of the visibility of the label
-  void setMessage(const QString& message)
-  {
-    this->AttributeTableMessageLabel->setVisible(!message.isEmpty());
-    this->AttributeTableMessageLabel->setText(message);
-  };
-
 public:
   /// MRML node to inspect
   vtkMRMLNode* InspectedNode;
+  QPoint MessagePosition;
+  QString MessageText;
+  QTimer MessageDisplayTimer;
 };
 
 // --------------------------------------------------------------------------
@@ -68,10 +66,12 @@ void qMRMLNodeAttributeTableViewPrivate::init()
   Q_Q(qMRMLNodeAttributeTableView);
   this->setupUi(q);
 
+  this->MessageDisplayTimer.setSingleShot(true);
+
   QObject::connect(this->NodeAttributesTable, SIGNAL(itemChanged(QTableWidgetItem*)),
           q, SLOT(onAttributeChanged(QTableWidgetItem*)));
 
-  this->setMessage(QString());
+  QObject::connect(&this->MessageDisplayTimer, SIGNAL(timeout()), q, SLOT(showMessage()));
 }
 
 // --------------------------------------------------------------------------
@@ -115,8 +115,6 @@ void qMRMLNodeAttributeTableView::populateAttributeTable()
 {
   Q_D(qMRMLNodeAttributeTableView);
 
-  d->setMessage(QString());
-
   // Block signals so that onAttributeChanged function is not called when populating
   bool wasBlocked = d->NodeAttributesTable->blockSignals(true);
 
@@ -130,7 +128,6 @@ void qMRMLNodeAttributeTableView::populateAttributeTable()
 
   if (!d->InspectedNode)
     {
-    d->setMessage(tr("No node is selected"));
     d->NodeAttributesTable->setRowCount(0);
     d->NodeAttributesTable->blockSignals(wasBlocked);
     return;
@@ -139,7 +136,6 @@ void qMRMLNodeAttributeTableView::populateAttributeTable()
   std::vector< std::string > attributeNames = d->InspectedNode->GetAttributeNames();
   if (attributeNames.size() == 0)
     {
-    d->setMessage(tr("Selected node has no attributes"));
     d->NodeAttributesTable->setRowCount(0);
     }
   else
@@ -173,8 +169,6 @@ void qMRMLNodeAttributeTableView::onAttributeChanged(QTableWidgetItem* changedIt
 {
   Q_D(qMRMLNodeAttributeTableView);
 
-  d->setMessage(QString());
-
   if (!changedItem || !d->InspectedNode)
     {
     return;
@@ -193,12 +187,19 @@ void qMRMLNodeAttributeTableView::onAttributeChanged(QTableWidgetItem* changedIt
     QString attributeNameBeforeEditing = changedItem->data(Qt::UserRole).toString();
     if (d->InspectedNode->GetAttribute(changedItem->text().toUtf8().constData()))
       {
-      // Don't set if there is another attribute with the same name (would overwrite it),
-      // revert to the original value.
-      d->setMessage(tr("There is already an attribute with the same name"));
       bool wasBlocked = d->NodeAttributesTable->blockSignals(true);
       changedItem->setText(attributeNameBeforeEditing);
       d->NodeAttributesTable->blockSignals(wasBlocked);
+
+      // Don't set if there is another attribute with the same name (would overwrite it),
+      // revert to the original value and display a message.
+      d->MessageText = tr("There is already an attribute with the same name");
+      QRect rect = d->NodeAttributesTable->visualItemRect(changedItem);
+      d->MessagePosition = d->NodeAttributesTable->mapToGlobal(rect.bottomLeft());
+      // If we directly show the tooltip in this callback function now then the tooltip
+      // does not appear, therefore we trigger a timer to display it once the attribute change
+      // is fully completed.
+      d->MessageDisplayTimer.start(0);
       }
     else
       {
@@ -251,11 +252,8 @@ void qMRMLNodeAttributeTableView::addAttribute()
 
   if (!d->InspectedNode)
     {
-    d->setMessage(tr("No node is selected"));
     return;
     }
-
-  d->setMessage(QString());
 
   bool wasBlocked = d->NodeAttributesTable->blockSignals(true);
   int rowCountBefore = d->NodeAttributesTable->rowCount();
@@ -280,11 +278,8 @@ void qMRMLNodeAttributeTableView::removeSelectedAttributes()
 
   if (!d->InspectedNode)
     {
-    d->setMessage(tr("No node is selected"));
     return;
     }
-
-  d->setMessage(QString());
 
   // Extract selected row indices out of the selected table widget items list
   // (there may be more items selected in a row)
@@ -421,4 +416,11 @@ QItemSelectionModel* qMRMLNodeAttributeTableView::selectionModel()
   Q_D(qMRMLNodeAttributeTableView);
 
   return d->NodeAttributesTable->selectionModel();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLNodeAttributeTableView::showMessage()
+{
+  Q_D(qMRMLNodeAttributeTableView);
+  QToolTip::showText(d->MessagePosition, d->MessageText);
 }

--- a/Libs/MRML/Widgets/qMRMLNodeAttributeTableView.h
+++ b/Libs/MRML/Widgets/qMRMLNodeAttributeTableView.h
@@ -98,6 +98,8 @@ protected slots:
   /// Handles changing of text in a cell (attribute name or value)
   void onAttributeChanged(QTableWidgetItem* changedItem);
 
+  void showMessage();
+
 protected:
   QScopedPointer<qMRMLNodeAttributeTableViewPrivate> d_ptr;
 

--- a/Libs/MRML/Widgets/qMRMLNodeAttributeTableWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeAttributeTableWidget.cxx
@@ -132,14 +132,14 @@ void qMRMLNodeAttributeTableWidget::updateWidgetFromMRML()
 
   if (d->MRMLNode.GetPointer())
     {
-    d->NodeInformationGroupBox->setVisible(true);
+    d->NodePropertiesGroupBox->setVisible(true);
     std::stringstream infoStream;
     d->MRMLNode->PrintSelf(infoStream, vtkIndent(0));
     d->MRMLNodeInfoLabel->setText(infoStream.str().c_str());
     }
   else
     {
-    d->NodeInformationGroupBox->setVisible(false);
+    d->NodePropertiesGroupBox->setVisible(false);
     d->MRMLNodeInfoLabel->clear();
     }
 }


### PR DESCRIPTION
In Data module, "MRML node information" section had a "Node information" section and an untitled node attributes section. The node attributes section displayed messages (e.g., attribute name already exists) above the table. This all looked quite confusing.

Updated the GUI to have a "Properties" and "Attributes" section under "MRML node information". Also replaced the label above the table by a tooltip for showing "attribute name already exists" message.

![image](https://github.com/Slicer/Slicer/assets/307929/c04ec227-705b-431b-a459-7984dac91af7)
