### PR TITLE
ENH: Hide angle markups when the line doesn't intersect with the slice

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.cxx
@@ -238,6 +238,14 @@ void vtkSlicerAngleRepresentation2D::UpdateFromMRMLInternal(vtkMRMLNode* caller,
   this->LineActor->SetVisibility(numberOfDefinedControlPoints >= 2);
   this->ArcActor->SetVisibility(numberOfDefinedControlPoints == 3);
 
+  // Hide the actor if it doesn't intersect the current slice
+  this->LineSliceDistance->Update();
+  if (!this->IsRepresentationIntersectingSlice(vtkPolyData::SafeDownCast(this->LineSliceDistance->GetOutput()), this->LineSliceDistance->GetScalarArrayName()))
+  {
+    this->LineActor->SetVisibility(false);
+    this->ArcActor->SetVisibility(false);
+  }
+
   int controlPointType = Unselected;
   if (this->MarkupsDisplayNode->GetActiveComponentType() == vtkMRMLMarkupsDisplayNode::ComponentLine)
   {


### PR DESCRIPTION
For line/curve markup types, the lines are hidden whenever they don't intersect with the current slice, however the current behavior for angle markups is that they continue to be visible even when they no longer intersect. This commit updates the behavior of angle lines to be consistent with that of the other markup types.

See discussion: https://discourse.slicer.org/t/visibility-of-markups-angle-in-2d-slice-views-is-unlike-other-markups/37091