### PR TITLE
ENH: Allow setting ambient shadows intensity

### DIFF
--- a/Base/QTGUI/Resources/UI/qSlicerSettingsViewsPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsViewsPanel.ui
@@ -357,6 +357,70 @@
             </property>
            </widget>
           </item>
+          <item row="10" column="0">
+           <widget class="QLabel" name="ThreeDAmbientShadowsIntensityScaleLabel">
+            <property name="text">
+             <string>Intensity scale:</string>
+            </property>
+            <property name="indent">
+             <number>10</number>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="1">
+           <widget class="ctkSliderWidget" name="ThreeDAmbientShadowsIntensityScaleSlider">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="singleStep">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="pageStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="minimum">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>3.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="0">
+           <widget class="QLabel" name="ThreeDAmbientShadowsIntensityShiftLabel">
+            <property name="text">
+             <string>Intensity offset:</string>
+            </property>
+            <property name="indent">
+             <number>10</number>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="1">
+           <widget class="ctkSliderWidget" name="ThreeDAmbientShadowsIntensityShiftSlider">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="singleStep">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="pageStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="minimum">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.000000000000000</double>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/Base/QTGUI/qSlicerSettingsViewsPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsViewsPanel.cxx
@@ -155,6 +155,12 @@ void qSlicerSettingsViewsPanelPrivate::init()
   q->registerProperty("Default3DView/AmbientShadowsVolumeOpacityThreshold", this->ThreeDAmbientShadowsVolumeOpacityThresholdSlider,
                       /*no tr*/"value", SIGNAL(valueChanged(double)),
                       qSlicerSettingsViewsPanel::tr("Ambient shadows volume opacity threshold"));
+  q->registerProperty("Default3DView/AmbientShadowsIntensityScale", this->ThreeDAmbientShadowsIntensityScaleSlider,
+                      /*no tr*/"value", SIGNAL(valueChanged(double)),
+                      qSlicerSettingsViewsPanel::tr("Ambient shadows intensity scale"));
+  q->registerProperty("Default3DView/AmbientShadowsIntensityShift", this->ThreeDAmbientShadowsIntensityShiftSlider,
+                      /*no tr*/"value", SIGNAL(valueChanged(double)),
+                      qSlicerSettingsViewsPanel::tr("Ambient shadows intensity shift"));
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLViewNode.cxx
@@ -114,6 +114,8 @@ void vtkMRMLViewNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBooleanMacro(shadowsVisibility, ShadowsVisibility);
   vtkMRMLWriteXMLFloatMacro(ambientShadowsSizeScale, AmbientShadowsSizeScale);
   vtkMRMLWriteXMLFloatMacro(ambientShadowsVolumeOpacityThreshold, AmbientShadowsVolumeOpacityThreshold);
+  vtkMRMLWriteXMLFloatMacro(ambientShadowsIntensityScale, AmbientShadowsIntensityScale);
+  vtkMRMLWriteXMLFloatMacro(ambientShadowsIntensityShift, AmbientShadowsIntensityShift);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -154,6 +156,8 @@ void vtkMRMLViewNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBooleanMacro(shadowsVisibility, ShadowsVisibility);
   vtkMRMLReadXMLFloatMacro(ambientShadowsSizeScale, AmbientShadowsSizeScale);
   vtkMRMLReadXMLFloatMacro(ambientShadowsVolumeOpacityThreshold, AmbientShadowsVolumeOpacityThreshold);
+  vtkMRMLReadXMLFloatMacro(ambientShadowsIntensityScale, AmbientShadowsIntensityScale);
+  vtkMRMLReadXMLFloatMacro(ambientShadowsIntensityShift, AmbientShadowsIntensityShift);
   vtkMRMLReadXMLIntMacro(linkedControl, LinkedControl);
   vtkMRMLReadXMLEndMacro();
 
