### PR TITLE
ENH: Add cancel action for interaction handles

### DIFF
--- a/Libs/MRML/Core/vtkMRMLTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.cxx
@@ -340,7 +340,7 @@ else
 }
 
   // copy the center of transformation
-  node->SetCenterOfTransformation(this->GetCenterOfTransformation());
+  this->SetCenterOfTransformation(node->GetCenterOfTransformation());
 
   this->Modified();
   this->TransformModified();

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidget.h
@@ -28,9 +28,12 @@
 #ifndef vtkMRMLInteractionWidget_h
 #define vtkMRMLInteractionWidget_h
 
+// MRMLDisplayableManager includes
 #include "vtkMRMLDisplayableManagerExport.h"
-
 #include "vtkMRMLAbstractWidget.h"
+
+// MRML includes
+#include <vtkMRMLNode.h>
 
 class vtkMRMLAbstractViewNode;
 class vtkMRMLApplicationLogic;
@@ -68,16 +71,18 @@ public:
     WidgetStateOnTranslationHandle = WidgetStateInteraction_First, // hovering over a translation interaction handle
     WidgetStateOnRotationHandle, // hovering over a rotation interaction handle
     WidgetStateOnScaleHandle, // hovering over a scale interaction handle
+    WidgetStateUniformScale, // uniform scaling
     WidgetStateInteraction_Last
   };
 
   /// Widget events
   enum
   {
-    WidgetEventReserved = WidgetEventUser,  // this events is only to prevent other widgets from processing an event
-    WidgetStateUniformScale,
+    WidgetEventInteraction_First = WidgetEventUser,
+    WidgetEventReserved = WidgetEventInteraction_First,  // this events is only to prevent other widgets from processing an event
     WidgetEventUniformScaleStart,
     WidgetEventUniformScaleEnd,
+    WidgetEventCancel,
     WidgetEventInteraction_Last
   };
 
@@ -129,6 +134,11 @@ protected:
   virtual bool ProcessWidgetUniformScaleStart(vtkMRMLInteractionEventData* eventData);
   virtual bool ProcessEndMouseDrag(vtkMRMLInteractionEventData* eventData);
   virtual bool ProcessJumpCursor(vtkMRMLInteractionEventData* eventData);
+  virtual bool ProcessCancelEvent(vtkMRMLInteractionEventData* eventData);
+
+  virtual vtkMRMLNode* GetMRMLNode() = 0;
+  virtual void SaveInitialState();
+  virtual void RestoreInitialState();
 
   // Jump to the handle position for the given type and index. Returns true if successful.
   virtual bool JumpToHandlePosition(int type, int index);
@@ -143,10 +153,8 @@ protected:
 
   /// Variables for translate/rotate/scale
   double LastEventPosition[2];
-  double StartEventOffsetPosition[2];
 
-  bool ConvertDisplayPositionToWorld(const int displayPos[2],
-    double worldPos[3], double worldOrientationMatrix[9], double* refWorldPos = nullptr);
+  vtkSmartPointer<vtkMRMLNode> OriginalStateNode{ nullptr };
 
 private:
   vtkMRMLInteractionWidget(const vtkMRMLInteractionWidget&) = delete;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.cxx
@@ -103,12 +103,11 @@ void vtkMRMLMarkupsPlaneNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=tr
   MRMLNodeModifyBlocker blocker(this);
   vtkMRMLCopyBeginMacro(anode);
   vtkMRMLCopyEnumMacro(PlaneType);
-  vtkMRMLCopyIntMacro(MaximumNumberOfControlPoints);
-  vtkMRMLCopyIntMacro(RequiredNumberOfControlPoints);
   vtkMRMLCopyEnumMacro(SizeMode);
   vtkMRMLCopyVectorMacro(Size, double, 2);
   vtkMRMLCopyVectorMacro(Normal, double, 3);
   vtkMRMLCopyVectorMacro(Center, double, 3);
+  vtkMRMLCopyVectorMacro(PlaneBounds, double, 4);
   vtkMRMLCopyFloatMacro(AutoSizeScalingFactor);
   vtkMRMLCopyEndMacro();
 
@@ -126,10 +125,15 @@ void vtkMRMLMarkupsPlaneNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   Superclass::PrintSelf(os,indent);
   vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintEnumMacro(PlaneType);
   vtkMRMLPrintEnumMacro(SizeMode);
   vtkMRMLPrintVectorMacro(Size, double, 2);
