### PR TITLE
STYLE: Update CTK with source files converted to "Allman" indentation style

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "51c9f4a5a55f38ddce9d8b75a72c02fca64bf17a"
+    "5a5c9f62a822ea48174cf544e0f05210f3810292"
     QUIET
     )
 


### PR DESCRIPTION
List of CTK changes:

```
$ git shortlog 51c9f4a5a..5a5c9f62a --no-merges
Jean-Christophe Fillion-Robin (1):
      STYLE: Convert C++ source files from old-style "Whitesmiths" to "Allman" style (#1193)
```