@@ -196,6 +200,8 @@ void vtkMRMLViewNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
   vtkMRMLCopyBooleanMacro(ShadowsVisibility);
   vtkMRMLCopyFloatMacro(AmbientShadowsSizeScale);
   vtkMRMLCopyFloatMacro(AmbientShadowsVolumeOpacityThreshold);
+  vtkMRMLCopyFloatMacro(AmbientShadowsIntensityScale);
+  vtkMRMLCopyFloatMacro(AmbientShadowsIntensityShift);
   vtkMRMLCopyIntMacro(LinkedControl);
   vtkMRMLCopyEndMacro();
 }
@@ -236,6 +242,8 @@ void vtkMRMLViewNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBooleanMacro(ShadowsVisibility);
   vtkMRMLPrintFloatMacro(AmbientShadowsSizeScale);
   vtkMRMLPrintFloatMacro(AmbientShadowsVolumeOpacityThreshold);
+  vtkMRMLPrintFloatMacro(AmbientShadowsIntensityScale);
+  vtkMRMLPrintFloatMacro(AmbientShadowsIntensityShift);
   vtkMRMLPrintIntMacro(LinkedControl);
   vtkMRMLPrintEndMacro();
 }

--- a/Libs/MRML/Core/vtkMRMLViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLViewNode.h
@@ -302,6 +302,8 @@ public:
     ShadowsVisibilityFlag,
     AmbientShadowsSizeScaleFlag,
     AmbientShadowsVolumeOpacityThresholdFlag,
+    AmbientShadowsIntensityScaleFlag,
+    AmbientShadowsIntensityShiftFlag,
   };
 
   ///
@@ -320,8 +322,8 @@ public:
 
   //@{
   /// Show shadows to improve depth perception.
-  /// Currently, only ambient shadows (screen-space ambient occlusion) method is supported and AmbientShadowsSizeScale and AmbientShadowsVolumeOpacityThreshold
-  /// parameters control its appearance.
+  /// Currently, only ambient shadows (screen-space ambient occlusion) method is supported and AmbientShadowsSizeScale, AmbientShadowsVolumeOpacityThreshold,
+  /// AmbientShadowsIntensityScale, and AmbientShadowsIntensityShift parameters control its appearance.
   vtkGetMacro(ShadowsVisibility, bool);
   vtkSetMacro(ShadowsVisibility, bool);
   vtkBooleanMacro(ShadowsVisibility, bool);
@@ -341,6 +343,24 @@ public:
   vtkGetMacro(AmbientShadowsVolumeOpacityThreshold, double);
   vtkSetMacro(AmbientShadowsVolumeOpacityThreshold, double);
   vtkBooleanMacro(AmbientShadowsVolumeOpacityThreshold, double);
+  //@}
+
+  //@{
+  /// Ambient shadows intensity scale.
+  /// Specifies the strength of darkening by to shadows.
+  /// Higher value means stronger darkening.
+  /// Default is 1.0.
+  vtkGetMacro(AmbientShadowsIntensityScale, double);
+  vtkSetMacro(AmbientShadowsIntensityScale, double);
+  //@}
+
+  //@{
+  /// Ambient shadows intensity shift.
+  /// Specifies the minimum level of occlusion that results in visible darkening.
+  /// Higher value means darkening only appear at stronger occlusions.
+  /// Default is 0.0.
+  vtkGetMacro(AmbientShadowsIntensityShift, double);
+  vtkSetMacro(AmbientShadowsIntensityShift, double);
   //@}
 
 protected:
@@ -426,6 +446,8 @@ protected:
   bool ShadowsVisibility{false};
   double AmbientShadowsSizeScale{0.3};
   double AmbientShadowsVolumeOpacityThreshold{0.25};
+  double AmbientShadowsIntensityScale{ 1.0 };
+  double AmbientShadowsIntensityShift{ 0.0 };
 
   int LinkedControl;
   int Interacting;

