### PR TITLE
COMP: Update python packages to latest

### DIFF
--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -41,31 +41,33 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pydicom]
-  pydicom==2.4.3 --hash=sha256:797e84f7b22e5f8bce403da505935b0787dca33550891f06495d14b3f6c70504
+  pydicom==2.4.4 --hash=sha256:f9f8e19b78525be57aa6384484298833e4d06ac1d6226c79459131ddb0bd7c42
   # [/pydicom]
   # [six]
   six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
   # [/six]
   # [Pillow]
   # Hashes correspond to the following packages:
-  #  - Pillow-10.1.0-cp39-cp39-macosx_10_10_x86_64.whl
-  #  - Pillow-10.1.0-cp39-cp39-macosx_11_0_arm64.whl
-  #  - Pillow-10.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - Pillow-10.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - Pillow-10.1.0-cp39-cp39-manylinux_2_28_aarch64.whl
-  #  - Pillow-10.1.0-cp39-cp39-manylinux_2_28_x86_64.whl
-  #  - Pillow-10.1.0-cp39-cp39-musllinux_1_1_aarch64.whl
-  #  - Pillow-10.1.0-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - Pillow-10.1.0-cp39-cp39-win_amd64.whl
-  Pillow==10.1.0 --hash=sha256:0a026c188be3b443916179f5d04548092e253beb0c3e2ee0a4e2cdad72f66099 \
-                 --hash=sha256:04f6f6149f266a100374ca3cc368b67fb27c4af9f1cc8cb6306d849dcdf12616 \
-                 --hash=sha256:bb40c011447712d2e19cc261c82655f75f32cb724788df315ed992a4d65696bb \
-                 --hash=sha256:1a8413794b4ad9719346cd9306118450b7b00d9a15846451549314a58ac42219 \
-                 --hash=sha256:c9aeea7b63edb7884b031a35305629a7593272b54f429a9869a4f63a1bf04c34 \
-                 --hash=sha256:b4005fee46ed9be0b8fb42be0c20e79411533d1fd58edabebc0dd24626882cfd \
-                 --hash=sha256:4d0152565c6aa6ebbfb1e5d8624140a440f2b99bf7afaafbdbf6430426497f28 \
-                 --hash=sha256:d921bc90b1defa55c9917ca6b6b71430e4286fc9e44c55ead78ca1a9f9eba5f2 \
-                 --hash=sha256:cfe96560c6ce2f4c07d6647af2d0f3c54cc33289894ebd88cfbb3bcd5391e256
+  #  - pillow-10.2.0-cp39-cp39-macosx_10_10_x86_64.whl
+  #  - pillow-10.2.0-cp39-cp39-macosx_11_0_arm64.whl
+  #  - pillow-10.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - pillow-10.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - pillow-10.2.0-cp39-cp39-manylinux_2_28_aarch64.whl
+  #  - pillow-10.2.0-cp39-cp39-manylinux_2_28_x86_64.whl
+  #  - pillow-10.2.0-cp39-cp39-musllinux_1_1_aarch64.whl
+  #  - pillow-10.2.0-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - pillow-10.2.0-cp39-cp39-win_amd64.whl
+  #  - pillow-10.2.0-cp39-cp39-win_arm64.whl
+  Pillow==10.2.0 --hash=sha256:b792a349405fbc0163190fde0dc7b3fef3c9268292586cf5645598b48e63dc67 \
+                 --hash=sha256:c570f24be1e468e3f0ce7ef56a89a60f0e05b30a3669a459e419c6eac2c35364 \
+                 --hash=sha256:d8ecd059fdaf60c1963c58ceb8997b32e9dc1b911f5da5307aab614f1ce5c2fb \
+                 --hash=sha256:c365fd1703040de1ec284b176d6af5abe21b427cb3a5ff68e0759e1e313a5e7e \
+                 --hash=sha256:70c61d4c475835a19b3a5aa42492409878bbca7438554a1f89d20d58a7c75c01 \
+                 --hash=sha256:b6f491cdf80ae540738859d9766783e3b3c8e5bd37f5dfa0b76abdecc5081f13 \
+                 --hash=sha256:9d189550615b4948f45252d7f005e53c2040cea1af5b60d6f79491a6e147eef7 \
+                 --hash=sha256:49d9ba1ed0ef3e061088cd1e7538a0759aab559e2e0a80a36f9fd9d8c0c21591 \
+                 --hash=sha256:0304004f8067386b477d20a518b50f3fa658a28d44e4116970abfcd94fac34a8 \
+                 --hash=sha256:0fb3e7fc88a14eacd303e90481ad983fd5b69c761e9e6ef94c983f91025da869
   # [/Pillow]
   # [retrying]
   retrying==1.3.4 --hash=sha256:8cc4d43cb8e1125e0ff3344e9de678fefd85db3b750b81b2240dc0183af37b35

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -40,13 +40,13 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   couchdb==1.2 --hash=sha256:13a28a1159c49f8346732e8724b9a4d65cba54bec017c4a7eeb1499fe88151d1
   # [/CouchDB]
   # [gitdb]
