### PR TITLE
ENH: Make translations in Python scripts more robust

### DIFF
--- a/Base/Python/slicer/i18n.py
+++ b/Base/Python/slicer/i18n.py
@@ -54,7 +54,13 @@ def tr(text):
     """
 
     def findBracedStrings(text):
-        """Get all strings enclosed in braces, except when enclosed in double-braces."""
+"""Get all strings corresponding to f-string expressions.
+
+All expression delimited by curly braces are returned except the ones enclosed in
+double-braces.
+
+See https://docs.python.org/3/reference/lexical_analysis.html#f-strings.
+"""
         pattern = r"(?<!\{)\{([^\{\}]+)\}(?!\})"
         matches = re.findall(pattern, text)
         return matches
@@ -65,8 +71,8 @@ def tr(text):
 
     # Accept the translation only if all placeholders are present in the translated text to prevent runtime errors.
     # For example:
-    #   text = "{count} items will be deleted"
-    #   translatedText = "{compter} elements seront supprimes" (incorrect, because `count` should not have been translated)
+    #   text = f"{count} items will be deleted"
+    #   translatedText = f"{compter} éléments seront supprimés" (incorrect, because `count` should not have been translated)
     # would fail at runtime with a KeyError when `_("{count} items will be deleted").format(count=numberOfSomeItems)` is called.
     # The check prevents the runtime error, only a warning is logged and the incorrect translation is ignored.
     if set(findBracedStrings(text)) != set(findBracedStrings(translatedText)):

--- a/Base/Python/slicer/i18n.py
+++ b/Base/Python/slicer/i18n.py
@@ -71,9 +71,10 @@ def tr(text):
 
     # Accept the translation only if all placeholders are present in the translated text to prevent runtime errors.
     # For example:
-    #   text = f"delete {count} files"
-    #   translatedText = f"supprimer {compter} fichiers" (incorrect, because `count` should not have been translated)
-    # would fail at runtime with a KeyError when `_("delete {count} files").format(count=numberOfSomeItems)` is called.
+    #   text = "delete {count} files"
+    #   translatedText = "supprimer {compter} fichiers" (incorrect, because `count` should not have been translated)
+    # would fail at runtime with a KeyError when `_("delete {count} files").format(count=numberOfSomeItems)` is called,
+    # as after translation it turns into `"supprimer {compter} fichiers".format(count=numberOfSomeItems)`.
     # The check prevents the runtime error: only a warning is logged and the incorrect translation is ignored.
     if set(findBracedStrings(text)) != set(findBracedStrings(translatedText)):
         logging.warning(f"In context '{contextName}', translation of '{text}' to '{translatedText}' is incorrect: placeholders do not match")

--- a/Base/Python/slicer/i18n.py
+++ b/Base/Python/slicer/i18n.py
@@ -54,13 +54,13 @@ def tr(text):
     """
 
     def findBracedStrings(text):
-"""Get all strings corresponding to f-string expressions.
+        """Get all placeholders (replacement fields) in the input format string text.
 
-All expression delimited by curly braces are returned except the ones enclosed in
-double-braces.
+        All placeholders delimited by curly braces are returned except the ones enclosed in
+        double-braces.
 
-See https://docs.python.org/3/reference/lexical_analysis.html#f-strings.
-"""
+        See https://docs.python.org/3/library/string.html#formatstrings
+        """
         pattern = r"(?<!\{)\{([^\{\}]+)\}(?!\})"
         matches = re.findall(pattern, text)
         return matches
@@ -71,10 +71,10 @@ See https://docs.python.org/3/reference/lexical_analysis.html#f-strings.
 
     # Accept the translation only if all placeholders are present in the translated text to prevent runtime errors.
     # For example:
-    #   text = f"{count} items will be deleted"
-    #   translatedText = f"{compter} éléments seront supprimés" (incorrect, because `count` should not have been translated)
+    #   text = f"delete {count} files"
+    #   translatedText = f"supprimer {compter} fichiers" (incorrect, because `count` should not have been translated)
     # would fail at runtime with a KeyError when `_("{count} items will be deleted").format(count=numberOfSomeItems)` is called.
-    # The check prevents the runtime error, only a warning is logged and the incorrect translation is ignored.
+    # The check prevents the runtime error: only a warning is logged and the incorrect translation is ignored.
     if set(findBracedStrings(text)) != set(findBracedStrings(translatedText)):
         logging.warning(f"In context '{contextName}', translation of '{text}' to '{translatedText}' is incorrect: placeholders do not match")
         return text

--- a/Base/Python/slicer/i18n.py
+++ b/Base/Python/slicer/i18n.py
@@ -73,7 +73,7 @@ def tr(text):
     # For example:
     #   text = f"delete {count} files"
     #   translatedText = f"supprimer {compter} fichiers" (incorrect, because `count` should not have been translated)
-    # would fail at runtime with a KeyError when `_("{count} items will be deleted").format(count=numberOfSomeItems)` is called.
+    # would fail at runtime with a KeyError when `_("delete {count} files").format(count=numberOfSomeItems)` is called.
     # The check prevents the runtime error: only a warning is logged and the incorrect translation is ignored.
     if set(findBracedStrings(text)) != set(findBracedStrings(translatedText)):
         logging.warning(f"In context '{contextName}', translation of '{text}' to '{translatedText}' is incorrect: placeholders do not match")


### PR DESCRIPTION
If a Python string with placeholders (e.g., Loading {filename}) is translated incorrectly so that the placeholder is not in the translated string (e.g., Carga {nombre de archivo}) then currently an exception is raised and execution of the Python code stops.

Fixed by only using the translated string if the placeholders match. Otherwise a warning is logged and the translation is not used.

fixes #7235