### PR TITLE
ENH: Add finer control of 2D interaction handle axis display

### DIFF
--- a/Libs/MRML/Core/vtkMRMLTransformDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformDisplayNode.cxx
@@ -91,18 +91,28 @@ vtkMRMLTransformDisplayNode::vtkMRMLTransformDisplayNode()
     }
 
   this->EditorVisibility = false;
-  this->EditorSliceIntersectionVisibility = false;
+  this->EditorVisibility3D = true;
+  this->EditorSliceIntersectionVisibility = true;
   this->EditorTranslationEnabled = true;
+  this->EditorTranslationSliceEnabled = true;
   this->EditorRotationEnabled = true;
+  this->EditorRotationSliceEnabled = true;
   this->EditorScalingEnabled = false;
+  this->EditorScalingSliceEnabled = false;
 
   for (int i = 0; i < 4; ++i)
     {
-    this->RotationHandleComponentVisibility[i] = true;
-    this->ScaleHandleComponentVisibility[i] = true;
-    this->TranslationHandleComponentVisibility[i] = true;
+    this->RotationHandleComponentVisibility3D[i] = true;
+    this->ScaleHandleComponentVisibility3D[i] = true;
+    this->TranslationHandleComponentVisibility3D[i] = true;
+
+    this->RotationHandleComponentVisibilitySlice[i] = false;
+    this->ScaleHandleComponentVisibilitySlice[i] = true;
+    this->TranslationHandleComponentVisibilitySlice[i] = false;
     }
-  this->RotationHandleComponentVisibility[3] = false;
+  this->RotationHandleComponentVisibility3D[3] = false;
+  this->RotationHandleComponentVisibilitySlice[3] = true;
+  this->TranslationHandleComponentVisibilitySlice[3] = true;
 
   vtkNew<vtkIntArray> regionModifiedEvents;
   regionModifiedEvents->InsertNextValue(vtkCommand::ModifiedEvent);
@@ -152,16 +162,19 @@ void vtkMRMLTransformDisplayNode::WriteXML(ostream& of, int nIndent)
   of << " EditorRotationEnabled=\"" << this->EditorRotationEnabled << "\"";
   of << " EditorScalingEnabled=\""<< this->EditorScalingEnabled << "\"";
 
+  vtkMRMLWriteXMLBooleanMacro(EditorVisibility3D, EditorVisibility3D);
   vtkMRMLWriteXMLFloatMacro(InteractionSizeAbsolute, InteractionSizeAbsolute);
   vtkMRMLWriteXMLFloatMacro(InteractionSizeMm, InteractionSizeMm);
   vtkMRMLWriteXMLFloatMacro(InteractionScalePercent, InteractionScalePercent);
-  vtkMRMLWriteXMLVectorMacro(TranslationHandleComponentVisibility, TranslationHandleComponentVisibility, bool, 4);
-  vtkMRMLWriteXMLVectorMacro(RotationHandleComponentVisibility, RotationHandleComponentVisibility, bool, 4)
-  vtkMRMLWriteXMLVectorMacro(ScaleHandleComponentVisibility, ScaleHandleComponentVisibility, bool, 4);
+  vtkMRMLWriteXMLVectorMacro(TranslationHandleComponentVisibility3D, TranslationHandleComponentVisibility3D, bool, 4);
+  vtkMRMLWriteXMLVectorMacro(RotationHandleComponentVisibility3D, RotationHandleComponentVisibility3D, bool, 4)
+  vtkMRMLWriteXMLVectorMacro(ScaleHandleComponentVisibility3D, ScaleHandleComponentVisibility3D, bool, 4);
+  vtkMRMLWriteXMLVectorMacro(TranslationHandleComponentVisibilitySlice, TranslationHandleComponentVisibilitySlice, bool, 4);
+  vtkMRMLWriteXMLVectorMacro(RotationHandleComponentVisibilitySlice, RotationHandleComponentVisibilitySlice, bool, 4)
+  vtkMRMLWriteXMLVectorMacro(ScaleHandleComponentVisibilitySlice, ScaleHandleComponentVisibilitySlice, bool, 4);
 
   vtkMRMLWriteXMLEndMacro();
 }
-
 
 #define READ_FROM_ATT(varName)    \
   if (!strcmp(xmlReadAttName,#varName))  \
@@ -217,13 +230,17 @@ void vtkMRMLTransformDisplayNode::ReadXMLAttributes(const char** atts)
   READ_FROM_ATT(EditorRotationEnabled);
   READ_FROM_ATT(EditorScalingEnabled);
 
+  vtkMRMLReadXMLBooleanMacro(EditorVisibility3D, EditorVisibility3D);
   vtkMRMLReadXMLFloatMacro(InteractionSizeAbsolute, InteractionSizeAbsolute);
   vtkMRMLReadXMLFloatMacro(InteractionSizeMm, InteractionSizeMm);
   vtkMRMLReadXMLFloatMacro(InteractionScalePercent, InteractionScalePercent);
 
-  vtkMRMLReadXMLVectorMacro(RotationHandleComponentVisibility, RotationHandleComponentVisibility, bool, 4);
-  vtkMRMLReadXMLVectorMacro(ScaleHandleComponentVisibility, ScaleHandleComponentVisibility, bool, 4);
-  vtkMRMLReadXMLVectorMacro(TranslationHandleComponentVisibility, TranslationHandleComponentVisibility, bool, 4);
+  vtkMRMLReadXMLVectorMacro(RotationHandleComponentVisibility3D, RotationHandleComponentVisibility3D, bool, 4);
+  vtkMRMLReadXMLVectorMacro(ScaleHandleComponentVisibility3D, ScaleHandleComponentVisibility3D, bool, 4);
+  vtkMRMLReadXMLVectorMacro(TranslationHandleComponentVisibility3D, TranslationHandleComponentVisibility3D, bool, 4);
+  vtkMRMLReadXMLVectorMacro(RotationHandleComponentVisibilitySlice, RotationHandleComponentVisibilitySlice, bool, 4);
+  vtkMRMLReadXMLVectorMacro(ScaleHandleComponentVisibilitySlice, ScaleHandleComponentVisibilitySlice, bool, 4);
+  vtkMRMLReadXMLVectorMacro(TranslationHandleComponentVisibilitySlice, TranslationHandleComponentVisibilitySlice, bool, 4);
 
   vtkMRMLReadXMLEndMacro();
 }
@@ -270,9 +287,13 @@ void vtkMRMLTransformDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/
   this->EditorRotationEnabled = node->EditorRotationEnabled;
   this->EditorScalingEnabled = node->EditorScalingEnabled;
 
-  vtkMRMLCopyVectorMacro(RotationHandleComponentVisibility, bool, 4);
-  vtkMRMLCopyVectorMacro(ScaleHandleComponentVisibility, bool, 4);
-  vtkMRMLCopyVectorMacro(TranslationHandleComponentVisibility, bool, 4);
+  vtkMRMLCopyBooleanMacro(EditorVisibility3D);
+  vtkMRMLCopyVectorMacro(RotationHandleComponentVisibility3D, bool, 4);
+  vtkMRMLCopyVectorMacro(ScaleHandleComponentVisibility3D, bool, 4);
+  vtkMRMLCopyVectorMacro(TranslationHandleComponentVisibility3D, bool, 4);
+  vtkMRMLCopyVectorMacro(RotationHandleComponentVisibilitySlice, bool, 4);
+  vtkMRMLCopyVectorMacro(ScaleHandleComponentVisibilitySlice, bool, 4);
+  vtkMRMLCopyVectorMacro(TranslationHandleComponentVisibilitySlice, bool, 4);
 
   vtkMRMLCopyEndMacro();
 }
@@ -310,9 +331,13 @@ void vtkMRMLTransformDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << " EditorRotationEnabled=\"" << this->EditorRotationEnabled << "\n";
   os << indent << " EditorScalingEnabled=\""<< this->EditorScalingEnabled << "\n";
 
