### PR TITLE
BUG: Ensure launcher scripts installed from wheels are accessible

### DIFF
--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -278,6 +278,14 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
   mark_as_superbuild(PYTHON_VALGRIND_SUPPRESSIONS_FILE:FILEPATH)
 
   #-----------------------------------------------------------------------------
+  # Directory where executable scripts associated with "project.scripts" or "project.gui-scripts"
+  # entry-points are generated
+  set(_scripts_subdir bin)
+  if(WIN32)
+    set(_scripts_subdir Scripts)
+  endif()
+
+  #-----------------------------------------------------------------------------
   # Slicer Launcher setting specific to build tree
 
   set(_lib_subdir lib)
@@ -293,7 +301,10 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
     )
 
   # paths
-  set(${proj}_PATHS_LAUNCHER_BUILD ${python_DIR}/bin)
+  set(${proj}_PATHS_LAUNCHER_BUILD
+    ${python_DIR}/bin
+    ${python_DIR}/${_scripts_subdir}
+    )
   mark_as_superbuild(
     VARS ${proj}_PATHS_LAUNCHER_BUILD
     LABELS "PATHS_LAUNCHER_BUILD"
@@ -332,6 +343,15 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
       LABELS "LIBRARY_PATHS_LAUNCHER_INSTALLED"
       )
   endif()
+
+  # paths
+  set(${proj}_PATHS_LAUNCHER_INSTALLED
+    <APPLAUNCHER_SETTINGS_DIR>/../lib/Python/${_scripts_subdir}
+    )
+  mark_as_superbuild(
+    VARS ${proj}_PATHS_LAUNCHER_INSTALLED
+    LABELS "PATHS_LAUNCHER_INSTALLED"
+    )
 
   # pythonpath
   set(${proj}_PYTHONPATH_LAUNCHER_INSTALLED

--- a/SuperBuild/python_configure_python_launcher.cmake
+++ b/SuperBuild/python_configure_python_launcher.cmake
@@ -79,6 +79,13 @@ endforeach()
 
 find_package(CTKAppLauncher REQUIRED)
 
+# Directory where executable scripts associated with "project.scripts" or "project.gui-scripts"
+# entry-points are generated.
+set(_scripts_subdir bin)
+if(WIN32)
+  set(_scripts_subdir Scripts)
+endif()
+
 #
 # Settings specific to the build tree.
 #
@@ -129,6 +136,7 @@ slicer_dll_directories.add()
 # PATHS
 set(PYTHONLAUNCHER_PATHS_BUILD
   <APPLAUNCHER_DIR>
+  <APPLAUNCHER_DIR>/../${_scripts_subdir}
   )
 
 # LIBRARY_PATHS
@@ -184,6 +192,7 @@ set(PYTHONHOME "<APPLAUNCHER_DIR>/../lib/Python")
 # PATHS
 set(PYTHONLAUNCHER_PATHS_INSTALLED
   <APPLAUNCHER_DIR>
+  <APPLAUNCHER_DIR>/../lib/Python/${_scripts_subdir}
   )
 
 # LIBRARY_PATHS


### PR DESCRIPTION
This commit addresses an issue where launcher scripts installed from wheels were not correctly added to the PATH. Specifically, it updates the PATH for both "Slicer" and "PythonSlicer" launcher settings in the build and install tree. This adjustment ensures that convenience executables created after installing wheels with specified entry-points such as "project.scripts" or "project.gui-scripts" can be easily located and accessed within the project environment.