### PR TITLE
ENH: Update Ruff configuration checking for numpy2 deprecation issues

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -26,6 +26,7 @@ select = [
 #  "SIM",         # flake8-simplify
   "UP",          # pyupgrade
   "YTT",         # flake8-2020
+  "NPY201",      # numpy2-deprecation
 ]
 extend-ignore = [
   "E402",    # Module level import not at top of file


### PR DESCRIPTION
See https://docs.astral.sh/ruff/rules/numpy2-deprecation/

To prep for users potentially using Numpy 2, this runs a numpy2 deprecation check to avoid any incompatibilities. It appears that Slicer's numpy usage is already compatible, but this additional check makes sure that continues.