-  gitdb==4.0.10 --hash=sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7
+  gitdb==4.0.11 --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4
   # [/gitdb]
   # [smmap]
   smmap==5.0.1 --hash=sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da
   # [/smmap]
   # [GitPython]
-  GitPython==3.1.37 --hash=sha256:5f4c4187de49616d710a77e98ddf17b4782060a1788df441846bddefbb89ab33
+  GitPython==3.1.42 --hash=sha256:1bf9cd7c9e7255f77778ea54359e54ac22a72a5b51288c457c881057b7bb9ecd
   # [/GitPython]
   # [six]
   six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -34,24 +34,48 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [cryptography]
   # Hashes correspond to the following packages:
-  #  - cryptography-41.0.4-cp37-abi3-macosx_10_12_universal2.whl
-  #  - cryptography-41.0.4-cp37-abi3-macosx_10_12_x86_64.whl
-  #  - cryptography-41.0.4-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - cryptography-41.0.4-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - cryptography-41.0.4-cp37-abi3-manylinux_2_28_aarch64.whl
-  #  - cryptography-41.0.4-cp37-abi3-manylinux_2_28_x86_64.whl
-  #  - cryptography-41.0.4-cp37-abi3-musllinux_1_1_aarch64.whl
-  #  - cryptography-41.0.4-cp37-abi3-musllinux_1_1_x86_64.whl
-  #  - cryptography-41.0.4-cp37-abi3-win_amd64.whl
-  cryptography==41.0.4 --hash=sha256:80907d3faa55dc5434a16579952ac6da800935cd98d14dbd62f6f042c7f5e839 \
-                       --hash=sha256:35c00f637cd0b9d5b6c6bd11b6c3359194a8eba9c46d4e875a3660e3b400005f \
-                       --hash=sha256:cecfefa17042941f94ab54f769c8ce0fe14beff2694e9ac684176a2535bf9714 \
-                       --hash=sha256:e40211b4923ba5a6dc9769eab704bdb3fbb58d56c5b336d30996c24fcf12aadb \
-                       --hash=sha256:23a25c09dfd0d9f28da2352503b23e086f8e78096b9fd585d1d14eca01613e13 \
-                       --hash=sha256:2ed09183922d66c4ec5fdaa59b4d14e105c084dd0febd27452de8f6f74704143 \
-                       --hash=sha256:5a0f09cefded00e648a127048119f77bc2b2ec61e736660b5789e638f43cc397 \
-                       --hash=sha256:9eeb77214afae972a00dee47382d2591abe77bdae166bda672fb1e24702a3860 \
-                       --hash=sha256:c880eba5175f4307129784eca96f4e70b88e57aa3f680aeba3bab0e980b0f37d
+  #  - cryptography-42.0.3-cp37-abi3-macosx_10_12_universal2.whl
+  #  - cryptography-42.0.3-cp37-abi3-macosx_10_12_x86_64.whl
+  #  - cryptography-42.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - cryptography-42.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - cryptography-42.0.3-cp37-abi3-manylinux_2_28_aarch64.whl
+  #  - cryptography-42.0.3-cp37-abi3-manylinux_2_28_x86_64.whl
+  #  - cryptography-42.0.3-cp37-abi3-musllinux_1_1_aarch64.whl
+  #  - cryptography-42.0.3-cp37-abi3-musllinux_1_1_x86_64.whl
+  #  - cryptography-42.0.3-cp37-abi3-musllinux_1_2_aarch64.whl
+  #  - cryptography-42.0.3-cp37-abi3-musllinux_1_2_x86_64.whl
+  #  - cryptography-42.0.3-cp37-abi3-win_amd64.whl
+  #  - cryptography-42.0.3-cp39-abi3-macosx_10_12_universal2.whl
+  #  - cryptography-42.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - cryptography-42.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - cryptography-42.0.3-cp39-abi3-manylinux_2_28_aarch64.whl
+  #  - cryptography-42.0.3-cp39-abi3-manylinux_2_28_x86_64.whl
+  #  - cryptography-42.0.3-cp39-abi3-musllinux_1_1_aarch64.whl
+  #  - cryptography-42.0.3-cp39-abi3-musllinux_1_1_x86_64.whl
+  #  - cryptography-42.0.3-cp39-abi3-musllinux_1_2_aarch64.whl
+  #  - cryptography-42.0.3-cp39-abi3-musllinux_1_2_x86_64.whl
+  #  - cryptography-42.0.3-cp39-abi3-win_amd64.whl
+  cryptography==42.0.3 --hash=sha256:de5086cd475d67113ccb6f9fae6d8fe3ac54a4f9238fd08bfdb07b03d791ff0a \
+                       --hash=sha256:935cca25d35dda9e7bd46a24831dfd255307c55a07ff38fd1a92119cffc34857 \
+                       --hash=sha256:20100c22b298c9eaebe4f0b9032ea97186ac2555f426c3e70670f2517989543b \
+                       --hash=sha256:2eb6368d5327d6455f20327fb6159b97538820355ec00f8cc9464d617caecead \
+                       --hash=sha256:39d5c93e95bcbc4c06313fc6a500cee414ee39b616b55320c1904760ad686938 \
+                       --hash=sha256:3d96ea47ce6d0055d5b97e761d37b4e84195485cb5a38401be341fabf23bc32a \
+                       --hash=sha256:d1998e545081da0ab276bcb4b33cce85f775adb86a516e8f55b3dac87f469548 \
+                       --hash=sha256:93fbee08c48e63d5d1b39ab56fd3fdd02e6c2431c3da0f4edaf54954744c718f \
+                       --hash=sha256:90147dad8c22d64b2ff7331f8d4cddfdc3ee93e4879796f837bdbb2a0b141e0c \
+                       --hash=sha256:4dcab7c25e48fc09a73c3e463d09ac902a932a0f8d0c568238b3696d06bf377b \
+                       --hash=sha256:762f3771ae40e111d78d77cbe9c1035e886ac04a234d3ee0856bf4ecb3749d54 \
+                       --hash=sha256:0d3ec384058b642f7fb7e7bff9664030011ed1af8f852540c76a1317a9dd0d20 \
+                       --hash=sha256:35772a6cffd1f59b85cb670f12faba05513446f80352fe811689b4e439b5d89e \
+                       --hash=sha256:04859aa7f12c2b5f7e22d25198ddd537391f1695df7057c8700f71f26f47a129 \
+                       --hash=sha256:c3d1f5a1d403a8e640fa0887e9f7087331abb3f33b0f2207d2cc7f213e4a864c \
+                       --hash=sha256:df34312149b495d9d03492ce97471234fd9037aa5ba217c2a6ea890e9166f151 \
+                       --hash=sha256:de4ae486041878dc46e571a4c70ba337ed5233a1344c14a0790c4c4be4bbb8b4 \
+                       --hash=sha256:0fab2a5c479b360e5e0ea9f654bcebb535e3aa1e493a715b13244f4e07ea8eec \
+                       --hash=sha256:25b09b73db78facdfd7dd0fa77a3f19e94896197c86e9f6dc16bce7b37a96504 \
+                       --hash=sha256:d5cf11bc7f0b71fb71af26af396c83dfd3f6eed56d4b6ef95d57867bf1e4ba65 \
+                       --hash=sha256:2619487f37da18d6826e27854a7f9d4d013c51eafb066c80d09c63cf24505306
   # [/cryptography]
   # Specifying "[crypto]" is required since PyGithub 1.58.1
   # See https://github.com/Slicer/Slicer/issues/7112
