### PR TITLE
ENH: Make qMRMLSequenceBrowserPlayWidget shortcuts accessible from python

### DIFF
--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.cxx
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.cxx
@@ -37,6 +37,9 @@ protected:
 public:
   qMRMLSequenceBrowserPlayWidgetPrivate(qMRMLSequenceBrowserPlayWidget& object);
   bool RecordingControlsVisible{ true };
+  QString PlayPauseShortcut{ "Ctrl+Shift+Down" };
+  QString PreviousFrameShortcut{ "Ctrl+Shift+Left" };
+  QString NextFrameShortcut{ "Ctrl+Shift+Right" };
   void init();
 
   vtkWeakPointer<vtkMRMLSequenceBrowserNode> SequenceBrowserNode;
@@ -67,6 +70,10 @@ void qMRMLSequenceBrowserPlayWidgetPrivate::init()
   QObject::connect( this->doubleSpinBox_VcrPlaybackRate, SIGNAL(valueChanged(double)), q, SLOT(setPlaybackRateFps(double)) );
   QObject::connect(this->pushButton_VcrRecord, SIGNAL(toggled(bool)), q, SLOT(setRecordingEnabled(bool)));
   QObject::connect(this->pushButton_Snapshot, SIGNAL(clicked()), q, SLOT(onRecordSnapshot()));
+
+  q->setPlayPauseShortcut(this->PlayPauseShortcut);
+  q->setPreviousFrameShortcut(this->PreviousFrameShortcut);
+  q->setNextFrameShortcut(this->NextFrameShortcut);
 
   q->updateWidgetFromMRML();
 }
@@ -307,7 +314,15 @@ void qMRMLSequenceBrowserPlayWidget::setPlayPauseShortcut(QString keySequence)
 {
   Q_D(qMRMLSequenceBrowserPlayWidget);
   QObject::connect(new QShortcut(QKeySequence(keySequence), this), SIGNAL(activated()), SLOT(onVcrPlayPause()));
-  d->pushButton_VcrPlayPause->setToolTip(d->pushButton_VcrPlayPause->toolTip()+" ("+keySequence+")");
+  d->pushButton_VcrPlayPause->setToolTip(tr("Play/Pause (%1)").arg(keySequence));
+  d->PlayPauseShortcut = keySequence;
+}
+
+//---------------------------------------------------------------------------
+QString qMRMLSequenceBrowserPlayWidget::playPauseShortcut() const
+{
+  Q_D(const qMRMLSequenceBrowserPlayWidget);
+  return d->PlayPauseShortcut;
 }
 
 //-----------------------------------------------------------------------------
