### PR TITLE
ENH: Allow aliases for NRRD "type" header in postNRRD

### DIFF
--- a/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
@@ -375,7 +375,7 @@ class SlicerRequestHandler(BaseRequestHandler):
                 value = line[colonIndex + 2 :]
                 fields[key] = value
 
-        if fields[b"type"] != b"short":
+        if fields[b"type"] not in [b"short", b"short int", b"signed short", b"signed short int", b"int16", b"int16_t"]:
             raise RuntimeError("Can only read short volumes")
         if fields[b"dimension"] != b"3":
             raise RuntimeError("Can only read 3D, 1 component volumes")


### PR DESCRIPTION
The NRRD definition lists various aliases
to specify the for the "short" datatype in
the "type" nrrd header field (see
https://teem.sourceforge.net/nrrd/format.html#type).

Pynnrd as a widely used nnrd library
e.g. creates NRRD headers with short
datatypes identified as "int16" and
does not allow to override this.
Consequently, a POST request to the
slicer/volume endpoint will always fail
with data from pynnrrd.

This commit relaxes the type check to
also allow aliases of "short" to pass.