### PR TITLE
ENH: Add API for finding terminology from codes

### DIFF
--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.h
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.h
@@ -49,7 +49,7 @@ public:
     public:
       CodeIdentifier()
         { };
-      CodeIdentifier(std::string codingSchemeDesignator, std::string codeValue, std::string codeMeaning)
+      CodeIdentifier(std::string codingSchemeDesignator, std::string codeValue, std::string codeMeaning=std::string())
         : CodingSchemeDesignator(codingSchemeDesignator)
         , CodeValue(codeValue)
         , CodeMeaning(codeMeaning)
@@ -106,6 +106,24 @@ public:
   ///   from the categories found in the given terminology
   /// \return Success flag
   bool FindCategoriesInTerminology(std::string terminologyName, std::vector<CodeIdentifier>& categories, std::string search);
+
+  /// Return collection of vtkSlicerTerminologyEntry objects designated by the given codes.
+  /// \param preferredTerminologyNames List of terminology names in order of preference. If an empty list is provided then all terminologies are searched.
+  std::vector<std::string> FindTerminologyNames(
+    std::string categoryCodingSchemeDesignator, std::string categoryCodeValue,
+    std::string typeCodingSchemeDesignator, std::string typeCodeValue,
+    std::string typeModifierCodingSchemeDesignator, std::string typeModifierCodeValue,
+    std::vector<std::string> preferredTerminologyNames,
+    vtkCollection* foundEntries=nullptr);
+
+  /// Return list of anatomic context names containing the specified anatomic region.
+  /// \param preferredAnatomicContextNames List of anatomic context names in order of preference. If an empty list is provided then all context are searched.
+  std::vector<std::string> FindAnatomicContextNames(
+    std::string anatomicRegionCodingSchemeDesignator, std::string anatomicRegionCodeValue,
+    std::string anatomicRegionModifierCodingSchemeDesignator, std::string anatomicRegionModifierCodeValue,
+    std::vector<std::string> preferredAnatomicContextNames,
+    vtkCollection* foundEntries=nullptr);
+
   /// Get a category with given name from a terminology
   /// \param category Output argument containing the details of the found category if any (if return value is true)
   /// \return Success flag

--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyType.cxx
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyType.cxx
@@ -73,16 +73,16 @@ void vtkSlicerTerminologyType::PrintSelf(ostream& os, vtkIndent indent)
 {
   Superclass::PrintSelf(os,indent);
 
-  os << indent << "RecommendedDisplayRGBValue:   ("
-    << this->RecommendedDisplayRGBValue[0] << ","
-    << this->RecommendedDisplayRGBValue[1] << ","
-    << this->RecommendedDisplayRGBValue[2] << ")\n";
-  os << indent << "SlicerLabel:   " << (this->SlicerLabel?this->SlicerLabel:"NULL") << "\n";
-  os << indent << "SNOMEDCTConceptID:   " << (this->SNOMEDCTConceptID?this->SNOMEDCTConceptID:"NULL") << "\n";
-  os << indent << "UMLSConceptUID:   " << (this->UMLSConceptUID?this->UMLSConceptUID:"NULL") << "\n";
-  os << indent << "Cid:   " << (this->Cid?this->Cid:"NULL") << "\n";
-  os << indent << "ContextGroupName:   " << (this->ContextGroupName?this->ContextGroupName:"NULL") << "\n";
-  os << indent << "HasModifiers:   " << (this->HasModifiers?"true":"false") << "\n";
+  os << indent << "RecommendedDisplayRGBValue: ("
+    << int(this->RecommendedDisplayRGBValue[0]) << ","
+    << int(this->RecommendedDisplayRGBValue[1]) << ","
+    << int(this->RecommendedDisplayRGBValue[2]) << ")\n";
+  os << indent << "SlicerLabel: " << (this->SlicerLabel?this->SlicerLabel:"NULL") << "\n";
+  os << indent << "SNOMEDCTConceptID: " << (this->SNOMEDCTConceptID?this->SNOMEDCTConceptID:"NULL") << "\n";
+  os << indent << "UMLSConceptUID: " << (this->UMLSConceptUID?this->UMLSConceptUID:"NULL") << "\n";
+  os << indent << "Cid: " << (this->Cid?this->Cid:"NULL") << "\n";
+  os << indent << "ContextGroupName: " << (this->ContextGroupName?this->ContextGroupName:"NULL") << "\n";
+  os << indent << "HasModifiers: " << (this->HasModifiers?"true":"false") << "\n";
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Often the segment category&type and anatomic region codes are available in multiple contexts. This commit adds FindTerminologyNames and FindAnatomicContextNames methods to the terminology logic that allows getting a list of contexts where the codes are listed in.

The methods can also return the terminology objects, which makes it very easy to get properties (such as name and color) from codes.