### PR TITLE
ENH: Log more information when NRRD reading fails

### DIFF
--- a/Libs/vtkTeem/vtkTeemNRRDReader.cxx
+++ b/Libs/vtkTeem/vtkTeemNRRDReader.cxx
@@ -216,6 +216,15 @@ int vtkTeemNRRDReader::CanReadFile(const char* filename)
   if (nrrdLoad(nrrdTemp, filename, nio) != 0)
   {
     supported = false;
+    // We have already checked the magic, so the file should be readable.
+    // If it is not readable then it is an error, which we should report
+    // to make troubleshooting easier.
+    char* err = biffGetDone(NRRD);
+    if (err)
+    {
+      vtkErrorMacro("CanReadFile failed: " << err);
+      free(err);
+    }
   }
   if (nrrdTypeBlock == nrrdTemp->type)
   {


### PR DESCRIPTION
When some required fields in the NRRD file were missing, the user just got a generic error message. This commit logs detailed information about why Teem library could not load the NRRD file.

see https://discourse.slicer.org/t/slicer-rejects-modified-header/35549