### PR TITLE
Misc extensions tweaks

### DIFF
--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -1962,8 +1962,15 @@ bool qSlicerExtensionsManagerModel::installExtension(
 
     // Copy expected keys from archive description
     QStringList expectedKeys;
-    expectedKeys << /*no tr*/"category" << /*no tr*/"contributors" << /*no tr*/"description" << /*no tr*/"homepage"
-      << /*no tr*/"iconurl" << /*no tr*/"screenshots" << /*no tr*/"status" << /*no tr*/"updated";
+    expectedKeys
+        << /*no tr*/"category"
+        << /*no tr*/"contributors"
+        << /*no tr*/"description"
+        << /*no tr*/"homepage"
+        << /*no tr*/"iconurl"
+        << /*no tr*/"screenshots"
+        << /*no tr*/"status"
+        << /*no tr*/"updated";
 
     const ExtensionMetadataType::const_iterator notFound =
       extensionIndexMetadata.constEnd();

--- a/Extensions/CMake/SlicerExtensionPackageAndUploadTarget.cmake
+++ b/Extensions/CMake/SlicerExtensionPackageAndUploadTarget.cmake
@@ -30,14 +30,12 @@
 #
 # The following variables are internally set by extracting corresponding values
 # from the locally generated "<extension_name>.s4ext" file:
-#  EXTENSION_EXT_CATEGORY
 #  EXTENSION_EXT_CONTRIBUTORS
 #  EXTENSION_EXT_DEPENDS
 #  EXTENSION_EXT_DESCRIPTION
 #  EXTENSION_EXT_HOMEPAGE
 #  EXTENSION_EXT_ICONURL
 #  EXTENSION_EXT_SCREENSHOTURLS
-#  EXTENSION_EXT_ENABLED
 #
 # The following variables can either be defined in the including scope or
 # as environment variables:
@@ -108,8 +106,6 @@ if(NOT PACKAGEUPLOAD)
     CTEST_MODEL
     Slicer_REVISION
     EXTENSION_NAME
-    EXTENSION_CATEGORY
-    EXTENSION_ENABLED
     EXTENSION_OPERATING_SYSTEM
     EXTENSION_ARCHITECTURE
     )

--- a/Extensions/CMake/SlicerFunctionExtractExtensionDescription.cmake
+++ b/Extensions/CMake/SlicerFunctionExtractExtensionDescription.cmake
@@ -162,7 +162,7 @@ function(slicerFunctionExtractExtensionDescriptionFromJson)
     if(${name} IN_LIST Slicer_EXT_OPTIONAL_METADATA_NAMES)
       string(JSON type ERROR_VARIABLE error TYPE "${extension_file_content}" "${token}")
       if(error)
-        set(${MY_VAR_PREFIX}_EXT_${upper_case_token} ${${upper_case_token}_DEFAULT} PARENT_SCOPE)
+        set(${MY_VAR_PREFIX}_EXT_${upper_case_token} "${${upper_case_token}_DEFAULT}" PARENT_SCOPE)
         continue()
       endif()
     else()
@@ -357,7 +357,7 @@ function(slicer_extract_extension_description_from_json_test)
   set(expected_BUILD_DEPENDENCIES "")
   set(expected_ENABLED "1")
 
-  foreach(name IN LISTS required)
+  foreach(name IN LISTS required optional)
     if(NOT foo_EXT_${name} STREQUAL "${expected_${name}}")
       message(FATAL_ERROR "Problem with foo_EXT_${name}
   Expected: [${expected_${name}}]

--- a/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake
+++ b/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake
@@ -172,15 +172,16 @@ This is a line of text.<br>And another one."
     #EXTENSION_DEPENDS
     #EXTENSION_ENABLED
     )