-  vtkMRMLPrintVectorMacro(RotationHandleComponentVisibility, bool, 4);
-  vtkMRMLPrintVectorMacro(ScaleHandleComponentVisibility, bool, 4);
-  vtkMRMLPrintVectorMacro(TranslationHandleComponentVisibility, bool, 4);
+  vtkMRMLPrintBooleanMacro(EditorVisibility3D);
+  vtkMRMLPrintVectorMacro(RotationHandleComponentVisibility3D, bool, 4);
+  vtkMRMLPrintVectorMacro(ScaleHandleComponentVisibility3D, bool, 4);
+  vtkMRMLPrintVectorMacro(TranslationHandleComponentVisibility3D, bool, 4);
+  vtkMRMLPrintVectorMacro(RotationHandleComponentVisibilitySlice, bool, 4);
+  vtkMRMLPrintVectorMacro(ScaleHandleComponentVisibilitySlice, bool, 4);
+  vtkMRMLPrintVectorMacro(TranslationHandleComponentVisibilitySlice, bool, 4);
 
   vtkMRMLPrintEndMacro();
 }

--- a/Libs/MRML/Core/vtkMRMLTransformDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformDisplayNode.h
@@ -170,18 +170,30 @@ class VTK_MRML_EXPORT vtkMRMLTransformDisplayNode : public vtkMRMLDisplayNode
   vtkGetMacro(EditorVisibility, bool);
   vtkSetMacro(EditorVisibility, bool);
   vtkBooleanMacro(EditorVisibility, bool);
+  vtkGetMacro(EditorVisibility3D, bool);
+  vtkSetMacro(EditorVisibility3D, bool);
+  vtkBooleanMacro(EditorVisibility3D, bool);
   vtkGetMacro(EditorSliceIntersectionVisibility, bool);
   vtkSetMacro(EditorSliceIntersectionVisibility, bool);
   vtkBooleanMacro(EditorSliceIntersectionVisibility, bool);
   vtkGetMacro(EditorTranslationEnabled, bool);
   vtkSetMacro(EditorTranslationEnabled, bool);
   vtkBooleanMacro(EditorTranslationEnabled, bool);
+  vtkGetMacro(EditorTranslationSliceEnabled, bool);
+  vtkSetMacro(EditorTranslationSliceEnabled, bool);
+  vtkBooleanMacro(EditorTranslationSliceEnabled, bool);
   vtkGetMacro(EditorRotationEnabled, bool);
   vtkSetMacro(EditorRotationEnabled, bool);
   vtkBooleanMacro(EditorRotationEnabled, bool);
+  vtkGetMacro(EditorRotationSliceEnabled, bool);
+  vtkSetMacro(EditorRotationSliceEnabled, bool);
+  vtkBooleanMacro(EditorRotationSliceEnabled, bool);
   vtkGetMacro(EditorScalingEnabled, bool);
   vtkSetMacro(EditorScalingEnabled, bool);
   vtkBooleanMacro(EditorScalingEnabled, bool);
+  vtkGetMacro(EditorScalingSliceEnabled, bool);
+  vtkSetMacro(EditorScalingSliceEnabled, bool);
+  vtkBooleanMacro(EditorScalingSliceEnabled, bool);
 
   /// Ask the editor to recompute its bounds by invoking the
   /// TransformUpdateEditorBoundsEvent event.
@@ -224,12 +236,18 @@ class VTK_MRML_EXPORT vtkMRMLTransformDisplayNode : public vtkMRMLDisplayNode
   /// The order of the vector is: [X, Y, Z, ViewPlane]
   /// "ViewPlane" scale/translation allows transformations to take place along the active view plane.
   /// (ex. center translation point and ROI corner scale handles.
-  vtkSetVector4Macro(RotationHandleComponentVisibility, bool);
-  vtkGetVector4Macro(RotationHandleComponentVisibility, bool);
-  vtkSetVector4Macro(ScaleHandleComponentVisibility, bool);
-  vtkGetVector4Macro(ScaleHandleComponentVisibility, bool);
-  vtkSetVector4Macro(TranslationHandleComponentVisibility, bool);
-  vtkGetVector4Macro(TranslationHandleComponentVisibility, bool);
+  vtkSetVector4Macro(RotationHandleComponentVisibility3D, bool);
+  vtkGetVector4Macro(RotationHandleComponentVisibility3D, bool);
+  vtkSetVector4Macro(ScaleHandleComponentVisibility3D, bool);
+  vtkGetVector4Macro(ScaleHandleComponentVisibility3D, bool);
+  vtkSetVector4Macro(TranslationHandleComponentVisibility3D, bool);
+  vtkGetVector4Macro(TranslationHandleComponentVisibility3D, bool);
+  vtkSetVector4Macro(RotationHandleComponentVisibilitySlice, bool);
+  vtkGetVector4Macro(RotationHandleComponentVisibilitySlice, bool);
+  vtkSetVector4Macro(ScaleHandleComponentVisibilitySlice, bool);
+  vtkGetVector4Macro(ScaleHandleComponentVisibilitySlice, bool);
+  vtkSetVector4Macro(TranslationHandleComponentVisibilitySlice, bool);
+  vtkGetVector4Macro(TranslationHandleComponentVisibilitySlice, bool);
   //@}
 
 protected:
@@ -270,10 +288,14 @@ protected:
 
   // Interaction Parameters
   bool EditorVisibility;
+  bool EditorVisibility3D;
   bool EditorSliceIntersectionVisibility;
   bool EditorTranslationEnabled;
+  bool EditorTranslationSliceEnabled;
   bool EditorRotationEnabled;
+  bool EditorRotationSliceEnabled;
   bool EditorScalingEnabled;
+  bool EditorScalingSliceEnabled;
 
   int ActiveInteractionType{-1};
   int ActiveInteractionIndex{-1};
@@ -281,9 +303,13 @@ protected:
   double InteractionSizeMm{5.0};
   double InteractionScalePercent{15.0};
 
