### PR TITLE
ENH: Add Python-wrappable methods for accessing anatomical regions

### DIFF
--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.cxx
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.cxx
@@ -1776,6 +1776,40 @@ bool vtkSlicerTerminologiesModuleLogic::GetRegionsInAnatomicContext(std::string 
 }
 
 //---------------------------------------------------------------------------
+int vtkSlicerTerminologiesModuleLogic::GetNumberOfRegionsInAnatomicContext(std::string anatomicContextName)
+{
+    std::vector<CodeIdentifier> regions;
+    if (!this->GetRegionsInAnatomicContext(anatomicContextName, regions))
+    {
+      return 0;
+    }
+    return regions.size();
+}
+
+//---------------------------------------------------------------------------
+bool vtkSlicerTerminologiesModuleLogic::GetNthRegionInAnatomicContext(std::string anatomicContextName, int regionIndex, vtkSlicerTerminologyType* regionObject)
+{
+  if (!regionObject)
+  {
+    vtkErrorMacro("GetNthRegionInAnatomicContext failed: regionObject is invalid)");
+    return false;
+  }
+  std::vector<CodeIdentifier> regions;
+  if (!this->GetRegionsInAnatomicContext(anatomicContextName, regions))
+  {
+    return false;
+  }
+  if (regionIndex < 0 || regionIndex >= regions.size())
+  {
+    vtkErrorMacro("GetNthRegionInAnatomicContext failed: region index of " << regionIndex << " is out of range"
+      << " (number of regions: " << regions.size() << ")");
+    return false;
+  }
+
+  return this->GetRegionInAnatomicContext(anatomicContextName, regions[regionIndex], regionObject);
+}
+
+//---------------------------------------------------------------------------
 bool vtkSlicerTerminologiesModuleLogic::FindRegionsInAnatomicContext(std::string anatomicContextName, std::vector<CodeIdentifier>& regions, std::string search)
 {
   regions.clear();
@@ -1899,6 +1933,50 @@ bool vtkSlicerTerminologiesModuleLogic::GetRegionModifierInAnatomicRegion(std::s
 
   // Region modifier with specified name found
   return this->Internal->PopulateTerminologyTypeFromJson(regionModifierObject, regionModifier);
+}
+
+//---------------------------------------------------------------------------
+int vtkSlicerTerminologiesModuleLogic::GetNumberOfRegionModifierInAnatomicRegion(
+  std::string anatomicContextName, vtkSlicerTerminologyType* regionObject)
+{
+  if (!regionObject)
+  {
+    vtkErrorMacro("GetNumberOfRegionModifierInAnatomicRegion failed: regionObject is invalid)");
+    return 0;
+  }
+  CodeIdentifier regionId(regionObject->GetCodingSchemeDesignator(), regionObject->GetCodeValue(), regionObject->GetCodeMeaning());
+  std::vector<CodeIdentifier> regionModifiers;
+  if (!this->GetRegionModifiersInAnatomicRegion(anatomicContextName, regionId, regionModifiers))
+  {
+    return 0;
+  }
+  return regionModifiers.size();
+}
+
+//---------------------------------------------------------------------------
+bool vtkSlicerTerminologiesModuleLogic::GetNthRegionModifierInAnatomicRegion(
+  std::string anatomicContextName, vtkSlicerTerminologyType* regionObject, int regionModifierIndex, vtkSlicerTerminologyType* regionModifier)
+{
+  if (!regionObject)
+  {
+    vtkErrorMacro("GetNthRegionInAnatomicContext failed: regionObject is invalid)");
+    return false;
+  }
+  CodeIdentifier regionId(regionObject->GetCodingSchemeDesignator(), regionObject->GetCodeValue(), regionObject->GetCodeMeaning());
+  std::vector<CodeIdentifier> regionModifiers;
+  if (!this->GetRegionModifiersInAnatomicRegion(anatomicContextName, regionId, regionModifiers))
+  {
+    return false;
+  }
+
+  if (regionModifierIndex < 0 || regionModifierIndex >= regionModifiers.size())
+  {
+    vtkErrorMacro("GetNthRegionModifierInAnatomicRegion failed: regionModifier index of " << regionModifierIndex << " is out of range"
+      << " (number of regionModifiers: " << regionModifiers.size() << ")");
+    return false;
+  }
+  CodeIdentifier modifierId = regionModifiers[regionModifierIndex];
+  return this->GetRegionModifierInAnatomicRegion(anatomicContextName, regionId, modifierId, regionModifier);
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.h
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.h
@@ -168,6 +168,17 @@ public:
   ///   from the regions found in the given anatomic context
   /// \return Success flag
   bool GetRegionsInAnatomicContext(std::string anatomicContextName, std::vector<CodeIdentifier>& regions);
+  /// Get number of anatomic regions in anatomic context.
+  /// Allows iterating through all anatomic regions in Python.
+  int GetNumberOfRegionsInAnatomicContext(std::string anatomicContextName);
+  /// Get anatomic region by index.
+  /// Allows iterating through all anatomic regions in Python.
+  /// \param anatomicContextName anatomic context name
+  /// \param regionIndex index of region to return, must be between 0 and GetNumberOfRegionsInAnatomicContext(...)-1
+  /// \param regionObject found anatomical region
+  /// \return Success flag
+  bool GetNthRegionInAnatomicContext(std::string anatomicContextName, int regionIndex, vtkSlicerTerminologyType* regionObject);
+
   /// Get all region names (codeMeaning) in an anatomic context
   /// \return Success flag
   bool FindRegionsInAnatomicContext(std::string anatomicContextName, std::vector<CodeIdentifier>& regions, std::string search);
@@ -186,6 +197,18 @@ public:
   /// \return Success flag
   bool GetRegionModifierInAnatomicRegion(std::string anatomicContextName,
     CodeIdentifier regionId, CodeIdentifier modifierId, vtkSlicerTerminologyType* regionModifier);
+  /// Get number of anatomic regions in anatomic context.
+  /// Allows iterating through anatomic region modifiers in Python.
+  int GetNumberOfRegionModifierInAnatomicRegion(std::string anatomicContextName, vtkSlicerTerminologyType* regionObject);
+  /// Get anatomic region by index.
+  /// Allows iterating through anatomic region modifiers in Python.
+  /// \param anatomicContextName anatomic context name
+  /// \param regionObject anatomical region
+  /// \param regionModifierIndex index of region to return, must be between 0 and GetNumberOfRegionsInAnatomicContext(...)-1
+  /// \param regionModifier found region modifier object
+  /// \return Success flag
+  bool GetNthRegionModifierInAnatomicRegion(std::string anatomicContextName, vtkSlicerTerminologyType* regionObject,
+    int regionModifierIndex, vtkSlicerTerminologyType* regionModifier);
 
   /// Find terminology type or type modifier based on '3dSlicerLabel' attribute
   /// \param terminologyName Terminology context in which the attribute is looked for


### PR DESCRIPTION
Terminology logic only offered access to anatomical regions and their modifiers using C++ API (due to CodeIdentifier type is not accessible in Python). This commit adds helper functions that allow developers to iterate through all anatomical regions and their modifiers.