### PR TITLE
DOC: Reorganize Ubuntu console example of required dev tools

### DIFF
--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -57,7 +57,7 @@ Install the development tools and the support libraries:
 ```console
 sudo apt update && sudo apt install git git-lfs build-essential \
   libqt5x11extras5-dev qtmultimedia5-dev libqt5svg5-dev qtwebengine5-dev libqt5xmlpatterns5-dev qttools5-dev qtbase5-private-dev \
-  qtscript5-dev libxt-dev
+  libxt-dev
 ```
 
 Install CMake manually by downloading CMake 3.25.3 or higher from the [CMake website](https://cmake.org/download/)
@@ -88,7 +88,7 @@ Install the development tools and the support libraries:
 sudo apt update && sudo apt install git build-essential \
   cmake cmake-curses-gui cmake-qt-gui \
   libqt5x11extras5-dev qtmultimedia5-dev libqt5svg5-dev qtwebengine5-dev libqt5xmlpatterns5-dev qttools5-dev qtbase5-private-dev \
-  qtscript5-dev libxt-dev libssl-dev
+  libxt-dev libssl-dev
 ```
 
 ### Ubuntu 20.04 (Focal Fossa)
@@ -105,7 +105,7 @@ Install the development tools and the support libraries:
 sudo apt update && sudo apt install git build-essential \
   cmake cmake-curses-gui cmake-qt-gui \
   libqt5x11extras5-dev qtmultimedia5-dev libqt5svg5-dev qtwebengine5-dev libqt5xmlpatterns5-dev qttools5-dev qtbase5-private-dev \
-  qtscript5-dev libxt-dev qt5-default
+  libxt-dev qt5-default
 ```
 
 ### ArchLinux

--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -56,8 +56,8 @@ Install the development tools and the support libraries:
 
 ```console
 sudo apt update && sudo apt install git git-lfs build-essential \
-  qtmultimedia5-dev qttools5-dev libqt5xmlpatterns5-dev libqt5svg5-dev qtwebengine5-dev qtscript5-dev \
-  qtbase5-private-dev libqt5x11extras5-dev libxt-dev
+  libqt5x11extras5-dev qtmultimedia5-dev libqt5svg5-dev qtwebengine5-dev libqt5xmlpatterns5-dev qttools5-dev qtbase5-private-dev \
+  qtscript5-dev libxt-dev
 ```
 
 Install CMake manually by downloading CMake 3.25.3 or higher from the [CMake website](https://cmake.org/download/)
@@ -76,7 +76,8 @@ Install the development tools and the support libraries:
 ```console
 sudo apt update && sudo apt install git build-essential \
   cmake cmake-curses-gui cmake-qt-gui \
-  qtbase5-dev qt5-qmake libqt5x11extras5-dev qtmultimedia5-dev libqt5svg5-dev qtwebengine5-dev libqt5xmlpatterns5-dev qttools5-dev qtbase5-private-dev
+  libqt5x11extras5-dev qtmultimedia5-dev libqt5svg5-dev qtwebengine5-dev libqt5xmlpatterns5-dev qttools5-dev qtbase5-private-dev \
+  qtbase5-dev qt5-qmake
 ```
 
 ### Ubuntu 21.10 (Impish Indri)
@@ -84,9 +85,10 @@ sudo apt update && sudo apt install git build-essential \
 Install the development tools and the support libraries:
 
 ```console
-sudo apt update && sudo apt install git build-essential cmake cmake-curses-gui cmake-qt-gui \
-  qtmultimedia5-dev qttools5-dev libqt5xmlpatterns5-dev libqt5svg5-dev qtwebengine5-dev qtscript5-dev \
-  qtbase5-private-dev libqt5x11extras5-dev libxt-dev libssl-dev
+sudo apt update && sudo apt install git build-essential \
+  cmake cmake-curses-gui cmake-qt-gui \
+  libqt5x11extras5-dev qtmultimedia5-dev libqt5svg5-dev qtwebengine5-dev libqt5xmlpatterns5-dev qttools5-dev qtbase5-private-dev \
+  qtscript5-dev libxt-dev libssl-dev
 ```
 
 ### Ubuntu 20.04 (Focal Fossa)
@@ -100,9 +102,10 @@ To use Qt 5.15.2, we recommend you download and install following [these instruc
 Install the development tools and the support libraries:
 
 ```console
-sudo apt update && sudo apt install git build-essential cmake cmake-curses-gui cmake-qt-gui \
-  qt5-default qtmultimedia5-dev qttools5-dev libqt5xmlpatterns5-dev libqt5svg5-dev qtwebengine5-dev qtscript5-dev \
-  qtbase5-private-dev libqt5x11extras5-dev libxt-dev
+sudo apt update && sudo apt install git build-essential \
+  cmake cmake-curses-gui cmake-qt-gui \
+  libqt5x11extras5-dev qtmultimedia5-dev libqt5svg5-dev qtwebengine5-dev libqt5xmlpatterns5-dev qttools5-dev qtbase5-private-dev \
+  qtscript5-dev libxt-dev qt5-default
 ```
 
 ### ArchLinux


### PR DESCRIPTION
This is a follow-up to https://github.com/Slicer/Slicer/pull/7689, by trying to organize the required dev tools to be in a similar order between the different Ubuntu versions. This to hopefully better manage updates to required packages in the future.