### PR TITLE
ENH: Disable shadows in 3D views by default

### DIFF
--- a/Base/QTGUI/Resources/UI/qSlicerSettingsViewsPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsViewsPanel.ui
@@ -289,7 +289,7 @@
              <string>Show shadows by default to improve depth perception</string>
             </property>
             <property name="checked">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -305,6 +305,9 @@
           </item>
           <item row="7" column="1">
            <widget class="ctkSliderWidget" name="ThreeDAmbientShadowsSizeScaleSlider">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
             <property name="singleStep">
              <double>0.010000000000000</double>
             </property>
@@ -331,6 +334,9 @@
           </item>
           <item row="8" column="1">
            <widget class="ctkSliderWidget" name="ThreeDAmbientShadowsVolumeOpacityThresholdSlider">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
             <property name="decimals">
              <number>2</number>
             </property>


### PR DESCRIPTION
Shadows feature is not yet mature enough to be enabled by default. It may make rendering darker, not compatible with MIP, and the shader fails to compile if shading (normal computation) is disabled.

See #7560 for MIP incompatibility
See discussion about darkened look at https://discourse.slicer.org/t/are-shadows-enabled-by-default-for-volume-rendering-in-new-previews/34219