### PR TITLE
BUG: Fix incorrect tooltip for rotate to volume reformat button

### DIFF
--- a/Modules/Loadable/Reformat/Resources/UI/qSlicerReformatModuleWidget.ui
+++ b/Modules/Loadable/Reformat/Resources/UI/qSlicerReformatModuleWidget.ui
@@ -357,7 +357,7 @@
          <item row="1" column="1">
           <widget class="QPushButton" name="RotateToVolumePlanePushButton">
            <property name="toolTip">
-            <string>Flip slice view horizontally (left-right)</string>
+            <string>Rotate the slice view to be aligned with the axes of the displayed volume</string>
            </property>
            <property name="text">
             <string>Rotate to volume plane</string>


### PR DESCRIPTION
This was copy-paste error made in https://github.com/Slicer/Slicer/commit/e7578581612779b3d83ba976d35328427d398b97.