-  bool RotationHandleComponentVisibility[4];
-  bool ScaleHandleComponentVisibility[4];
-  bool TranslationHandleComponentVisibility[4];
+  bool RotationHandleComponentVisibility3D[4];
+  bool ScaleHandleComponentVisibility3D[4];
+  bool TranslationHandleComponentVisibility3D[4];
+
+  bool RotationHandleComponentVisibilitySlice[4];
+  bool ScaleHandleComponentVisibilitySlice[4];
+  bool TranslationHandleComponentVisibilitySlice[4];
 
  protected:
   vtkMRMLTransformDisplayNode ( );

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager2D.cxx
@@ -246,7 +246,7 @@ void vtkMRMLLinearTransformsDisplayableManager2D::vtkInternal::RemoveDisplayNode
 //---------------------------------------------------------------------------
 void vtkMRMLLinearTransformsDisplayableManager2D::vtkInternal::AddDisplayNode(vtkMRMLTransformNode* mNode, vtkMRMLTransformDisplayNode* displayNode)
 {
-  if (!mNode || !displayNode)
+  if (!mNode || !displayNode || !mNode->IsLinear())
     {
     return;
     }
@@ -277,6 +277,12 @@ void vtkMRMLLinearTransformsDisplayableManager2D::vtkInternal::UpdateDisplayNode
   //   otherwise, add as new node
 
   if (!displayNode)
+    {
+    return;
+    }
+
+  vtkMRMLTransformNode* transformNode = vtkMRMLTransformNode::SafeDownCast(displayNode->GetDisplayableNode());
+  if (!transformNode || !transformNode->IsLinear())
     {
     return;
     }

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager3D.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager3D.cxx
@@ -339,7 +339,7 @@ void vtkMRMLLinearTransformsDisplayableManager3D::vtkInternal::UpdateInteraction
 void vtkMRMLLinearTransformsDisplayableManager3D::vtkInternal::UpdateInteractionPipeline(
   vtkMRMLTransformNode* displayableNode, unsigned long event, vtkMRMLTransformDisplayNode* displayNode)
 {
-  if (!displayableNode || !displayNode)
+  if (!displayableNode || !displayNode || !displayableNode->IsLinear())
     {
     return;
     }
@@ -347,7 +347,7 @@ void vtkMRMLLinearTransformsDisplayableManager3D::vtkInternal::UpdateInteraction
   vtkSmartPointer<vtkMRMLTransformHandleWidget> widget;
   InteractionPipelinesCacheType::iterator pipelineIt = this->InteractionPipelines.find(displayNode);
 
-  bool visible = displayNode->GetEditorVisibility();
+  bool visible = displayNode->GetEditorVisibility() && displayNode->GetEditorVisibility3D();
   if (visible && pipelineIt == this->InteractionPipelines.end())
     {
     // No pipeline, yet interaction visibility is on, create a new one

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidgetRepresentation.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidgetRepresentation.cxx
@@ -115,7 +115,7 @@ bool vtkMRMLTransformHandleWidgetRepresentation::IsDisplayable()
     return this->GetDisplayNode()->GetEditorSliceIntersectionVisibility();
     }
 
-  return true;
+  return this->GetDisplayNode()->GetEditorVisibility3D();
 }
 
 //----------------------------------------------------------------------
@@ -205,32 +205,40 @@ bool vtkMRMLTransformHandleWidgetRepresentation::GetHandleVisibility(int type, i
     return false;
     }
 
+  vtkMRMLSliceNode* sliceNode = this->GetSliceNode();
+
   bool visible = Superclass::GetHandleVisibility(type, index);
   if (type == InteractionRotationHandle)
     {
-    visible &= displayNode->GetEditorRotationEnabled();
+    visible &= sliceNode ? displayNode->GetEditorRotationSliceEnabled() : displayNode->GetEditorRotationEnabled();
     }
   else if (type == InteractionTranslationHandle)
     {
-    visible &= displayNode->GetEditorTranslationEnabled();
+    visible &= sliceNode ? displayNode->GetEditorTranslationSliceEnabled() : displayNode->GetEditorTranslationEnabled();
     }
   else if (type == InteractionScaleHandle)
     {
-    visible &= displayNode->GetEditorScalingEnabled();
+    visible &= sliceNode ? displayNode->GetEditorScalingSliceEnabled() : displayNode->GetEditorScalingEnabled();
     }
 
   bool handleVisibility[4] = { false, false, false, false };
   if (type == InteractionRotationHandle)
     {
-    this->GetDisplayNode()->GetRotationHandleComponentVisibility(handleVisibility);
+    sliceNode
+      ? this->GetDisplayNode()->GetRotationHandleComponentVisibilitySlice(handleVisibility)
+      : this->GetDisplayNode()->GetRotationHandleComponentVisibility3D(handleVisibility);
     }
   else if (type == InteractionScaleHandle)
     {
-    this->GetDisplayNode()->GetScaleHandleComponentVisibility(handleVisibility);
+    sliceNode
+      ? this->GetDisplayNode()->GetScaleHandleComponentVisibilitySlice(handleVisibility)
+      : this->GetDisplayNode()->GetScaleHandleComponentVisibility3D(handleVisibility);
     }
   else if (type == InteractionTranslationHandle)
     {
-    this->GetDisplayNode()->GetTranslationHandleComponentVisibility(handleVisibility);
+    sliceNode
+      ? this->GetDisplayNode()->GetTranslationHandleComponentVisibilitySlice(handleVisibility)
+      : this->GetDisplayNode()->GetTranslationHandleComponentVisibility3D(handleVisibility);
     }
 
   if (index >= 0 && index <= 3)

--- a/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.cxx
+++ b/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.cxx
@@ -121,12 +121,12 @@ void qSlicerSubjectHierarchyTransformsPluginPrivate::init()
   this->ResetCenterOfTransformCurrentItemAction = new QAction(qSlicerSubjectHierarchyTransformsPlugin::tr("Reset center of transformation"), q);
   QObject::connect(this->ResetCenterOfTransformCurrentItemAction, SIGNAL(triggered()), q, SLOT(resetCenterOfTransformationCurrentItem()));
 
-  this->ToggleInteractionAction = new QAction(qSlicerSubjectHierarchyTransformsPlugin::tr("Interaction in 3D view"), q);
+  this->ToggleInteractionAction = new QAction(qSlicerSubjectHierarchyTransformsPlugin::tr("Interaction"), q);
   QObject::connect(this->ToggleInteractionAction, SIGNAL(toggled(bool)), q, SLOT(toggleInteractionBox(bool)));
   this->ToggleInteractionAction->setCheckable(true);
   this->ToggleInteractionAction->setChecked(false);
 
-  this->ToggleInteractionItemAction = new QAction(qSlicerSubjectHierarchyTransformsPlugin::tr("Interaction in 3D view"), q);
+  this->ToggleInteractionItemAction = new QAction(qSlicerSubjectHierarchyTransformsPlugin::tr("Interaction"), q);
   QObject::connect(this->ToggleInteractionItemAction, SIGNAL(toggled(bool)), q, SLOT(toggleInteractionBox(bool)));
   this->ToggleInteractionItemAction->setCheckable(true);
   this->ToggleInteractionItemAction->setChecked(false);
@@ -440,14 +440,10 @@ void qSlicerSubjectHierarchyTransformsPlugin::showVisibilityContextMenuActionsFo
       }
 
     vtkMRMLTransformNode* transformNode = vtkMRMLTransformNode::SafeDownCast(shNode->GetItemDataNode(itemID));
-    if (transformNode)
+    if (!transformNode)
       {
-      // We only display this option for transformable nodes, not transform nodes where
-      // the option is controlled by regular visibility options.
-      return;
+      transformNode = transformableNode->GetParentTransformNode();
       }
-
-    transformNode = transformableNode->GetParentTransformNode();
 
     vtkMRMLTransformDisplayNode* displayNode = transformNode ? vtkMRMLTransformDisplayNode::SafeDownCast(transformNode->GetDisplayNode()) : nullptr;
 
@@ -661,6 +657,8 @@ void qSlicerSubjectHierarchyTransformsPlugin::toggleInteractionBox(bool visible)
     qCritical() << Q_FUNC_INFO << ": Failed to get or create transform node";
     return;
     }
+  transformNode->CreateDefaultDisplayNodes();
+
   vtkMRMLTransformDisplayNode* displayNode = vtkMRMLTransformDisplayNode::SafeDownCast(
     transformNode->GetDisplayNode() );
   if (!displayNode)

--- a/Modules/Loadable/Transforms/Widgets/Resources/UI/qMRMLTransformDisplayNodeWidget.ui
+++ b/Modules/Loadable/Transforms/Widgets/Resources/UI/qMRMLTransformDisplayNodeWidget.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>499</width>
-    <height>835</height>
+    <height>919</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -38,348 +38,41 @@
    <property name="bottomMargin">
     <number>4</number>
    </property>
-   <item row="5" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>1</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="0" colspan="3">
-    <widget class="ctkCollapsibleGroupBox" name="InteractionCollapsibleGroupBox">
-     <property name="title">
-      <string>Interaction</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-     <property name="collapsed">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_7">
-      <item row="0" column="0">
-       <widget class="QLabel" name="InteractionVisibleLabel">
-        <property name="text">
-         <string>Visibility: </string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_9">
-        <property name="text">
-         <string>Visibility in slice view:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QFrame" name="InteractiveAdvancedOptionsFrame">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
-        <property name="lineWidth">
-         <number>0</number>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_8">
-         <property name="leftMargin">
-          <number>12</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item row="1" column="1">
-          <widget class="QCheckBox" name="InteractiveTranslationCheckBox">
-           <property name="toolTip">
-            <string>Enable scaling by manpulating 3D widget (shift +left click and drag the handle at the center of widget face, or left click and drag the center handle)</string>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="4">
-          <widget class="QLabel" name="label_14">
-           <property name="text">
-            <string>Z</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QCheckBox" name="InteractiveRotationCheckBox">
-           <property name="toolTip">
-            <string>Enable translating by manpulating 3D widget (left click and drag anywhere on the widget face)</string>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QLabel" name="label_12">
-           <property name="text">
-            <string>X</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="InteractiveTranslationLabel">
-           <property name="text">
-            <string>Enable translation: </string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="InteractiveRotationLabel">
-           <property name="text">
-            <string>Enable rotation: </string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QCheckBox" name="InteractiveScalingCheckBox">
-           <property name="toolTip">
-            <string>Enable scaling by manpulating 3D widget (left click and drag the handle at the center of widget face)</string>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="3">
-          <widget class="QLabel" name="label_13">
-           <property name="text">
-            <string>Y</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="InteractiveScalingLabel">
-           <property name="text">
-            <string>Enable scaling: </string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="5">
-          <widget class="QLabel" name="label_15">
-           <property name="text">
-            <string>View plane</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2" alignment="Qt::AlignHCenter">
-          <widget class="QCheckBox" name="translateXCheckBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="3" alignment="Qt::AlignHCenter">
-          <widget class="QCheckBox" name="translateYCheckBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="4" alignment="Qt::AlignHCenter">
-          <widget class="QCheckBox" name="translateZCheckBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="2" alignment="Qt::AlignHCenter">
-          <widget class="QCheckBox" name="rotateXCheckBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="3" alignment="Qt::AlignHCenter">
-          <widget class="QCheckBox" name="rotateYCheckBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="4" alignment="Qt::AlignHCenter">
-          <widget class="QCheckBox" name="rotateZCheckBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="2" alignment="Qt::AlignHCenter">
-          <widget class="QCheckBox" name="scaleXCheckBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="3" alignment="Qt::AlignHCenter">
-          <widget class="QCheckBox" name="scaleYCheckBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="4" alignment="Qt::AlignHCenter">
-          <widget class="QCheckBox" name="scaleZCheckBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="5" alignment="Qt::AlignHCenter">
-          <widget class="QCheckBox" name="translateViewPlaneCheckBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="5" alignment="Qt::AlignHCenter">
-          <widget class="QCheckBox" name="rotateViewPlaneCheckBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="5" alignment="Qt::AlignHCenter">
-          <widget class="QCheckBox" name="scaleViewPlaneCheckBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="InteractionVisible2dCheckBox">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QPushButton" name="ShowInteractionAdvancedOptionsButton">
-        <property name="text">
-         <string>More options...</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="InteractionVisibleCheckBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Show/Hide the transform widget in the 3D view.</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="3">
+   <item row="2" column="0" colspan="3">
     <widget class="ctkCollapsibleGroupBox" name="VisualizationCollapsibleGroupBox">
      <property name="title">
       <string>Visualization</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Visibility:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="Visible2dCheckBox">