+  vtkMRMLPrintVectorMacro(Normal, double, 3);
+  vtkMRMLPrintVectorMacro(Center, double, 3);
+  vtkMRMLPrintVectorMacro(PlaneBounds, double, 4);
   vtkMRMLPrintFloatMacro(AutoSizeScalingFactor);
   vtkMRMLPrintMatrix4x4Macro(ObjectToBaseMatrix);
+  vtkMRMLPrintMatrix4x4Macro(BaseToNodeMatrix);
   vtkMRMLPrintEndMacro();
 }
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidget.cxx
@@ -938,3 +938,9 @@ void vtkSlicerMarkupsInteractionWidget::FlipROIHandles(bool flipLRHandle, bool f
 
   displayNode->SetActiveComponent(displayNode->GetActiveComponentType(), index);
 }
+
+//-------------------------------------------------------------------------
+vtkMRMLNode* vtkSlicerMarkupsInteractionWidget::GetMRMLNode()
+{
+  return this->GetMarkupsNode();
+}

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidget.h
@@ -82,6 +82,8 @@ public:
 
   bool ProcessWidgetMenu(vtkMRMLInteractionEventData* eventData) override;
 
+  vtkMRMLNode* GetMRMLNode() override;
+
 protected:
   vtkSlicerMarkupsInteractionWidget();
   ~vtkSlicerMarkupsInteractionWidget() override;

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidget.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidget.cxx
@@ -51,6 +51,9 @@ vtkMRMLTransformHandleWidget::vtkMRMLTransformHandleWidget()
   // Handle interactions
   this->SetEventTranslationClickAndDrag(WidgetStateOnTranslationHandle, vtkCommand::LeftButtonPressEvent, vtkEvent::AltModifier,
     WidgetStateTranslateTransformCenter, WidgetEventTranslateTransformCenterStart, WidgetEventTranslateTransformCenterEnd);
+
+  this->SetEventTranslation(WidgetStateTranslateTransformCenter, vtkCommand::RightButtonPressEvent, vtkEvent::NoModifier, WidgetEventCancel);
+  this->SetKeyboardEventTranslation(WidgetStateTranslateTransformCenter, vtkEvent::NoModifier, 0, 0, "Escape", WidgetEventCancel);
 }
 
 //----------------------------------------------------------------------
@@ -413,4 +416,10 @@ bool vtkMRMLTransformHandleWidget::ProcessJumpCursor(vtkMRMLInteractionEventData
   }
 
   return Superclass::ProcessJumpCursor(eventData);
+}
+
+//-------------------------------------------------------------------------
+vtkMRMLNode* vtkMRMLTransformHandleWidget::GetMRMLNode()
+{
+  return this->GetTransformNode();
 }

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidget.h
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidget.h
@@ -18,7 +18,6 @@
 
 ==============================================================================*/
 
-
 ///
 /// \class vtkMRMLTransformHandleWidget
 /// \brief Process interaction events to update state of interaction widgets
@@ -33,16 +32,17 @@
 
 #include "vtkMRMLInteractionWidget.h"
 
+class vtkIdList;
+class vtkMatrix4x4;
 class vtkMRMLAbstractViewNode;
 class vtkMRMLApplicationLogic;
 class vtkMRMLDisplayableNode;
 class vtkMRMLInteractionEventData;
 class vtkMRMLInteractionNode;
-class vtkIdList;
-class vtkPolyData;
-class vtkTransform;
 class vtkMRMLTransformDisplayNode;
 class vtkMRMLTransformNode;
+class vtkPolyData;
+class vtkTransform;
 
 class VTK_SLICER_TRANSFORMS_MODULE_MRMLDISPLAYABLEMANAGER_EXPORT vtkMRMLTransformHandleWidget
   : public vtkMRMLInteractionWidget
@@ -91,6 +91,8 @@ protected:
   virtual void TranslateTransformCenter(double eventPos[2]);
 
   void ApplyTransform(vtkTransform* transform) override;
+
+  vtkMRMLNode* GetMRMLNode() override;
 
 private:
   vtkMRMLTransformHandleWidget(const vtkMRMLTransformHandleWidget&) = delete;


### PR DESCRIPTION
This commit adds a cancel action when translating/rotating/scaling using interaction handles. Users can press "Escape" or right-click to cancel the current action and restore the Transform or Markups node back to its original state.

Re #7570