### PR TITLE
BUG: Fix markups handle scale not updating

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -1196,7 +1196,6 @@ double vtkSlicerMarkupsWidgetRepresentation3D::GetViewScaleFactorAtPosition(doub
   return viewScaleFactorMmPerPixel;
 }
 
-
 //----------------------------------------------------------------------
 void vtkSlicerMarkupsWidgetRepresentation3D::UpdateViewScaleFactor()
 {
@@ -1206,9 +1205,10 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateViewScaleFactor()
   {
     return;
   }
-  if (!this->Renderer->GetRenderWindow()->GetGenericContext())
+
+  if (this->Renderer->GetRenderWindow()->GetNeverRendered())
   {
-    // Calling GetScreenSize() without a context set will cause a crash.
+    // In VR, calling GetScreenSize() without rendering can cause a crash.
     return;
   }
 


### PR DESCRIPTION
Addresses issue introduced in 580e1875b1c0fa20d1db123d5feeb6487fca2c2d which caused markups handle scale to not update. The original fix was meant to prevent a crash when starting VR with Markups in the scene, however it disabled scale update in all situations. Fixed by checking GetNeverRendered() instead of GetGenericContext(), before calling GetScreenSize(). Once the window has been rendered at least once, it is safe to call GetScreenSize().

Related issues and pull requests:
* https://github.com/Slicer/Slicer/issues/7570
* https://github.com/Slicer/Slicer/pull/7630