-        <property name="toolTip">
-         <string>Show transform in the slice views</string>
-        </property>
-        <property name="text">
-         <string/>
+      <item row="4" column="0" colspan="2">
+       <widget class="ctkCollapsibleGroupBox" name="ColorsSection">
+        <property name="title">
+         <string>Colors</string>
         </property>
         <property name="checked">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Visibility in slice view:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Visibility in 3D view:</string>
-        </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <widget class="ctkVTKScalarsToColorsWidget" name="ColorMapWidget">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>80</height>
+            </size>
+           </property>
+           <property name="verticalSliderVisible">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
       <item row="3" column="0" colspan="2">
@@ -618,35 +311,11 @@
         </item>
        </layout>
       </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="ctkCollapsibleGroupBox" name="ColorsSection">
-        <property name="title">
-         <string>Colors</string>
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="VisibleCheckBox">
+        <property name="text">
+         <string/>
         </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="ctkVTKScalarsToColorsWidget" name="ColorMapWidget">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>80</height>
-            </size>
-           </property>
-           <property name="verticalSliderVisible">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </widget>
       </item>
       <item row="5" column="0" colspan="2">
@@ -1363,11 +1032,546 @@
         </layout>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="VisibleCheckBox">
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Visibility in 3D view:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="Visible2dCheckBox">
+        <property name="toolTip">
+         <string>Show transform in the slice views</string>
+        </property>
         <property name="text">
          <string/>
         </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Visibility:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Visibility in slice view:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>1</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0" colspan="3">
+    <widget class="ctkCollapsibleGroupBox" name="InteractionCollapsibleGroupBox">
+     <property name="title">
+      <string>Interaction</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="collapsed">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_7">
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="InteractionVisibleCheckBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Show/Hide the transform widget in the 3D view.</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>Visibility in slice view:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QCheckBox" name="InteractionVisible2dCheckBox">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QPushButton" name="ShowInteractionAdvancedOptionsButton">
+        <property name="text">
+         <string>More options...</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="InteractionVisible3dCheckBox">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="InteractionVisibleLabel">
+        <property name="text">
+         <string>Visibility: </string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_17">
+        <property name="text">
+         <string>Visibility in 3D view:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QFrame" name="InteractiveAdvancedOptions3DFrame">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <property name="lineWidth">
+         <number>0</number>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_8">
+         <property name="leftMargin">
+          <number>12</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>12</number>
+         </property>
+         <item row="3" column="1">
+          <widget class="QCheckBox" name="InteractiveScaling3DCheckBox">
+           <property name="toolTip">
+            <string>Enable scaling by manpulating 3D widget (left click and drag the handle at the center of widget face)</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="translateX3DCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3">
+          <widget class="QLabel" name="label_13">
+           <property name="text">
+            <string>Y</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="rotateX3DCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="5" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="scaleViewPlane3DCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="5" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="translateViewPlane3DCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="5">
+          <widget class="QLabel" name="label_15">
+           <property name="text">
+            <string>View plane</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="scaleX3DCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="InteractiveRotationLabel">
+           <property name="text">
+            <string>Enable rotation: </string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="4" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="translateZ3DCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="3" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="rotateY3DCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="4">
+          <widget class="QLabel" name="label_14">
+           <property name="text">
+            <string>Z</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="3" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="translateY3DCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QCheckBox" name="InteractiveRotation3DCheckBox">
+           <property name="toolTip">
+            <string>Enable translating by manpulating 3D widget (left click and drag anywhere on the widget face)</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="4" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="rotateZ3DCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="label_12">
+           <property name="text">
+            <string>X</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="InteractiveScalingLabel">
+           <property name="text">
+            <string>Enable scaling: </string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="5" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="rotateViewPlane3DCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="4" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="scaleZ3DCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="InteractiveTranslation3DCheckBox">
+           <property name="toolTip">
+            <string>Enable scaling by manpulating 3D widget (shift +left click and drag the handle at the center of widget face, or left click and drag the center handle)</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="InteractiveTranslationLabel">
+           <property name="text">
+            <string>Enable translation: </string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="3" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="scaleY3DCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="3">
+       <widget class="QFrame" name="InteractiveAdvancedOptionsSliceFrame">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <property name="lineWidth">
+         <number>0</number>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_9">
+         <property name="leftMargin">
+          <number>12</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>12</number>
+         </property>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_22">
+           <property name="text">
+            <string>Enable rotation: </string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="InteractiveTranslationSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_21">
+           <property name="text">
+            <string>Enable translation: </string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="4" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="translateZSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="3" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="rotateYSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QCheckBox" name="InteractiveScalingSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="5" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="rotateViewPlaneSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="3" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="scaleYSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="translateXSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QCheckBox" name="InteractiveRotationSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="4" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="scaleZSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="scaleXSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="5" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="translateViewPlaneSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_23">
+           <property name="text">
+            <string>Enable scaling: </string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="4" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="rotateZSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="5" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="scaleViewPlaneSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="rotateXSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="3" alignment="Qt::AlignHCenter">
+          <widget class="QCheckBox" name="translateYSliceCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="label_11">
+           <property name="text">
+            <string>X</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3">
+          <widget class="QLabel" name="label_16">
+           <property name="text">
+            <string>Y</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="4">
+          <widget class="QLabel" name="label_18">
+           <property name="text">
+            <string>Z</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="5">
+          <widget class="QLabel" name="label_19">
+           <property name="text">
+            <string>View plane</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>
@@ -1741,7 +1945,7 @@
   <connection>
    <sender>ShowInteractionAdvancedOptionsButton</sender>
    <signal>toggled(bool)</signal>
-   <receiver>InteractiveAdvancedOptionsFrame</receiver>
+   <receiver>InteractiveAdvancedOptions3DFrame</receiver>
    <slot>setVisible(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -1751,6 +1955,22 @@
     <hint type="destinationlabel">
      <x>780</x>
      <y>108</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ShowInteractionAdvancedOptionsButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>InteractiveAdvancedOptionsSliceFrame</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>441</x>
+     <y>39</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>249</x>
+     <y>205</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.cxx
@@ -110,27 +110,49 @@ void qMRMLTransformDisplayNodeWidgetPrivate
 
   // Interaction panel
   QObject::connect(this->InteractionVisibleCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorVisibility(bool)));
