### PR TITLE
ENH: Improve terminology selector speed

### DIFF
--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.cxx
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.cxx
@@ -1541,7 +1541,8 @@ bool vtkSlicerTerminologiesModuleLogic::GetTypesInTerminologyCategory(std::strin
 
 //---------------------------------------------------------------------------
 bool vtkSlicerTerminologiesModuleLogic::FindTypesInTerminologyCategory(
-  std::string terminologyName, CodeIdentifier categoryId, std::vector<CodeIdentifier>& types, std::string search)
+  std::string terminologyName, CodeIdentifier categoryId, std::vector<CodeIdentifier>& types, std::string search,
+  std::vector<vtkSmartPointer<vtkSlicerTerminologyType>> *typeObjects/*=nullptr*/)
 {
   types.clear();
 
@@ -1576,6 +1577,12 @@ bool vtkSlicerTerminologiesModuleLogic::FindTypesInTerminologyCategory(
         {
           CodeIdentifier typeId(typeCodingSchemeDesignator.GetString(), typeCodeValue.GetString(), typeNameStr);
           types.push_back(typeId);
+          if (typeObjects)
+          {
+            vtkSmartPointer<vtkSlicerTerminologyType> typeObject = vtkSmartPointer<vtkSlicerTerminologyType>::New();
+            this->Internal->PopulateTerminologyTypeFromJson(type, typeObject);
+            typeObjects->push_back(typeObject);
+          }
         }
       }
       else

--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.h
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.h
@@ -119,15 +119,18 @@ public:
   bool GetNthCategoryInTerminology(std::string terminologyName, int categoryIndex, vtkSlicerTerminologyCategory* category);
 
   /// Get terminology types from a terminology category as collection of \sa vtkSlicerTerminologyType container objects
-  /// \param typeCollection Output argument containing all the \sa vtkSlicerTerminologyType objects created
+  /// \param types Output argument containing all the \sa vtkSlicerTerminologyType objects created
   ///   from the types found in the given terminology category
   /// \return Success flag
   bool GetTypesInTerminologyCategory(std::string terminologyName, CodeIdentifier categoryId, std::vector<CodeIdentifier>& types);
-  /// Get all type names (codeMeaning) in a terminology category
-  /// \param typeCollection Output argument containing all the \sa vtkSlicerTerminologyType objects created
+  /// Get terminology types from a terminology category as collection of \sa vtkSlicerTerminologyType container objects
+  /// \param types Output argument containing all the \sa type IDs in the category.
   ///   from the types found in the given terminology category
+  /// \param typeObjects Output argument containing all the \sa type objects in the category.. This is useful if type objects
+  ///   need to be retrieved for a large number of types, because it avoids the need to do a costly search in the json tree.
   /// \return Success flag
-  bool FindTypesInTerminologyCategory(std::string terminologyName, CodeIdentifier categoryId, std::vector<CodeIdentifier>& types, std::string search);
+  bool FindTypesInTerminologyCategory(std::string terminologyName, CodeIdentifier categoryId, std::vector<CodeIdentifier>& types, std::string search,
+    std::vector<vtkSmartPointer<vtkSlicerTerminologyType>>* typeObjects=nullptr);
   /// Get a type with given name from a terminology category
   /// \param type Output argument containing the details of the found type if any (if return value is true)
   /// \return Success flag


### PR DESCRIPTION
When the type selector was populated, all the type IDs were retrieved first, and then the type objects were looked up based on these IDs. This lookup is very slow if there are tens of thousands of types in the terminology.

Improved performance by returning not just all the type IDs but also all the corresponding type objects, therefore avoiding the costly lookup for each type.

see https://discourse.slicer.org/t/exporting-a-segmentation-paired-to-a-custom-colortable/35719/15
