### PR TITLE
COMP: Fix pull request description generated by pre-commit-autoupdate workflow

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -51,13 +51,12 @@ jobs:
           import sys
 
           for line in sys.stdin:
-              match = re.match(r"\[https://github.com/([^/]+/[^/]+)\] updating (v[\d.]+) -> (v[\d.]+)\.", line.strip())
+              match = re.match(r"\[https://github.com/([^/]+/[^/]+)\] updating (v[\d.]+) -> (v[\d.]+)", line.strip())
               if match:
                   repo_url = match.group(1)
                   old_version = match.group(2)
                   new_version = match.group(3)
-                  repo_name = repo_url.split('/')[-1]
-                  print(f"- [{repo_url}: {old_version} -> {new_version}](pre-commit/{repo_name}@{old_version}...{new_version})")
+                  print(f"- [{repo_url}: {old_version} -> {new_version}](https://github.com/{repo_url}/compare/{old_version}...{new_version})")
           EOF
 
       - name: Parse autoupdate output


### PR DESCRIPTION
Update workflow introduced in 0f047b65c3 ("COMP: Add Github workflow for keeping pre-commit configuration up-to-date", 2024-03-17) ensuring the compare links referenced in the pull request description are correct.

Related pull requests:
* https://github.com/Slicer/Slicer/pull/7636

## After

Raw:

```
- [pre-commit/pre-commit-hooks: v4.5.0 -> v4.6.0](https://github.com/pre-commit/pre-commit-hooks/compare/v4.5.0...v4.6.0)
- [astral-sh/ruff-pre-commit: v0.3.3 -> v0.3.6](https://github.com/astral-sh/ruff-pre-commit/compare/v0.3.3...v0.3.6)
- [asottile/pyupgrade: v3.15.1 -> v3.15.2](https://github.com/asottile/pyupgrade/compare/v3.15.1...v3.15.2)
```

Rendered:

- [pre-commit/pre-commit-hooks: v4.5.0 -> v4.6.0](https://github.com/pre-commit/pre-commit-hooks/compare/v4.5.0...v4.6.0)
- [astral-sh/ruff-pre-commit: v0.3.3 -> v0.3.6](https://github.com/astral-sh/ruff-pre-commit/compare/v0.3.3...v0.3.6)
- [asottile/pyupgrade: v3.15.1 -> v3.15.2](https://github.com/asottile/pyupgrade/compare/v3.15.1...v3.15.2)


## Before

Raw:

```
- [pre-commit/pre-commit-hooks: v4.5.0 -> v4.6](pre-commit/pre-commit-hooks@v4.5.0...v4.6)
- [astral-sh/ruff-pre-commit: v0.3.3 -> v0.3](pre-commit/ruff-pre-commit@v0.3.3...v0.3)
- [asottile/pyupgrade: v3.15.1 -> v3.15](pre-commit/pyupgrade@v3.15.1...v3.15)
```

Rendered:

- [pre-commit/pre-commit-hooks: v4.5.0 -> v4.6](pre-commit/pre-commit-hooks@v4.5.0...v4.6)
- [astral-sh/ruff-pre-commit: v0.3.3 -> v0.3](pre-commit/ruff-pre-commit@v0.3.3...v0.3)
- [asottile/pyupgrade: v3.15.1 -> v3.15](pre-commit/pyupgrade@v3.15.1...v3.15)