@@ -315,7 +330,15 @@ void qMRMLSequenceBrowserPlayWidget::setPreviousFrameShortcut(QString keySequenc
 {
   Q_D(qMRMLSequenceBrowserPlayWidget);
   QObject::connect(new QShortcut(QKeySequence(keySequence), this), SIGNAL(activated()), SLOT(onVcrPrevious()));
-  d->pushButton_VcrPrevious->setToolTip(d->pushButton_VcrPrevious->toolTip() + " (" + keySequence + ")");
+  d->pushButton_VcrPrevious->setToolTip(tr("Previous frame (%1)").arg(keySequence));
+  d->PreviousFrameShortcut = keySequence;
+}
+
+//---------------------------------------------------------------------------
+QString qMRMLSequenceBrowserPlayWidget::previousFrameShortcut() const
+{
+  Q_D(const qMRMLSequenceBrowserPlayWidget);
+  return d->PreviousFrameShortcut;
 }
 
 //-----------------------------------------------------------------------------
@@ -323,7 +346,15 @@ void qMRMLSequenceBrowserPlayWidget::setNextFrameShortcut(QString keySequence)
 {
   Q_D(qMRMLSequenceBrowserPlayWidget);
   QObject::connect(new QShortcut(QKeySequence(keySequence), this), SIGNAL(activated()), SLOT(onVcrNext()));
-  d->pushButton_VcrNext->setToolTip(d->pushButton_VcrNext->toolTip() + " (" + keySequence + ")");
+  d->pushButton_VcrNext->setToolTip(tr("Next frame (%1)").arg(keySequence));
+  d->NextFrameShortcut = keySequence;
+}
+
+//---------------------------------------------------------------------------
+QString qMRMLSequenceBrowserPlayWidget::nextFrameShortcut() const
+{
+  Q_D(const qMRMLSequenceBrowserPlayWidget);
+  return d->NextFrameShortcut;
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.h
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.h
@@ -48,20 +48,24 @@ class Q_SLICER_MODULE_SEQUENCES_WIDGETS_EXPORT qMRMLSequenceBrowserPlayWidget
   /// has recording enabled.
   Q_PROPERTY(bool RecordingControlsVisible READ recordingControlsVisible WRITE setRecordingControlsVisible)
 
+  Q_PROPERTY(QString PlayPauseShortcut READ playPauseShortcut WRITE setPlayPauseShortcut)
+  Q_PROPERTY(QString PreviousFrameShortcut READ previousFrameShortcut WRITE setPreviousFrameShortcut)
+  Q_PROPERTY(QString NextFrameShortcut READ nextFrameShortcut WRITE setNextFrameShortcut)
+
 
 public:
   typedef qMRMLWidget Superclass;
   qMRMLSequenceBrowserPlayWidget(QWidget *newParent = 0);
   ~qMRMLSequenceBrowserPlayWidget() override;
 
-  /// Add a keyboard shortcut for play/pause button
-  void setPlayPauseShortcut(QString keySequence);
+  /// Get keyboard shortcut string for play/pause button
+  QString playPauseShortcut()const;
 
-  /// Add a keyboard shortcut for previous frame button
-  void setPreviousFrameShortcut(QString keySequence);
+  /// Get keyboard shortcut string for previous frame button
+  QString previousFrameShortcut()const;
 
-  /// Add a keyboard shortcut for next frame button
-  void setNextFrameShortcut(QString keySequence);
+  /// Get keyboard shortcut string for next frame button
+  QString nextFrameShortcut()const;
 
   /// Returns true if recording controls (record and snapshot buttons) are allowed to be shown.
   ///
@@ -77,6 +81,16 @@ public slots:
   void setPlaybackRateFps(double playbackRateFps);
   void setPlaybackLoopEnabled(bool loopEnabled);
   void setRecordingControlsVisible(bool show);
+
+  /// Add a keyboard shortcut for play/pause button
+  void setPlayPauseShortcut(QString keySequence);
+
+  /// Add a keyboard shortcut for previous frame button
+  void setPreviousFrameShortcut(QString keySequence);
+
+  /// Add a keyboard shortcut for next frame button
+  void setNextFrameShortcut(QString keySequence);
+
   void onVcrFirst();
   void onVcrPrevious();
   void onVcrNext();

--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserToolBar.cxx
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserToolBar.cxx
@@ -85,10 +85,6 @@ void qMRMLSequenceBrowserToolBarPrivate::init()
   q->addWidget(this->SequenceBrowserSeekWidget);
   q->addWidget(this->SequenceBrowserNodeSelector);
 
-  this->SequenceBrowserPlayWidget->setPlayPauseShortcut("Ctrl+Shift+Down");
-  this->SequenceBrowserPlayWidget->setPreviousFrameShortcut("Ctrl+Shift+Left");
-  this->SequenceBrowserPlayWidget->setNextFrameShortcut("Ctrl+Shift+Right");
-
   QObject::connect(this->SequenceBrowserNodeSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
     this->SequenceBrowserPlayWidget, SLOT(setMRMLSequenceBrowserNode(vtkMRMLNode*)) );
   QObject::connect(this->SequenceBrowserNodeSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)),


### PR DESCRIPTION
This makes the shortcuts for the qMRMLSequenceBrowserPlayWidget able to be customized from python. I have used this when showing multiple qMRMLSequenceBrowserPlayWidget objects and needing unique shortcuts for each.