### PR TITLE
BUG: Fix qSlicerExtensionsManagerModelTest

### DIFF
--- a/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
@@ -1849,7 +1849,8 @@ void qSlicerExtensionsManagerModelTester::testExtensionExtensionsSettingsUpdated
             << this->Tmp.filePath("MarkupsToModel/" + lib_dir)
             << this->Tmp.filePath("MarkupsToModel/" + qtloadablemodules_lib_dir))
         << QStringList()
-        << QStringList();
+        << (QStringList()
+            << this->Tmp.filePath("MarkupsToModel/" + qtloadablemodules_lib_dir));
   }
 
 #ifdef Slicer_USE_PYTHONQT


### PR DESCRIPTION
Update test based on change introduced in 9c87503363 (`"BUG: Fix loading of modules that depend on another extension", 2024-02-09`) through https://github.com/Slicer/Slicer/pull/7580