### PR TITLE
BUG: Fix loading of modules that depend on another extension

### DIFF
--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -958,9 +958,16 @@ QStringList qSlicerExtensionsManagerModelPrivate::extensionPythonPaths(const QSt
     {
     return QStringList();
     }
+
+  // When an extension depends on another extension then a .pyd file may depend on .pyd file in the other extension.
+  // The .pyd file can only be loaded if it is in the PYTHONPATH folder list.
+  // Since .pyd files are in the Slicer_QTLOADABLEMODULES_LIB_DIR, this folder needs to be added to
+  // Python paths.
+
   QString path = q->extensionInstallPath(extensionName);
   return appendToPathList(QStringList(), QStringList()
                           << path + "/" + QString(Slicer_QTSCRIPTEDMODULES_LIB_DIR).replace(Slicer_VERSION, this->SlicerVersion)
+                          << path + "/" + QString(Slicer_QTLOADABLEMODULES_LIB_DIR).replace(Slicer_VERSION, this->SlicerVersion)
                           << path + "/" + QString(Slicer_QTLOADABLEMODULES_PYTHON_LIB_DIR).replace(Slicer_VERSION, this->SlicerVersion)
                           << path + "/" + QString(PYTHON_SITE_PACKAGES_SUBDIR)
                           );


### PR DESCRIPTION
This is an attempt to fix #7579 by adding loadable module paths of extensions to `PYTHONPATH` section of `Slicer-NNN.ini`.

For example, before this fix, `PYTHONPATH` section of `Slicer-NNN.ini` was this:

```
[PYTHONPATH]
size=2
1\path=slicer.org/Extensions-30987/SlicerVMTK/lib/Slicer-5.7/qt-scripted-modules
2\path=slicer.org/Extensions-30987/SlicerVMTK/lib/Slicer-5.7/qt-loadable-modules/Python
```

After this fix:

```
[PYTHONPATH]
size=4
1\path=slicer.org/Extensions-30987/SlicerVMTK/lib/Slicer-5.7/qt-scripted-modules
2\path=slicer.org/Extensions-30987/SlicerVMTK/lib/Slicer-5.7/qt-loadable-modules
3\path=slicer.org/Extensions-30987/SlicerVMTK/lib/Slicer-5.7/qt-loadable-modules/Python
4\path=slicer.org/Extensions-30987/ExtraMarkups/lib/Slicer-5.7/qt-loadable-modules
```

The added  `slicer.org/Extensions-30987/ExtraMarkups/lib/Slicer-5.7/qt-loadable-modules` was needed because VMTK extension's `ArterialCalcificationPreProcessor` module was instantiated first and that imported all .pyd files (using `qSlicerScriptedUtils::importModulePythonExtensions`) of VMTK extension. However, VMTK extension's `vtkSlicerCrossSectionAnalysisModuleLogicPython.pyd` required ExtraMarkups extension's `vtkSlicerShapeModuleMRMLPython.pyd`, but the `slicer.org/Extensions-30987/ExtraMarkups/lib/Slicer-5.7/qt-loadable-modules` folder was not yet in the Python paths and so import of `vtkSlicerCrossSectionAnalysisModuleLogicPython` failed.