### PR TITLE
BUG: Update VTK to backport vtkSSAOPass intensity adjustment feature

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "9f48d797ada1069e5717116e3e62e1d6d37ddc4c") # slicer-v9.2.20230607-1ff325c54-2
+    set(_git_tag "1923c43205ef6041f21e112807874ec9ae045b52") # slicer-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
List of VTK changes:

```
Andras Lasso (1):
      [Backport MR-11192] Make SSAO intensity configurable

Lucas Gandel (1):
      [Backport MR-11192] Make SSAO intensity configurable
```

```
$ git shortlog --group=author --group=trailer:co-authored-by 9f48d797ada1069e5717116e3e62e1d6d37ddc4c..1923c43205ef6041f21e112807874ec9ae045b52
```