### PR TITLE
COMP: Fix version extraction in pre-commit-autoupdate workflow

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -51,7 +51,7 @@ jobs:
           import sys
 
           for line in sys.stdin:
-              match = re.match(r"\[https://github.com/([^/]+/[^/]+)\] updating (v[\d.]+) -> (v[\d.]+)", line.strip())
+              match = re.match(r"\[https://github.com/([^/]+/[^/]+)\] updating (v?[\d.]+) -> (v?[\d.]+)", line.strip())
               if match:
                   repo_url = match.group(1)
                   old_version = match.group(2)


### PR DESCRIPTION
Add support for versions specified without the "v" prefix.

This fixes the description generated in pull request like the following:
* https://github.com/Slicer/Slicer/pull/7754