### PR TITLE
`longflag` is required, `name` is optional in SEM XML

### DIFF
--- a/Modules/CLI/ExecutionModelTour/ExecutionModelTour.xml
+++ b/Modules/CLI/ExecutionModelTour/ExecutionModelTour.xml
@@ -38,6 +38,7 @@
     <description><![CDATA[Variations on vector parameters]]></description>
     <float-vector>
       <name>floatVector</name>
+      <longflag>float_vector</longflag>
       <flag>f</flag>
       <description><![CDATA[A vector of floats]]></description>
       <label>Float Vector Parameter</label>

--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -85,7 +85,7 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "4325526343f582dd2080d0ffd93a63c8817dfb95"
+    "0e28e41aa167b477bc4889725ca08157c152e584"
     QUIET
     )
 

--- a/Utilities/Templates/Modules/CLI/TemplateKey.xml
+++ b/Utilities/Templates/Modules/CLI/TemplateKey.xml
@@ -12,9 +12,9 @@
     <label>IO</label>
     <description><![CDATA[Input/output parameters]]></description>
     <double>
-      <name>sigma</name>
-      <longflag>sigma</longflag>
-      <flag>s</flag>
+      <name>sigma</name><!-- This is the variable name in C++ source code. If unspecified, C++ variable name is taken from longflag. -->
+      <longflag>sigma</longflag><!-- Parameter name used in the command line interface. -->
+      <flag>s</flag> <!-- Shortened version of the parameter name used in the command line interface. If specified then longflag must be specified, too. -->
       <label>Sigma</label>
       <description><![CDATA[A double value (in units of mm) passed to the algorithm]]></description>
       <default>1.0</default>


### PR DESCRIPTION
This should spare someone else from the same issue I encountered [here](https://github.com/Slicer/SlicerExecutionModel/issues/140) by changing the input and output image from positional to flag argument.