### PR TITLE
ENH: Add SegmentationGeometryLogic API to set reference image geometry

### DIFF
--- a/Docs/developer_guide/script_repository/segmentations.md
+++ b/Docs/developer_guide/script_repository/segmentations.md
@@ -635,6 +635,30 @@ sourceSegmentId = segmentation.GetSegmentIdBySegmentName(sourceSegmentName)
 segmentation.CopySegmentFromSegmentation(segmentation, sourceSegmentId)
 ```
 
+### Resample segmentation to higher resolution
+
+This code snippet can be used to resample internal binary labelmap representation of a segmentation to allow segmenting finer details
+
+```python
+# Set inputs
+volumeNode = getNode("MRHead")
+segmentationNode = getNode("Segmentation")
+
+# The higher the oversampling factor is the finer resolution the segmentation will be,
+# at the cost of more memory usage and longer computation times.
+# Note that oversampling by a factor of 2 increases memory usage by a factor of 2 * 2 * 2 = 8.
+oversamplingFactor = 2.0
+
+# Make spacing value uniform for all axes.
+# It is useful for removing staircase artifacts in 3D reconstructions but may increase
+# memory usage and computation time.
+isotropicSpacing = True
+
+# Update geometry of internal binary labelmap representation in segmentation node
+segmentationGeometryLogic.SetReferenceImageGeometryInSegmentationNode()
+segmentationGeometryLogic.ResampleLabelmapsInSegmentationNode()
+```
+
 ### Quantifying segments
 
 #### Get volume of each segment

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.h
@@ -59,6 +59,9 @@ public:
 
   /// Sets the computed reference image geometry into the input segmentation node
   /// (in the ReferenceImageGeometry conversion parameter and node reference).
+  /// For example, reference geometry may be used for determining the geometry of the segmentation
+  /// when saving into file, to make the extents of the segmentation match the extents of the
+  /// segmented image (instead of making the segmentation just big enough to store all the segments).
   bool SetReferenceImageGeometryInSegmentationNode();
 
   /// Resample labelmap representation of the input segmentation node according to the current

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.h
@@ -57,6 +57,10 @@ public:
   /// Use this calculated permutation for updating spacing widget from geometry and interpreting spacing input
   void ComputeSourceAxisIndexForInputAxis();
 
+  /// Sets the computed reference image geometry into the input segmentation node
+  /// (in the ReferenceImageGeometry conversion parameter and node reference).
+  bool SetReferenceImageGeometryInSegmentationNode();
+
   /// Resample labelmap representation the input segmentation node according to the current
   /// output geometry setting.
   bool ResampleLabelmapsInSegmentationNode();

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.h
@@ -61,8 +61,10 @@ public:
   /// (in the ReferenceImageGeometry conversion parameter and node reference).
   bool SetReferenceImageGeometryInSegmentationNode();
 
-  /// Resample labelmap representation the input segmentation node according to the current
+  /// Resample labelmap representation of the input segmentation node according to the current
   /// output geometry setting.
+  ///
+  /// \sa SetReferenceImageGeometryInSegmentationNode()
   bool ResampleLabelmapsInSegmentationNode();
 
   /// Oriented image data containing output geometry. This is what the class calculates from the inputs

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationGeometryWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationGeometryWidget.cxx
@@ -479,37 +479,16 @@ void qMRMLSegmentationGeometryWidget::setReferenceImageGeometryForSegmentationNo
   Q_D(qMRMLSegmentationGeometryWidget);
   if (!d->SegmentationNode.GetPointer())
   {
-    qCritical() << Q_FUNC_INFO << "No input segmentation specified";
+    qCritical() << Q_FUNC_INFO << ": No input segmentation specified";
     return;
   }
 
-  // Save reference geometry
+  d->Logic->SetReferenceImageGeometryInSegmentationNode();
+
   vtkOrientedImageData* geometryImageData = d->Logic->GetOutputGeometryImageData();
   std::string geometryString = vtkSegmentationConverter::SerializeImageGeometry(geometryImageData);
-  d->SegmentationNode->GetSegmentation()->SetConversionParameter(
-    vtkSegmentationConverter::GetReferenceImageGeometryParameterName(), geometryString );
-
-  // Save reference geometry node (this is shown in Segmentations module
-  // to gives a hint about which node the current geometry is based on)
-  const char* referenceGeometryNodeID = nullptr;
-  if (d->Logic->GetSourceGeometryNode())
-  {
-    referenceGeometryNodeID = d->Logic->GetSourceGeometryNode()->GetID();
-  }
-
-  // If the reference geometry node is the same as the segmentation node, then don't change the node reference
-  if (vtkMRMLSegmentationNode::SafeDownCast(d->Logic->GetSourceGeometryNode()) != d->SegmentationNode)
-  {
-    d->SegmentationNode->SetNodeReferenceID(
-      vtkMRMLSegmentationNode::GetReferenceImageGeometryReferenceRole().c_str(), referenceGeometryNodeID);
-  }
-
-  // Note: it could be also useful to save oversampling value and isotropic flag,
-  // we could then allow the user to modify these settings instead of always
-  // setting from scratch.
-
-  qDebug() << Q_FUNC_INFO << "Reference image geometry of " << d->SegmentationNode->GetName()
-    << " has been set to '" << geometryString.c_str() << "'";
+  qDebug() << Q_FUNC_INFO << ": Reference image geometry of" << d->SegmentationNode->GetName()
+    << "is set to '" << geometryString.c_str() << "'";
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Added `SetReferenceImageGeometryInSegmentationNode` function to `vtkSlicerSegmentationGeometryLogic`. This feature was only available in the segmentation geometry widget, which was not convenient for scripting.