### PR TITLE
Fix reading of images that have left-handed IJK coordinate system

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLVolumeArchetypeStorageNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLVolumeArchetypeStorageNodeTest1.cxx
@@ -21,6 +21,7 @@
 #include "vtkNew.h"
 #include "vtkPointData.h"
 #include <vtksys/SystemTools.hxx>
+#include <vtkTransform.h>
 
 std::string tempFilename(std::string tempDir, std::string suffix, std::string fileExtension, bool remove=false)
 {
@@ -141,45 +142,79 @@ int TestFlipsLeftHandedVolumes(const std::string& tempDir)
   imageData->AllocateScalars(VTK_FLOAT, 1);
   imageData->GetPointData()->GetScalars()->Fill(0);
 
+  // Fill the volume with non-uniform content
   for (int i = 0; i < n_i; i++)
   {
     for (int j = 0; j < n_j; j++)
     {
       for (int k = 0; k < n_k; k++)
       {
-        imageData->SetScalarComponentFromDouble(i, j, k, 0, k);
+        imageData->SetScalarComponentFromDouble(i, j, k, 0, i * 11 + j * 13 + k * 17);
       }
     }
   }
-  volumeNode->SetIJKToRASDirections(-1., 0., 0., 0., -1., 0., 0., 0., -1.);
 
-  const auto fileName = tempFilename(tempDir, "flipped_volume", "mha", true);
+  // Generate an arbitrary left-handed IJK to RAS transform
+  vtkNew<vtkTransform> ijkToRasTransform;
+  ijkToRasTransform->Translate(10.0, 20.0, -35.0);
+  ijkToRasTransform->RotateY(30.0);
+  ijkToRasTransform->RotateZ(45.0);
+  ijkToRasTransform->Scale(1.2, -0.3, 1.7); // left-handed due to single negative value
+  volumeNode->SetIJKToRASMatrix(ijkToRasTransform->GetMatrix());
+
+  // Verify that IJK coordinate system is left-handed
+  CHECK_BOOL(vtkMRMLVolumeNode::IsIJKCoordinateSystemRightHanded(ijkToRasTransform->GetMatrix()), false);
+
+  // Write the volume to a file and then read it
+  const auto fileName = tempFilename(tempDir, "left_handed_ijk_volume", "mha", true);
   auto storageNode =
     vtkMRMLVolumeArchetypeStorageNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLVolumeArchetypeStorageNode"));
   CHECK_NOT_NULL(storageNode);
   storageNode->SetSingleFile(true);
   volumeNode->SetAndObserveImageData(imageData);
   volumeNode->SetAndObserveStorageNodeID(storageNode->GetID());
-
-  // Check that when loading, the K axis is flipped
   storageNode->SetFileName(fileName.c_str());
   CHECK_BOOL(storageNode->WriteData(volumeNode), true);
-  CHECK_BOOL(storageNode->ReadData(volumeNode), true);
+  auto volumeNode2 = vtkMRMLScalarVolumeNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLScalarVolumeNode"));
+  CHECK_BOOL(storageNode->ReadData(volumeNode2), true);
 
-  vtkNew<vtkMatrix4x4> matrix;
-  volumeNode->GetIJKToRASDirectionMatrix(matrix);
+  // Check that in the saved and loaded image IJK is right-handed
+  vtkNew<vtkMatrix4x4> ijkToRas2;
+  volumeNode2->GetIJKToRASMatrix(ijkToRas2);
+  CHECK_BOOL(vtkMRMLVolumeNode::IsIJKCoordinateSystemRightHanded(ijkToRas2), true);
 
-  CHECK_DOUBLE(matrix->GetElement(0, 0), -1.);
-  CHECK_DOUBLE(matrix->GetElement(1, 1), -1.);
-  CHECK_DOUBLE(matrix->GetElement(2, 2), 1.);
-
+  // Check that the loaded volume has the same voxel values at the same physical locations
+  vtkNew<vtkMatrix4x4> rasToIjk2;
+  volumeNode2->GetRASToIJKMatrix(rasToIjk2);
   for (int i = 0; i < n_i; i++)
   {
     for (int j = 0; j < n_j; j++)
     {
       for (int k = 0; k < n_k; k++)
       {
-        CHECK_DOUBLE(volumeNode->GetImageData()->GetScalarComponentAsDouble(i, j, k, 0), n_k - k - 1.);
+        // Get IJK position in flipped volume at the same physical location
+        double ijk[4] = { static_cast<double>(i), static_cast<double>(j), static_cast<double>(k), 1 };
+        double ras[4] = { 0, 0, 0, 1 };
+        ijkToRasTransform->MultiplyPoint(ijk, ras);
+        double ijk2[4] = { 0, 0, 0, 1 };
+        rasToIjk2->MultiplyPoint(ras, ijk2);
+        double i2 = static_cast<int>(ijk2[0] + 0.5);
+        double j2 = static_cast<int>(ijk2[1] + 0.5);
+        double k2 = static_cast<int>(ijk2[2] + 0.5);
+        if (i != i2 || j != j2 || k != (volumeNode2->GetImageData()->GetDimensions()[2] - 1 - k2))
+        {
+          std::cerr << "IJK mismatch: volume[" << i << ", " << j << ", " << k << "] != volume2[" << i2 << ", " << j2 << ", " << k2 << "]" << std::endl;
+          return EXIT_FAILURE;
+        }
+        // Check voxel values
+        double voxelValue = volumeNode->GetImageData()->GetScalarComponentAsDouble(i, j, k, 0);
+        double voxelValue2 = volumeNode2->GetImageData()->GetScalarComponentAsDouble(i2, j2, k2, 0);
+        if (voxelValue != voxelValue2)
+        {
+          std::cerr << "Voxel value mismatch: volume[" << i << ", " << j << ", " << k << "]=" << voxelValue
+            << " != volume2[" << i2 << ", " << j2 << ", " << k2 << "]=" << voxelValue2 << std::endl;
+          return EXIT_FAILURE;
+        }
       }
     }
   }

--- a/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
@@ -40,7 +40,6 @@ Version:   $Revision: 1.6 $
 #include <vtkDataArray.h>
 #include <vtkErrorCode.h>
 #include <vtkImageChangeInformation.h>
-#include <vtkImageFlip.h>
 #include <vtkMatrix3x3.h>
 #include <vtkNew.h>
 #include <vtkPointData.h>
@@ -88,6 +87,7 @@ vtkMRMLVolumeArchetypeStorageNode::vtkMRMLVolumeArchetypeStorageNode()
   this->CenterImage = 0;
   this->SingleFile  = 0;
   this->UseOrientationFromFile = 1;
+  this->ForceRightHandedIJKCoordinateSystem = true;
   this->DefaultWriteFileExtension = "nrrd";
 }
 
