### PR TITLE
COMP: Add support for codespell 2.3.0 and fix identified typos

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,10 +1,13 @@
 als
+assertin
 cleary
 dependees
 dur
 extracter
 hist
 inactivate
+indexin
+inpt
 loosing
 nd
 nin
@@ -15,9 +18,11 @@ pullrequest
 ro
 serie
 sinc
+socio-economic
 supercede
 sur
 te
+thirdparty
 thru
 toolsbox
 unselect

--- a/Docs/user_guide/modules/screencapture.md
+++ b/Docs/user_guide/modules/screencapture.md
@@ -34,9 +34,9 @@ This module is for creating videos, image sequences, or lightbox image from 3D a
 ### Output
 
 - **Output type:**
-  - **image series:** Save screnshots as separate image files (in jpg or png file format).
+  - **image series:** Save screenshots as separate image files (in jpg or png file format).
   - **video:** Save animation as a compressed video file. Requires installation of [ffmpeg video encoder](#setting-up-ffmpeg).
-  - **lightbox image:** Save screnshots as separate jpg pr png files.
+  - **lightbox image:** Save screenshots as separate jpg pr png files.
 
     ![lightbox image](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_screencapture_lightbox.png)
 

--- a/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
+++ b/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
@@ -111,7 +111,7 @@ int main(int argc, char* * argv)
 
   if( !maskImage )
   {
-    std::cout << "Mask no read.  Creaing Otsu mask." << std::endl;
+    std::cout << "Mask no read.  Creating Otsu mask." << std::endl;
     typedef itk::OtsuThresholdImageFilter<ImageType, MaskImageType>
     ThresholderType;
     ThresholderType::Pointer otsu = ThresholderType::New();

--- a/Modules/Loadable/Colors/MRMLDM/vtkMRMLColorLegendDisplayableManager.cxx
+++ b/Modules/Loadable/Colors/MRMLDM/vtkMRMLColorLegendDisplayableManager.cxx
@@ -78,7 +78,7 @@ public:
   bool UpdateActor(vtkMRMLColorLegendDisplayNode* dispNode);
 
   // Show/hide the actor by adding to the renderer and enabling visibility; or removing from the renderer.
-  // Returns tru if visibility changed.
+  // Returns true if visibility changed.
   bool ShowActor(vtkSlicerScalarBarActor* actor, bool show);
 
   void UpdateSliceNode();


### PR DESCRIPTION
This is required because the `codespell-project/actions-codespell` does not pin the version of `codespell` and a new version was just released. 


| https://github.com/codespell-project/actions-codespell/blob/master/requirements.txt |https://pypi.org/project/codespell/#history |
| --- | -- |
| ![image](https://github.com/Slicer/Slicer/assets/219043/651e76d3-336e-4752-b5f3-fb2ccae83a37) | ![image](https://github.com/Slicer/Slicer/assets/219043/81f62cfc-3558-46e3-b4f5-f71e1a21de33) |
