### PR TITLE
ENH: Add jump to handle action for interaction handles

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidget.h
@@ -64,7 +64,8 @@ public:
   /// Widget states
   enum
   {
-    WidgetStateOnTranslationHandle = WidgetStateUser, // hovering over a translation interaction handle
+    WidgetStateInteraction_First = WidgetStateUser,
+    WidgetStateOnTranslationHandle = WidgetStateInteraction_First, // hovering over a translation interaction handle
     WidgetStateOnRotationHandle, // hovering over a rotation interaction handle
     WidgetStateOnScaleHandle, // hovering over a scale interaction handle
     WidgetStateInteraction_Last
@@ -127,6 +128,10 @@ protected:
   virtual bool ProcessWidgetScaleStart(vtkMRMLInteractionEventData* eventData);
   virtual bool ProcessWidgetUniformScaleStart(vtkMRMLInteractionEventData* eventData);
   virtual bool ProcessEndMouseDrag(vtkMRMLInteractionEventData* eventData);
+  virtual bool ProcessJumpCursor(vtkMRMLInteractionEventData* eventData);
+
+  // Jump to the handle position for the given type and index. Returns true if successful.
+  virtual bool JumpToHandlePosition(int type, int index);
 
   /// Get the closest point on the line defined by the interaction handle axis.
   /// Input coordinates are in display coordinates, while output are in world coordinates.
@@ -146,10 +151,6 @@ protected:
 private:
   vtkMRMLInteractionWidget(const vtkMRMLInteractionWidget&) = delete;
   void operator=(const vtkMRMLInteractionWidget&) = delete;
-
-  int TranslationHandleType{InteractionTranslationHandle};
-  int RotationHandleType {InteractionRotationHandle};
-  int ScaleHandleType {InteractionScaleHandle};
 };
 
 #endif

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.h
@@ -166,6 +166,30 @@ public:
   vtkGetMacro(Interacting, bool);
   vtkBooleanMacro(Interacting, bool);
 
+  /// Get the color of the specified handle
+  /// Type is specified using InteractionType enum
+  virtual void GetHandleColor(int type, int index, double color[4]);
+  /// Get the opacity of the specified handle
+  virtual double GetHandleOpacity(int type, int index);
+  /// Get the visibility of the specified handle
+  virtual bool GetHandleVisibility(int type, int index);
+  ///  Get the type of glyph (Arrow, Circle, Ring, etc.) of the specified handle.
+  virtual int GetHandleGlyphType(int type, int index);
+  /// Get if the view scaling should be applied to the position of the handle.
+  virtual bool GetApplyScaleToPosition(int type, int index);
+  /// Get the position of the interaction handle in local coordinates
+  /// Type is specified using vtkMRMLInteractionDisplayNode::ComponentType
+  virtual void GetInteractionHandlePositionLocal(int type, int index, double position[3]);
+  /// Get the position of the interaction handle in world coordinates
+  /// Type is specified using vtkMRMLInteractionDisplayNode::ComponentType
+  virtual void GetInteractionHandlePositionWorld(int type, int index, double position[3]);
+
+  ///@{
+  /// Update HandleToWorldTransform. This controls the position and orientation of the interaction handles.
+  virtual void UpdateHandleToWorldTransform();
+  virtual void UpdateHandleToWorldTransform(vtkTransform* handleToWorldTransform) = 0;
+  ///@}
+
 protected:
   vtkMRMLInteractionWidgetRepresentation();
   ~vtkMRMLInteractionWidgetRepresentation() override;
@@ -260,35 +284,10 @@ protected:
 
   /// Set the scale of the interaction handles in world coordinates
   virtual void SetWidgetScale(double scale);