@@ -60,22 +84,22 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [/PyJWT]
   # [wrapt]
   # Hashes correspond to the following packages:
-  #  - wrapt-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - wrapt-1.15.0-cp39-cp39-macosx_11_0_arm64.whl
-  #  - wrapt-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - wrapt-1.15.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - wrapt-1.15.0-cp39-cp39-musllinux_1_1_aarch64.whl
-  #  - wrapt-1.15.0-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - wrapt-1.15.0-cp39-cp39-win_amd64.whl
-  #  - wrapt-1.15.0-py3-none-any.whl
-  wrapt==1.15.0 --hash=sha256:2e51de54d4fb8fb50d6ee8327f9828306a959ae394d3e01a1ba8b2f937747d86 \
-                --hash=sha256:0970ddb69bba00670e58955f8019bec4a42d1785db3faa043c33d81de2bf843c \
-                --hash=sha256:76407ab327158c510f44ded207e2f76b657303e17cb7a572ffe2f5a8a48aa04d \
-                --hash=sha256:9d37ac69edc5614b90516807de32d08cb8e7b12260a285ee330955604ed9dd29 \
-                --hash=sha256:078e2a1a86544e644a68422f881c48b84fef6d18f8c7a957ffd3f2e0a74a0d4a \
-                --hash=sha256:7dc0713bf81287a00516ef43137273b23ee414fe41a3c14be10dd95ed98a2df9 \
-                --hash=sha256:eef4d64c650f33347c1f9266fa5ae001440b232ad9b98f1f43dfe7a79435c0a6 \
-                --hash=sha256:64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640
+  #  - wrapt-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - wrapt-1.16.0-cp39-cp39-macosx_11_0_arm64.whl
+  #  - wrapt-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - wrapt-1.16.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - wrapt-1.16.0-cp39-cp39-musllinux_1_1_aarch64.whl
+  #  - wrapt-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - wrapt-1.16.0-cp39-cp39-win_amd64.whl
+  #  - wrapt-1.16.0-py3-none-any.whl
+  wrapt==1.16.0 --hash=sha256:9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2 \
+                --hash=sha256:2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb \
+                --hash=sha256:c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8 \
+                --hash=sha256:f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a \
+                --hash=sha256:5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664 \
+                --hash=sha256:edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537 \
+                --hash=sha256:eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35 \
+                --hash=sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1
   # [/wrapt]
   # [Deprecated]
   Deprecated==1.2.14 --hash=sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c
