### PR TITLE
BUG: Fix issues caused by invalid Segmentation binary labelmap scalar types

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLSegmentationStorageNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSegmentationStorageNodeTest1.cxx
@@ -33,7 +33,7 @@ Care Ontario.
 #include "vtkFractionalLabelmapToClosedSurfaceConversionRule.h"
 #include "vtkClosedSurfaceToFractionalLabelmapConversionRule.h"
 
-int vtkMRMLSegmentationStorageNodeTest1(int argc, char * argv[] )
+int vtkMRMLSegmentationStorageNodeTest1(int argc, char* argv[])
 {
   vtkNew<vtkMRMLSegmentationStorageNode> node1;
   vtkNew<vtkMRMLScene> scene;
@@ -43,9 +43,9 @@ int vtkMRMLSegmentationStorageNodeTest1(int argc, char * argv[] )
   if (argc != 5)
   {
     std::cerr << "Line " << __LINE__
-              << " - Missing or extra parameters!\n"
-              << "Usage: " << argv[0] << " /path/to/ITKSnapSegmentation.nii.gz /path/to/OldSlicerSegmentation.seg.nrrd /path/to/SlicerSegmentation.seg.nrrd"
-              << std::endl;
+      << " - Missing or extra parameters!\n"
+      << "Usage: " << argv[0] << " /path/to/ITKSnapSegmentation.nii.gz /path/to/OldSlicerSegmentation.seg.nrrd /path/to/SlicerSegmentation.seg.nrrd"
+      << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
+++ b/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
@@ -23,6 +23,7 @@
 #include "vtkSegmentation.h"
 
 #include "vtkOrientedImageData.h"
+#include "vtkOrientedImageDataResample.h"
 
 // VTK includes
 #include <vtkCompositeDataIterator.h>
@@ -156,6 +157,12 @@ bool vtkBinaryLabelmapToClosedSurfaceConversionRule::Convert(vtkSegment* segment
   if (!orientedBinaryLabelmap)
   {
     vtkErrorMacro("Convert: Source representation is not oriented image data");
+    return false;
+  }
+
+  if (vtkOrientedImageDataResample::IsImageScalarTypeValid(orientedBinaryLabelmap) != vtkOrientedImageDataResample::TYPE_OK)
+  {
+    vtkErrorMacro("Convert: Source representation scalar type is not a valid integer type");
     return false;
   }
 

--- a/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.h
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.h
@@ -183,10 +183,41 @@ public:
   static bool IsLabelInMask(vtkOrientedImageData* binaryLabelmap, vtkOrientedImageData* mask,
     int extent[6]=nullptr, int maskThreshold=0);
 
+  enum ImageTypeCheckResult
+  {
+    TYPE_OK,
+    TYPE_CONVERSION_NEEDED,
+    TYPE_CONVERSION_TRUNCATION_NEEDED,
+    TYPE_CONVERSION_CLAMPING_NEEDED,
+    TYPE_ERROR
+  };
+
+  /// Determine if the scalar type of the image is valid for representing segmentations.
+  /// \param image Image to validate
+  /// \return ImageTypeCheckResult value representing if the image scalar type is valid, and if not, what kind of conversion is needed.
+  /// \sa vtkImageData::GetScalarType()
+  static int IsImageScalarTypeValid(vtkImageData* image);
+
+  /// Determine the smallest integer type that can contain the specified scalar range.
+  /// \param scalarRange Range of the scalar values that should be representable by the image data type
+  /// \return Smallest integer type that can contain the specified scalar range. Possible values are VTK_UNSIGNED_CHAR, VTK_CHAR, VTK_UNSIGNED_SHORT, VTK_SHORT, VTK_UNSIGNED_INT, VTK_INT and -1 if no valid integer type can contain the scalar range.
+  static int GetSmallestIntegerTypeForSegmentationScalarRange(double scalarRange[2]);
+
+  /// Cast the data type of the image to the smallest possible size that can contain the currently stored values
+  /// \param image Image to cast.
+  /// \return True if the image cast was successful, false otherwise
+  static bool CastSegmentationToSmallestIntegerType(vtkImageData* image);
+
+  /// Cast the data type of the image to the smallest possible size that can contain the specified value
+  /// \param image Image to convert
+  /// \param scalarRange Range of the scalar values that should be representable by the image data type
+  /// \return True if the image cast was successful, false otherwise
+  static bool CastSegmentationToSmallestIntegerType(vtkImageData* image, double scalarRange[2]);
+
   /// Cast the data type of the image to be able to contain the specified value
   /// \param image Image to convert
   /// \param value Value that should be representable by the image data type
-  static void CastImageForValue(vtkOrientedImageData* image, double value);
+  static void CastImageForValue(vtkImageData* image, double value);
 
 protected:
   vtkOrientedImageDataResample();

--- a/Libs/vtkSegmentationCore/vtkSegmentationConverterFactory.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentationConverterFactory.cxx
@@ -23,9 +23,11 @@
 // VTK includes
 #include <vtkObjectFactory.h>
 #include <vtkDataObject.h>
+#include <vtkImageData.h>
 
 // SegmentationCore includes
 #include "vtkSegmentationConverterRule.h"
+#include "vtkSegmentationConverter.h"
 
 //----------------------------------------------------------------------------
 // The segmentation converter rule manager singleton.
@@ -212,10 +214,18 @@ vtkDataObject* vtkSegmentationConverterFactory::ConstructRepresentationObjectByR
   for (RuleListType::iterator ruleIt = this->Rules.begin(); ruleIt != this->Rules.end(); ++ruleIt)
   {
     vtkDataObject* representationObject = (*ruleIt)->ConstructRepresentationObjectByRepresentation(representationName);
-    if (representationObject)
+    if (!representationObject)
     {
-      return representationObject;
+      continue;
     }
+
+    vtkImageData* imageData = vtkImageData::SafeDownCast(representationObject);
+    if (imageData && representationName == vtkSegmentationConverter::GetBinaryLabelmapRepresentationName())
+    {
+      // If we are creating a binary labelmap, we should ensure that it is using unsigned char by default.
+      imageData->AllocateScalars(VTK_UNSIGNED_CHAR, 1);
+    }
+    return representationObject;
   }
 
   // None of the registered rules can instantiate this type

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
@@ -77,7 +77,7 @@ public:
   /// \param colorTableNode Optional color node used to name the segments and set segment color.
   /// \return Loaded segmentation node
   vtkMRMLSegmentationNode* LoadSegmentationFromFile(const char* filename, bool autoOpacities = true, const char* nodeName=nullptr,
-    vtkMRMLColorTableNode* colorTableNode=nullptr);
+    vtkMRMLColorTableNode* colorTableNode=nullptr, vtkMRMLMessageCollection* userMessages=nullptr);
 
   /// Create labelmap volume MRML node from oriented image data.
   /// Creates a display node if a display node does not exist. Shifts image extent to start from zero.
@@ -215,7 +215,7 @@ public:
   /// The colors of the new segments are set from the color table corresponding to the labelmap volume.
   /// \param insertBeforeSegmentId New segments will be inserted before this segment.
   static bool ImportLabelmapToSegmentationNode(vtkMRMLLabelMapVolumeNode* labelmapNode,
-    vtkMRMLSegmentationNode* segmentationNode, std::string insertBeforeSegmentId="");
+    vtkMRMLSegmentationNode* segmentationNode, std::string insertBeforeSegmentId="", vtkMRMLMessageCollection* userMessages=nullptr);
 
   /// Import all labels from a labelmap image to a segmentation node, each label to a separate segment
   /// The colors of the new segments are randomly generated, unless terminology context is specified, in which case the terminology
@@ -224,25 +224,27 @@ public:
   /// (parent transform of the segmentation node is not used during import).
   /// \param baseSegmentName Prefix for the names of the new segments. Empty by default, in which case the prefix will be "Label"
   static bool ImportLabelmapToSegmentationNode(vtkOrientedImageData* labelmapImage,
-    vtkMRMLSegmentationNode* segmentationNode, std::string baseSegmentName="", std::string insertBeforeSegmentId="") ;
+    vtkMRMLSegmentationNode* segmentationNode, std::string baseSegmentName="", std::string insertBeforeSegmentId="",
+    vtkMRMLMessageCollection* userMessages=nullptr) ;
 
   /// Update segmentation from segments in a labelmap node.
   /// \param updatedSegmentIDs Defines how label values 1..N are mapped to segment IDs (0..N-1).
   static bool ImportLabelmapToSegmentationNode(vtkMRMLLabelMapVolumeNode* labelmapNode,
-    vtkMRMLSegmentationNode* segmentationNode, vtkStringArray* updatedSegmentIDs);
+    vtkMRMLSegmentationNode* segmentationNode, vtkStringArray* updatedSegmentIDs, vtkMRMLMessageCollection* userMessages = nullptr);
 
   /// Update segmentation from segments in a labelmap node.
   /// \param updatedSegmentIDs Defines how label values 1..N are mapped to segment IDs (0..N-1).
   static bool ImportLabelmapToSegmentationNode(vtkOrientedImageData* labelmapImage,
     vtkMRMLSegmentationNode* segmentationNode, vtkStringArray* updatedSegmentIDs,
-    vtkGeneralTransform* labelmapToSegmentationTransform=nullptr );
+    vtkGeneralTransform* labelmapToSegmentationTransform=nullptr, vtkMRMLMessageCollection* userMessages = nullptr);
 
   /// Import all labels from a labelmap node to a segmentation node, each label to a separate segment.
   /// Terminology and color is set to the segments based on the color table corresponding to the labelmap volume node.
   /// \param terminologyContextName Terminology context the entries of which are mapped to the labels imported from the labelmap node
   /// \param insertBeforeSegmentId New segments will be inserted before this segment.
   bool ImportLabelmapToSegmentationNodeWithTerminology(vtkMRMLLabelMapVolumeNode* labelmapNode,
-    vtkMRMLSegmentationNode* segmentationNode, std::string terminologyContextName, std::string insertBeforeSegmentId="");
+    vtkMRMLSegmentationNode* segmentationNode, std::string terminologyContextName, std::string insertBeforeSegmentId="",
+    vtkMRMLMessageCollection* userMessages = nullptr);
 
   /// Import model into the segmentation as a segment.
   static bool ImportModelToSegmentationNode(vtkMRMLModelNode* modelNode, vtkMRMLSegmentationNode* segmentationNode, std::string insertBeforeSegmentId = "");

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsReader.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsReader.cxx
@@ -226,7 +226,7 @@ bool qSlicerSegmentationsReader::load(const IOProperties& properties)
     }
 
     vtkMRMLSegmentationNode* node = d->SegmentationsLogic->LoadSegmentationFromFile(
-      fileName.toUtf8().constData(), autoOpacities, name.toUtf8(), colorTableNode);
+      fileName.toUtf8().constData(), autoOpacities, name.toUtf8(), colorTableNode, this->userMessages());
     if (!node)
     {
       this->setLoadedNodes(QStringList());


### PR DESCRIPTION
Adds the functions `ValidateSegmentationImageType` and `CastToSmallestUnsignedIntegerType` to vtkOrientedImageDataResample.
- `IsImageScalarTypeValid`: Returns True if the scalar type of the image is valid for representing segmentations. False otherwise.
- `CastToSmallestUnsignedIntegerType`: Casts the contents of the image to the smallest unsigned integer type that can contain all values in the image.
- `ValidateSegmentationImageType`: Checks to see if the scalar type of the image is a valid type, and casts the image to the smallest valid type if it is not.

The function `ValidateSegmentationImageType` is used during binary labelmap read/import to automatically convert the labelmap.
If a labelmap representation with an invalid scalar type is added to a segment, we only log a warning and don't automatically convert the labelmap.
Before performing binary labelmap to closed surface conversion, we check that the scalar type is valid, and log/return an error if it is not.

This should prevent errors from arising due to the use of floating point images for segmentations.

Re #6941