+  set(generated "${CMAKE_CURRENT_BINARY_DIR}/SlicerToKiwiExporter.s4ext")
+  set(baseline "${Slicer_SOURCE_DIR}/Extensions/CMake/Testing/extension_description_without_depends.s4ext")
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol
-      ${CMAKE_CURRENT_BINARY_DIR}/SlicerToKiwiExporter.s4ext
-      ${Slicer_SOURCE_DIR}/Extensions/CMake/Testing/extension_description_without_depends.s4ext
-    ERROR_VARIABLE error
+      ${generated}
+      ${baseline}
     RESULT_VARIABLE result
     )
   if(NOT result EQUAL 0)
-    message(FATAL_ERROR "${error}")
+    message(FATAL_ERROR "The generated and baseline files are different but are expected to match. Generated [${generated}]. Baseline [${baseline}]")
   endif()
 
   # Generate description file of an extension *with* dependencies
@@ -191,15 +192,16 @@ This is a line of text.<br>And another one."
     EXTENSION_DEPENDS "Foo Bar"
     EXTENSION_ENABLED 0
     )
+  set(generated "${CMAKE_CURRENT_BINARY_DIR}/SlicerToKiwiExporter.s4ext")
+  set(baseline "${Slicer_SOURCE_DIR}/Extensions/CMake/Testing/extension_description_with_depends.s4ext")
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol
-      ${CMAKE_CURRENT_BINARY_DIR}/SlicerToKiwiExporter.s4ext
-      ${Slicer_SOURCE_DIR}/Extensions/CMake/Testing/extension_description_with_depends.s4ext
-    ERROR_VARIABLE error
+      ${generated}
+      ${baseline}
     RESULT_VARIABLE result
     )
   if(NOT result EQUAL 0)
-    message(FATAL_ERROR "${error}")
+    message(FATAL_ERROR "The generated and baseline files are different but are expected to match. Generated [${generated}]. Baseline [${baseline}]")
   endif()
 
   # Generate description file of an extension *with* dependencies
@@ -211,15 +213,16 @@ This is a line of text.<br>And another one."
     EXTENSION_ENABLED 0
     EXTENSION_STATUS ""
     )
+  set(generated "${CMAKE_CURRENT_BINARY_DIR}/SlicerToKiwiExporter.s4ext")
+  set(baseline "${Slicer_SOURCE_DIR}/Extensions/CMake/Testing/extension_description_with_depends.s4ext")
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol
-      ${CMAKE_CURRENT_BINARY_DIR}/SlicerToKiwiExporter.s4ext
-      ${Slicer_SOURCE_DIR}/Extensions/CMake/Testing/extension_description_with_depends.s4ext
-    ERROR_VARIABLE error
+      ${generated}
+      ${baseline}
     RESULT_VARIABLE result
     )
   if(NOT result EQUAL 0)
-    message(FATAL_ERROR "${error}")
+    message(FATAL_ERROR "The generated and baseline files are different but are expected to match. Generated [${generated}]. Baseline [${baseline}]")
   endif()
 
   message("SUCCESS")


### PR DESCRIPTION
These changes are ready to be reviewed & integrated.

List of changes:
* Ensure ExtractExtensionDescriptionFromJson sets empty output variable: This ensures that output variables are defined in the parent scope event if they are empty.
* Remove obsolete requirements from `SlicerExtensionPackageAndUploadTarget`
  - Follow-up of 437e338 (`ENH: Switch extension index entry format from
"s4ext" to "json"`, 2024-03-13).
  - It removes setting of `EXTENSION_CATEGORY` and `EXTENSION_ENABLED` into the `SCRIPT_ARGS_FILE`. These variables are now extracted from the ".json" file copied into the extension build directory.
* Improve error reporting in `slicer_generate_extension_description_test`: Since using "cmake -E compare_files" does not report any details, this commit explicitly report that the baseline and generated files do not match.
* Improve readability of metadata keys in `qSlicerExtensionsManagerModel`

This changes were created while working on the following pull request:
* https://github.com/Slicer/Slicer/pull/7748