### PR TITLE
ENH: Improve interaction options in Transforms SH plugin and module widget

### DIFF
--- a/Libs/MRML/Core/vtkMRMLTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.cxx
@@ -1724,3 +1724,23 @@ void vtkMRMLTransformNode::CreateDefaultSequenceDisplayNodes()
 {
   // don't create display nodes for transforms by default
 }
+
+//----------------------------------------------------------------------------
+void vtkMRMLTransformNode::SetCenterOfTransformation(double x, double y, double z)
+{
+  vtkDebugMacro(<< " setting CenterOfTransformation to (" << x << "," << y << "," << z << ")");
+  if ((this->CenterOfTransformation[0] != x) || (this->CenterOfTransformation[1] != y) || (this->CenterOfTransformation[2] != z))
+  {
+    this->CenterOfTransformation[0] = x;
+    this->CenterOfTransformation[1] = y;
+    this->CenterOfTransformation[2] = z;
+    this->Modified();
+    this->TransformModified();
+  }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLTransformNode::SetCenterOfTransformation(const double center[3])
+{
+  this->SetCenterOfTransformation(center[0], center[1], center[2]);
+}

--- a/Libs/MRML/Core/vtkMRMLTransformNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.h
@@ -371,7 +371,8 @@ public:
   static const char* GetFixedNodeReferenceRole() { return "spatialRegistrationFixed"; };
 
   /// The transformation center (rotation/scaling) that is rotated/scaled around
-  vtkSetVector3Macro(CenterOfTransformation, double);
+  virtual void SetCenterOfTransformation(double x, double y, double z);
+  virtual void SetCenterOfTransformation(const double xyz[3]);
   vtkGetVector3Macro(CenterOfTransformation, double);
 
 protected:

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidgetRepresentation.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidgetRepresentation.cxx
@@ -565,7 +565,7 @@ void vtkSlicerMarkupsInteractionWidgetRepresentation::UpdateHandleToWorldTransfo
 //----------------------------------------------------------------------
 double vtkSlicerMarkupsInteractionWidgetRepresentation::GetInteractionScalePercent()
 {
-  return this->GetDisplayNode()->GetGlyphScale() * 5.0;
+  return this->GetDisplayNode()->GetInteractionHandleScale() * 5.0;
 }
 
 //----------------------------------------------------------------------
@@ -594,22 +594,7 @@ bool vtkSlicerMarkupsInteractionWidgetRepresentation::GetHandleVisibility(int ty
     return false;
   }
 
-  bool handleVisibility[4] = { false, false, false, false };
-  if (markupsComponentType == vtkMRMLMarkupsDisplayNode::ComponentRotationHandle)
-  {
-    this->GetDisplayNode()->GetRotationHandleComponentVisibility(handleVisibility);
-  }
-  else if (markupsComponentType == vtkMRMLMarkupsDisplayNode::ComponentScaleHandle)
-  {
-    this->GetDisplayNode()->GetScaleHandleComponentVisibility(handleVisibility);
-  }
-  else if (markupsComponentType == vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle)
-  {
-    this->GetDisplayNode()->GetTranslationHandleComponentVisibility(handleVisibility);
-  }
-
   int visibilityIndex = index;
-  bool visibility = true;
   if (type == InteractionScaleHandle && vtkMRMLMarkupsROINode::SafeDownCast(this->GetMarkupsNode()))
   {
     switch (index)
@@ -649,12 +634,27 @@ bool vtkSlicerMarkupsInteractionWidgetRepresentation::GetHandleVisibility(int ty
     }
   }
 
-  if (visibilityIndex >= 0 || visibilityIndex <= 3)
+  if (visibilityIndex < 0 || visibilityIndex > 3)
   {
-    visibility = handleVisibility[visibilityIndex];
+    // Index out of range.
+    return false;
   }
 
-  return visibility && Superclass::GetHandleVisibility(type, index);
+  bool handleVisibility[4] = { false, false, false, false };
+  if (markupsComponentType == vtkMRMLMarkupsDisplayNode::ComponentRotationHandle)
+  {
+    this->GetDisplayNode()->GetRotationHandleComponentVisibility(handleVisibility);
+  }
+  else if (markupsComponentType == vtkMRMLMarkupsDisplayNode::ComponentScaleHandle)
+  {
+    this->GetDisplayNode()->GetScaleHandleComponentVisibility(handleVisibility);
+  }
+  else if (markupsComponentType == vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle)
+  {
+    this->GetDisplayNode()->GetTranslationHandleComponentVisibility(handleVisibility);
+  }
+
+  return handleVisibility[visibilityIndex] && Superclass::GetHandleVisibility(type, index);
 }
 
 //----------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -268,9 +268,10 @@ void qMRMLSubjectHierarchyTreeViewPrivate::init()
   // Transform
   this->TransformMenu = new QMenu(q);
 
