### PR TITLE
[5.6] ENH: Update VTK backporting SlicerVirtualReality extension specific changes

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "46201478cdf2dc1e5dda260ba61505195bbcc932") # slicer-v9.2.20230607-1ff325c54-2
+    set(_git_tag "d4be5ea25426489880f110cd8813bb40305e7790") # slicer-5.6-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
This commit updates the external project to explicitly reference the VTK version that was manually checked out within the Slicer release-specific build tree to support building the SlicerVirtualReality extension.

Related pull requests:
* https://github.com/Slicer/VTK/pull/47
* https://github.com/Slicer/VTK/pull/49
* https://github.com/Slicer/VTK/pull/50
* https://github.com/Slicer/VTK/pull/52
* https://github.com/Slicer/VTK/pull/54

List of VTK changes:

```
$ git shortlog 46201478c..d4be5ea25 --no-merges
Alexy Pellegrini (6):
      [Backport] Enable switching from remoting XR runtime to default XR runtime dynamically
      [Backport] Add a utility function to query OpenXR instance version
      [Backport] OpenXR: Add missing EndInitialize in QueryInstanceVersion
      [Backport] VR: enable interaction methods to be overrideable
      [Backport] VR: Add VTKIS_USCALE support in VR interactor style
      [Backport] XR: Move device pose update in interactor

Ben Boeckel (1):
      [Backport] Rendering/VR: make `glew` a public dependency

Jean-Christophe Fillion-Robin (24):
      Revert "[Backport MR-10450] OpenXRRemoting: Fix windows build using XrCheckOutput instead of XrCheckError"
      Revert "[Backport MR-10450] OpenXR: Improve XrCheckOutput API fixing constness of level parameter"
      Revert "[Backport MR-10449] OpenXRRemoting: Streamline integration as plugin"
      [Backport] OpenXRRemoting: Streamline integration as plugin
      [SlicerVirtualReality] ENH: Update OpenVR json binding to map right and left trigger with triggeraction
      [Backport MR-10778] BUG: Recognize OpenVR gesture where buttons are pressed consecutively
      [SlicerVirtualReality] BUG: Support Slicer 5.6.1 adding fixed Dolly3D function to vtkVRInteractorStyle
      [Backport MR-10784] VR: Update interactor style API adding GetMappedAction()
      [Backport MR-10785] VR: Declare AddAction() functions as virtual
      [Backport MR-10786] VR: Mark ComplexGesture recognition functions as public
      [Backport MR-10786] VR: Add GetCurrentGesture() API for retrieving the gesture being recognized
      [Backport MR-10786] VR: Add SetCurrentGesture() API for setting the gesture being recognized
      [Backport MR-10786] VR: Add GetDeviceInputDownCount() API
:...skipping...
Alexy Pellegrini (6):
      [Backport] Enable switching from remoting XR runtime to default XR runtime dynamically
      [Backport] Add a utility function to query OpenXR instance version
      [Backport] OpenXR: Add missing EndInitialize in QueryInstanceVersion
      [Backport] VR: enable interaction methods to be overrideable
      [Backport] VR: Add VTKIS_USCALE support in VR interactor style
      [Backport] XR: Move device pose update in interactor

Ben Boeckel (1):
      [Backport] Rendering/VR: make `glew` a public dependency

Jean-Christophe Fillion-Robin (24):
      Revert "[Backport MR-10450] OpenXRRemoting: Fix windows build using XrCheckOutput instead of XrCheckError"
      Revert "[Backport MR-10450] OpenXR: Improve XrCheckOutput API fixing constness of level parameter"
      Revert "[Backport MR-10449] OpenXRRemoting: Streamline integration as plugin"
      [Backport] OpenXRRemoting: Streamline integration as plugin
      [SlicerVirtualReality] ENH: Update OpenVR json binding to map right and left trigger with triggeraction
      [Backport MR-10778] BUG: Recognize OpenVR gesture where buttons are pressed consecutively
      [SlicerVirtualReality] BUG: Support Slicer 5.6.1 adding fixed Dolly3D function to vtkVRInteractorStyle
      [Backport MR-10784] VR: Update interactor style API adding GetMappedAction()
      [Backport MR-10785] VR: Declare AddAction() functions as virtual
      [Backport MR-10786] VR: Mark ComplexGesture recognition functions as public
      [Backport MR-10786] VR: Add GetCurrentGesture() API for retrieving the gesture being recognized
      [Backport MR-10786] VR: Add SetCurrentGesture() API for setting the gesture being recognized
      [Backport MR-10786] VR: Add GetDeviceInputDownCount() API
      [Backport MR-10786] VR: Add SetDeviceInputDownCount() API
      [Backport MR-10786] VR: Add SetStartingPhysicalToWorldMatrix() API
      [Backport MR-10786] VR: Add SetStartingPhysicalEventPose() API
      [Backport MR-10789] VR: Add SetInteractionState() API to VR interactor style
      [Backport MR-10789] VR: Improve robustness of GetInteractionState() by checking input
      Revert "[Backport MR-10785] VR: Declare AddAction() functions as virtual"
      [Backport MR-10785] VR: Improve consistency in OpenVR interactor AddAction()
      [Backport MR-10785] VR: Declare AddAction() functions as virtual
      [Backport MR-10794] VR: Resolve "Not rendered" warnings after XR RenderWindow Initialization
      [SlicerVirtualReality] ENH: Add OpenXR bindings for oculus_touch
      [Backport MR-10814] OpenXRRemoting: Support building against Holographic.Remoting.OpenXr >= 2.9.3

Mathieu Westphal (2):
      [Backport] OpenXRRemoting: Using XrCheckOutput
      [Backport] Dolly3D: Remove incorrect check in Y axis only

Mohamed Mssaouri (2):
      [Backport] Add teleportation to VR
      [Backport] Move teleportation to interaction modes

Sankhesh Jhaveri (4):
      [Backport MR-10783] VR: Move the TrackHMD flag to the camera
      [Backport MR-10783] VR: Deprecate vtkVRRenderWindow::TrackHMD
      [Backport MR-10783] VR: Provide stereo projection transforms for rendering
      [Backport MR-10792] OpenXR: Use the OpenXRConfig.cmake files provided by OpenXR-SDK

Software Solution Team (1):
      [Backport] improve FindOpenXR.cmake for windows platform

Thibault Bruyère (1):
      [Backport] Add volume clipping to vtkVRInteractorStyle

Tiffany Chhim (1):
      [Backport] VR Renderer: Add cross markers at tip of controllers

willdunklin (1):
      [Backport] vtkDeprecation: add VTK_DEPRECATED_IN_9_4_0 macro
```