### PR TITLE
BUG: Fix crash when deleting multiple markups in subject hierarchy

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidgetRepresentation.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidgetRepresentation.cxx
@@ -559,6 +559,10 @@ void vtkSlicerMarkupsInteractionWidgetRepresentation::UpdateROIScaleHandles2D()
 void vtkSlicerMarkupsInteractionWidgetRepresentation::UpdateHandleToWorldTransform(vtkTransform* handleToWorldTransform)
 {
   handleToWorldTransform->Identity();
+  if (!this->GetMarkupsNode())
+  {
+    return;
+  }
   handleToWorldTransform->Concatenate(this->GetMarkupsNode()->GetInteractionHandleToWorldMatrix());
 }
 


### PR DESCRIPTION
Add nullptr check to vtkSlicerMarkupsInteractionWidgetRepresentation::UpdateHandleToWorldTransform.

See discussion: https://discourse.slicer.org/t/reproducible-slicer-crash-deleting-markupsroinodes-from-subject-hierarchy/36007