### PR TITLE
[5.6] BUG: Improve surface smoothing accuracy in segmentations

### DIFF
--- a/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
+++ b/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
@@ -411,13 +411,23 @@ bool vtkBinaryLabelmapToClosedSurfaceConversionRule::CreateClosedSurface(vtkOrie
     {
     vtkSmartPointer<vtkWindowedSincPolyDataFilter> smoother = vtkSmartPointer<vtkWindowedSincPolyDataFilter>::New();
     smoother->SetInputData(processingResult);
-    smoother->SetNumberOfIterations(20); // based on VTK documentation ("Ten or twenty iterations is all the is usually necessary")
-    // This formula maps:
-    // 0.0  -> 1.0   (almost no smoothing)
-    // 0.25 -> 0.1   (average smoothing)
-    // 0.5  -> 0.01  (more smoothing)
-    // 1.0  -> 0.001 (very strong smoothing)
+
+    // Smoothing factor is a user-friendly linear scale that we need to maps to low-pass filter parameters.
+    // Default smoothing aims for removing blocky appearance (staircase artifacts) while avoiding shrinking.
+    // Typically a few ten iterations are sufficient, but stronger smoothing requires more iterations.
+    //
+    //   Smoothing factor                             Passband   Iterations
+    //
+    //     0.0  (almost no smoothing, blocky)      ->   1.0          20
+    //     0.25 (less smoothing, somewhat blocky)  ->   0.1          30
+    //     0.5  (default smoothing)                ->   0.01         40
+    //     0.75 (more smoothing, somewhat shrinks) ->   0.001        50
+    //     1.0  (very strong smoothing, shrinks)   ->   0.0001       60
+    //
     double passBand = pow(10.0, -4.0 * smoothingFactor);
+    int numberOfIterations = 20 + smoothingFactor * 40;
+
+    smoother->SetNumberOfIterations(numberOfIterations);
     smoother->SetPassBand(passBand);
     smoother->BoundarySmoothingOff();
     smoother->FeatureEdgeSmoothingOff();

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "d4be5ea25426489880f110cd8813bb40305e7790") # slicer-5.6-v9.2.20230607-1ff325c54-2
+    set(_git_tag "4c46b5221d02722fb089028f5d0b02d1d0832129") # slicer-5.6-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
Backport of https://github.com/Slicer/Slicer/pull/7643

-----------

Surface low-pass filter did not use an optimal window function, which sometimes resulted in small (<1%) scale difference in smoothed output.

The issue was fixed in VTK by implementing Nuttall window function and use it by default. We also slightly increment the number of iterations at stronger smoothing settings, as the default 20 iterations is only enough for moderate smoothing factors.

More information:
- https://discourse.slicer.org/t/accuracy-of-segmentation-smoothing/34723
- https://discourse.vtk.org/t/slight-offset-in-vtkwindowedsincpolydatafilter-if-normalization-is-enabled/7676

List of VTK changes:

```
$ git shortlog d4be5ea25..4c46b5221 --no-merges
Andras Lasso (2):
      [Backport] Improve accuracy of vtkWindowedSincPolyDataFilter
      [Backport] Add vtkWindowedSincPolyDataFilter test with Nuttall window function
```

(cherry picked from commit ddc0379b368e3dc884e0504223f3c5a365664f82)