@@ -127,7 +151,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   typing-extensions==4.8.0 --hash=sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0
   # [/typing-extensions]
   # [PyGithub]
-  PyGithub==2.1.1 --hash=sha256:4b528d5d6f35e991ea5fd3f942f58748f24938805cb7fcf24486546637917337
+  PyGithub==2.2.0 --hash=sha256:41042ea53e4c372219db708c38d2ca1fd4fadab75475bac27d89d339596cfad1
   # [/PyGithub]
   ]===])
 

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -31,18 +31,20 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [numpy]
   # Hashes correspond to the following packages:
-  #  - numpy-1.26.1-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - numpy-1.26.1-cp39-cp39-macosx_11_0_arm64.whl
-  #  - numpy-1.26.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - numpy-1.26.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - numpy-1.26.1-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - numpy-1.26.1-cp39-cp39-win_amd64.whl
-  numpy==1.26.1 --hash=sha256:bb894accfd16b867d8643fc2ba6c8617c78ba2828051e9a69511644ce86ce83e \
-                --hash=sha256:e44ccb93f30c75dfc0c3aa3ce38f33486a75ec9abadabd4e59f114994a9c4617 \
-                --hash=sha256:9696aa2e35cc41e398a6d42d147cf326f8f9d81befcb399bc1ed7ffea339b64e \
-                --hash=sha256:a5b411040beead47a228bde3b2241100454a6abde9df139ed087bd73fc0a4908 \
-                --hash=sha256:1e11668d6f756ca5ef534b5be8653d16c5352cbb210a5c2a79ff288e937010d5 \
-                --hash=sha256:59227c981d43425ca5e5c01094d59eb14e8772ce6975d4b2fc1e106a833d5ae2
+  #  - numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl
+  #  - numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl
+  #  - numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - numpy-1.26.4-cp39-cp39-win_amd64.whl
+  numpy==1.26.4 --hash=sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c \
+                --hash=sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be \
+                --hash=sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764 \
+                --hash=sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3 \
+                --hash=sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd \
+                --hash=sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c \
+                --hash=sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea
   # [/numpy]
   ]===])
 

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pip]
-  pip==23.3 --hash=sha256:bc38bb52bc286514f8f7cb3a1ba5ed100b76aaef29b521d48574329331c5ae7b
+  pip==24.0 --hash=sha256:ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc
   # [/pip]
   ]===])
 

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -27,34 +27,34 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [certifi]
-  certifi==2023.7.22 --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
+  certifi==2024.2.2 --hash=sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
   # [/certifi]
   # [idna]
-  idna==3.4 --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
+  idna==3.6 --hash=sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
   # [/idna]
   # [charset-normalizer]
   # Hashes correspond to the following packages:
