### PR TITLE
ENH: Only translate python strings when necessary

### DIFF
--- a/Docs/developer_guide/debugging/python.md
+++ b/Docs/developer_guide/debugging/python.md
@@ -3,3 +3,51 @@
 Python code running in Slicer can be debugged (execute code line-by-line, inspect variables, browse the call stack, etc.) by attaching a debugger to the running Slicer application. Detailed instructions are provided in documentation of [DebuggingTools extension](https://github.com/SlicerRt/SlicerDebuggingTools).
 
 ![](https://raw.githubusercontent.com/SlicerRt/SlicerDebuggingTools/master/Docs/VisualStudioCodePythonDebuggerExample.png)
+
+## Profiling
+
+The following code snippet can be used to get detailed performance analysis Python code:
+
+```python
+# Start profiling
+detailedProfiling = True  # set to False to just get elapsed time
+if detailedProfiling:
+    import cProfile
+    cp=cProfile.Profile()
+    cp.enable()
+else:
+    startTime = time.time()
+
+# --------------------------------------------
+# Put the tested code here, for example:
+import SampleData
+sampleDataLogic = SampleData.SampleDataLogic()
+mrHead = sampleDataLogic.downloadMRHead()
+import SegmentStatistics
+segStatLogic = SegmentStatistics.SegmentStatisticsLogic()
+# --------------------------------------------
+
+# Finish profiling and display result
+if detailedProfiling:
+    profileFilePath = os.path.join(slicer.app.temporaryPath, 'profile.prof')
+    cp.disable()
+    cp.dump_stats(profileFilePath)
+    # Import visualization tool
+    try:
+      import snakeviz
+    except ImportError:
+      pip_install("snakeviz")
+    # Show profiling results in the web browser
+    import shutil
+    pythonSlicerExecutablePath = shutil.which("PythonSlicer")
+    commandLine = [pythonSlicerExecutablePath, "-m", "snakeviz", profileFilePath]
+    proc = slicer.util.launchConsoleProcess(commandLine, useStartupEnvironment=False)
+    # proc.kill()
+else:
+    stopTime = time.time()
+    print(f"Elapsed time: {stopTime-startTime} s")
+```
+
+Detailed profiling result is shown in the default web browser:
+
+![](https://github.com/Slicer/Slicer/releases/download/docs-resources/python_profiler.png)

--- a/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/ClosedSurfaceSegmentStatisticsPlugin.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/ClosedSurfaceSegmentStatisticsPlugin.py
@@ -50,32 +50,31 @@ class ClosedSurfaceSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
 
     def getMeasurementInfo(self, key):
         """Get information (name, description, units, ...) about the measurement for the given key"""
-        info = dict()
 
         # I searched BioPortal, and found seemingly most suitable code.
         # Prefixed with "99" since CHEMINF is not a recognized DICOM coding scheme.
         # See https://bioportal.bioontology.org/ontologies/CHEMINF?p=classes&conceptid=http%3A%2F%2Fsemanticscience.org%2Fresource%2FCHEMINF_000247
         #
-        info["surface_mm2"] = \
-            self.createMeasurementInfo(name="Surface mm2",
+        if key == "surface_mm2":
+            return self.createMeasurementInfo(name="Surface mm2",
                                        title=_("Surface area"),
                                        description=_("Surface area computed from closed surface representation."),
                                        units=_("mm2"),
                                        quantityDicomCode=self.createCodedEntry("000247", "99CHEMINF", "Surface area", True),
                                        unitsDicomCode=self.createCodedEntry("mm2", "UCUM", "square millimeter", True))
 
-        info["volume_mm3"] = \
-            self.createMeasurementInfo(name="Volume mm3",
+        elif key == "volume_mm3":
+            return self.createMeasurementInfo(name="Volume mm3",
                                        title=_("Volume"), description=_("Volume computed from closed surface representation."),
                                        units=_("mm3"),
                                        quantityDicomCode=self.createCodedEntry("118565006", "SCT", "Volume", True),
                                        unitsDicomCode=self.createCodedEntry("mm3", "UCUM", "cubic millimeter", True))
 
-        info["volume_cm3"] = \
-            self.createMeasurementInfo(name="Volume cm3",
+        elif key == "volume_cm3":
+            return self.createMeasurementInfo(name="Volume cm3",
                                        title=_("Volume"), description=_("Volume computed from closed surface representation."),
                                        units=_("cm3"),
                                        quantityDicomCode=self.createCodedEntry("118565006", "SCT", "Volume", True),
                                        unitsDicomCode=self.createCodedEntry("cm3", "UCUM", "cubic centimeter", True))
 
-        return info[key] if key in info else None
+        return None

--- a/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/LabelmapSegmentStatisticsPlugin.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/LabelmapSegmentStatisticsPlugin.py
@@ -394,30 +394,29 @@ class LabelmapSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
 
     def getMeasurementInfo(self, key):
         """Get information (name, description, units, ...) about the measurement for the given key"""
-        info = {}
 
         # @fedorov could not find any suitable DICOM quantity code for "number of voxels".
         # DCM has "Number of needles" etc., so probably "Number of voxels"
         # should be added too. Need to discuss with @dclunie. For now, a
         # QIICR private scheme placeholder.
-        info["voxel_count"] = \
-            self.createMeasurementInfo(name="Voxel count",
+        if key == "voxel_count":
+            return self.createMeasurementInfo(name="Voxel count",
                                        title=_("Voxel count"),
                                        description=_("Number of voxels in the binary labelmap representation of the segment."),
                                        units="",
                                        quantityDicomCode=self.createCodedEntry("nvoxels", "99QIICR", "Number of voxels", True),
                                        unitsDicomCode=self.createCodedEntry("voxels", "UCUM", "voxels", True))
 
-        info["volume_mm3"] = \
-            self.createMeasurementInfo(name="Volume mm3",
+        elif key == "volume_mm3":
+            return self.createMeasurementInfo(name="Volume mm3",
                                        title=_("Volume"),
                                        description=_("Volume of the segment computed from binary labelmap representation."),
                                        units=_("mm3"),
                                        quantityDicomCode=self.createCodedEntry("118565006", "SCT", "Volume", True),
                                        unitsDicomCode=self.createCodedEntry("mm3", "UCUM", "cubic millimeter", True))
 
-        info["volume_cm3"] = \
-            self.createMeasurementInfo(name="Volume cm3",
+        elif key == "volume_cm3":
+            return self.createMeasurementInfo(name="Volume cm3",
                                        title=_("Volume"),
                                        description=_("Volume of the segment computed from binary labelmap representation."),
                                        units=_("cm3"),
@@ -425,117 +424,117 @@ class LabelmapSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
                                        unitsDicomCode=self.createCodedEntry("cm3", "UCUM", "cubic centimeter", True),
                                        measurementMethodDicomCode=self.createCodedEntry("126030", "DCM", "Sum of segmented voxel volumes", True))
 
-        info["centroid_ras"] = \
-            self.createMeasurementInfo(name="Centroid",
+        elif key == "centroid_ras":
+            return self.createMeasurementInfo(name="Centroid",
                                        title=_("Centroid"),
                                        description=_("Location of the centroid in RAS. Computed from binary labelmap representation."),
                                        units="", componentNames=["r", "a", "s"])
 
-        info["feret_diameter_mm"] = \
-            self.createMeasurementInfo(name="Feret diameter mm",
+        elif key == "feret_diameter_mm":
+            return self.createMeasurementInfo(name="Feret diameter mm",
                                        title=_("Feret diameter"),
                                        description=_("Feret diameter of the segment computed from binary labelmap representation."), units=_("mm"))
 
-        info["surface_area_mm2"] = \
-            self.createMeasurementInfo(name="Surface mm2",
+        elif key == "surface_area_mm2":
+            return self.createMeasurementInfo(name="Surface mm2",
                                        title=_("Surface area"),
                                        description=_("Surface area of the segment computed from binary labelmap representation."), units=_("mm2"),
                                        quantityDicomCode=self.createCodedEntry("000247", "99CHEMINF", "Surface area", True),
                                        unitsDicomCode=self.createCodedEntry("mm2", "UCUM", "square millimeter", True))
 
-        info["roundness"] = \
-            self.createMeasurementInfo(name="Roundness",
+        elif key == "roundness":
+            return self.createMeasurementInfo(name="Roundness",
                                       title=_("Roundness"),
                                       description=_("Segment roundness. Calculated from ratio of the area of the hypersphere by the actual area. "
                                                     "Value of 1 represents a spherical structure. Computed from binary labelmap representation."),
                                       units="")
 
-        info["flatness"] = \
-            self.createMeasurementInfo(name="Flatness",
+        elif key == "flatness":
+            return self.createMeasurementInfo(name="Flatness",
                                        title=_("Flatness"),
                                        description=_("Segment flatness. Calculated from square root of the ratio of the second smallest principal moment by "
                                                      "the smallest. Value of 0 represents a flat structure. Computed from binary labelmap representation.")
                                                      + " ( https://hdl.handle.net/1926/584 )",
                                        units="")
 
-        info["elongation"] = \
-            self.createMeasurementInfo(name="Elongation",
+        elif key == "elongation":
+            return self.createMeasurementInfo(name="Elongation",
                                        title=_("Elongation"),
                                        description=_("Segment elongation. Calculated from square root of the ratio of the second largest principal moment "
                                                      "by the second smallest. Computed from binary labelmap representation.")
                                                      + " ( https://hdl.handle.net/1926/584 )",
                                        units="")
 
-        info["oriented_bounding_box"] = \
-            self.createMeasurementInfo(name="Oriented bounding box",
+        elif key == "oriented_bounding_box":
+            return self.createMeasurementInfo(name="Oriented bounding box",
                                        title=_("Oriented bounding box"),
                                        description=_("Oriented bounding box. Computed from binary labelmap representation of the segment."),
                                        units="")
 
-        info["obb_origin_ras"] = \
-            self.createMeasurementInfo(name="OBB origin",
+        elif key == "obb_origin_ras":
+            return self.createMeasurementInfo(name="OBB origin",
                                        title=_("OBB origin"),
                                        description=_("Oriented bounding box origin in RAS coordinates."
                                                      " Computed from binary labelmap representation of the segment."),
                                        units="",
                                        componentNames=["r", "a", "s"])
 
-        info["obb_diameter_mm"] = \
-            self.createMeasurementInfo(name="OBB diameter",
+        elif key == "obb_diameter_mm":
+            return self.createMeasurementInfo(name="OBB diameter",
                                        title=_("OBB diameter"),
                                        description=_("Oriented bounding box diameter. Computed from binary labelmap representation of the segment."),
                                        units=_("mm"),
                                        componentNames=["x", "y", "z"])
 
-        info["obb_direction_ras_x"] = \
-            self.createMeasurementInfo(name="OBB X direction",
-            title=_("OBB X direction"),
-            description=_("Oriented bounding box X direction in RAS coordinates. Computed from binary labelmap representation of the segment."),
-            units="", componentNames=["r", "a", "s"])
+        elif key == "obb_direction_ras_x":
+            return self.createMeasurementInfo(name="OBB X direction",
+                title=_("OBB X direction"),
+                description=_("Oriented bounding box X direction in RAS coordinates. Computed from binary labelmap representation of the segment."),
+                units="", componentNames=["r", "a", "s"])
 
-        info["obb_direction_ras_y"] = \
-            self.createMeasurementInfo(name="OBB Y direction",
+        elif key == "obb_direction_ras_y":
+            return self.createMeasurementInfo(name="OBB Y direction",
                                        title=_("OBB Y direction"),
                                        description=_("Oriented bounding box Y direction in RAS coordinates."
                                                      " Computed from binary labelmap representation of the segment."),
                                        units="",
                                        componentNames=["r", "a", "s"])
 
-        info["obb_direction_ras_z"] = \
-            self.createMeasurementInfo(name="OBB Z direction",
+        elif key == "obb_direction_ras_z":
+            return self.createMeasurementInfo(name="OBB Z direction",
                                        title=_("OBB Z direction"),
                                        description=_("Oriented bounding box Z direction in RAS coordinates."
                                                      " Computed from binary labelmap representation of the segment."),
                                        units="",
                                        componentNames=["r", "a", "s"])
 
-        info["principal_moments"] = \
-            self.createMeasurementInfo(name="Principal moments",
+        elif key == "principal_moments":
+            return self.createMeasurementInfo(name="Principal moments",
                                        title=_("Principal moments"),
                                        description=_("Principal moments of inertia for x, y and z axes."
                                                      " Computed from binary labelmap representation of the segment."),
                                        units="",
                                        componentNames=["x", "y", "z"])
 
-        info["principal_axis_x"] = \
-            self.createMeasurementInfo(name="Principal X axis", title=_("Principal X axis"),
+        elif key == "principal_axis_x":
+            return self.createMeasurementInfo(name="Principal X axis", title=_("Principal X axis"),
                                        description=_("Principal X axis of rotation in RAS coordinates."
                                                      " Computed from binary labelmap representation of the segment."),
                                        units="",
                                        componentNames=["r", "a", "s"])
 
-        info["principal_axis_y"] = \
-            self.createMeasurementInfo(name="Principal Y axis", title=_("Principal Y axis"),
+        elif key == "principal_axis_y":
+            return self.createMeasurementInfo(name="Principal Y axis", title=_("Principal Y axis"),
                                        description=_("Principal Y axis of rotation in RAS coordinates."
                                                      " Computed from binary labelmap representation of the segment."),
                                        units="",
                                        componentNames=["r", "a", "s"])
 
-        info["principal_axis_z"] = \
-            self.createMeasurementInfo(name="Principal Z axis", title=_("Principal Z axis"),
+        elif key == "principal_axis_z":
+            return self.createMeasurementInfo(name="Principal Z axis", title=_("Principal Z axis"),
                                        description=_("Principal Z axis of rotation in RAS coordinates."
                                                      " Computed from binary labelmap representation of the segment."),
                                        units="",
                                        componentNames=["r", "a", "s"])
 
-        return info[key] if key in info else None
+        return None

--- a/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/ScalarVolumeSegmentStatisticsPlugin.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/ScalarVolumeSegmentStatisticsPlugin.py
@@ -136,16 +136,14 @@ class ScalarVolumeSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
         if not scalarVolumeUnits:
             scalarVolumeUnits = self.createCodedEntry("", "", "")
 
-        info = dict()
-
         # @fedorov could not find any suitable DICOM quantity code for "number of voxels".
         # DCM has "Number of needles" etc., so probably "Number of voxels"
         # should be added too. Need to discuss with @dclunie. For now, a
         # QIICR private scheme placeholder.
         # @moselhy also could not find DICOM quantity code for "median"
 
-        info["voxel_count"] = \
-            self.createMeasurementInfo(name="Voxel count",
+        if key == "voxel_count":
+            return self.createMeasurementInfo(name="Voxel count",
                                        title=_("Voxel count"),
                                        description=_("Number of voxels. Computed from region of the binary labelmap representation of the segment"
                                                      " that overlaps with the input scalar volume."),
@@ -153,16 +151,16 @@ class ScalarVolumeSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
                                        quantityDicomCode=self.createCodedEntry("nvoxels", "99QIICR", "Number of voxels", True),
                                        unitsDicomCode=self.createCodedEntry("voxels", "UCUM", "voxels", True))
 
-        info["volume_mm3"] = \
-            self.createMeasurementInfo(name="Volume mm3",
+        elif key == "volume_mm3":
+            return self.createMeasurementInfo(name="Volume mm3",
                                        title=_("Volume"),
                                        description=_("Volume of the region of the binary labelmap representation that overlaps with the input scalar volume."),
                                        units=_("mm3"),
                                        quantityDicomCode=self.createCodedEntry("118565006", "SCT", "Volume", True),
                                        unitsDicomCode=self.createCodedEntry("mm3", "UCUM", "cubic millimeter", True))
 
-        info["volume_cm3"] = \
-            self.createMeasurementInfo(name="Volume cm3",
+        elif key == "volume_cm3":
+            return self.createMeasurementInfo(name="Volume cm3",
                                        title=_("Volume"),
                                        description=_("Volume of the region of the binary labelmap representation that overlaps with the input scalar volume."),
                                        units=_("cm3"),
@@ -170,36 +168,36 @@ class ScalarVolumeSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
                                        unitsDicomCode=self.createCodedEntry("cm3", "UCUM", "cubic centimeter", True),
                                        measurementMethodDicomCode=self.createCodedEntry("126030", "DCM", "Sum of segmented voxel volumes", True))
 
-        info["min"] = \
-            self.createMeasurementInfo(name="Minimum", title=_("Minimum"), description=_("Minimum input scalar volume voxel value within the segment."),
+        elif key == "min":
+            return self.createMeasurementInfo(name="Minimum", title=_("Minimum"), description=_("Minimum input scalar volume voxel value within the segment."),
                                        units=scalarVolumeUnits.GetCodeMeaning(),
                                        quantityDicomCode=scalarVolumeQuantity.GetAsString(),
                                        unitsDicomCode=scalarVolumeUnits.GetAsString(),
                                        derivationDicomCode=self.createCodedEntry("255605001", "SCT", "Minimum", True))
 
-        info["max"] = \
-            self.createMeasurementInfo(name="Maximum", title=_("Maximum"), description=_("Maximum input scalar volume voxel value within the segment."),
+        elif key == "max":
+            return self.createMeasurementInfo(name="Maximum", title=_("Maximum"), description=_("Maximum input scalar volume voxel value within the segment."),
                                        units=scalarVolumeUnits.GetCodeMeaning(),
                                        quantityDicomCode=scalarVolumeQuantity.GetAsString(),
                                        unitsDicomCode=scalarVolumeUnits.GetAsString(),
                                        derivationDicomCode=self.createCodedEntry("56851009", "SCT", "Maximum", True))
 
-        info["mean"] = \
-            self.createMeasurementInfo(name="Mean", title=_("Mean"), description=_("Mean input scalar volume voxel value within the segment."),
+        elif key == "mean":
+            return self.createMeasurementInfo(name="Mean", title=_("Mean"), description=_("Mean input scalar volume voxel value within the segment."),
                                        units=scalarVolumeUnits.GetCodeMeaning(),
                                        quantityDicomCode=scalarVolumeQuantity.GetAsString(),
                                        unitsDicomCode=scalarVolumeUnits.GetAsString(),
                                        derivationDicomCode=self.createCodedEntry("373098007", "SCT", "Mean", True))
 
-        info["median"] = \
-            self.createMeasurementInfo(name="Median", title=_("Median"), description=_("Median input scalar volume voxel value within the segment."),
+        elif key == "median":
+            return self.createMeasurementInfo(name="Median", title=_("Median"), description=_("Median input scalar volume voxel value within the segment."),
                                        units=scalarVolumeUnits.GetCodeMeaning(),
                                        quantityDicomCode=scalarVolumeQuantity.GetAsString(),
                                        unitsDicomCode=scalarVolumeUnits.GetAsString(),
                                        derivationDicomCode=self.createCodedEntry("median", "SCT", "Median", True))
 
-        info["stdev"] = \
-            self.createMeasurementInfo(name="Standard deviation",
+        elif key == "stdev":
+            return self.createMeasurementInfo(name="Standard deviation",
                                        title=_("Standard Deviation"),
                                        description=_("Standard deviation of input scalar volume voxel values within the segment."),
                                        units=scalarVolumeUnits.GetCodeMeaning(),
@@ -207,4 +205,4 @@ class ScalarVolumeSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
                                        unitsDicomCode=scalarVolumeUnits.GetAsString(),
                                        derivationDicomCode=self.createCodedEntry("386136009", "SCT", "Standard Deviation", True))
 
-        return info[key] if key in info else None
+        return None


### PR DESCRIPTION
This has performance implications where runtime is faster if English is the desired language for the application because the source code is in English.

## Testing Methods

Segmentation file to extract and put into User Downloads location (or modify script below)
[Segmentation.seg.zip](https://github.com/user-attachments/files/15920920/Segmentation.seg.zip)
```python
import os
import cProfile
cp=cProfile.Profile()
cp.enable()

# Load sample volume
import SampleData
sampleDataLogic = SampleData.SampleDataLogic()
mrHead = sampleDataLogic.downloadMRHead()
slicer.util.loadSegmentation(os.path.join(os.path.expanduser('~'), 'downloads', 'Segmentation.seg.nrrd'))

# Copied from https://slicer.readthedocs.io/en/latest/developer_guide/script_repository.html#get-volume-of-each-segment
segmentationNode = getNode("Segmentation")

# Compute segment statistics
import SegmentStatistics
segStatLogic = SegmentStatistics.SegmentStatisticsLogic()
segStatLogic.getParameterNode().SetParameter("Segmentation", segmentationNode.GetID())
segStatLogic.computeStatistics()
stats = segStatLogic.getStatistics()

# Display volume of each segment
for segmentId in stats["SegmentIDs"]:
  volume_cm3 = stats[segmentId,"LabelmapSegmentStatisticsPlugin.volume_cm3"]
  segmentName = segmentationNode.GetSegmentation().GetSegment(segmentId).GetName()
  print(f"{segmentName} volume = {volume_cm3} cm3")

cp.disable()
cp.dump_stats(os.path.join(os.path.expanduser('~'), 'downloads', 'profile.prof'))
```

## Results

With the changes in this PR, the above script in the testing method is overwhelming quicker going from several seconds to nearly instantaneous.

Using [`snakeviz`](https://jiffyclub.github.io/snakeviz/) for display of the `cProfile` results:
```PS
python -m snakeviz "C:\Users\butlej30383\Downloads\profile.prof"
```

| Slicer 5.7.0-2024-06-18 | This PR |
|---------------------------|---------|
|![image](https://github.com/Slicer/Slicer/assets/15837524/d4e1ccfe-5b0e-4617-a5f7-b1b483aa2e3b)|![image](https://github.com/Slicer/Slicer/assets/15837524/1c9c8d69-cff2-479a-8b02-72134fa0974a)|