+  QObject::connect(this->InteractionVisible3dCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorVisibility3d(bool)));
   QObject::connect(this->InteractionVisible2dCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorVisibility2d(bool)));
-  QObject::connect(this->InteractiveTranslationCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorTranslationEnabled(bool)));
-  QObject::connect(this->InteractiveRotationCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorRotationEnabled(bool)));
-  QObject::connect(this->InteractiveScalingCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorScalingEnabled(bool)));
 
-  QObject::connect(this->translateXCheckBox, SIGNAL(clicked()), q, SLOT(updateTranslationComponentVisibility()));
-  QObject::connect(this->translateYCheckBox, SIGNAL(clicked()), q, SLOT(updateTranslationComponentVisibility()));
-  QObject::connect(this->translateZCheckBox, SIGNAL(clicked()), q, SLOT(updateTranslationComponentVisibility()));
-  QObject::connect(this->translateViewPlaneCheckBox, SIGNAL(clicked()), q, SLOT(updateTranslationComponentVisibility()));
+  QObject::connect(this->InteractiveTranslation3DCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorTranslationEnabled(bool)));
+  QObject::connect(this->InteractiveRotation3DCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorRotationEnabled(bool)));
+  QObject::connect(this->InteractiveScaling3DCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorScalingEnabled(bool)));
 
-  QObject::connect(this->rotateXCheckBox, SIGNAL(clicked()), q, SLOT(updateRotationComponentVisibility()));
-  QObject::connect(this->rotateYCheckBox, SIGNAL(clicked()), q, SLOT(updateRotationComponentVisibility()));
-  QObject::connect(this->rotateZCheckBox, SIGNAL(clicked()), q, SLOT(updateRotationComponentVisibility()));
-  QObject::connect(this->rotateViewPlaneCheckBox, SIGNAL(clicked()), q, SLOT(updateRotationComponentVisibility()));
+  QObject::connect(this->InteractiveTranslationSliceCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorTranslationSliceEnabled(bool)));
+  QObject::connect(this->InteractiveRotationSliceCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorRotationSliceEnabled(bool)));
+  QObject::connect(this->InteractiveScalingSliceCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorScalingSliceEnabled(bool)));
 