-  #  - charset_normalizer-3.3.0-cp39-cp39-macosx_10_9_universal2.whl
-  #  - charset_normalizer-3.3.0-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - charset_normalizer-3.3.0-cp39-cp39-macosx_11_0_arm64.whl
-  #  - charset_normalizer-3.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - charset_normalizer-3.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - charset_normalizer-3.3.0-cp39-cp39-musllinux_1_1_aarch64.whl
-  #  - charset_normalizer-3.3.0-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - charset_normalizer-3.3.0-cp39-cp39-win_amd64.whl
-  #  - charset_normalizer-3.3.0-py3-none-any.whl
-  charset-normalizer==3.3.0 --hash=sha256:e0fc42822278451bc13a2e8626cf2218ba570f27856b536e00cfa53099724828 \
-                            --hash=sha256:09c77f964f351a7369cc343911e0df63e762e42bac24cd7d18525961c81754f4 \
-                            --hash=sha256:12ebea541c44fdc88ccb794a13fe861cc5e35d64ed689513a5c03d05b53b7c82 \
-                            --hash=sha256:805dfea4ca10411a5296bcc75638017215a93ffb584c9e344731eef0dcfb026a \
-                            --hash=sha256:619d1c96099be5823db34fe89e2582b336b5b074a7f47f819d6b3a57ff7bdb86 \
-                            --hash=sha256:93aa7eef6ee71c629b51ef873991d6911b906d7312c6e8e99790c0f33c576f89 \
-                            --hash=sha256:153e7b6e724761741e0974fc4dcd406d35ba70b92bfe3fedcb497226c93b9da7 \
-                            --hash=sha256:d97d85fa63f315a8bdaba2af9a6a686e0eceab77b3089af45133252618e70884 \
-                            --hash=sha256:e46cd37076971c1040fc8c41273a8b3e2c624ce4f2be3f5dfcb7a430c1d3acc2
+  #  - charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl
+  #  - charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl
+  #  - charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl
+  #  - charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl
+  #  - charset_normalizer-3.3.2-py3-none-any.whl
+  charset-normalizer==3.3.2 --hash=sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4 \
+                            --hash=sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d \
+                            --hash=sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0 \
+                            --hash=sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269 \
+                            --hash=sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796 \
+                            --hash=sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c \
+                            --hash=sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561 \
+                            --hash=sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d \
+                            --hash=sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc
   # [/charset-normalizer]
   # [urllib3]
-  urllib3==2.0.6 --hash=sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2
+  urllib3==2.2.1 --hash=sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d
   # [/urllib3]
   # [requests]
   requests==2.31.0 --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f

--- a/SuperBuild/External_python-scipy.cmake
+++ b/SuperBuild/External_python-scipy.cmake
@@ -31,18 +31,18 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [scipy]
   # Hashes correspond to the following packages:
-  #  - scipy-1.11.3-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - scipy-1.11.3-cp39-cp39-macosx_12_0_arm64.whl
-  #  - scipy-1.11.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - scipy-1.11.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - scipy-1.11.3-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - scipy-1.11.3-cp39-cp39-win_amd64.whl
-  scipy==1.11.3 --hash=sha256:a63d1ec9cadecce838467ce0631c17c15c7197ae61e49429434ba01d618caa83 \
-                --hash=sha256:5305792c7110e32ff155aed0df46aa60a60fc6e52cd4ee02cdeb67eaccd5356e \
-                --hash=sha256:9ea7f579182d83d00fed0e5c11a4aa5ffe01460444219dedc448a36adf0c3917 \
-                --hash=sha256:c77da50c9a91e23beb63c2a711ef9e9ca9a2060442757dffee34ea41847d8156 \
-                --hash=sha256:15f237e890c24aef6891c7d008f9ff7e758c6ef39a2b5df264650eb7900403c0 \
-                --hash=sha256:4b4bb134c7aa457e26cc6ea482b016fef45db71417d55cc6d8f43d799cdf9ef2
+  #  - scipy-1.12.0-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - scipy-1.12.0-cp39-cp39-macosx_12_0_arm64.whl
+  #  - scipy-1.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - scipy-1.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - scipy-1.12.0-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - scipy-1.12.0-cp39-cp39-win_amd64.whl
+  scipy==1.12.0 --hash=sha256:913d6e7956c3a671de3b05ccb66b11bc293f56bfdef040583a7221d9e22a2e35 \
+                --hash=sha256:bba1b0c7256ad75401c73e4b3cf09d1f176e9bd4248f0d3112170fb2ec4db067 \
+                --hash=sha256:730badef9b827b368f351eacae2e82da414e13cf8bd5051b4bdfd720271a5371 \
+                --hash=sha256:6546dc2c11a9df6926afcbdd8a3edec28566e4e785b915e849348c6dd9f3f490 \
+                --hash=sha256:196ebad3a4882081f62a5bf4aeb7326aa34b110e533aab23e4374fcccb0890dc \
+                --hash=sha256:b360f1b6b2f742781299514e99ff560d1fe9bd1bff2712894b52abe528d1fd1e
   # [/scipy]
   ]===])
 

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -26,7 +26,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [setuptools]
-  setuptools==68.2.2 --hash=sha256:b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a
+  setuptools==69.1.0 --hash=sha256:c054629b81b946d63a9c6e732bc8b2513a7c3ea645f11d0139a2191d735c60c6
   # [/setuptools]
   ]===])
 

--- a/SuperBuild/External_python-wheel.cmake
+++ b/SuperBuild/External_python-wheel.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [wheel]
-  wheel==0.41.2 --hash=sha256:75909db2664838d015e3d9139004ee16711748a52c8f336b52882266540215d8
+  wheel==0.42.0 --hash=sha256:177f9c9b0d45c47873b619f5b650346d632cdc35fb5e4d25058e09c9e581433d
   # [/wheel]
   ]===])
 