--- a/Libs/MRML/Logic/vtkMRMLViewLinkLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLViewLinkLogic.cxx
@@ -468,5 +468,13 @@ void vtkMRMLViewLinkLogic::BroadcastViewNodeEvent(vtkMRMLViewNode* viewNode)
     {
       vNode->SetAmbientShadowsVolumeOpacityThreshold(viewNode->GetAmbientShadowsVolumeOpacityThreshold());
     }
+    else if (viewNode->GetInteractionFlags() == vtkMRMLViewNode::AmbientShadowsIntensityScaleFlag)
+    {
+      vNode->SetAmbientShadowsIntensityScale(viewNode->GetAmbientShadowsIntensityScale());
+    }
+    else if (viewNode->GetInteractionFlags() == vtkMRMLViewNode::AmbientShadowsIntensityShiftFlag)
+    {
+      vNode->SetAmbientShadowsIntensityShift(viewNode->GetAmbientShadowsIntensityShift());
+    }
   }
 }

--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -214,6 +214,8 @@ void qMRMLThreeDViewPrivate::updateWidgetFromMRML()
   q->setShadowsVisibility(this->MRMLViewNode->GetShadowsVisibility());
   q->setAmbientShadowsSizeScale(this->MRMLViewNode->GetAmbientShadowsSizeScale());
   q->setAmbientShadowsVolumeOpacityThreshold(this->MRMLViewNode->GetAmbientShadowsVolumeOpacityThreshold());
+  q->setAmbientShadowsIntensityScale(this->MRMLViewNode->GetAmbientShadowsIntensityScale());
+  q->setAmbientShadowsIntensityShift(this->MRMLViewNode->GetAmbientShadowsIntensityShift());
 }
 
 // --------------------------------------------------------------------------
@@ -659,4 +661,32 @@ vtkSSAOPass* qMRMLThreeDView::ssaoPass()const
 {
   Q_D(const qMRMLThreeDView);
   return d->ShadowsRenderPass;
+}
+
+//------------------------------------------------------------------------------
+double qMRMLThreeDView::ambientShadowsIntensityScale()const
+{
+  Q_D(const qMRMLThreeDView);
+  return d->ShadowsRenderPass->GetIntensityScale();
+}
+
+//------------------------------------------------------------------------------
+void qMRMLThreeDView::setAmbientShadowsIntensityScale(double intensityScale)
+{
+  Q_D(const qMRMLThreeDView);
+  d->ShadowsRenderPass->SetIntensityScale(intensityScale);
+}
+
+//------------------------------------------------------------------------------
+double qMRMLThreeDView::ambientShadowsIntensityShift()const
+{
+  Q_D(const qMRMLThreeDView);
+  return d->ShadowsRenderPass->GetIntensityShift();
+}
+
+//------------------------------------------------------------------------------
+void qMRMLThreeDView::setAmbientShadowsIntensityShift(double intensityShift)
+{
+  Q_D(const qMRMLThreeDView);
+  d->ShadowsRenderPass->SetIntensityShift(intensityShift);
 }

--- a/Libs/MRML/Widgets/qMRMLThreeDView.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.h
@@ -54,6 +54,12 @@ class QMRML_WIDGETS_EXPORT qMRMLThreeDView : public ctkVTKRenderView
   Q_PROPERTY(double ambientShadowsSizeScale READ ambientShadowsSizeScale WRITE setAmbientShadowsSizeScale)
   /// Volume rendering opacity above this value will cast shadows.
   Q_PROPERTY(double ambientShadowsVolumeOpacityThreshold READ ambientShadowsVolumeOpacityThreshold WRITE setAmbientShadowsVolumeOpacityThreshold)
+  /// Ambient shadows intensity scale.
+  /// Default is 1.0, larger value means stronger darkening.
+  Q_PROPERTY(double ambientShadowsIntensityScale READ ambientShadowsIntensityScale WRITE setAmbientShadowsIntensityScale)
+  /// Ambient shadows intensity shift.
+  /// Default is 0.0, larger value means darkening is only visible where occlusion is stronger.
+  Q_PROPERTY(double ambientShadowsIntensityShift READ ambientShadowsIntensityShift WRITE setAmbientShadowsIntensityShift)
 
 public:
   /// Superclass typedef
