### PR TITLE
BUG: Update CTK to fix Visual DICOM Browser

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "7ed1da357b9e7e2462b4b764882612484c6fa051"
+    "4c7154624e9a1a528ca04c067e7f35549339b53e"
     QUIET
     )
 


### PR DESCRIPTION
Contains these CTK fixes and improvements:

Revision: acfc526a2a7f646dd9cd27d2a35625825302ee4a
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Fri May 17 06:07:02 2024 +0200
Message:
BUG: Ensure all studies metadata are queried before filtering

Revision: 4ac8f132bb2fbff0023f898d323b82a97de3192b
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Thu May 16 15:15:12 2024 +0200
Message:
BUG: Update dicom-qr-schema.sql to version 0.8.1

Revision: 9eda3b8baa9d7f9ea109770e5c348f086a735e88
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Wed May 15 19:57:28 2024 +0200
Message:
BUG: Conceal empty patient and study widgets during filtering

Revision: 890e51bfc02f9d9c028300423752af255c85027c
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Tue May 14 15:16:48 2024 +0200
Message:
BUG: Match thumbnail background color to rendered image

Revision: 5767aff7c2a5bdd6c2a288a723f2abdc6c8a9388
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Tue May 14 15:11:12 2024 +0200
Message:
BUG: Remove white box from selected thumbnails

Revision: 831a5415987c07cf46da566f061f0c9bb210537f
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Tue May 14 15:06:22 2024 +0200
Message:
BUG: Adjust thumbnail rendering for OS scaling compatibility

Revision: 5bef417a02120351d617038cd411ce28d86bb70a
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Tue May 14 11:09:59 2024 +0200
Message:
ENH: Autoselect last inserted patient during DICOM import

Revision: ab95f3f2bb89df8bc67786237391bd59ed762b15
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Tue May 7 12:06:50 2024 +0200
Message:
BUG: Standardize DICOM Tags to upper case