### PR DESCRIPTION
Python packages were last updated on October 16th 2023 (https://github.com/Slicer/Slicer/commit/028fb31981eec40056d52759e42723e44b30bf86). This PR updates python packages to their latest versions. This type of update is something I usually do on about a quarterly cadence (every 3 months).

Note that SimpleITK isn't being updated here as we build it from source rather than using the provided whl on pypi.
```
PS C:\Users\butlej30383\AppData\Local\slicer.org\Slicer 5.7.0-2024-02-17\bin> ./PythonSlicer.exe "C:\Slicer\Utilities\Scripts\python_package_updater.py"
Searching external projects in C:\Slicer\SuperBuild
Validate external projects
Package            Version       Latest   Type
------------------ ------------- -------- -----
certifi            2023.7.22     2024.2.2 wheel
charset-normalizer 3.3.0         3.3.2    wheel
cryptography       41.0.4        42.0.3   wheel
gitdb              4.0.10        4.0.11   wheel
GitPython          3.1.37        3.1.42   wheel
idna               3.4           3.6      wheel
numpy              1.26.1        1.26.4   wheel
Pillow             10.1.0        10.2.0   wheel
pip                23.3          24.0     wheel
pydicom            2.4.3         2.4.4    wheel
PyGithub           2.1.1         2.2.0    wheel
scipy              1.11.3        1.12.0   wheel
setuptools         68.2.2        69.1.0   wheel
SimpleITK          2.2.1rc2.dev4 2.3.1    wheel
typing_extensions  4.8.0         4.9.0    wheel
urllib3            2.0.6         2.2.1    wheel
vtk                9.2.20230607  9.3.0    wheel
wheel              0.41.2        0.42.0   wheel
wrapt              1.15.0        1.16.0   wheel

  certifi==2024.2.2 --hash=sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
  # Hashes correspond to the following packages:
  #  - charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl
  #  - charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl
  #  - charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl
  #  - charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl
  #  - charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl
  #  - charset_normalizer-3.3.2-py3-none-any.whl
  charset-normalizer==3.3.2 --hash=sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4 \
                            --hash=sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d \
                            --hash=sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0 \
                            --hash=sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269 \
                            --hash=sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796 \
                            --hash=sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c \
                            --hash=sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561 \
                            --hash=sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d \
                            --hash=sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc
  # Hashes correspond to the following packages:
  #  - cryptography-42.0.3-cp37-abi3-macosx_10_12_universal2.whl
  #  - cryptography-42.0.3-cp37-abi3-macosx_10_12_x86_64.whl
  #  - cryptography-42.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - cryptography-42.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - cryptography-42.0.3-cp37-abi3-manylinux_2_28_aarch64.whl
  #  - cryptography-42.0.3-cp37-abi3-manylinux_2_28_x86_64.whl
  #  - cryptography-42.0.3-cp37-abi3-musllinux_1_1_aarch64.whl
  #  - cryptography-42.0.3-cp37-abi3-musllinux_1_1_x86_64.whl
  #  - cryptography-42.0.3-cp37-abi3-musllinux_1_2_aarch64.whl
  #  - cryptography-42.0.3-cp37-abi3-musllinux_1_2_x86_64.whl
  #  - cryptography-42.0.3-cp37-abi3-win_amd64.whl
  #  - cryptography-42.0.3-cp39-abi3-macosx_10_12_universal2.whl
  #  - cryptography-42.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - cryptography-42.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - cryptography-42.0.3-cp39-abi3-manylinux_2_28_aarch64.whl
  #  - cryptography-42.0.3-cp39-abi3-manylinux_2_28_x86_64.whl
  #  - cryptography-42.0.3-cp39-abi3-musllinux_1_1_aarch64.whl
  #  - cryptography-42.0.3-cp39-abi3-musllinux_1_1_x86_64.whl
  #  - cryptography-42.0.3-cp39-abi3-musllinux_1_2_aarch64.whl
  #  - cryptography-42.0.3-cp39-abi3-musllinux_1_2_x86_64.whl
  #  - cryptography-42.0.3-cp39-abi3-win_amd64.whl
  cryptography==42.0.3 --hash=sha256:de5086cd475d67113ccb6f9fae6d8fe3ac54a4f9238fd08bfdb07b03d791ff0a \
                       --hash=sha256:935cca25d35dda9e7bd46a24831dfd255307c55a07ff38fd1a92119cffc34857 \
                       --hash=sha256:20100c22b298c9eaebe4f0b9032ea97186ac2555f426c3e70670f2517989543b \
                       --hash=sha256:2eb6368d5327d6455f20327fb6159b97538820355ec00f8cc9464d617caecead \
                       --hash=sha256:39d5c93e95bcbc4c06313fc6a500cee414ee39b616b55320c1904760ad686938 \
                       --hash=sha256:3d96ea47ce6d0055d5b97e761d37b4e84195485cb5a38401be341fabf23bc32a \
                       --hash=sha256:d1998e545081da0ab276bcb4b33cce85f775adb86a516e8f55b3dac87f469548 \
                       --hash=sha256:93fbee08c48e63d5d1b39ab56fd3fdd02e6c2431c3da0f4edaf54954744c718f \
                       --hash=sha256:90147dad8c22d64b2ff7331f8d4cddfdc3ee93e4879796f837bdbb2a0b141e0c \
                       --hash=sha256:4dcab7c25e48fc09a73c3e463d09ac902a932a0f8d0c568238b3696d06bf377b \
                       --hash=sha256:762f3771ae40e111d78d77cbe9c1035e886ac04a234d3ee0856bf4ecb3749d54 \
                       --hash=sha256:0d3ec384058b642f7fb7e7bff9664030011ed1af8f852540c76a1317a9dd0d20 \
                       --hash=sha256:35772a6cffd1f59b85cb670f12faba05513446f80352fe811689b4e439b5d89e \
                       --hash=sha256:04859aa7f12c2b5f7e22d25198ddd537391f1695df7057c8700f71f26f47a129 \
                       --hash=sha256:c3d1f5a1d403a8e640fa0887e9f7087331abb3f33b0f2207d2cc7f213e4a864c \
                       --hash=sha256:df34312149b495d9d03492ce97471234fd9037aa5ba217c2a6ea890e9166f151 \
                       --hash=sha256:de4ae486041878dc46e571a4c70ba337ed5233a1344c14a0790c4c4be4bbb8b4 \
                       --hash=sha256:0fab2a5c479b360e5e0ea9f654bcebb535e3aa1e493a715b13244f4e07ea8eec \
                       --hash=sha256:25b09b73db78facdfd7dd0fa77a3f19e94896197c86e9f6dc16bce7b37a96504 \
                       --hash=sha256:d5cf11bc7f0b71fb71af26af396c83dfd3f6eed56d4b6ef95d57867bf1e4ba65 \
                       --hash=sha256:2619487f37da18d6826e27854a7f9d4d013c51eafb066c80d09c63cf24505306
  gitdb==4.0.11 --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4
  GitPython==3.1.42 --hash=sha256:1bf9cd7c9e7255f77778ea54359e54ac22a72a5b51288c457c881057b7bb9ecd
  idna==3.6 --hash=sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
  # Hashes correspond to the following packages:
  #  - numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl
  #  - numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl
  #  - numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl
  #  - numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - numpy-1.26.4-cp39-cp39-win_amd64.whl
  numpy==1.26.4 --hash=sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c \
                --hash=sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be \
                --hash=sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764 \
                --hash=sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3 \
                --hash=sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd \
                --hash=sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c \
                --hash=sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea
  # Hashes correspond to the following packages:
  #  - pillow-10.2.0-cp39-cp39-macosx_10_10_x86_64.whl
  #  - pillow-10.2.0-cp39-cp39-macosx_11_0_arm64.whl
  #  - pillow-10.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - pillow-10.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - pillow-10.2.0-cp39-cp39-manylinux_2_28_aarch64.whl
  #  - pillow-10.2.0-cp39-cp39-manylinux_2_28_x86_64.whl
  #  - pillow-10.2.0-cp39-cp39-musllinux_1_1_aarch64.whl
  #  - pillow-10.2.0-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - pillow-10.2.0-cp39-cp39-win_amd64.whl
  #  - pillow-10.2.0-cp39-cp39-win_arm64.whl
  Pillow==10.2.0 --hash=sha256:b792a349405fbc0163190fde0dc7b3fef3c9268292586cf5645598b48e63dc67 \
                 --hash=sha256:c570f24be1e468e3f0ce7ef56a89a60f0e05b30a3669a459e419c6eac2c35364 \
                 --hash=sha256:d8ecd059fdaf60c1963c58ceb8997b32e9dc1b911f5da5307aab614f1ce5c2fb \
                 --hash=sha256:c365fd1703040de1ec284b176d6af5abe21b427cb3a5ff68e0759e1e313a5e7e \
                 --hash=sha256:70c61d4c475835a19b3a5aa42492409878bbca7438554a1f89d20d58a7c75c01 \
                 --hash=sha256:b6f491cdf80ae540738859d9766783e3b3c8e5bd37f5dfa0b76abdecc5081f13 \
                 --hash=sha256:9d189550615b4948f45252d7f005e53c2040cea1af5b60d6f79491a6e147eef7 \
                 --hash=sha256:49d9ba1ed0ef3e061088cd1e7538a0759aab559e2e0a80a36f9fd9d8c0c21591 \
                 --hash=sha256:0304004f8067386b477d20a518b50f3fa658a28d44e4116970abfcd94fac34a8 \
                 --hash=sha256:0fb3e7fc88a14eacd303e90481ad983fd5b69c761e9e6ef94c983f91025da869
  pip==24.0 --hash=sha256:ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc
  pydicom==2.4.4 --hash=sha256:f9f8e19b78525be57aa6384484298833e4d06ac1d6226c79459131ddb0bd7c42
  PyGithub==2.2.0 --hash=sha256:41042ea53e4c372219db708c38d2ca1fd4fadab75475bac27d89d339596cfad1
  # Hashes correspond to the following packages:
  #  - scipy-1.12.0-cp39-cp39-macosx_10_9_x86_64.whl
  #  - scipy-1.12.0-cp39-cp39-macosx_12_0_arm64.whl
  #  - scipy-1.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - scipy-1.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - scipy-1.12.0-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - scipy-1.12.0-cp39-cp39-win_amd64.whl
  scipy==1.12.0 --hash=sha256:913d6e7956c3a671de3b05ccb66b11bc293f56bfdef040583a7221d9e22a2e35 \
                --hash=sha256:bba1b0c7256ad75401c73e4b3cf09d1f176e9bd4248f0d3112170fb2ec4db067 \
                --hash=sha256:730badef9b827b368f351eacae2e82da414e13cf8bd5051b4bdfd720271a5371 \
                --hash=sha256:6546dc2c11a9df6926afcbdd8a3edec28566e4e785b915e849348c6dd9f3f490 \
                --hash=sha256:196ebad3a4882081f62a5bf4aeb7326aa34b110e533aab23e4374fcccb0890dc \
                --hash=sha256:b360f1b6b2f742781299514e99ff560d1fe9bd1bff2712894b52abe528d1fd1e
  setuptools==69.1.0 --hash=sha256:c054629b81b946d63a9c6e732bc8b2513a7c3ea645f11d0139a2191d735c60c6
  # Hashes correspond to the following packages:
  #  - SimpleITK-2.3.1-cp39-cp39-macosx_10_9_x86_64.whl
  #  - SimpleITK-2.3.1-cp39-cp39-macosx_11_0_arm64.whl
  #  - SimpleITK-2.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - SimpleITK-2.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - SimpleITK-2.3.1-cp39-cp39-win_amd64.whl
  SimpleITK==2.3.1 --hash=sha256:8a1470a1c83f4765ff869240d1a57fc2f16e73007858d4055e171eefb5e753c0 \
                   --hash=sha256:decf5296fd112334e8450a7ac9c360781ac7b250368cf26b9d90a4b04fdd36a2 \
                   --hash=sha256:61847b4c2edbeb88a5943f7a6ea51ffbba32df33df2c05d36640832dae4b075f \
                   --hash=sha256:0a81f950b76f34db65feb6c38629ecac5dcfd31a3d89a53789eefbeb6bfa4e19 \
                   --hash=sha256:aec45af0ec031ed2a18f4dc8e2a12188817c789ea1db0a2c863506dce9ae2b87
  typing_extensions==4.9.0 --hash=sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd
  urllib3==2.2.1 --hash=sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d
  wheel==0.42.0 --hash=sha256:177f9c9b0d45c47873b619f5b650346d632cdc35fb5e4d25058e09c9e581433d
  # Hashes correspond to the following packages:
  #  - wrapt-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl
  #  - wrapt-1.16.0-cp39-cp39-macosx_11_0_arm64.whl
  #  - wrapt-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - wrapt-1.16.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - wrapt-1.16.0-cp39-cp39-musllinux_1_1_aarch64.whl
  #  - wrapt-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - wrapt-1.16.0-cp39-cp39-win_amd64.whl
  #  - wrapt-1.16.0-py3-none-any.whl
  wrapt==1.16.0 --hash=sha256:9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2 \
                --hash=sha256:2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb \
                --hash=sha256:c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8 \
                --hash=sha256:f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a \
                --hash=sha256:5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664 \
                --hash=sha256:edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537 \
                --hash=sha256:eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35 \
                --hash=sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1
PS C:\Users\butlej30383\AppData\Local\slicer.org\Slicer 5.7.0-2024-02-17\bin>
```

Changes to note with the scipy version update from 1.11 to 1.12 are the following:

- https://scipy.github.io/devdocs/release/1.12.0-notes.html#deprecated-features
- https://scipy.github.io/devdocs/release/1.12.0-notes.html#expired-deprecations

Since scipy is not directly used in Slicer core, we may have to update extensions to account for changes.

## Testing Results:
Windows
- [X] Build ✔️  
- [X] Tests ✔️ 