-  QObject::connect(this->scaleXCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
-  QObject::connect(this->scaleYCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
-  QObject::connect(this->scaleZCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
-  QObject::connect(this->scaleViewPlaneCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
+  QObject::connect(this->translateX3DCheckBox, SIGNAL(clicked()), q, SLOT(updateTranslationComponentVisibility()));
+  QObject::connect(this->translateY3DCheckBox, SIGNAL(clicked()), q, SLOT(updateTranslationComponentVisibility()));
+  QObject::connect(this->translateZ3DCheckBox, SIGNAL(clicked()), q, SLOT(updateTranslationComponentVisibility()));
+  QObject::connect(this->translateViewPlane3DCheckBox, SIGNAL(clicked()), q, SLOT(updateTranslationComponentVisibility()));
 
-  this->InteractiveAdvancedOptionsFrame->hide();
+  QObject::connect(this->rotateX3DCheckBox, SIGNAL(clicked()), q, SLOT(updateRotationComponentVisibility()));
+  QObject::connect(this->rotateY3DCheckBox, SIGNAL(clicked()), q, SLOT(updateRotationComponentVisibility()));
+  QObject::connect(this->rotateZ3DCheckBox, SIGNAL(clicked()), q, SLOT(updateRotationComponentVisibility()));
+  QObject::connect(this->rotateViewPlane3DCheckBox, SIGNAL(clicked()), q, SLOT(updateRotationComponentVisibility()));
+
+  QObject::connect(this->scaleX3DCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
+  QObject::connect(this->scaleY3DCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
+  QObject::connect(this->scaleZ3DCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
+  QObject::connect(this->scaleViewPlane3DCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
+
+  QObject::connect(this->translateXSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateTranslationComponentVisibility()));
+  QObject::connect(this->translateYSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateTranslationComponentVisibility()));
+  QObject::connect(this->translateZSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateTranslationComponentVisibility()));
+  QObject::connect(this->translateViewPlaneSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateTranslationComponentVisibility()));
+
+  QObject::connect(this->rotateXSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateRotationComponentVisibility()));
+  QObject::connect(this->rotateYSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateRotationComponentVisibility()));
+  QObject::connect(this->rotateZSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateRotationComponentVisibility()));
+  QObject::connect(this->rotateViewPlaneSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateRotationComponentVisibility()));
+
+  QObject::connect(this->scaleXSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
+  QObject::connect(this->scaleYSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
+  QObject::connect(this->scaleZSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
+  QObject::connect(this->scaleViewPlaneSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
+
+  this->InteractiveAdvancedOptions3DFrame->hide();
+  this->InteractiveAdvancedOptionsSliceFrame->hide();
 
   // Visualization panel
   // by default the glyph option is selected, so hide the parameter sets for the other options
@@ -234,61 +256,6 @@ void qMRMLTransformDisplayNodeWidget
 
   // Update widget if different from MRML node
 
-  // Interaction
-
-  d->InteractionVisibleCheckBox->setChecked(d->TransformDisplayNode->GetEditorVisibility());
-  d->InteractionVisible2dCheckBox->setChecked(d->TransformDisplayNode->GetEditorSliceIntersectionVisibility());
-  d->InteractiveTranslationCheckBox->setChecked(d->TransformDisplayNode->GetEditorTranslationEnabled());
-  d->InteractiveRotationCheckBox->setChecked(d->TransformDisplayNode->GetEditorRotationEnabled());
-  d->InteractiveScalingCheckBox->setChecked(d->TransformDisplayNode->GetEditorScalingEnabled());
-
-  bool wasBlocking = false;
-
-  bool translationComponentVisibility[4] = { false, false, false, false };
-  d->TransformDisplayNode->GetTranslationHandleComponentVisibility(translationComponentVisibility);
-  wasBlocking = d->translateXCheckBox->blockSignals(true);
-  d->translateXCheckBox->setChecked(translationComponentVisibility[0]);
-  d->translateXCheckBox->blockSignals(wasBlocking);
-  wasBlocking = d->translateYCheckBox->blockSignals(true);
-  d->translateYCheckBox->setChecked(translationComponentVisibility[1]);
-  d->translateYCheckBox->blockSignals(wasBlocking);
-  wasBlocking = d->translateZCheckBox->blockSignals(true);
-  d->translateZCheckBox->setChecked(translationComponentVisibility[2]);
-  d->translateZCheckBox->blockSignals(wasBlocking);
-  wasBlocking = d->translateViewPlaneCheckBox->blockSignals(true);
-  d->translateViewPlaneCheckBox->setChecked(translationComponentVisibility[3]);
-  d->translateViewPlaneCheckBox->blockSignals(wasBlocking);
-
-  bool rotationComponentVisibility[4] = { false, false, false, false };
-  d->TransformDisplayNode->GetRotationHandleComponentVisibility(rotationComponentVisibility);
-  wasBlocking = d->rotateXCheckBox->blockSignals(true);
-  d->rotateXCheckBox->setChecked(rotationComponentVisibility[0]);
-  d->rotateXCheckBox->blockSignals(wasBlocking);
-  wasBlocking = d->rotateYCheckBox->blockSignals(true);
-  d->rotateYCheckBox->setChecked(rotationComponentVisibility[1]);
-  d->rotateYCheckBox->blockSignals(wasBlocking);
-  wasBlocking = d->rotateZCheckBox->blockSignals(true);
-  d->rotateZCheckBox->setChecked(rotationComponentVisibility[2]);
-  d->rotateZCheckBox->blockSignals(wasBlocking);
-  wasBlocking = d->rotateViewPlaneCheckBox->blockSignals(true);
-  d->rotateViewPlaneCheckBox->setChecked(rotationComponentVisibility[3]);
-  d->rotateViewPlaneCheckBox->blockSignals(wasBlocking);
-
-  bool scalingComponentVisibility[4] = { false, false, false, false };
-  d->TransformDisplayNode->GetScaleHandleComponentVisibility(scalingComponentVisibility);
-  wasBlocking = d->scaleXCheckBox->blockSignals(true);
-  d->scaleXCheckBox->setChecked(scalingComponentVisibility[0]);
-  d->scaleXCheckBox->blockSignals(wasBlocking);
-  wasBlocking = d->scaleYCheckBox->blockSignals(true);
-  d->scaleYCheckBox->setChecked(scalingComponentVisibility[1]);
-  d->scaleYCheckBox->blockSignals(wasBlocking);
-  wasBlocking = d->scaleZCheckBox->blockSignals(true);
-  d->scaleZCheckBox->setChecked(scalingComponentVisibility[2]);
-  d->scaleZCheckBox->blockSignals(wasBlocking);
-  wasBlocking = d->scaleViewPlaneCheckBox->blockSignals(true);
-  d->scaleViewPlaneCheckBox->setChecked(scalingComponentVisibility[3]);
-  d->scaleViewPlaneCheckBox->blockSignals(wasBlocking);
-
   // Display
 
   d->VisibleCheckBox->setChecked(d->TransformDisplayNode->GetVisibility());
@@ -352,7 +319,233 @@ void qMRMLTransformDisplayNodeWidget
     }
 
   // Interaction
+  bool wasBlocking = false;
+
+  wasBlocking = d->InteractionVisibleCheckBox->blockSignals(true);
   d->InteractionVisibleCheckBox->setChecked(d->TransformDisplayNode->GetEditorVisibility());
+  d->InteractionVisibleCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->InteractionVisible3dCheckBox->blockSignals(true);
+  d->InteractionVisible3dCheckBox->setChecked(d->TransformDisplayNode->GetEditorVisibility3D());
+  d->InteractionVisible3dCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->InteractionVisible2dCheckBox->blockSignals(true);
+  d->InteractionVisible2dCheckBox->setChecked(d->TransformDisplayNode->GetEditorSliceIntersectionVisibility());
+  d->InteractionVisible2dCheckBox->blockSignals(wasBlocking);
+
+  this->updateInteraction3DWidgetsFromDisplayNode();
+  this->updateInteractionSliceWidgetsFromDisplayNode();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLTransformDisplayNodeWidget
+::updateInteraction3DWidgetsFromDisplayNode()
+{
+  Q_D(qMRMLTransformDisplayNodeWidget);
+
+  if (!d->TransformDisplayNode)
+    {
+    return;
+    }
+
+  bool wasBlocking = false;
+
+  bool enabled3D = d->TransformDisplayNode->GetEditorVisibility3D();
+
+  //////////////
+  // Translation
+  wasBlocking = d->InteractiveTranslation3DCheckBox->blockSignals(true);
+  bool translationEnabled = d->TransformDisplayNode->GetEditorTranslationEnabled();
+  d->InteractiveTranslation3DCheckBox->setChecked(translationEnabled);
+  d->InteractiveTranslation3DCheckBox->blockSignals(wasBlocking);
+  d->InteractiveTranslation3DCheckBox->setEnabled(enabled3D);
+
+  bool translationComponentVisibility[4] = { false, false, false, false };
+  d->TransformDisplayNode->GetTranslationHandleComponentVisibility3D(translationComponentVisibility);
+  wasBlocking = d->translateX3DCheckBox->blockSignals(true);
+  d->translateX3DCheckBox->setChecked(translationComponentVisibility[0]);
+  d->translateX3DCheckBox->blockSignals(wasBlocking);
+  d->translateX3DCheckBox->setEnabled(translationEnabled && enabled3D);
+
+  wasBlocking = d->translateY3DCheckBox->blockSignals(true);
+  d->translateY3DCheckBox->setChecked(translationComponentVisibility[1]);
+  d->translateY3DCheckBox->blockSignals(wasBlocking);
+  d->translateY3DCheckBox->setEnabled(translationEnabled && enabled3D);
+
+  wasBlocking = d->translateZ3DCheckBox->blockSignals(true);
+  d->translateZ3DCheckBox->setChecked(translationComponentVisibility[2]);
+  d->translateZ3DCheckBox->blockSignals(wasBlocking);
+  d->translateZ3DCheckBox->setEnabled(translationEnabled && enabled3D);
+
+  wasBlocking = d->translateViewPlane3DCheckBox->blockSignals(true);
+  d->translateViewPlane3DCheckBox->setChecked(translationComponentVisibility[3]);
+  d->translateViewPlane3DCheckBox->blockSignals(wasBlocking);
+  d->translateViewPlane3DCheckBox->setEnabled(translationEnabled && enabled3D);
+
+  //////////////
+  // Rotation
+  wasBlocking = d->InteractiveRotation3DCheckBox->blockSignals(true);
+  bool rotationEnabled = d->TransformDisplayNode->GetEditorRotationEnabled();
+  d->InteractiveRotation3DCheckBox->setChecked(rotationEnabled);
+  d->InteractiveRotation3DCheckBox->blockSignals(wasBlocking);
+  d->InteractiveRotation3DCheckBox->setEnabled(enabled3D);
+
+  bool rotationComponentVisibility[4] = { false, false, false, false };
+  d->TransformDisplayNode->GetRotationHandleComponentVisibility3D(rotationComponentVisibility);
+  wasBlocking = d->rotateX3DCheckBox->blockSignals(true);
+  d->rotateX3DCheckBox->setChecked(rotationComponentVisibility[0]);
+  d->rotateX3DCheckBox->blockSignals(wasBlocking);
+  d->rotateX3DCheckBox->setEnabled(rotationEnabled && enabled3D);
+
+  wasBlocking = d->rotateY3DCheckBox->blockSignals(true);
+  d->rotateY3DCheckBox->setChecked(rotationComponentVisibility[1]);
+  d->rotateY3DCheckBox->blockSignals(wasBlocking);
+  d->rotateY3DCheckBox->setEnabled(rotationEnabled && enabled3D);
+
+  wasBlocking = d->rotateZ3DCheckBox->blockSignals(true);
+  d->rotateZ3DCheckBox->setChecked(rotationComponentVisibility[2]);
+  d->rotateZ3DCheckBox->blockSignals(wasBlocking);
+  d->rotateZ3DCheckBox->setEnabled(rotationEnabled && enabled3D);
+
+  wasBlocking = d->rotateViewPlane3DCheckBox->blockSignals(true);
+  d->rotateViewPlane3DCheckBox->setChecked(rotationComponentVisibility[3]);
+  d->rotateViewPlane3DCheckBox->blockSignals(wasBlocking);
+  d->rotateViewPlane3DCheckBox->setEnabled(rotationEnabled && enabled3D);
+
+  //////////////
+  // Scaling
+  wasBlocking = d->InteractiveScaling3DCheckBox->blockSignals(true);
+  bool scalingEnabled = d->TransformDisplayNode->GetEditorScalingEnabled();
+  d->InteractiveScaling3DCheckBox->setChecked(scalingEnabled);
+  d->InteractiveScaling3DCheckBox->blockSignals(wasBlocking);
+  d->InteractiveScaling3DCheckBox->setEnabled(enabled3D);
+
+  bool scalingComponentVisibility[4] = { false, false, false, false };
+  d->TransformDisplayNode->GetScaleHandleComponentVisibility3D(scalingComponentVisibility);
+  wasBlocking = d->scaleX3DCheckBox->blockSignals(true);
+  d->scaleX3DCheckBox->setChecked(scalingComponentVisibility[0]);
+  d->scaleX3DCheckBox->blockSignals(wasBlocking);
+  d->scaleX3DCheckBox->setEnabled(scalingEnabled && enabled3D);
+
+  wasBlocking = d->scaleY3DCheckBox->blockSignals(true);
+  d->scaleY3DCheckBox->setChecked(scalingComponentVisibility[1]);
+  d->scaleY3DCheckBox->blockSignals(wasBlocking);
+  d->scaleY3DCheckBox->setEnabled(scalingEnabled && enabled3D);
+
+  wasBlocking = d->scaleZ3DCheckBox->blockSignals(true);
+  d->scaleZ3DCheckBox->setChecked(scalingComponentVisibility[2]);
+  d->scaleZ3DCheckBox->blockSignals(wasBlocking);
+  d->scaleZ3DCheckBox->setEnabled(scalingEnabled && enabled3D);
+
+  wasBlocking = d->scaleViewPlane3DCheckBox->blockSignals(true);
+  d->scaleViewPlane3DCheckBox->setChecked(scalingComponentVisibility[3]);
+  d->scaleViewPlane3DCheckBox->blockSignals(wasBlocking);
+  d->scaleViewPlane3DCheckBox->setEnabled(scalingEnabled && enabled3D);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLTransformDisplayNodeWidget::updateInteractionSliceWidgetsFromDisplayNode()
+{
+  Q_D(qMRMLTransformDisplayNodeWidget);
+
+  if (!d->TransformDisplayNode)
+    {
+    return;
+    }
+
+  bool wasBlocking = false;
+
+  bool enabledSlice = d->TransformDisplayNode->GetEditorSliceIntersectionVisibility();
+
+  //////////////
+  // Translation
+  wasBlocking = d->InteractiveTranslationSliceCheckBox->blockSignals(true);
+  bool translationEnabled = d->TransformDisplayNode->GetEditorTranslationSliceEnabled();
+  d->InteractiveTranslationSliceCheckBox->setChecked(translationEnabled);
+  d->InteractiveTranslationSliceCheckBox->blockSignals(wasBlocking);
+  d->InteractiveTranslationSliceCheckBox->setEnabled(enabledSlice);
+
+  bool translationComponentVisibility[4] = { false, false, false, false };
+  d->TransformDisplayNode->GetTranslationHandleComponentVisibilitySlice(translationComponentVisibility);
+  wasBlocking = d->translateXSliceCheckBox->blockSignals(true);
+  d->translateXSliceCheckBox->setChecked(translationComponentVisibility[0]);
+  d->translateXSliceCheckBox->blockSignals(wasBlocking);
+  d->translateXSliceCheckBox->setEnabled(translationEnabled && enabledSlice);
+
+  wasBlocking = d->translateYSliceCheckBox->blockSignals(true);
+  d->translateYSliceCheckBox->setChecked(translationComponentVisibility[1]);
+  d->translateYSliceCheckBox->blockSignals(wasBlocking);
+  d->translateYSliceCheckBox->setEnabled(translationEnabled && enabledSlice);
+
+  wasBlocking = d->translateZSliceCheckBox->blockSignals(true);
+  d->translateZSliceCheckBox->setChecked(translationComponentVisibility[2]);
+  d->translateZSliceCheckBox->blockSignals(wasBlocking);
+  d->translateZSliceCheckBox->setEnabled(translationEnabled && enabledSlice);
+
+  wasBlocking = d->translateViewPlaneSliceCheckBox->blockSignals(true);
+  d->translateViewPlaneSliceCheckBox->setChecked(translationComponentVisibility[3]);
+  d->translateViewPlaneSliceCheckBox->blockSignals(wasBlocking);
+  d->translateViewPlaneSliceCheckBox->setEnabled(translationEnabled && enabledSlice);
+
+  //////////////
+  // Rotation
+  wasBlocking = d->InteractiveRotationSliceCheckBox->blockSignals(true);
+  bool rotationEnabled = d->TransformDisplayNode->GetEditorRotationSliceEnabled();
+  d->InteractiveRotationSliceCheckBox->setChecked(rotationEnabled);
+  d->InteractiveRotationSliceCheckBox->blockSignals(wasBlocking);
+  d->InteractiveRotationSliceCheckBox->setEnabled(enabledSlice);
+
+  bool rotationComponentVisibility[4] = { false, false, false, false };
+  d->TransformDisplayNode->GetRotationHandleComponentVisibilitySlice(rotationComponentVisibility);
+  wasBlocking = d->rotateXSliceCheckBox->blockSignals(true);
+  d->rotateXSliceCheckBox->setChecked(rotationComponentVisibility[0]);
+  d->rotateXSliceCheckBox->blockSignals(wasBlocking);
+  d->rotateXSliceCheckBox->setEnabled(rotationEnabled && enabledSlice);
+
+  wasBlocking = d->rotateYSliceCheckBox->blockSignals(true);
+  d->rotateYSliceCheckBox->setChecked(rotationComponentVisibility[1]);
+  d->rotateYSliceCheckBox->blockSignals(wasBlocking);
+  d->rotateYSliceCheckBox->setEnabled(rotationEnabled && enabledSlice);
+
+  wasBlocking = d->rotateZSliceCheckBox->blockSignals(true);
+  d->rotateZSliceCheckBox->setChecked(rotationComponentVisibility[2]);
+  d->rotateZSliceCheckBox->blockSignals(wasBlocking);
+  d->rotateZSliceCheckBox->setEnabled(rotationEnabled && enabledSlice);
+
+  wasBlocking = d->rotateViewPlaneSliceCheckBox->blockSignals(true);
+  d->rotateViewPlaneSliceCheckBox->setChecked(rotationComponentVisibility[3]);
+  d->rotateViewPlaneSliceCheckBox->blockSignals(wasBlocking);
+  d->rotateViewPlaneSliceCheckBox->setEnabled(rotationEnabled && enabledSlice);
+
+  //////////////
+  // Scaling
+  wasBlocking = d->InteractiveScalingSliceCheckBox->blockSignals(true);
+  bool scalingEnabled = d->TransformDisplayNode->GetEditorScalingSliceEnabled();
+  d->InteractiveScalingSliceCheckBox->setChecked(scalingEnabled);
+  d->InteractiveScalingSliceCheckBox->blockSignals(wasBlocking);
+  d->InteractiveScalingSliceCheckBox->setEnabled(enabledSlice);
+
+  bool scalingComponentVisibility[4] = { false, false, false, false };
+  d->TransformDisplayNode->GetScaleHandleComponentVisibilitySlice(scalingComponentVisibility);
+  wasBlocking = d->scaleXSliceCheckBox->blockSignals(true);
+  d->scaleXSliceCheckBox->setChecked(scalingComponentVisibility[0]);
+  d->scaleXSliceCheckBox->blockSignals(wasBlocking);
+  d->scaleXSliceCheckBox->setEnabled(scalingEnabled && enabledSlice);
+
+  wasBlocking = d->scaleYSliceCheckBox->blockSignals(true);
+  d->scaleYSliceCheckBox->setChecked(scalingComponentVisibility[1]);
+  d->scaleYSliceCheckBox->blockSignals(wasBlocking);
+  d->scaleYSliceCheckBox->setEnabled(scalingEnabled && enabledSlice);
+
+  wasBlocking = d->scaleZSliceCheckBox->blockSignals(true);
+  d->scaleZSliceCheckBox->setChecked(scalingComponentVisibility[2]);
+  d->scaleZSliceCheckBox->blockSignals(wasBlocking);
+  d->scaleZSliceCheckBox->setEnabled(scalingEnabled && enabledSlice);
+
+  wasBlocking = d->scaleViewPlaneSliceCheckBox->blockSignals(true);
+  d->scaleViewPlaneSliceCheckBox->setChecked(scalingComponentVisibility[3]);
+  d->scaleViewPlaneSliceCheckBox->blockSignals(wasBlocking);
+  d->scaleViewPlaneSliceCheckBox->setEnabled(scalingEnabled && enabledSlice);
 }
 
 //-----------------------------------------------------------------------------
@@ -649,6 +842,17 @@ void qMRMLTransformDisplayNodeWidget::setEditorVisibility(bool enabled)
 }
 
 //-----------------------------------------------------------------------------
+void qMRMLTransformDisplayNodeWidget::setEditorVisibility3d(bool enabled)
+{
+  Q_D(qMRMLTransformDisplayNodeWidget);
+  if (!d->TransformDisplayNode)
+    {
+    return;
+    }
+  d->TransformDisplayNode->SetEditorVisibility3D(enabled);
+}
+
+//-----------------------------------------------------------------------------
 void qMRMLTransformDisplayNodeWidget::setEditorVisibility2d(bool enabled)
 {
   Q_D(qMRMLTransformDisplayNodeWidget);
@@ -671,6 +875,17 @@ void qMRMLTransformDisplayNodeWidget::setEditorTranslationEnabled(bool enabled)
 }
 
 //-----------------------------------------------------------------------------
+void qMRMLTransformDisplayNodeWidget::setEditorTranslationSliceEnabled(bool enabled)
+{
+  Q_D(qMRMLTransformDisplayNodeWidget);
+  if (!d->TransformDisplayNode)
+    {
+    return;
+    }
+  d->TransformDisplayNode->SetEditorTranslationSliceEnabled(enabled);
+}
+
+//-----------------------------------------------------------------------------
 void qMRMLTransformDisplayNodeWidget::setEditorRotationEnabled(bool enabled)
 {
   Q_D(qMRMLTransformDisplayNodeWidget);
@@ -682,6 +897,17 @@ void qMRMLTransformDisplayNodeWidget::setEditorRotationEnabled(bool enabled)
 }
 
 //-----------------------------------------------------------------------------
+void qMRMLTransformDisplayNodeWidget::setEditorRotationSliceEnabled(bool enabled)
+{
+  Q_D(qMRMLTransformDisplayNodeWidget);
+  if (!d->TransformDisplayNode)
+    {
+    return;
+    }
+  d->TransformDisplayNode->SetEditorRotationSliceEnabled(enabled);
+}
+
+//-----------------------------------------------------------------------------
 void qMRMLTransformDisplayNodeWidget::setEditorScalingEnabled(bool enabled)
 {
   Q_D(qMRMLTransformDisplayNodeWidget);
@@ -690,6 +916,17 @@ void qMRMLTransformDisplayNodeWidget::setEditorScalingEnabled(bool enabled)
     return;
     }
   d->TransformDisplayNode->SetEditorScalingEnabled(enabled);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLTransformDisplayNodeWidget::setEditorScalingSliceEnabled(bool enabled)
+{
+  Q_D(qMRMLTransformDisplayNodeWidget);
+  if (!d->TransformDisplayNode)
+    {
+    return;
+    }
+  d->TransformDisplayNode->SetEditorScalingSliceEnabled(enabled);
 }
 
 //-----------------------------------------------------------------------------
@@ -805,12 +1042,18 @@ void qMRMLTransformDisplayNodeWidget::updateTranslationComponentVisibility()
     }
 
   bool componentVisibility[4] = {
-    d->translateXCheckBox->isChecked(),
-    d->translateYCheckBox->isChecked(),
-    d->translateZCheckBox->isChecked(),
-    d->translateViewPlaneCheckBox->isChecked()
+    d->translateX3DCheckBox->isChecked(),
+    d->translateY3DCheckBox->isChecked(),
+    d->translateZ3DCheckBox->isChecked(),
+    d->translateViewPlane3DCheckBox->isChecked()
   };
-  d->TransformDisplayNode->SetTranslationHandleComponentVisibility(componentVisibility);
+  d->TransformDisplayNode->SetTranslationHandleComponentVisibility3D(componentVisibility);
+
+  componentVisibility[0] = d->translateXSliceCheckBox->isChecked();
+  componentVisibility[1] = d->translateYSliceCheckBox->isChecked();
+  componentVisibility[2] = d->translateZSliceCheckBox->isChecked();
+  componentVisibility[3] = d->translateViewPlaneSliceCheckBox->isChecked();
+  d->TransformDisplayNode->SetTranslationHandleComponentVisibilitySlice(componentVisibility);
 }
 
 // ----------------------------------------------------------------------------
@@ -823,12 +1066,18 @@ void qMRMLTransformDisplayNodeWidget::updateRotationComponentVisibility()
     }
 
   bool componentVisibility[4] = {
-    d->rotateXCheckBox->isChecked(),
-    d->rotateYCheckBox->isChecked(),
-    d->rotateZCheckBox->isChecked(),
-    d->rotateViewPlaneCheckBox->isChecked()
+    d->rotateX3DCheckBox->isChecked(),
+    d->rotateY3DCheckBox->isChecked(),
+    d->rotateZ3DCheckBox->isChecked(),
+    d->rotateViewPlane3DCheckBox->isChecked()
   };