@@ -103,11 +103,13 @@ void vtkMRMLVolumeArchetypeStorageNode::WriteXML(ostream& of, int nIndent)
   ss << this->CenterImage;
   of << " centerImage=\"" << ss.str() << "\"";
   }
+  of << " forceRightHandedIJKCoordinateSystem=\"" << (this->ForceRightHandedIJKCoordinateSystem ? "true" : "false") << "\"";
   {
-  std::stringstream ss;
-  ss << this->UseOrientationFromFile;
-  of << " UseOrientationFromFile=\"" << ss.str() << "\"";
+    std::stringstream ss;
+    ss << this->UseOrientationFromFile;
+    of << " UseOrientationFromFile=\"" << ss.str() << "\"";
   }
+
   // SingleFile attribute is not written to file. GetNumberOfFileNames()
   // is used to determine if reader should read from single/multiple files.
 }
@@ -127,15 +129,23 @@ void vtkMRMLVolumeArchetypeStorageNode::ReadXMLAttributes(const char** atts)
     attValue = *(atts++);
     if (!strcmp(attName, "centerImage"))
     {
+      int centerImage = 0;
       std::stringstream ss;
       ss << attValue;
-      ss >> this->CenterImage;
+      ss >> centerImage;
+      this->SetCenterImage(centerImage);
     }
     if (!strcmp(attName, "UseOrientationFromFile"))
     {
+      int useOrientationFromFile = 1;
       std::stringstream ss;
       ss << attValue;
-      ss >> this->UseOrientationFromFile;
+      ss >> useOrientationFromFile;
+      this->SetUseOrientationFromFile(useOrientationFromFile);
+    }
+    if (!strcmp(attName, "forceRightHandedIJKCoordinateSystem"))
+    {
+      this->SetForceRightHandedIJKCoordinateSystem(strcmp(attValue, "true") == 0);
     }
   }
 
