### PR TITLE
BUG: Fix warnings when vtkMRMLModelNode has no mesh data

### DIFF
--- a/Libs/MRML/Core/vtkMRMLModelDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelDisplayNode.cxx
@@ -42,6 +42,7 @@ static const char* SliceDistanceEncodedProjectionColorNodeReferenceRole = "dista
 vtkMRMLModelDisplayNode::vtkMRMLModelDisplayNode()
 {
   this->PassThrough = vtkPassThrough::New();
+  this->PassThrough->AllowNullInputOn();
   this->AssignAttribute = vtkAssignAttribute::New();
   this->ThresholdFilter = vtkThreshold::New();
   this->ThresholdFilter->SetLowerThreshold(0.0);

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -785,8 +785,9 @@ bool vtkMRMLModelDisplayableManager::IsModelDisplayable(vtkMRMLDisplayableNode* 
   {
     displayable |= this->IsModelDisplayable(node->GetNthDisplayNode(i));
     if (displayable)
-    {// Optimization: no need to search any further.
-      continue;
+    {
+      // Optimization: no need to search any further.
+      break;
     }
   }
   return displayable;
@@ -818,15 +819,12 @@ bool vtkMRMLModelDisplayableManager::OnMRMLDisplayableModelNodeModifiedEvent(
     return false;
   }
 
-  if (!this->IsModelDisplayable(modelNode))
-  {
-    return false;
-  }
   // If the node is already cached with an actor process only this one
   // If it was not visible and is still not visible do nothing
   int ndnodes = modelNode->GetNumberOfDisplayNodes();
   bool updateModel = false;
   bool updateMRML = false;
+  bool modelDisplayable = this->IsModelDisplayable(modelNode);
   for (int i=0; i<ndnodes; i++)
   {
     vtkMRMLDisplayNode *dnode = modelNode->GetNthDisplayNode(i);
@@ -836,7 +834,7 @@ bool vtkMRMLModelDisplayableManager::OnMRMLDisplayableModelNodeModifiedEvent(
       updateMRML = true;
       break;
     }
-    bool visible =
+    bool visible = modelDisplayable &&
       (dnode->GetVisibility() == 1) && (dnode->GetVisibility3D() == 1) && this->IsModelDisplayable(dnode);
     bool hasActor =
       this->Internal->DisplayedActors.find(dnode->GetID()) != this->Internal->DisplayedActors.end();


### PR DESCRIPTION
Fixes warnings during rendering such as:

> Algorithm vtkPassThrough (00000223357FFBC0) returned failure for request: vtkInformation (000002233CEA6520)

Fixed by enabling AllowNullInput on the vtkPassThrough in vtkMRMLModelDisplayNode.

This commit also fixes an issue where the views would not be immediately rendered when vtkMRMLModelNode::SetAndObserveMesh(nullptr) was called for a model node that previously had a mesh. Fixed by requesting a render in vtkMRMLModelDisplayableManager whenever an actor that was previously visible is no longer displayable.