### PR TITLE
BUG: Improve surface smoothing accuracy in segmentations

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "4308220744e4848b91f3434476eabc9df8daa279") # slicer-v9.2.20230607-1ff325c54-2
+    set(_git_tag "9f48d797ada1069e5717116e3e62e1d6d37ddc4c") # slicer-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
Surface low-pass filter did not use an optimal window function, which sometimes resulted in small (<1%) scale difference in smoothed output.

The issue was fixed in VTK by implementing Nuttall window function and use it by default. We also slightly increment the number of iterations at stronger smoothing settings, as the default 20 iterations is only enough for moderate smoothing factors.

More information:
- https://discourse.slicer.org/t/accuracy-of-segmentation-smoothing/34723
- https://discourse.vtk.org/t/slight-offset-in-vtkwindowedsincpolydatafilter-if-normalization-is-enabled/7676

VTK is updated to include these commits:


* Slicer/VTK@9f48d797ada1069e5717116e3e62e1d6d37ddc4c:

  ```
  Revision: 9f48d797ada1069e5717116e3e62e1d6d37ddc4c
  Author: Andras Lasso <lasso@queensu.ca>
  Date: 2024-03-11 9:44:38 AM
  Message:
  [Backport] Add vtkWindowedSincPolyDataFilter test with Nuttall window function
  
  Merge-request: vtk/vtk!10956
  (cherry picked from commit 81e945b1b3fb464cdcd28759d966d7358b54acbc)
  ```

* Slicer/VTK@c254a4cb65f6be22cbf70cd13b489ca4a5a126cd:

  ```
  Revision: c254a4cb65f6be22cbf70cd13b489ca4a5a126cd
  Author: Andras Lasso <lasso@queensu.ca>
  Date: 2024-03-09 10:05:19 AM
  Message:
  [Backport] Improve accuracy of vtkWindowedSincPolyDataFilter
  
  Using Hamming windowing function resulted in inaccurate scaling of the output (up to about 1% error, either increase or decrease of the scale).
  
  This commit implements all three window functions that are described in Taubin's paper and adds Nuttal window and changes the default to Nuttal to eliminate the scaling error.
  
  Note that when passband is set to very small value then shrinkage may occur regardless of the choice of window function.
  
  Merge-request: vtk/vtk!10956
  (cherry picked from commit 387c737e04379968e125da3b9129dfd2ebf543fb)
  ```