### PR TITLE
COMP: Update .gitignore ensuring changes to .github files are reported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !.codespellignore
 !.gitattributes
 !.git-blame-ignore-revs
+!.github/
 !.pre-commit-config.yaml
 !.readthedocs.yaml
 !.ruff.toml
@@ -13,9 +14,6 @@
 
 # except for .gitignore
 !.gitignore
-
-# ... and .circleci
-!.circleci
 
 # Exclude Kdevelop4 files ...
 .kdev*


### PR DESCRIPTION
Also remove unneeded entry related to `.circleci` directory that was removed in 991cd64b9a ("COMP: Add "CI" GitHub action workflow to replace CircleCI", 2021-11-30)