### PR TITLE
STYLE: Add missing semicolon after statement macros

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -2098,7 +2098,7 @@ void qSlicerCoreApplication::loadTranslations(const QString& dir)
     app->installTranslator(translator);
   }
 #else
-  Q_UNUSED(dir)
+  Q_UNUSED(dir);
 #endif
 }
 

--- a/Base/QTGUI/qSlicerWebWidget.cxx
+++ b/Base/QTGUI/qSlicerWebWidget.cxx
@@ -486,8 +486,8 @@ void qSlicerWebWidget::handleSslErrors(QNetworkReply* reply,
                                        const QList<QSslError> &errors)
 {
 #ifdef QT_NO_SSL
-  Q_UNUSED(reply)
-  Q_UNUSED(errors)
+  Q_UNUSED(reply);
+  Q_UNUSED(errors);
 #else
   foreach (QSslError e, errors)
   {

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -133,7 +133,7 @@ void vtkMRMLAbstractViewNode::ReadXMLAttributes(const char** atts)
   // the mrml version. Scene with a newer version number would consider the
   // serialized attribute whereas older scene would not.
   //
-  // vtkMRMLReadXMLBooleanMacro(visibility, Visibility)
+  // vtkMRMLReadXMLBooleanMacro(visibility, Visibility);
 
   vtkMRMLReadXMLVectorMacro(backgroundColor, BackgroundColor, double, 3);
   vtkMRMLReadXMLVectorMacro(backgroundColor2, BackgroundColor2, double, 3);

--- a/Libs/MRML/Core/vtkMRMLModelNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelNode.h
@@ -100,7 +100,7 @@ public:
 
   /// Return the input mesh pipeline.
   /// \sa GetPolyDataConnection(), GetUnstructuredGridConnection()
-  vtkGetObjectMacro(MeshConnection,vtkAlgorithmOutput)
+  vtkGetObjectMacro(MeshConnection,vtkAlgorithmOutput);
 
   /// Return the input mesh pipeline if the mesh
   /// is a polydata.

--- a/Libs/MRML/Core/vtkMRMLNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNode.cxx
@@ -306,7 +306,7 @@ void vtkMRMLNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBooleanMacro(HideFromEditors);
   vtkMRMLPrintBooleanMacro(Selectable);
   vtkMRMLPrintBooleanMacro(Selected);
-  vtkMRMLPrintBooleanMacro(UndoEnabled)
+  vtkMRMLPrintBooleanMacro(UndoEnabled);
   vtkMRMLPrintEndMacro();
 
   if (!this->Attributes.empty())
@@ -367,7 +367,7 @@ void vtkMRMLNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBooleanMacro(selectable, Selectable);
   vtkMRMLReadXMLBooleanMacro(selected, Selected);
   vtkMRMLReadXMLStringMacro(singletonTag, SingletonTag);
-  vtkMRMLReadXMLBooleanMacro(undoEnabled, UndoEnabled)
+  vtkMRMLReadXMLBooleanMacro(undoEnabled, UndoEnabled);
   vtkMRMLReadXMLEndMacro();
 
   std::set<std::string> references;

--- a/Libs/MRML/Core/vtkMRMLProceduralColorNode.h
+++ b/Libs/MRML/Core/vtkMRMLProceduralColorNode.h
@@ -116,12 +116,12 @@ public:
   /// Get number of entries used when discretizing
   /// the color transfer function into a lookup table
   /// \sa SetNumberOfTableValues(), GetLookupTable()
-  vtkGetMacro(NumberOfTableValues, unsigned int)
+  vtkGetMacro(NumberOfTableValues, unsigned int);
 
   /// Set number of entries used when discretizing
   /// the color transfer function into a lookup table
   /// \sa GetNumberOfTableValues(), GetLookupTable()
-  vtkSetMacro(NumberOfTableValues, unsigned int)
+  vtkSetMacro(NumberOfTableValues, unsigned int);
 
 protected:
   vtkMRMLProceduralColorNode();

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -106,10 +106,10 @@ Version:   $Revision: 1.18 $
 # include <vtkTimerLog.h>
 #endif
 
-vtkCxxSetObjectMacro(vtkMRMLScene, CacheManager, vtkCacheManager)
-vtkCxxSetObjectMacro(vtkMRMLScene, DataIOManager, vtkDataIOManager)
-vtkCxxSetObjectMacro(vtkMRMLScene, UserTagTable, vtkTagTable)
-vtkCxxSetObjectMacro(vtkMRMLScene, URIHandlerCollection, vtkCollection)
+vtkCxxSetObjectMacro(vtkMRMLScene, CacheManager, vtkCacheManager);
+vtkCxxSetObjectMacro(vtkMRMLScene, DataIOManager, vtkDataIOManager);
+vtkCxxSetObjectMacro(vtkMRMLScene, UserTagTable, vtkTagTable);
+vtkCxxSetObjectMacro(vtkMRMLScene, URIHandlerCollection, vtkCollection);
 
 //------------------------------------------------------------------------------
 vtkMRMLScene::vtkMRMLScene()

--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -268,7 +268,7 @@ public:
   ///
   /// Number of samples in each direction
   /// -- note that the spacing is implicitly FieldOfView / Dimensions
-  vtkGetVectorMacro(Dimensions,int,3)
+  vtkGetVectorMacro(Dimensions,int,3);
   void SetDimensions(int x, int y, int z);
   void SetDimensions(int xyz[3]) { SetDimensions(xyz[0], xyz[1], xyz[2]); }
 
@@ -279,13 +279,13 @@ public:
   ///    to the full Dimensions
   /// -- note that z, the number of slices, should be the same for both
   ///    Dimensions and UVWDimensions
-  vtkGetVectorMacro(UVWDimensions,int,3)
+  vtkGetVectorMacro(UVWDimensions,int,3);
   void SetUVWDimensions(int x, int y, int z);
   void SetUVWDimensions(int xyz[3]);
 
   ///
   ///    maximum limit for  UVWDimensions
-  vtkGetVectorMacro(UVWMaximumDimensions,int,3)
+  vtkGetVectorMacro(UVWMaximumDimensions,int,3);
   void SetUVWMaximumDimensions(int x, int y, int z);
   void SetUVWMaximumDimensions(int xyz[3]);
 

--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -37,7 +37,7 @@ Version:   $Revision: 1.1.1.1 $
 #include <sstream>
 
 //----------------------------------------------------------------------------
-vtkCxxSetObjectMacro(vtkMRMLStorageNode, URIHandler, vtkURIHandler)
+vtkCxxSetObjectMacro(vtkMRMLStorageNode, URIHandler, vtkURIHandler);
 
 //----------------------------------------------------------------------------
 vtkMRMLStorageNode::vtkMRMLStorageNode()

--- a/Libs/MRML/Core/vtkMRMLTransformDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformDisplayNode.cxx
@@ -167,10 +167,10 @@ void vtkMRMLTransformDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLFloatMacro(InteractionSizeMm, InteractionSizeMm);
   vtkMRMLWriteXMLFloatMacro(InteractionScalePercent, InteractionScalePercent);
   vtkMRMLWriteXMLVectorMacro(TranslationHandleComponentVisibility3D, TranslationHandleComponentVisibility3D, bool, 4);
-  vtkMRMLWriteXMLVectorMacro(RotationHandleComponentVisibility3D, RotationHandleComponentVisibility3D, bool, 4)
+  vtkMRMLWriteXMLVectorMacro(RotationHandleComponentVisibility3D, RotationHandleComponentVisibility3D, bool, 4);
   vtkMRMLWriteXMLVectorMacro(ScaleHandleComponentVisibility3D, ScaleHandleComponentVisibility3D, bool, 4);
   vtkMRMLWriteXMLVectorMacro(TranslationHandleComponentVisibilitySlice, TranslationHandleComponentVisibilitySlice, bool, 4);
-  vtkMRMLWriteXMLVectorMacro(RotationHandleComponentVisibilitySlice, RotationHandleComponentVisibilitySlice, bool, 4)
+  vtkMRMLWriteXMLVectorMacro(RotationHandleComponentVisibilitySlice, RotationHandleComponentVisibilitySlice, bool, 4);
   vtkMRMLWriteXMLVectorMacro(ScaleHandleComponentVisibilitySlice, ScaleHandleComponentVisibilitySlice, bool, 4);
 
   vtkMRMLWriteXMLEndMacro();

--- a/Libs/vtkITK/vtkITKImageThresholdCalculator.h
+++ b/Libs/vtkITK/vtkITKImageThresholdCalculator.h
@@ -93,6 +93,6 @@ private:
   void operator=(const vtkITKImageThresholdCalculator&) = delete;
 };
 
-//vtkStandardNewMacro(vtkITKImageThresholdCalculator)
+//vtkStandardNewMacro(vtkITKImageThresholdCalculator);
 
 #endif

--- a/Libs/vtkITK/vtkITKImageWriter.h
+++ b/Libs/vtkITK/vtkITKImageWriter.h
@@ -96,6 +96,6 @@ private:
   void operator=(const vtkITKImageWriter&) = delete;
 };
 
