### PR TITLE
ENH: Update CTK with visual DICOM browser improvements

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "a0ea618f1af08f7810d36f00e5427ff1b900507d"
+    "fb72e1aa2b143bb942e6c7cdc5603a676884a80a"
     QUIET
     )
 


### PR DESCRIPTION
Reference PR: https://github.com/commontk/CTK/pull/1191
@lassoan 

List of CTK changes:

BUG: Fix issue with proxy server attribute in ctkDICOMServerNodeWidget2.
     Resolved a bug where the proxy server attribute in the servers settings UI was being cleared at startup.
     The fix ensures that the proxy server option is now correctly retained during initialization.

BUG: Fix sorting of Study Widgets in the Visual DICOM Browser.
     Addressed a bug related to the sorting of study widgets in the visual DICOM browser.
     Previously, the sorting mechanism was compromised when studies shared the same date,
     leading to incorrect layout additions and missing study widgets. This issue has been fixed,
     ensuring proper sorting even when studies have identical dates.

BUG: Fix ctkJobScheduler crash when stopping jobs by changing servers ENH: Clean setting jobs status and firing correlated signals in workers 

BUG: Fix studies widget sorting when there are multiple groups studies with same multiple julian days 

BUG: Fix memory access to queue list

ENH: Improve failed series fetch mechanism and UI report ENH: Add force retrieve series as right click menu for study and series widgets 

BUG: Fix crash when stopping jobs