-  d->TransformDisplayNode->SetRotationHandleComponentVisibility(componentVisibility);
+  d->TransformDisplayNode->SetRotationHandleComponentVisibility3D(componentVisibility);
+
+  componentVisibility[0] = d->rotateXSliceCheckBox->isChecked();
+  componentVisibility[1] = d->rotateYSliceCheckBox->isChecked();
+  componentVisibility[2] = d->rotateZSliceCheckBox->isChecked();
+  componentVisibility[3] = d->rotateViewPlaneSliceCheckBox->isChecked();
+  d->TransformDisplayNode->SetRotationHandleComponentVisibilitySlice(componentVisibility);
 }
 
 // ----------------------------------------------------------------------------
@@ -841,10 +1090,16 @@ void qMRMLTransformDisplayNodeWidget::updateScalingComponentVisibility()
     }
 
   bool componentVisibility[4] = {
-    d->scaleXCheckBox->isChecked(),
-    d->scaleYCheckBox->isChecked(),
-    d->scaleZCheckBox->isChecked(),
-    d->scaleViewPlaneCheckBox->isChecked()
+    d->scaleX3DCheckBox->isChecked(),
+    d->scaleY3DCheckBox->isChecked(),
+    d->scaleZ3DCheckBox->isChecked(),
+    d->scaleViewPlane3DCheckBox->isChecked()
   };
