### PR TITLE
BUG: Skip creation of markups interaction widget in VR windows

### DIFF
--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
@@ -971,6 +971,14 @@ void vtkMRMLMarkupsDisplayableManager::Create()
 
   vtkRenderer* renderer = this->GetRenderer();
   vtkRenderWindow* renderWindow = renderer->GetRenderWindow();
+
+  // Do not add add the interaction widget if the displayable manager is associated with a VR render
+  // window. The interaction renderer instantiated below is not supported in VR.
+  if (renderWindow->IsA("vtkVRRenderWindow"))
+  {
+    return;
+  }
+
   if (renderWindow->GetNumberOfLayers() < INTERACTION_RENDERER_LAYER + 1)
   {
     renderWindow->SetNumberOfLayers(INTERACTION_RENDERER_LAYER + 1);

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManagerHelper.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManagerHelper.cxx
@@ -30,6 +30,8 @@
 #include <vtkObjectFactory.h>
 #include <vtkProperty.h>
 #include <vtkPickingManager.h>
+#include <vtkRenderer.h>
+#include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkSlicerMarkupsWidgetRepresentation.h>
 #include <vtkSlicerMarkupsWidget.h>
@@ -310,6 +312,14 @@ void vtkMRMLMarkupsDisplayableManagerHelper::AddInteractionWidget(vtkMRMLMarkups
   {
     return;
   }
+  // Do not add add the interaction widget if the displayable manager is associated with a VR render
+  // window. The interaction renderer instantiated in vtkMRMLMarkupsDisplayableManager::Create() is
+  // not supported in VR.
+  if (this->DisplayableManager->GetRenderer()->GetRenderWindow()->IsA("vtkVRRenderWindow"))
+  {
+    return;
+  }
+
   // Do not add the display node if displayNodeIt is already associated with a widget object.
   // This happens when a segmentation node already associated with a display node
   // is copied into an other (using vtkMRMLNode::Copy()) and is added to the scene afterward.

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager.cxx
@@ -134,9 +134,13 @@ void vtkMRMLLinearTransformsDisplayableManager::vtkInternal::UpdatePipelineFromD
     return;
   }
 
+  // Do not add add the interaction widget if the displayable manager is associated with a VR render
+  // window. The interaction renderer instantiated below is not supported in VR.
+
   vtkMRMLTransformNode* transformNode = vtkMRMLTransformNode::SafeDownCast(displayNode->GetDisplayableNode());
   bool visible = this->UseTransformNode(transformNode)
-              && this->UseDisplayNode(displayNode);
+              && this->UseDisplayNode(displayNode)
+              && !this->External->GetRenderer()->GetRenderWindow()->IsA("vtkVRRenderWindow");
 
   vtkSmartPointer<vtkMRMLTransformHandleWidget> widget;
   InteractionWidgetsCacheType::iterator pipelineIt;
@@ -480,6 +484,14 @@ void vtkMRMLLinearTransformsDisplayableManager::vtkInternal::SetupRenderer()
   }
 
   vtkRenderWindow* renderWindow = renderer->GetRenderWindow();
+
+  // Do not add add the interaction widget if the displayable manager is associated with a VR render
+  // window. The interaction renderer instantiated below is not supported in VR.
+  if (renderWindow->IsA("vtkVRRenderWindow"))
+  {
+    return;
+  }
+
   if (renderWindow->GetNumberOfLayers() < RENDERER_LAYER + 1)
   {
     renderWindow->SetNumberOfLayers(RENDERER_LAYER + 1);


### PR DESCRIPTION
The interaction renderer instantiated in vtkMRMLMarkupsDisplayableManager::Create() is not supported in VR.

Follow-up of Slicer/Slicer@4efda83181 (`ENH: Add interaction handle visualization for linear transform nodes (#7562)`, 2024-02-02) introduced in https://github.com/Slicer/Slicer/pull/7562

This addresses the following error reported when initializing an OpenVR or OpenXR connection:

```
[...]
Initializing "OpenXR" XR backend (1/1)
vtkOpenXRRenderWindow::AddRenderer: Failed to add renderer of type vtkOpenGLRenderer: A vtkOpenXRRenderer is expected

vtkOpenXRRenderWindow::AddRenderer: Failed to add renderer of type vtkOpenGLRenderer: A vtkOpenXRRenderer is expected
[...]
```

