### PR TITLE
Improve segmentation (.seg.nrrd) file reader robustness

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -74,7 +74,7 @@
 #include <sstream>
 
 //----------------------------------------------------------------------------
-static const std::string SERIALIZATION_SEPARATOR = "|";
+static const char LIST_SEPARATOR = '|';
 static const std::string KEY_SEGMENT_ID = "ID";
 static const std::string KEY_SEGMENT_NAME = "Name";
 static const std::string KEY_SEGMENT_COLOR = "Color";
@@ -862,35 +862,42 @@ int vtkMRMLSegmentationStorageNode::ReadBinaryLabelmapRepresentation(vtkMRMLSegm
         {
           currentBinaryLabelmap = vtkSmartPointer<vtkOrientedImageData>::New();
 
-          // Extent
-          int currentSegmentExtent[6] = { 0, -1, 0, -1, 0, -1 };
-          std::string currentExtentString;
-          if (this->GetSegmentMetaDataFromDicitionary(currentExtentString, dictionary, segmentIndex, KEY_SEGMENT_EXTENT))
+          // Get layer extent: union of all segment extents in this layer
+          int layerExtent[6] = { 0, -1, 0, -1, 0, -1 };
+          for (int segmentIndexForExtent : segmentIndexInLayer[frameIndex])
           {
-            GetImageExtentFromString(currentSegmentExtent, currentExtentString);
-          }
-          else
-          {
-            vtkWarningToMessageCollectionMacro(this->GetUserMessages(), "vtkMRMLSegmentationStorageNode::ReadBinaryLabelmapRepresentation",
-              "Segment extent is missing for segment " << segmentIndex);
-            for (int i = 0; i < 6; i++)
+            int currentSegmentExtent[6] = { 0, -1, 0, -1, 0, -1 };
+            std::string currentExtentString;
+            if (this->GetSegmentMetaDataFromDicitionary(currentExtentString, dictionary, segmentIndexForExtent, KEY_SEGMENT_EXTENT))
             {
-              currentSegmentExtent[i] = imageExtentInFile[i];
+              GetImageExtentFromString(currentSegmentExtent, currentExtentString);
+              vtkMRMLSegmentationStorageNode::AddToExtent(layerExtent, currentSegmentExtent);
+            }
+            else
+            {
+              // Extent is not specified, we don't know the extent of this layer, so use the entire region
+              vtkWarningToMessageCollectionMacro(this->GetUserMessages(), "vtkMRMLSegmentationStorageNode::ReadBinaryLabelmapRepresentation",
+                "Segment extent is missing for segment " << segmentIndexForExtent);
+              for (int i = 0; i < 6; i++)
+              {
+                layerExtent[i] = imageExtentInFile[i];
+              }
+              break;
             }
           }
           for (int i = 0; i < 3; i++)
           {
-            currentSegmentExtent[i * 2] += referenceImageExtentOffset[i];
-            currentSegmentExtent[i * 2 + 1] += referenceImageExtentOffset[i];
+            layerExtent[i * 2] += referenceImageExtentOffset[i];
+            layerExtent[i * 2 + 1] += referenceImageExtentOffset[i];
           }
           // Copy with clipping to specified extent
-          if (currentSegmentExtent[0] <= currentSegmentExtent[1]
-            && currentSegmentExtent[2] <= currentSegmentExtent[3]
-            && currentSegmentExtent[4] <= currentSegmentExtent[5])
+          if (layerExtent[0] <= layerExtent[1]
+            && layerExtent[2] <= layerExtent[3]
+            && layerExtent[4] <= layerExtent[5])
           {
             // non-empty segment
             extractComponents->SetComponents(frameIndex);
-            padder->SetOutputWholeExtent(currentSegmentExtent);
+            padder->SetOutputWholeExtent(layerExtent);
             padder->Update();
             currentBinaryLabelmap->DeepCopy(padder->GetOutput());
           }
@@ -899,10 +906,10 @@ int vtkMRMLSegmentationStorageNode::ReadBinaryLabelmapRepresentation(vtkMRMLSegm
             // empty segment
             for (int i = 0; i < 3; ++i)
             {
-              currentSegmentExtent[2 * i] = 0;
-              currentSegmentExtent[2 * i + 1] = -1;
+              layerExtent[2 * i] = 0;
+              layerExtent[2 * i + 1] = -1;
             }
-            currentBinaryLabelmap->SetExtent(currentSegmentExtent);
+            currentBinaryLabelmap->SetExtent(layerExtent);
             currentBinaryLabelmap->AllocateScalars(VTK_UNSIGNED_CHAR, 1);
           }
           currentBinaryLabelmap->SetImageToWorldMatrix(imageToWorldMatrix.GetPointer());
@@ -1007,6 +1014,43 @@ int vtkMRMLSegmentationStorageNode::ReadBinaryLabelmapRepresentation(vtkMRMLSegm
   this->CreateRepresentationsBySerializedNames(segmentation, containedRepresentationNames);
 
   return 1;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSegmentationStorageNode::AddToExtent(int extent[6], int extentToAdd[6])
+{
+  if (extentToAdd[0] > extentToAdd[1]
+    || extentToAdd[2] > extentToAdd[3]
+    || extentToAdd[4] > extentToAdd[5])
+  {
+    // extentToAdd is empty, no need to change the extent
+    return;
+  }
+  if (extent[0] > extent[1]
+    || extent[2] > extent[3]
+    || extent[4] > extent[5])
+  {
+    // initial extent is empty, use the added extent
+    for (int i = 0; i < 6; i++)
+    {
+      extent[i] = extentToAdd[i];
+    }
+  }
+  else
+  {
+    // add extentToAdd to extent
+    for (int i = 0; i < 3; i++)
+    {
+      if (extentToAdd[i * 2] < extent[i * 2])
+      {
+        extent[i * 2] = extentToAdd[i * 2];
+      }
+      if (extentToAdd[i * 2 + 1] > extent[i * 2 + 1])
+      {
+        extent[i * 2 + 1] = extentToAdd[i * 2 + 1];
+      }
+    }
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -1169,20 +1213,16 @@ int vtkMRMLSegmentationStorageNode::ReadPolyDataRepresentation(vtkMRMLSegmentati
       currentPolyData->GetFieldData()->GetAbstractArray(GetSegmentMetaDataKey(SINGLE_SEGMENT_INDEX, KEY_SEGMENT_TAGS).c_str()) );
     if (tagsArray)
     {
-      std::string tags(tagsArray->GetValue(0).c_str());
-      std::string separatorCharacter("|");
-      size_t separatorPosition = tags.find(separatorCharacter);
-      while (separatorPosition != std::string::npos)
+      std::stringstream tagsValueStr(tagsArray->GetValue(0));
+      std::string tagValue;
+      while (getline(tagsValueStr, tagValue, LIST_SEPARATOR))
       {
-        std::string mapPairStr = tags.substr(0, separatorPosition);
-        size_t colonPosition = mapPairStr.find(":");
+        size_t colonPosition = tagValue.find(":");
         if (colonPosition == std::string::npos)
         {
           continue;
         }
-        currentSegment->SetTag(mapPairStr.substr(0, colonPosition), mapPairStr.substr(colonPosition+1));
-        tags = tags.substr(separatorPosition+1);
-        separatorPosition = tags.find(separatorCharacter);
+        currentSegment->SetTag(tagValue.substr(0, colonPosition), tagValue.substr(colonPosition + 1));
       }
     }
 
@@ -1679,7 +1719,7 @@ std::string vtkMRMLSegmentationStorageNode::SerializeContainedRepresentationName
   for (std::vector<std::string>::iterator reprIt = containedRepresentationNames.begin();
     reprIt != containedRepresentationNames.end(); ++reprIt)
   {
-    ssRepresentationNames << (*reprIt) << SERIALIZATION_SEPARATOR;
+    ssRepresentationNames << (*reprIt) << LIST_SEPARATOR;
   }
 
   return ssRepresentationNames.str();
@@ -1705,19 +1745,15 @@ void vtkMRMLSegmentationStorageNode::CreateRepresentationsBySerializedNames(vtkS
   }
 
   std::string sourceRepresentation(segmentation->GetSourceRepresentationName());
-  size_t separatorPosition = representationNames.find(SERIALIZATION_SEPARATOR);
-  while (separatorPosition != std::string::npos)
+  std::string representationName;
+  std::stringstream representationNamesStr(representationNames);
+  while (getline(representationNamesStr, representationName, LIST_SEPARATOR))
   {
-    std::string representationName = representationNames.substr(0, separatorPosition);
-
     // Only create non-source representations
     if (representationName.compare(sourceRepresentation))
     {
       segmentation->CreateRepresentation(representationName);
     }
-
-    representationNames = representationNames.substr(separatorPosition+1);
-    separatorPosition = representationNames.find(SERIALIZATION_SEPARATOR);
   }
 }
 
@@ -1787,21 +1823,16 @@ std::string vtkMRMLSegmentationStorageNode::GetSegmentTagsAsString(vtkSegment* s
 //----------------------------------------------------------------------------
 void vtkMRMLSegmentationStorageNode::SetSegmentTagsFromString(vtkSegment* segment, std::string tagsValue)
 {
-  std::string separatorCharacter("|");
-  size_t separatorPosition = tagsValue.find(separatorCharacter);
-  while (separatorPosition != std::string::npos)
+  std::stringstream tagsValueStr(tagsValue);
+  std::string tagValue;
+  while (getline(tagsValueStr, tagValue, LIST_SEPARATOR))
   {
-    std::string mapPairStr = tagsValue.substr(0, separatorPosition);
-    size_t colonPosition = mapPairStr.find(":");
+    size_t colonPosition = tagValue.find(":");
     if (colonPosition == std::string::npos)
     {
-      tagsValue = tagsValue.substr(separatorPosition + 1);
-      separatorPosition = tagsValue.find(separatorCharacter);
       continue;
     }
-    segment->SetTag(mapPairStr.substr(0, colonPosition), mapPairStr.substr(colonPosition + 1));
-    tagsValue = tagsValue.substr(separatorPosition + 1);
-    separatorPosition = tagsValue.find(separatorCharacter);
+    segment->SetTag(tagValue.substr(0, colonPosition), tagValue.substr(colonPosition + 1));
   }
 }
 

--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.h
@@ -174,6 +174,8 @@ protected:
   static std::string GetSegmentColorAsString(vtkMRMLSegmentationNode* segmentationNode, const std::string& segmentId);
   static void GetSegmentColorFromString(double color[3], std::string colorString);
 
+  static void AddToExtent(int extent[6], int extentToAdd[6]);
+
 protected:
   bool CropToMinimumExtent{false};
 

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsReader.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsReader.cxx
@@ -126,10 +126,11 @@ double qSlicerSegmentationsReader::canLoadFileConfidence(const QString& fileName
       {
         QTextStream in(&file);
         // Segmentation NRRD files contain ID for each segment (such as Segment0_ID:=...)
+        // or common segmentation information (such as Segmentation_ContainedRepresentations:=...).
         // around position 500, read a bit further to account for slight variations in the header.
         QString line = in.read(800);
         // If this appears in the file header then declare higher confidence value.
-        confidence = (line.contains("Segment0_ID:=") ? 0.6 : 0.4);
+        confidence = (line.contains("Segment0_ID:=") || line.contains("Segmentation_") ? 0.6 : 0.4);
       }
     }
   }


### PR DESCRIPTION
Make the segmentation storage node read .seg.nrrd files that are created outside of Slicer (e.g., using slicerio Python package).
They may use different order of fields (therefore the file detection heuristics had to be tuned), some fields may be missing, and there could be minor syntax differences (e.g., Slicer always terminates a list with separator character, but other software may just use separators between components).