### PR TITLE
BUG: Remove obsolete Webkit-specific integration code from qSlicerWebWidget

### DIFF
--- a/Base/QTGUI/qSlicerWebWidget.cxx
+++ b/Base/QTGUI/qSlicerWebWidget.cxx
@@ -135,8 +135,6 @@ void qSlicerWebWidgetPrivate::init()
                    this, SLOT(onAppAboutToQuit()));
   this->verticalLayout->insertWidget(0, this->WebView);
 
-  this->WebView->installEventFilter(q);
-
   QObject::connect(this->WebView, SIGNAL(loadStarted()),
                    q, SLOT(onLoadStarted()));
 
@@ -429,8 +427,6 @@ void qSlicerWebWidget::printToPdf(const QString& filePath, const QPageLayout& pa
 // --------------------------------------------------------------------------
 void qSlicerWebWidget::initJavascript()
 {
-  Q_D(qSlicerWebWidget);
-  d->setDocumentWebkitHidden(!d->WebView->isVisible());
 }
 
 // --------------------------------------------------------------------------
@@ -495,20 +491,4 @@ void qSlicerWebWidget::handleSslErrors(QNetworkReply* reply,
              << qPrintable(e.errorString());
   }
 #endif
-}
-
-// --------------------------------------------------------------------------
-bool qSlicerWebWidget::eventFilter(QObject* obj, QEvent* event)
-{
-  Q_D(qSlicerWebWidget);
-  Q_ASSERT(d->WebView == obj);
-  if (d->WebView == obj && !event->spontaneous() &&
-      (event->type() == QEvent::Show || event->type() == QEvent::Hide))
-  {
-    d->setDocumentWebkitHidden(!d->WebView->isVisible());
-    this->evalJS("if (typeof $ != 'undefined') {"
-                 "  $.event.trigger({type: 'webkitvisibilitychange'})"
-                 "} else { console.info('JQuery not loaded - Failed to trigger webkitvisibilitychange') }");
-  }
-  return QObject::eventFilter(obj, event);
 }

--- a/Base/QTGUI/qSlicerWebWidget.h
+++ b/Base/QTGUI/qSlicerWebWidget.h
@@ -149,10 +149,6 @@ protected:
   qSlicerWebWidget(qSlicerWebWidgetPrivate* pimpl, QWidget* parent = nullptr);
   QScopedPointer<qSlicerWebWidgetPrivate> d_ptr;
 
-  /// Event filter used to capture WebView Show and Hide events in order to both set
-  /// "document.webkitHidden" property and trigger the associated event.
-  bool eventFilter(QObject *obj, QEvent *event) override;
-
   virtual bool acceptNavigationRequest(const QUrl & url, QWebEnginePage::NavigationType type, bool isMainFrame);
 
 private:


### PR DESCRIPTION
This commit updates `qSlicerWebWidget` to remove obsolete code related to Webkit integration. The removal of this code prevents the display of a warning message that occurs when loading a page after opening the extension manager or explicitly instantiating a `qSlicerWebWidget` and setting its URL property.

The warning message was:

```
"JQuery not loaded - Failed to trigger webkitvisibilitychange"
```

This integration was initially introduced in commit 8d7f94e4ee ("BUG: Prevent extensions from being loaded twice when 'Install' tab initially hidden", 2013-02-04), but the support for Webkit was later removed in commits:
* 6bd2db52ef ("COMP: Remove support for building against Qt WebKit module", 2019-03-08)
* f3edc8f609 ("STYLE: Remove obsolete code supporting use of Qt WebKit module", 2019-03-08)