### PR TITLE
BUG: Fix export of VTK unstructured grid

### DIFF
--- a/Libs/MRML/Core/vtkMRMLModelNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelNode.cxx
@@ -82,6 +82,7 @@ void vtkMRMLModelNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
   {
     return;
   }
+  this->MeshType = node->MeshType;
   if (deepCopy)
   {
     if (node->GetMesh())


### PR DESCRIPTION
Mesh type hint was not copied. Node export makes a copy of the node before saving and it did not get the right mesh type hint, which made saving of unstructured grid mesh saving fail.

Fixes the issue reported at https://discourse.slicer.org/t/error-when-exporting-3d-mesh-model-to-vtu-file-and-invisible-vtk-file-in-paraview/25150