### PR TITLE
ENH: Add SH options to control transform interaction handle type visibility

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.cxx
@@ -1132,7 +1132,7 @@ void vtkMRMLInteractionWidgetRepresentation::UpdateTranslationHandleOrientation(
   double viewDirection_World[3] = { 0.0, 0.0, 0.0 };
   double viewDirection_Handle[3] = { 0.0, 0.0, 0.0 };
   double viewUp_World[3] = { 0.0, 1.0, 0.0 };
-  double viewUp_Handle[3] = { 0.0, 0.0, 0.0 };
+  double viewUp_Handle[3] = { 0.0, 1.0, 0.0 };
   if (this->GetSliceNode())
   {
     double viewUp[4] = { 0.0, 1.0, 0.0, 0.0 };

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -136,7 +136,7 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   }
   this->RotationHandleComponentVisibility[3] = false; // Hide view plane rotation by default
 
-  this->CanDisplayScaleHandles = true;
+  this->CanDisplayScaleHandles = false;
 
   // Line color node
   vtkNew<vtkIntArray> events;

--- a/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.h
+++ b/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.h
@@ -127,6 +127,7 @@ protected slots:
 
   /// Toggle interaction box
   void toggleInteractionBox(bool);
+  void toggleCurrentItemHandleTypeVisibility(bool);
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyTransformsPluginPrivate> d_ptr;


### PR DESCRIPTION
Adds the subject hierarchy menu "Interaction options" for enabling/disabling transform handle types (Rotation/Translation/Scaling), and adds all of the interaction options to the view context menu. This commit also fixes an issue where markups interaction handles could not be enabled/disabled correctly, and scale handles could be shown for unsupported markups types.

Re #7570