### PR TITLE
ENH: Support returning the result when executing Python from qSlicerWebWidget

### DIFF
--- a/Base/QTGUI/qSlicerWebPythonProxy.cxx
+++ b/Base/QTGUI/qSlicerWebPythonProxy.cxx
@@ -76,15 +76,31 @@ bool qSlicerWebPythonProxy::isPythonEvaluationAllowed()
 }
 
 // --------------------------------------------------------------------------
-QString qSlicerWebPythonProxy::evalPython(const QString &python)
+QString qSlicerWebPythonProxy::evalPython(const QString &python, int mode)
 {
+  ctkAbstractPythonManager::ExecuteStringMode executeStringMode{ctkAbstractPythonManager::FileInput};
+  switch (mode)
+  {
+    case qSlicerWebPythonProxy::EvalInput:
+      executeStringMode = ctkAbstractPythonManager::EvalInput;
+      break;
+    case qSlicerWebPythonProxy::FileInput:
+      executeStringMode = ctkAbstractPythonManager::FileInput;
+      break;
+    case qSlicerWebPythonProxy::SingleInput:
+      executeStringMode = ctkAbstractPythonManager::SingleInput;
+      break;
+    default:
+      qWarning() << Q_FUNC_INFO << " failed: Unknown mode" << mode;
+      break;
+  }
 
   QString result;
 #ifdef Slicer_USE_PYTHONQT
   if (this->isPythonEvaluationAllowed())
   {
     qSlicerPythonManager *pythonManager = qSlicerApplication::application()->pythonManager();
-    result = pythonManager->executeString(python).toString();
+    result = pythonManager->executeString(python, executeStringMode).toString();
     qDebug() << "Running " << python << " result is " << result;
   }
 #else

--- a/Base/QTGUI/qSlicerWebPythonProxy.h
+++ b/Base/QTGUI/qSlicerWebPythonProxy.h
@@ -38,6 +38,22 @@ public:
   /// Constructor
   explicit qSlicerWebPythonProxy(QObject *parent = nullptr);
 
+  /// This enum maps to ctkAbstractPythonManager execution modes Py_eval_input,
+  /// Py_file_input and Py_single_input.
+  ///
+  /// \see https://docs.python.org/3/c-api/veryhigh.html#Py_eval_input
+  /// \see https://docs.python.org/3/c-api/veryhigh.html#Py_file_input
+  /// \see https://docs.python.org/3/c-api/veryhigh.html#Py_single_input
+  ///
+  /// \sa ctkAbstractPythonManager::ExecuteStringMode
+  enum EvalPythonMode
+    {
+    EvalInput = 0,
+    FileInput,
+    SingleInput
+    };
+  Q_ENUMS(EvalPythonMode);
+
 public slots:
 
   /// Convenient function to execute python code from
@@ -52,7 +68,7 @@ public slots:
   /// running python code from web pages.
   ///
   /// \sa qSlicerWebWidget::initializeWebEngineProfile
-  QString evalPython(const QString &python);
+  QString evalPython(const QString &python, int mode = FileInput);
 
 private:
   /// Keep track of user response to avoid going through ctk dialog to check

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "5a5c9f62a822ea48174cf544e0f05210f3810292"
+    "a0ea618f1af08f7810d36f00e5427ff1b900507d"
     QUIET
     )
 


### PR DESCRIPTION
Update `qSlicerWebPythonProxy` to allow specifying `EvalInput` as mode and ensure a result is returned as `QVariant`.

For example:

```js
await slicerPython.evalPython("40+2")
""

await slicerPython.evalPython("40+2", slicerPython.EvalPythonMode.EvalInput)
"42"
```

Note that the associated CTK changes are not strictly required to support passing the evalPython mode parameter.

List of CTK changes:

```
$ git shortlog 5a5c9f62a..a0ea618f1 --no-merges
Jean-Christophe Fillion-Robin (1):
      ENH: Support using ctkAbstractPythonManager::ExecuteStringMode from Python
```