-//vtkStandardNewMacro(vtkITKImageWriter)
+//vtkStandardNewMacro(vtkITKImageWriter);
 
 #endif

--- a/Modules/Loadable/Annotations/Logic/vtkSlicerAnnotationModuleLogic.cxx
+++ b/Modules/Loadable/Annotations/Logic/vtkSlicerAnnotationModuleLogic.cxx
@@ -38,7 +38,7 @@
 #include <sstream>
 
 //-----------------------------------------------------------------------------
-vtkStandardNewMacro(vtkSlicerAnnotationModuleLogic)
+vtkStandardNewMacro(vtkSlicerAnnotationModuleLogic);
 
 //-----------------------------------------------------------------------------
 // vtkSlicerAnnotationModuleLogic methods

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotNode.h
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotNode.h
@@ -33,7 +33,7 @@ public:
   const char* GetIcon() override {return ":/Icons/ViewCamera.png";}
 
   void SetSnapshotDescription(const vtkStdString& newDescription);
-  vtkGetMacro(SnapshotDescription, vtkStdString)
+  vtkGetMacro(SnapshotDescription, vtkStdString);
 
   void WriteXML(ostream& of, int nIndent) override;
   void ReadXMLAttributes(const char** atts) override;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -319,7 +319,7 @@ void vtkMRMLMarkupsNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBeginMacro(os, indent);
   vtkMRMLPrintBooleanMacro(Locked);
   vtkMRMLPrintStdStringMacro(ControlPointLabelFormat);