-  this->TransformInteractionInViewAction = new QAction(qMRMLSubjectHierarchyTreeView::tr("Interaction in 3D view"), this->TransformMenu);
+  this->TransformInteractionInViewAction = new QAction(qMRMLSubjectHierarchyTreeView::tr("Interaction"), this->TransformMenu);
   this->TransformInteractionInViewAction->setCheckable(true);
-  this->TransformInteractionInViewAction->setToolTip(qMRMLSubjectHierarchyTreeView::tr("Allow interactively modify the transform in 3D views"));
+  this->TransformInteractionInViewAction->setToolTip(
+    qMRMLSubjectHierarchyTreeView::tr("Allow the transform to be modified interactively in the 2D and 3D views"));
   this->TransformMenu->addAction(this->TransformInteractionInViewAction);
   QObject::connect(this->TransformInteractionInViewAction, SIGNAL(toggled(bool)), q, SLOT(onTransformInteractionInViewToggled(bool)));
 

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager.cxx
@@ -112,7 +112,8 @@ bool vtkMRMLLinearTransformsDisplayableManager::vtkInternal::UseDisplayNode(vtkM
 {
   return displayNode
       && displayNode->GetScene()
-      && displayNode->GetEditorVisibility() && displayNode->GetEditorSliceIntersectionVisibility()
+      && displayNode->GetEditorVisibility()
+      && (this->GetAbstractViewNode()->IsA("vtkMRMLSliceNode") ? displayNode->GetEditorSliceIntersectionVisibility() : displayNode->GetEditorVisibility3D())
       && displayNode->IsDisplayableInView(this->GetAbstractViewNode()->GetID());
 }
 
@@ -479,7 +480,7 @@ void vtkMRMLLinearTransformsDisplayableManager::vtkInternal::SetupRenderer()
   vtkRenderer* renderer = this->External->GetRenderer();
   if (renderer == nullptr)
   {
-    vtkErrorWithObjectMacro(this->External, "vtkMRMLLinearTransformsDisplayableManager3D::vtkInternal::SetupRenderer() failed: renderer is invalid");
+    vtkErrorWithObjectMacro(this->External, "vtkMRMLLinearTransformsDisplayableManager::vtkInternal::SetupRenderer() failed: renderer is invalid");
     return;
   }
 

--- a/Modules/Loadable/Transforms/Resources/UI/qSlicerTransformsModuleWidget.ui
+++ b/Modules/Loadable/Transforms/Resources/UI/qSlicerTransformsModuleWidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>391</width>
+    <width>514</width>
     <height>1223</height>
    </rect>
   </property>
@@ -24,7 +24,16 @@
     <normaloff>:/Icons/Transforms.png</normaloff>:/Icons/Transforms.png</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -69,9 +78,6 @@
      </property>
      <property name="collapsedHeight">
       <number>14</number>
-     </property>
-     <property name="contentsFrameShape">
-      <enum>QFrame::NoFrame</enum>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_8">
       <item>
@@ -267,6 +273,62 @@
         </item>
        </layout>
       </item>
+      <item>
+       <widget class="ctkCollapsibleGroupBox" name="CenterOfTransformationGroupBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="title">
+         <string>Center of transformation</string>
+        </property>
+        <property name="collapsed">
+         <bool>true</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="1">
+          <widget class="QComboBox" name="CenterOfTransformationCoordinatesComboBox">
+           <item>
+            <property name="text">
+             <string>World</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Local</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Coordinates:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QPushButton" name="ResetCenterOfTransformationButton">
+           <property name="text">
+            <string>Reset</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0" colspan="3">
+          <widget class="qMRMLCoordinatesWidget" name="CenterOfTransformationCoordinatesWidget">
+           <property name="quantity">
+            <string notr="true">length</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -302,11 +364,11 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
      <property name="text">
       <string>Apply transform</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
@@ -441,9 +503,6 @@
      <property name="checked">
       <bool>false</bool>
      </property>
-     <property name="contentsFrameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
      <layout class="QFormLayout" name="formLayout_2">
       <property name="fieldGrowthPolicy">
        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -575,6 +634,33 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>ctkCollapsibleButton</class>
+   <extends>QWidget</extends>
+   <header>ctkCollapsibleButton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>ctkCollapsibleGroupBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkCoordinatesWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkCoordinatesWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkMatrixWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkMatrixWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLCoordinatesWidget</class>
+   <extends>ctkCoordinatesWidget</extends>
+   <header>qMRMLCoordinatesWidget.h</header>
+  </customwidget>
+  <customwidget>
    <class>qMRMLMatrixWidget</class>
    <extends>ctkMatrixWidget</extends>
    <header>qMRMLMatrixWidget.h</header>
@@ -617,23 +703,6 @@
    <class>qMRMLTransformInfoWidget</class>
    <extends>qMRMLWidget</extends>
    <header>qMRMLTransformInfoWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>ctkCollapsibleButton</class>
-   <extends>QWidget</extends>
-   <header>ctkCollapsibleButton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>ctkCollapsibleGroupBox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkMatrixWidget</class>
-   <extends>QWidget</extends>
-   <header>ctkMatrixWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources>
@@ -974,6 +1043,22 @@
     <hint type="destinationlabel">
      <x>461</x>
      <y>1512</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerTransformsModuleWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>CenterOfTransformationCoordinatesWidget</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>256</x>
+     <y>611</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>256</x>
+     <y>724</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/Transforms/SubjectHierarchyPlugins/CMakeLists.txt
+++ b/Modules/Loadable/Transforms/SubjectHierarchyPlugins/CMakeLists.txt
@@ -10,6 +10,7 @@ set(${KIT}_INCLUDE_DIRECTORIES
   ${MRMLCore_INCLUDE_DIRS}
   ${MRMLLogic_INCLUDE_DIRS}
   ${qMRMLWidgets_INCLUDE_DIRS}
+  ${vtkSlicer${MODULE_NAME}ModuleLogic_INCLUDE_DIRS}
   )
 
 set(${KIT}_SRCS
@@ -36,6 +37,7 @@ set(${KIT}_TARGET_LIBRARIES
   MRMLLogic
   qMRMLWidgets
   ${QT_LIBRARIES}
+  vtkSlicer${MODULE_NAME}ModuleLogic
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.h
+++ b/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.h
@@ -115,14 +115,15 @@ public:
 protected slots:
   /// Invert selected transform
   void invert();
-  void invertCurrentItem();
 
   /// Set transform to identity (only available for linear transforms)
   void identity();
-  void identityCurrentItem();
 
-  void resetCenterOfTransformation();
-  void resetCenterOfTransformationCurrentItem();
+  ///  Reset the center of transformation
+  void resetCenterOfTransformationLocal();
+  void resetCenterOfTransformationWorld();
+  void resetCenterOfTransformationAllTransformedNodeBounds();
+  void resetCenterOfTransformationTransformedNodeBounds();
 
   /// Toggle interaction box
   void toggleInteractionBox(bool);

--- a/Modules/Loadable/Transforms/Widgets/Resources/UI/qMRMLTransformDisplayNodeWidget.ui
+++ b/Modules/Loadable/Transforms/Widgets/Resources/UI/qMRMLTransformDisplayNodeWidget.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>499</width>
-    <height>919</height>
+    <height>969</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -1094,77 +1094,14 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_7">
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="InteractionVisibleCheckBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Show/Hide the transform widget in the 3D view.</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_9">
-        <property name="text">
-         <string>Visibility in slice view:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QCheckBox" name="InteractionVisible2dCheckBox">
         <property name="text">
          <string/>
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <widget class="QPushButton" name="ShowInteractionAdvancedOptionsButton">
-        <property name="text">
-         <string>More options...</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="InteractionVisible3dCheckBox">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="InteractionVisibleLabel">
-        <property name="text">
-         <string>Visibility: </string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_17">
-        <property name="text">
-         <string>Visibility in 3D view:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="3">
+      <item row="3" column="0" colspan="3">
        <widget class="QFrame" name="InteractiveAdvancedOptions3DFrame">
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
@@ -1384,7 +1321,70 @@
         </layout>
        </widget>
       </item>
-      <item row="4" column="0" colspan="3">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_17">
+        <property name="text">
+         <string>Visibility in 3D view:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="InteractionVisibleCheckBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Show/Hide the transform widget in the 3D view.</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="InteractionVisibleLabel">
+        <property name="text">
+         <string>Visibility: </string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>Visibility in slice view:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="InteractionVisible3dCheckBox">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QPushButton" name="ShowInteractionAdvancedOptionsButton">
+        <property name="text">
+         <string>More options...</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="3">
        <widget class="QFrame" name="InteractiveAdvancedOptionsSliceFrame">
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
@@ -1572,6 +1572,29 @@
           </widget>
          </item>
         </layout>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_20">
+        <property name="text">
+         <string>Size:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1" colspan="2">
+       <widget class="qMRMLSliderWidget" name="interactionHandleScaleSlider">
+        <property name="maximum">
+         <double>100.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>5.000000000000000</double>
+        </property>
+        <property name="suffix">
+         <string>%</string>
+        </property>
+        <property name="quantity">
+         <string notr="true"/>
+        </property>
        </widget>
       </item>
      </layout>

--- a/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.cxx
@@ -151,6 +151,8 @@ void qMRMLTransformDisplayNodeWidgetPrivate
   QObject::connect(this->scaleZSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
   QObject::connect(this->scaleViewPlaneSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
 
+  QObject::connect(this->interactionHandleScaleSlider, SIGNAL(valueChanged(double)), q, SLOT(updateInteractionHandleScale()));
+
   this->InteractiveAdvancedOptions3DFrame->hide();
   this->InteractiveAdvancedOptionsSliceFrame->hide();
 
@@ -332,6 +334,10 @@ void qMRMLTransformDisplayNodeWidget
   wasBlocking = d->InteractionVisible2dCheckBox->blockSignals(true);
   d->InteractionVisible2dCheckBox->setChecked(d->TransformDisplayNode->GetEditorSliceIntersectionVisibility());
   d->InteractionVisible2dCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->interactionHandleScaleSlider->blockSignals(true);
+  d->interactionHandleScaleSlider->setValue(d->TransformDisplayNode->GetInteractionScalePercent());
+  d->interactionHandleScaleSlider->blockSignals(wasBlocking);
 
   this->updateInteraction3DWidgetsFromDisplayNode();
   this->updateInteractionSliceWidgetsFromDisplayNode();
@@ -1102,4 +1108,17 @@ void qMRMLTransformDisplayNodeWidget::updateScalingComponentVisibility()
   componentVisibility[2] = d->scaleZSliceCheckBox->isChecked();
   componentVisibility[3] = d->scaleViewPlaneSliceCheckBox->isChecked();
   d->TransformDisplayNode->SetScaleHandleComponentVisibilitySlice(componentVisibility);
+}
+
+// ----------------------------------------------------------------------------
+void qMRMLTransformDisplayNodeWidget::updateInteractionHandleScale()
+{
+  Q_D(qMRMLTransformDisplayNodeWidget);
+  if (!d->TransformDisplayNode)
+  {
+    return;
+  }
+
+  double scale = d->interactionHandleScaleSlider->value();
+  d->TransformDisplayNode->SetInteractionScalePercent(scale);
 }

--- a/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.h
+++ b/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.h
@@ -105,6 +105,7 @@ public slots:
   void updateTranslationComponentVisibility();
   void updateRotationComponentVisibility();
   void updateScalingComponentVisibility();
+  void updateInteractionHandleScale();
 
   void setColorTableNode(vtkMRMLNode* colorTableNode);
 

--- a/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.h
+++ b/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.h
@@ -72,6 +72,10 @@ protected slots:
   void copyTransform();
   void pasteTransform();
 
+  void updateCenterOfTransformationWidgets();
+  void onCenterOfTransformationChanged();
+  void resetCenterOfTransformation();
+
   void transformSelectedNodes();
   void untransformSelectedNodes();
   void hardenSelectedNodes();


### PR DESCRIPTION
New SH actions for resetting the center of transformation for a transform:
  - Reset to local origin
  - Reset to world origin
  - Reset to center of bounds for all transformed nodes
  - Reset to center of bounds for a single transformed node

![image](https://github.com/Slicer/Slicer/assets/9222709/2e8f49d0-7886-4807-a9fa-73ccffedd682)

Transforms module widget:
  - New widget for live display and editing of center of transformation
 
![image](https://github.com/Slicer/Slicer/assets/9222709/244d22a6-c07c-41b5-8d31-50366a0b3b74)

  - New slider for changing scale of interaction widget

![image](https://github.com/Slicer/Slicer/assets/9222709/66d8a16d-45ca-4fa6-b0fe-db3f8c23f724)

Bug fixes:
  - Use correct scale for markups interaction handles
  - Fix both 2D and 3D visibility being controlled by GetEditorSliceIntersectionVisibility

Re #7570