### PR TITLE
BUG: Fix crash in vtkPointLocator when markups curve polydata is empty

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
@@ -789,7 +789,7 @@ bool vtkMRMLMarkupsCurveNode::GetSampledCurvePointsBetweenStartEndPointsWorld(vt
 vtkIdType vtkMRMLMarkupsCurveNode::GetClosestCurvePointIndexToPositionWorld(const double posWorld[3])
 {
   vtkPoints* points = this->GetCurvePointsWorld();
-  if (!points)
+  if (!points || points->GetNumberOfPoints() == 0)
   {
     return -1;
   }


### PR DESCRIPTION
In some situations (such as between Start/EndModify calls on vtkMRMLMarkupsCurveNode), it is possible that the output curve polydata will be in a state it has no points.

If TransformedCurvePolyLocator had been previously initialized and FindClosestPoint is called when the curve polydata has no points, then it will cause a crash. This is due to the vtkPointLocator HashTable not being reset correctly. See related MR fixing the issue in VTK here: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/11114

This commit fixes the crash by returning if there are no points without checking the vtkPointLocator. This change also serves as an minor optimization.