-  vtkMRMLPrintMatrix4x4Macro(InteractionHandleToWorldMatrix)
+  vtkMRMLPrintMatrix4x4Macro(InteractionHandleToWorldMatrix);
   vtkMRMLPrintEndMacro();
 
   os << indent << "Control point number locked: ";

--- a/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx
@@ -479,7 +479,7 @@ void qSlicerSimpleMarkupsWidget::onMarkupsControlPointsTableContextMenu(const QP
 //-----------------------------------------------------------------------------
 void qSlicerSimpleMarkupsWidget::onMarkupsControlPointSelected(int row, int column)
 {
-  Q_UNUSED(column)
+  Q_UNUSED(column);
   Q_D(qSlicerSimpleMarkupsWidget);
 
   if (d->JumpToSliceEnabled)

--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
@@ -18,7 +18,7 @@
 #include <sstream>
 
 //-----------------------------------------------------------------------------
-vtkStandardNewMacro(vtkSlicerSceneViewsModuleLogic)
+vtkStandardNewMacro(vtkSlicerSceneViewsModuleLogic);
 
 //-----------------------------------------------------------------------------
 // vtkSlicerSceneViewsModuleLogic methods

--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
@@ -1661,7 +1661,7 @@ bool qSlicerTerminologyNavigatorWidget::setCurrentType(vtkSlicerTerminologyType*
 //-----------------------------------------------------------------------------
 void qSlicerTerminologyNavigatorWidget::onTypeSelected(QTableWidgetItem* currentItem, QTableWidgetItem* previousItem)
 {
-  Q_UNUSED(previousItem)
+  Q_UNUSED(previousItem);
   Q_D(qSlicerTerminologyNavigatorWidget);
 
   if (!currentItem)
@@ -2258,7 +2258,7 @@ bool qSlicerTerminologyNavigatorWidget::setCurrentRegion(vtkSlicerTerminologyTyp
 //-----------------------------------------------------------------------------
 void qSlicerTerminologyNavigatorWidget::onRegionSelected(QTableWidgetItem* currentItem, QTableWidgetItem* previousItem)
 {
-  Q_UNUSED(previousItem)
+  Q_UNUSED(previousItem);
   Q_D(qSlicerTerminologyNavigatorWidget);
 
   if (!currentItem)

--- a/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMExportDialog.cxx
+++ b/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMExportDialog.cxx
@@ -198,7 +198,7 @@ void qSlicerDICOMExportDialog::makeDialogSelections()
 //-----------------------------------------------------------------------------
 void qSlicerDICOMExportDialog::onCurrentItemChanged(vtkIdType itemID)
 {
-  Q_UNUSED(itemID)
+  Q_UNUSED(itemID);
   Q_D(qSlicerDICOMExportDialog);
 
   // Clear error label


### PR DESCRIPTION
These changes are done anticipating the integration of "clang-format" for automated formatting of source files.

Changes were identified using the following one-liners:

```
cd Slicer
ack -i "^[\s\/]*(ctk|itk|slicer|vtk)\s*[0-9a-zA-Z]+\([\,a-zA-Z0-9\s]+\)$"
ack "Q_UNUSED\([\,a-zA-Z0-9\s]+\)$"
ack "Q_[^P][A-Za-z0-9]+\([\,a-zA-Z0-9\s]+\)$" # To identify use of "Q_*" macros excluding "Q_PROPERTY"
```