### PR TITLE
Visual dicom browser

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMBrowser.py
+++ b/Modules/Scripted/DICOMLib/DICOMBrowser.py
@@ -66,10 +66,6 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
         if settingsValue("DICOM/detailedLogging", False, converter=toBool):
             ctk.ctk.setDICOMLogLevel(ctk.ctkErrorLogLevel.Debug)
 
-        self.useExpertimentalVisualDICOMBrowser = settingsValue("DICOM/UseExpertimentalVisualDICOMBrowser", False, converter=toBool)
-        self.dicomVisualBrowser.visible = self.useExpertimentalVisualDICOMBrowser
-        self.dicomBrowser.visible = not self.useExpertimentalVisualDICOMBrowser
-
         self.browserPersistent = settingsValue("DICOM/BrowserPersistent", False, converter=toBool)
         self.advancedView = settingsValue("DICOM/advancedView", 0, converter=int)
         self.horizontalTables = settingsValue("DICOM/horizontalTables", 0, converter=int)

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "e081be7dbbb5f3e3c4294c0edf9a0a96de815ee1"
+    "db10ff2b7067e82f29fc375def8a62051a01a2c3"
     QUIET
     )
 


### PR DESCRIPTION
**Fix minor bug:**
Prevent DICOM Browser popups on initial module entry

**Update CTK:**
Refs: 
1) https://github.com/commontk/CTK/pull/1206
2) https://github.com/commontk/CTK/issues/1162

Revision: db10ff2b7067e82f29fc375def8a62051a01a2c3
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Thu Jun 6 21:16:40 2024 +0200
Message:
BUG: Fix thumbnail scaling for high DPI displays.

Revision: 065f4df702e81f8f35f31f500c94295e487cbf7a
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Thu Jun 6 18:05:06 2024 +0200
Message:
PERF: Implement thumbnail storage to disk to avoid re-rendering after series widget destruction.
PERF: Disable SEG rendering in thumbnails due to limited support and potential performance issues. Replace with a blank thumbnail featuring a document SVG.
BUG: Resolve issue hanging job termination when status is 'Queued'.
BUG: Address issue with FreezeJobsScheduling during shutdown.
BUG: Correct retry functionality when status icon on series widget is clicked.

Revision: b7e17325ba82239a8aa4f563e7edac715d1912bd
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Tue Jun 4 15:03:35 2024 +0200
Message:
BUG: Fix series loading when widgets are still retrieving data

Revision: 7bc4184b8fa9da5388e79d33a0b5c46e59231897
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Tue Jun 4 13:48:59 2024 +0200
Message:
ENH: Improve study widget layout

Revision: a953295372470e7ab4ca6f75ed856a5487ab7e88
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Tue Jun 4 12:10:52 2024 +0200
Message:
ENH: Improve signals throttling

Revision: c1935389974ff93a4242feaf977e18fb8673b6b7
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Tue Jun 4 11:31:25 2024 +0200
Message:
ENH: Improve study widget layout

Revision: c35b810efbb092b7557011865b3814543c817c58
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Thu May 23 18:00:17 2024 +0200
Message:
ENH: Optimize observer pattern in ctkDICOMScheduler

Revision: 68ebfb3b2854e289d1e35ea7965ee32ddbc8cd20
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Thu May 23 16:24:25 2024 +0200
Message:
BUG: Update wait svg icon file

Revision: 36cce9745d467eae76b330731d9031e4617178a8
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Thu May 23 13:55:56 2024 +0200
Message:
ENH: Stream DCMTK logging per each job to the job list UI

Revision: 7af883e170e1e7d6366a1c876ee330cffdb1d741
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Tue May 21 19:00:06 2024 +0200
Message:
BUG: Fix ctkDICOMSchedulerTest1 and ctkDICOMScheduler connections

Revision: 42f908233dcbe6e7cb3d0b7715fff7639fc0eb58
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Mon May 20 19:33:38 2024 +0200
Message:
COMP: Fixing missing end of files for svg files

Revision: dd971a9e023f3e6eb67dbbe53f201ffda20f8801
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Mon May 20 19:28:01 2024 +0200
Message:
ENH: Add operation status icon for patient widgets

Revision: a36eec4ead10391c217f89e8f1580b9974169a02
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Mon May 20 18:20:23 2024 +0200
Message:
ENH: Improve search/query patients icons

Revision: b190f0908bf17aec756452cce538792c7082ba37
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Mon May 20 17:02:16 2024 +0200
Message:
ENH: Add operation status icon for studies widgets

Revision: 20acde0571b002354392636673a22031179d9872
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Mon May 20 15:46:39 2024 +0200
Message:
ENH: Add operation status icon for series widgets

Revision: fb1feae96d1297dfa3e1f598a0456cb8299e86ab
Author: Davide Punzo <punzodavide@hotmail.it>
Date: Mon May 20 11:37:05 2024 +0200
Message:
ENH: Move 'Clear All' push button outside of filter group box
ENH: Set 'Clear Completed' button to clear also 'Attempt Failed' jobs
ENH: Set job status to 'user-stopped' when user stops jobs
ENH: Set job status to 'attempt-failed' or 'failed' based on retry condition
ENH: Change filter settings to reduce log noise from failed attempts
ENH: Open corresponding patient widget when a job list row is clicked
ENH: Improve job details formatting: adjust separators and remove spaces before ':'

Revision: e081be7dbbb5f3e3c4294c0edf9a0a96de815ee1
Author: Dženan Zukić <dzenan.zukic@kitware.com>
Date: Thu May 30 09:53:20 2024 -0400
Message:
ENH: Increase minimum required CMake version to 3.16.3