### PR TITLE
BUG: Update CTK to fix Qt designer crash at startup

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "4aba4e20341c7111f5637337952a089464dc15db"
+    "51c9f4a5a55f38ddce9d8b75a72c02fca64bf17a"
     QUIET
     )
 


### PR DESCRIPTION
One of the DICOM widgets crashed the Qt designer because `ctkDICOMScheduler::~ctkDICOMScheduler()` called `ctkJobScheduler::waitForDone`, and that method called `processEvents()`. After returning from `processEvents()` the application crashed because the "this" pointer has become invalid (probably the `ctkDICOMScheduler` object got deleted).

Solved the issue by removing `processEvents()` from `ctkJobScheduler::waitForDone`, and instead calling `processEvents()` before calling `ctkJobScheduler::waitForDone`.

List of CTK changes:

```
$ git shortlog 4aba4e203..51c9f4a5a --no-merges
Andras Lasso (1):
      BUG: Fix Qt designer crash at startup
```