@@ -116,6 +122,8 @@ public:
   bool shadowsVisibility()const;
   double ambientShadowsSizeScale()const;
   double ambientShadowsVolumeOpacityThreshold()const;
+  double ambientShadowsIntensityScale()const;
+  double ambientShadowsIntensityShift()const;
 
   /// Advanced option to directly access SSAO pass used to render the ambient shadows.
   /// Intended for experimentation and troubleshooting only.
@@ -145,6 +153,8 @@ public slots:
   void setShadowsVisibility(bool);
   void setAmbientShadowsSizeScale(double);
   void setAmbientShadowsVolumeOpacityThreshold(double);
+  void setAmbientShadowsIntensityScale(double);
+  void setAmbientShadowsIntensityShift(double);
 
 private:
   Q_DECLARE_PRIVATE(qMRMLThreeDView);

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -321,6 +321,47 @@ void qMRMLThreeDViewControllerWidgetPrivate::setupShadowsMenu()
   ambientShadowsVolumeOpacityThresholdMenu->addAction(ambientShadowsVolumeOpacityThresholdAction);
   this->ShadowsMenu->addMenu(ambientShadowsVolumeOpacityThresholdMenu);
 
+  // Intensity scale
+  QMenu* ambientShadowsIntensityScaleMenu = new QMenu(qMRMLThreeDViewControllerWidget::tr("Intensity scale"), this->ShadowsButton);
+  ambientShadowsIntensityScaleMenu->setObjectName("ambienShadowsIntensityScale");
+  this->AmbientShadowsIntensityScaleSlider = new ctkSliderWidget(ambientShadowsIntensityScaleMenu);
+  this->AmbientShadowsIntensityScaleSlider->setToolTip(qMRMLThreeDViewControllerWidget::tr("Intensity of darkening by shadows."
+    " Larger value means more darkening. Default is 1."));
+  this->AmbientShadowsIntensityScaleSlider->setDecimals(2);
+  this->AmbientShadowsIntensityScaleSlider->setRange(0., 3.);
+  this->AmbientShadowsIntensityScaleSlider->setSingleStep(0.01);
+  this->AmbientShadowsIntensityScaleSlider->setPageStep(0.1);
+  this->AmbientShadowsIntensityScaleSlider->setValue(1.0);
+  QObject::connect(this->AmbientShadowsIntensityScaleSlider, SIGNAL(valueChanged(double)),
+    q, SLOT(setAmbientShadowsIntensityScale(double)));
+  this->connect(this->actionShadowsVisibility, SIGNAL(toggled(bool)),
+    this->AmbientShadowsIntensityScaleSlider, SLOT(setEnabled(bool)));
+  QWidgetAction* ambientShadowsIntensityScaleAction = new QWidgetAction(ambientShadowsIntensityScaleMenu);
+  ambientShadowsIntensityScaleAction->setDefaultWidget(this->AmbientShadowsIntensityScaleSlider);
+  ambientShadowsIntensityScaleMenu->addAction(ambientShadowsIntensityScaleAction);
+  this->ShadowsMenu->addMenu(ambientShadowsIntensityScaleMenu);
+
+  // Intensity shift
+  QMenu* ambientShadowsIntensityShiftMenu = new QMenu(qMRMLThreeDViewControllerWidget::tr("Intensity shift"), this->ShadowsButton);
+  ambientShadowsIntensityShiftMenu->setObjectName("ambienShadowsIntensityShift");
+  this->AmbientShadowsIntensityShiftSlider = new ctkSliderWidget(ambientShadowsIntensityShiftMenu);
+  this->AmbientShadowsIntensityShiftSlider->setToolTip(qMRMLThreeDViewControllerWidget::tr(
+    "Minimum amount of occlusion required for visible darkening by shadows."
+    " Larger value means more occlusion is needed to darkening. Default is 0."));
+  this->AmbientShadowsIntensityShiftSlider->setDecimals(2);
+  this->AmbientShadowsIntensityShiftSlider->setRange(0., 1.);
+  this->AmbientShadowsIntensityShiftSlider->setSingleStep(0.01);
+  this->AmbientShadowsIntensityShiftSlider->setPageStep(0.1);
+  this->AmbientShadowsIntensityShiftSlider->setValue(1.0);
+  QObject::connect(this->AmbientShadowsIntensityShiftSlider, SIGNAL(valueChanged(double)),
+    q, SLOT(setAmbientShadowsIntensityShift(double)));
+  this->connect(this->actionShadowsVisibility, SIGNAL(toggled(bool)),
+    this->AmbientShadowsIntensityShiftSlider, SLOT(setEnabled(bool)));
+  QWidgetAction* ambientShadowsIntensityShiftAction = new QWidgetAction(ambientShadowsIntensityShiftMenu);
+  ambientShadowsIntensityShiftAction->setDefaultWidget(this->AmbientShadowsIntensityShiftSlider);
+  ambientShadowsIntensityShiftMenu->addAction(ambientShadowsIntensityShiftAction);
+  this->ShadowsMenu->addMenu(ambientShadowsIntensityShiftMenu);
+
   this->ShadowsButton->setMenu(this->ShadowsMenu);
 }
 //---------------------------------------------------------------------------