-  /// Get the color of the specified handle
-  /// Type is specified using InteractionType enum
-  virtual void GetHandleColor(int type, int index, double color[4]);
-  /// Get the opacity of the specified handle
-  virtual double GetHandleOpacity(int type, int index);
-  /// Get the visibility of the specified handle
-  virtual bool GetHandleVisibility(int type, int index);
-  ///  Get the type of glyph (Arrow, Circle, Ring, etc.) of the specified handle.
-  virtual int GetHandleGlyphType(int type, int index);
-  /// Get if the view scaling should be applied to the position of the handle.
-  virtual bool GetApplyScaleToPosition(int type, int index);
 
   /// Get the vector from the interaction handle to the camera in world coordinates.
   /// In slice views and in 3D with parallel projection this is the same as the camera view direction.
   virtual void GetHandleToCameraVectorWorld(double handlePosition_World[3], double normal_World[3]);
-
-  /// Get the position of the interaction handle in local coordinates
-  /// Type is specified using vtkMRMLInteractionDisplayNode::ComponentType
-  virtual void GetInteractionHandlePositionLocal(int type, int index, double position[3]);
-
-  /// Get the position of the interaction handle in world coordinates
-  /// Type is specified using vtkMRMLInteractionDisplayNode::ComponentType
-  virtual void GetInteractionHandlePositionWorld(int type, int index, double position[3]);
-
-  ///@{
-  /// Update HandleToWorldTransform. This controls the position and orientation of the interaction handles.
-  virtual void UpdateHandleToWorldTransform();
-  virtual void UpdateHandleToWorldTransform(vtkTransform* handleToWorldTransform) = 0;
-  ///@}
 
   /// Orthogonalize the transform axes. The Z-axis will not be changed.
   virtual void OrthoganalizeTransform(vtkTransform* transform);

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidget.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidget.cxx
@@ -242,7 +242,10 @@ bool vtkMRMLTransformHandleWidget::ProcessEndMouseDrag(vtkMRMLInteractionEventDa
     }
 
   this->EndWidgetInteraction();
-  return true;
+
+  // only claim this as processed if the mouse was moved (this allows the event to be interpreted as button click)
+  bool processedEvent = eventData->GetMouseMovedSinceButtonDown();
+  return processedEvent;
 }
 
 //-------------------------------------------------------------------------
@@ -392,4 +395,22 @@ void vtkMRMLTransformHandleWidget::TranslateTransformCenter(double eventPos[2])
   this->GetTransformNode()->GetCenterOfTransformation(centerOfTransformation);
   vtkMath::Add(transform->TransformVectorAtPoint(origin_World, translationVector_World), centerOfTransformation, centerOfTransformation);
   this->GetTransformNode()->SetCenterOfTransformation(centerOfTransformation);
+}
+
+//-------------------------------------------------------------------------
+bool vtkMRMLTransformHandleWidget::ProcessJumpCursor(vtkMRMLInteractionEventData* eventData)
+{
+  int type = this->GetActiveComponentType();
+  if (type != InteractionTranslationHandle)
+    {
+    return false;
+    }
+
+  int index = this->GetActiveComponentIndex();
+  if (index != 3)
+    {
+    return false;
+    }
+
+  return Superclass::ProcessJumpCursor(eventData);
 }

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidget.h
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidget.h
@@ -65,7 +65,7 @@ public:
 
   enum
   {
-    WidgetEventTranslateTransformCenterStart = WidgetStateInteraction_Last,
+    WidgetEventTranslateTransformCenterStart = WidgetEventInteraction_Last,
     WidgetEventTranslateTransformCenterEnd,
   };
 
@@ -86,6 +86,7 @@ protected:
   bool ProcessMouseMove(vtkMRMLInteractionEventData* eventData) override;
   bool ProcessEndMouseDrag(vtkMRMLInteractionEventData* eventData) override;
   bool ProcessWidgetMenu(vtkMRMLInteractionEventData* eventData) override;
+  bool ProcessJumpCursor(vtkMRMLInteractionEventData* eventData) override;
 
   virtual void TranslateTransformCenter(double eventPos[2]);
 


### PR DESCRIPTION
This commit enables the jump to handle action when left-clicking on an interaction handle.

For Transform nodes:
  - Jump is only available when clicking on the center of transformation.

For Markups nodes:
  - Jump is available for any handle type.

Re #7570