### PR TITLE
COMP: Remove redundant call in vtkITKMorphologicalContourInterpolator

### DIFF
--- a/Libs/vtkITK/vtkITKMorphologicalContourInterpolator.cxx
+++ b/Libs/vtkITK/vtkITKMorphologicalContourInterpolator.cxx
@@ -85,7 +85,6 @@ void vtkITKMorphologicalContourInterpolator::SimpleExecute(vtkImageData *input, 
   // Initialize and check input
   //
   vtkPointData *pd = input->GetPointData();
-  pd=input->GetPointData();
   if (pd ==nullptr)
   {
     vtkErrorMacro(<<"PointData is NULL");


### PR DESCRIPTION
This removes duplicated code initially introduced in d0782fa233 (`ENH: Added contour interpolation`, 2016-10-04)