@@ -583,6 +624,8 @@ void qMRMLThreeDViewControllerWidget::updateWidgetFromMRMLView()
   d->actionShadowsVisibility->setChecked(viewNode->GetShadowsVisibility());
   d->AmbientShadowsSizeScaleSlider->setValue(viewNode->GetAmbientShadowsSizeScale());
   d->AmbientShadowsVolumeOpacityThresholdPercentSlider->setValue(viewNode->GetAmbientShadowsVolumeOpacityThreshold() * 100.0);
+  d->AmbientShadowsIntensityScaleSlider->setValue(viewNode->GetAmbientShadowsIntensityScale());
+  d->AmbientShadowsIntensityShiftSlider->setValue(viewNode->GetAmbientShadowsIntensityShift());
 }
 
 // --------------------------------------------------------------------------
@@ -1016,7 +1059,6 @@ void qMRMLThreeDViewControllerWidget::setAmbientShadowsSizeScale(double value)
   d->ViewLogic->EndViewNodeInteraction();
 }
 
-
 // --------------------------------------------------------------------------
 void qMRMLThreeDViewControllerWidget::setAmbientShadowsVolumeOpacityThresholdPercent(double opacityPercent)
 {
@@ -1028,5 +1070,33 @@ void qMRMLThreeDViewControllerWidget::setAmbientShadowsVolumeOpacityThresholdPer
 
   d->ViewLogic->StartViewNodeInteraction(vtkMRMLViewNode::AmbientShadowsVolumeOpacityThresholdFlag);
   this->mrmlThreeDViewNode()->SetAmbientShadowsVolumeOpacityThreshold(opacityPercent * 0.01);
+  d->ViewLogic->EndViewNodeInteraction();
+}
+
+// --------------------------------------------------------------------------
+void qMRMLThreeDViewControllerWidget::setAmbientShadowsIntensityScale(double value)
+{
+  Q_D(qMRMLThreeDViewControllerWidget);
+  if (!this->mrmlThreeDViewNode())
+  {
+    return;
+  }
+
+  d->ViewLogic->StartViewNodeInteraction(vtkMRMLViewNode::AmbientShadowsIntensityScaleFlag);
+  this->mrmlThreeDViewNode()->SetAmbientShadowsIntensityScale(value);
+  d->ViewLogic->EndViewNodeInteraction();
+}
+
+// --------------------------------------------------------------------------
+void qMRMLThreeDViewControllerWidget::setAmbientShadowsIntensityShift(double value)
+{
+  Q_D(qMRMLThreeDViewControllerWidget);
+  if (!this->mrmlThreeDViewNode())
+  {
+    return;
+  }
+
+  d->ViewLogic->StartViewNodeInteraction(vtkMRMLViewNode::AmbientShadowsIntensityShiftFlag);
+  this->mrmlThreeDViewNode()->SetAmbientShadowsIntensityShift(value);
   d->ViewLogic->EndViewNodeInteraction();
 }

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.h
@@ -126,6 +126,8 @@ public slots:
   void setShadowsVisibility(bool visibility);
   void setAmbientShadowsSizeScale(double value);
   void setAmbientShadowsVolumeOpacityThresholdPercent(double opacityPercent);