-  d->TransformDisplayNode->SetScaleHandleComponentVisibility(componentVisibility);
+  d->TransformDisplayNode->SetScaleHandleComponentVisibility3D(componentVisibility);
+
+  componentVisibility[0] = d->scaleXSliceCheckBox->isChecked();
+  componentVisibility[1] = d->scaleYSliceCheckBox->isChecked();
+  componentVisibility[2] = d->scaleZSliceCheckBox->isChecked();
+  componentVisibility[3] = d->scaleViewPlaneSliceCheckBox->isChecked();
+  d->TransformDisplayNode->SetScaleHandleComponentVisibilitySlice(componentVisibility);
 }

--- a/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.h
+++ b/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.h
@@ -88,10 +88,18 @@ public slots:
   void setContourOpacityPercent(double opacity);
 
   void setEditorVisibility(bool enabled);
+  void setEditorVisibility3d(bool enabled);
   void setEditorVisibility2d(bool enabled);
+
   void setEditorTranslationEnabled(bool enabled);
+  void setEditorTranslationSliceEnabled(bool enabled);
+
   void setEditorRotationEnabled(bool enabled);
+  void setEditorRotationSliceEnabled(bool enabled);
+
   void setEditorScalingEnabled(bool enabled);
+  void setEditorScalingSliceEnabled(bool enabled);
+
   void updateEditorBounds();
 
   void updateTranslationComponentVisibility();
@@ -106,6 +114,9 @@ public slots:
 
 protected slots:
   void updateWidgetFromDisplayNode();
+
+  void updateInteraction3DWidgetsFromDisplayNode();
+  void updateInteractionSliceWidgetsFromDisplayNode();
 
 protected:
   QScopedPointer<qMRMLTransformDisplayNodeWidgetPrivate> d_ptr;


### PR DESCRIPTION
The visibility of individual interaction axes can now be controlled separately for transform nodes.

### Default 3D visibility:
- Translation: X, Y, Z, View
- Rotation: X, Y, Z
- Scaling: None

![image](https://github.com/Slicer/Slicer/assets/9222709/8ffbf756-18ff-4c20-a1b9-a9d8568203a9)

### Default 2D visibility:
- Translation: View
- Rotation: View
- Scaling: None

![image](https://github.com/Slicer/Slicer/assets/9222709/0ab2c3d3-f10f-4805-bf63-6cb5336300e5)

### vtkMRMLTransformDisplayNode:
- EditorVisibility3D and EditorSliceIntersectionVisibility control the visibility in their respective views, while EditorVisibility controls visibility in both.
- Editor{XYZ}Enabled now only works for 3D while Editor{XYZ}SliceEnabled has been added to control 2D view visibility.
- {XYZ}HandleComponentVisibility3D allows individual axes to be enabled disabled in 3D, while {XYZ}HandleComponentVisibilitySlice does the same in 2D.

![image](https://github.com/Slicer/Slicer/assets/9222709/32941916-3e37-4961-b7a7-fab13a1c4623)

### qSlicerSubjectHierarchyTransformsPlugin:
- "Interaction in 3D view" is now "Interaction", and controls visibility in both views.

![image](https://github.com/Slicer/Slicer/assets/9222709/607fd8c2-8c59-4660-b056-8ea06fd7d10e)

Re #7570