### PR TITLE
BUG: Fix extension schema id

### DIFF
--- a/Extensions/CLIExtensionTemplate.json
+++ b/Extensions/CLIExtensionTemplate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-item-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Examples",

--- a/Extensions/LoadableExtensionTemplate.json
+++ b/Extensions/LoadableExtensionTemplate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-item-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Examples",

--- a/Extensions/ScriptedLoadableExtensionTemplate.json
+++ b/Extensions/ScriptedLoadableExtensionTemplate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-item-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Examples",

--- a/Extensions/ScriptedSegmentEditorEffectExtensionTemplate.json
+++ b/Extensions/ScriptedSegmentEditorEffectExtensionTemplate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-item-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
   "build_dependencies": [],
   "build_subdirectory": ".",
   "category": "Examples",

--- a/Extensions/SuperBuildExtensionTemplate.json
+++ b/Extensions/SuperBuildExtensionTemplate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-item-schema-v1.0.0.json#",
+  "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
   "build_dependencies": [],
   "build_subdirectory": "inner-build",
   "category": "Examples",

--- a/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json
+++ b/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-item-schema-v1.0.0.json#",
+  "$id": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json#",
   "type": "object",
   "title": "3D Slicer extensions catalog entry schema",
   "description": "Schema for storing information about a 3D Slicer extension to allow it to be listed in the extension catalog.",

--- a/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json
+++ b/Schemas/slicer-extension-catalog-entry-schema-v1.0.0.json
@@ -5,9 +5,9 @@
   "title": "3D Slicer extensions catalog entry schema",
   "description": "Schema for storing information about a 3D Slicer extension to allow it to be listed in the extension catalog.",
   "required": ["$schema", "category", "scm_url"],
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
-    "@schema": {
+    "$schema": {
       "$id": "#schema",
       "type": "string",
       "title": "Schema",


### PR DESCRIPTION
This is a follow-up of 1de721fd2b ("ENH: Add extension catalog entry file schema", 2024-03-19) in which the rename of the schema was partially applied.

Related pull request:
* #7709 