@@ -161,6 +171,7 @@ void vtkMRMLVolumeArchetypeStorageNode::Copy(vtkMRMLNode *anode)
   this->SetCenterImage(node->CenterImage);
   this->SetSingleFile(node->SingleFile);
   this->SetUseOrientationFromFile(node->UseOrientationFromFile);
+  this->SetForceRightHandedIJKCoordinateSystem(node->ForceRightHandedIJKCoordinateSystem);
 
   this->EndModify(disabledModify);
 }
@@ -172,6 +183,7 @@ void vtkMRMLVolumeArchetypeStorageNode::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "CenterImage:   " << this->CenterImage << "\n";
   os << indent << "SingleFile:   " << this->SingleFile << "\n";
   os << indent << "UseOrientationFromFile:   " << this->UseOrientationFromFile << "\n";
+  os << indent << "ForceRightHandedIJKCoordinateSystem:   " << (this->ForceRightHandedIJKCoordinateSystem ? "true" : "false") << "\n";
 }
 
 //----------------------------------------------------------------------------
@@ -283,38 +295,6 @@ void ApplyImageSeriesReaderWorkaround(vtkMRMLVolumeArchetypeStorageNode * storag
       reader->AddFileName(nthFileName.c_str());
     }
   }
-}
-
-//----------------------------------------------------------------------------
-bool IsIJKCoordinateSystemLeftHanded(vtkMatrix4x4* rasToIjkMatrix)
-{
-  // Check if the determinant of the orientation matrix is less than 0.
-  vtkNew<vtkMatrix3x3> orientation;
-  vtkAddonMathUtilities::GetOrientationMatrix(rasToIjkMatrix, orientation);
-  return orientation->Determinant() < 0.;
-}
-
-//----------------------------------------------------------------------------
-void FlipIJKCoordinateSystemHandedness(vtkImageData* imageData, vtkMatrix4x4* rasToIjkMatrix)
-{
-  // Flip third image axis (K) direction
-  vtkNew<vtkImageFlip> flip;
-  flip->SetFilteredAxes(2);
-  flip->SetInputData(imageData);
-  flip->Update();
-  imageData->ShallowCopy(flip->GetOutput());
-
-  // Update rasToIJK to reflect flip around the third axis and shift of the origin to the opposite corner.
-  vtkNew<vtkTransform> flipTransform;
-  int* imageDimensions = imageData->GetDimensions();
-  if (imageDimensions[2] > 1)
-  {
-    // There are more than 1 slice in the image, move the origin to the opposite corner
-    flipTransform->Translate(0.0, 0.0, imageDimensions[2] - 1);
-  }
-  flipTransform->Scale(1.0, 1.0, -1.0);
-  flipTransform->Concatenate(rasToIjkMatrix);
-  flipTransform->GetMatrix(rasToIjkMatrix);
 }
 
 } // end of anonymous namespace
@@ -550,15 +530,14 @@ int vtkMRMLVolumeArchetypeStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
     vtkErrorToMessageCollectionMacro(this->GetUserMessages(), "vtkMRMLVolumeArchetypeStorageNode::ReadDataInternal",
       vtkMRMLTr("vtkMRMLVolumeArchetypeStorageNode", "Image reader provided invalid RAS to IJK matrix"));
   }
+  volNode->SetRASToIJKMatrix(rasToIjkMatrix);
 
   // If volume is left-handed coordinates, modify it to right-handed coordinate
   // to have support for every algorithms in 3D Slicer
-  if (IsIJKCoordinateSystemLeftHanded(rasToIjkMatrix))
+  if (this->ForceRightHandedIJKCoordinateSystem)
   {
-    FlipIJKCoordinateSystemHandedness(outputImage, rasToIjkMatrix);
+    volNode->SetIJKCoordinateSystemToRightHanded();
   }