+  void setAmbientShadowsIntensityScale(double value);
+  void setAmbientShadowsIntensityShift(double value);
 
 protected slots:
   void updateWidgetFromMRMLViewLogic();

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget_p.h
@@ -75,8 +75,12 @@ public:
   QMenu* ShadowsMenu;
   QMenu* AmbientShadowsSizeScaleMenu;
   QMenu* AmbientShadowsVolumeOpacityThresholdMenu;
+  QMenu* AmbientShadowsIntensityScaleMenu;
+  QMenu* AmbientShadowsIntensityShiftMenu;
   ctkSliderWidget* AmbientShadowsSizeScaleSlider;
   ctkSliderWidget* AmbientShadowsVolumeOpacityThresholdPercentSlider;
+  ctkSliderWidget* AmbientShadowsIntensityScaleSlider;
+  ctkSliderWidget* AmbientShadowsIntensityShiftSlider;
 
   vtkSmartPointer<vtkMRMLViewLogic>   ViewLogic;
 

--- a/Modules/Loadable/ViewControllers/qSlicerViewControllersModule.cxx
+++ b/Modules/Loadable/ViewControllers/qSlicerViewControllersModule.cxx
@@ -184,6 +184,14 @@ void qSlicerViewControllersModule::readDefaultThreeDViewSettings(vtkMRMLViewNode
   {
     defaultViewNode->SetAmbientShadowsVolumeOpacityThreshold(settings.value("AmbientShadowsVolumeOpacityThreshold").toDouble());
   }
+  if (settings.contains("AmbientShadowsIntensityScale"))
+  {
+    defaultViewNode->SetAmbientShadowsIntensityScale(settings.value("AmbientShadowsIntensityScale").toDouble());
+  }
+  if (settings.contains("AmbientShadowsIntensityShift"))
+  {
+    defaultViewNode->SetAmbientShadowsIntensityShift(settings.value("AmbientShadowsIntensityShift").toDouble());
+  }
   readCommonViewSettings(defaultViewNode, settings);
 }
 
@@ -204,6 +212,8 @@ void qSlicerViewControllersModule::writeDefaultThreeDViewSettings(vtkMRMLViewNod
   settings.setValue("ShadowsVisibility", defaultViewNode->GetShadowsVisibility());
   settings.setValue("AmbientShadowsSizeScale", defaultViewNode->GetAmbientShadowsSizeScale());
   settings.setValue("AmbientShadowsVolumeOpacityThreshold", defaultViewNode->GetAmbientShadowsVolumeOpacityThreshold());
+  settings.setValue("AmbientShadowsIntensityScale", defaultViewNode->GetAmbientShadowsIntensityScale());
+  settings.setValue("AmbientShadowsIntensityShift", defaultViewNode->GetAmbientShadowsIntensityShift());
   writeCommonViewSettings(defaultViewNode, settings);
 }
 


### PR DESCRIPTION
Shadows intensity can be linearly adjusted by shift and scale sliders in the 3D view controller.

This can be used to make ambient shadows appear darker (by increasing scale), without making the entire 3D scene darker (by increasing shift).

Example: see shadow of the rib casted on the kidney behind it. Left- no shadows. Center - default shadows (100%/0%). Right - strong shadows (200%/20%):

![image](https://github.com/Slicer/Slicer/assets/307929/390fa547-1dcc-46ca-aabf-c72aff825d99)
