### PR TITLE
ENH: Add RemoveUnusedDisplayProperties to vtkMRMLSegmentationDisplayNode

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
@@ -91,6 +91,7 @@ void vtkMRMLSegmentationDisplayNode::WriteXML(ostream& of, int nIndent)
   of << " Opacity3D=\"" << this->Opacity3D << "\"";
   of << " Opacity2DFill=\"" << this->Opacity2DFill << "\"";
   of << " Opacity2DOutline=\"" << this->Opacity2DOutline << "\"";
+  of << " RemoveUnusedDisplayProperties=\"" << (this->RemoveUnusedDisplayProperties ? "true" : "false") << "\"";
 
   this->UpdateSegmentList();
 
@@ -158,6 +159,10 @@ void vtkMRMLSegmentationDisplayNode::ReadXMLAttributes(const char** atts)
     else if (!strcmp(attName, "Opacity2DOutline"))
     {
       this->Opacity2DOutline = vtkVariant(attValue).ToDouble();
+    }
+    else if (!strcmp(attName, "RemoveUnusedDisplayProperties"))
+    {
+      this->RemoveUnusedDisplayProperties = (strcmp(attValue, "true") ? false : true);
     }
     else if (!strcmp(attName, "SegmentationDisplayProperties"))
     {
@@ -245,6 +250,7 @@ void vtkMRMLSegmentationDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCo
   this->Opacity3D = node->Opacity3D;
   this->Opacity2DFill = node->Opacity2DFill;
   this->Opacity2DOutline = node->Opacity2DOutline;
+  this->RemoveUnusedDisplayProperties = node->RemoveUnusedDisplayProperties;
   this->SegmentationDisplayProperties = node->SegmentationDisplayProperties;
   // Reset segment list source to allow writing display properties to XML,
   // even if referenced segmentation node cannot be found (for example,
@@ -267,6 +273,7 @@ void vtkMRMLSegmentationDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << " Opacity3D:   " << this->Opacity3D << "\n";
   os << indent << " Opacity2DFill:   " << this->Opacity2DFill << "\n";
   os << indent << " Opacity2DOutline:   " << this->Opacity2DOutline << "\n";
+  os << indent << " RemoveUnusedDisplayProperties:   " << (this->RemoveUnusedDisplayProperties ? "true" : "false") << "\n";
 
   this->UpdateSegmentList();
 
@@ -1208,7 +1215,13 @@ void vtkMRMLSegmentationDisplayNode::GetVisibleSegmentIDs(vtkStringArray* segmen
 }
 
 //---------------------------------------------------------------------------
-void vtkMRMLSegmentationDisplayNode::UpdateSegmentList(bool removeUnusedDisplayProperties /*=true*/)
+void vtkMRMLSegmentationDisplayNode::UpdateSegmentList()
+{
+  this->UpdateSegmentList(this->RemoveUnusedDisplayProperties);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLSegmentationDisplayNode::UpdateSegmentList(bool removeUnusedDisplayProperties)
 {
   vtkMRMLSegmentationNode* segmentationNode = vtkMRMLSegmentationNode::SafeDownCast(this->GetDisplayableNode());
   vtkSegmentation* segmentation = segmentationNode ? segmentationNode->GetSegmentation() : nullptr;

--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.h
@@ -275,14 +275,28 @@ public:
   /// Get all visible segment IDs.
   std::vector<std::string> GetVisibleSegmentIDs();
 
+  //@{
+  /// Get/set flag to remove unused display properties when updating segment list.
+  /// When enabled, prevents unused display properties from accumulating in the display node.
+  /// By default it is enabled.
+  /// For use-cases such as replaying a segmentation sequence that has different segments at different time points
+  /// this flag should be disabled to ensure that display properties of all segments are preserved.
+  vtkGetMacro(RemoveUnusedDisplayProperties, bool);
+  vtkSetMacro(RemoveUnusedDisplayProperties, bool);
+  vtkBooleanMacro(RemoveUnusedDisplayProperties, bool);
+  //@}
+
 protected:
   /// Convenience function for getting all segment IDs.
   void GetSegmentIDs(std::vector<std::string>& segmentIDs, bool visibleSegmentsOnly);
 
+  //@{
   /// Update list of segment display properties.
   /// Remove entries for missing segments (if removeUnusedDisplayProperties is enabled)
   /// and add missing entries for existing segments.
-  void UpdateSegmentList(bool removeUnusedDisplayProperties = true);
+  void UpdateSegmentList();
+  void UpdateSegmentList(bool removeUnusedDisplayProperties);
+  //@}
 
 protected:
   vtkMRMLSegmentationDisplayNode();
@@ -329,6 +343,8 @@ protected:
   double Opacity2DFill{0.5};
   /// 2D outline opacity for the whole segmentation
   double Opacity2DOutline{1.0};
+
+  bool RemoveUnusedDisplayProperties{true};
 };
 
 #endif


### PR DESCRIPTION
Within the vtkMRMLSegmentationDisplayNode::UpdateSegmentList, there is an option to not remove unused display properties, however this argument is never used or exposed. This commit adds the RemoveUnusedDisplayProperties parameter to vtkMRMLSegmentationDisplayNode that allows display properties to be preserved when the segments are removed.

The default behavior is still to remove unused display properties.