-
-  volNode->SetRASToIJKMatrix(rasToIjkMatrix);
 
   if (volNode->IsA("vtkMRMLDiffusionTensorVolumeNode"))
   {

--- a/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.h
@@ -75,6 +75,17 @@ public:
   vtkSetMacro(UseOrientationFromFile, int);
   vtkGetMacro(UseOrientationFromFile, int);
 
+  //@{
+  /// Force right-handed IJK coordinate system when reading an image from file.
+  /// If enabled and the file stored on disk uses left-handed IJK coordinate system,
+  /// then the reader will flip the K axis direction and update the image origin
+  /// to make the IJK coordinate system of the loaded image right-handed.
+  /// Enabled by default, as certain processing algorithms assume this right-handed IJK.
+  vtkSetMacro(ForceRightHandedIJKCoordinateSystem, bool);
+  vtkGetMacro(ForceRightHandedIJKCoordinateSystem, bool);
+  vtkBooleanMacro(ForceRightHandedIJKCoordinateSystem, bool);
+  //@}
+
   /// Return true if the reference node is supported by the storage node
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
   bool CanWriteFromReferenceNode(vtkMRMLNode* refNode) override;
@@ -114,6 +125,7 @@ protected:
   int CenterImage;
   int SingleFile;
   int UseOrientationFromFile;
+  bool ForceRightHandedIJKCoordinateSystem;
 
 };
 

--- a/Libs/MRML/Core/vtkMRMLVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeNode.h
@@ -196,6 +196,10 @@ public:
   /// (0,dim[0],0,dim[1],0,dim[2]), which is not the case many times for segmentation merged labelmaps.
   void ShiftImageDataExtentToZeroStart();
 
+  /// Ensure that the IJK coordinate system is right-handed (IJKToRAS matrix determinant is positive).
+  /// This is the expectation in Slicer and most medical imaging software.
+  void SetIJKCoordinateSystemToRightHanded();
+
   ///
   /// alternative method to propagate events generated in Display nodes
   void ProcessMRMLEvents ( vtkObject * /*caller*/,
@@ -251,6 +255,14 @@ public:
   /// Convert between voxel type ID and name
   static const char *GetVoxelVectorTypeAsString(int id);
   static int GetVoxelVectorTypeFromString(const char *name);
+
+  /// Return true if the IJK coordinate system is right-handed (IJKToRAS matrix determinant is positive).
+  /// This is the expectation in Slicer and most medical imaging software.
+  static bool IsIJKCoordinateSystemRightHanded(vtkMatrix4x4* ijkToRasMatrix);
+
+  /// Switch the IJK coordinate system handedness between left-handed and right-handed
+  /// by inverting the K axis direction. The physical location of voxels do not change.
+  static void FlipIJKCoordinateSystemHandedness(vtkImageData* imageData, vtkMatrix4x4* ijkToRasMatrix);
 
 protected:
   vtkMRMLVolumeNode();

--- a/Modules/CLI/OrientScalarVolume/OrientScalarVolume.xml
+++ b/Modules/CLI/OrientScalarVolume/OrientScalarVolume.xml
@@ -28,7 +28,7 @@
   </parameters>
   <parameters>
     <label>Orientation Parameters</label>
-    <description><![CDATA[Orientation of output]]></description>
+    <description><![CDATA[Orientation of output. Note that these orientation code use ITK convention: each letters refer to where each axis originates FROM. This is opposite of commonly used orientation conventions, for example to get image with image axes corresponding to LPS coordinate system axis directions, this parameter has to be set to RAI.]]></description>
     <string-enumeration>
       <name>orientation</name>
       <flag>o</flag>


### PR DESCRIPTION
Fix regression introduced in https://github.com/Slicer/Slicer/pull/7627 that image origin is not computed correctly when flipping K axis of an image to make it right-handed.

Fixes issue discussed in https://discourse.slicer.org/t/geometry-all-messed-up-in-latest-5-7-0-pre-release/36072/12
