### PR TITLE
COMP: Fix fatal error not reported for MSVC + TBB compatibility

### DIFF
--- a/SuperBuild/External_tbb.cmake
+++ b/SuperBuild/External_tbb.cmake
@@ -83,7 +83,7 @@ if (WIN32)
     # Note that VS2022 covers both MSVC versions 193x and 194x as explained in
     # https://devblogs.microsoft.com/cppblog/msvc-toolset-minor-version-number-14-40-in-vs-2022-v17-10/
     set(tbb_vsdir vc14)
-  elseif (tbb_enabled)
+  else()
     message(FATAL_ERROR "TBB does not support your Visual Studio compiler. [MSVC_VERSION: ${MSVC_VERSION}]")
   endif ()
   set(tbb_libdir lib/${tbb_archdir}/${tbb_vsdir})


### PR DESCRIPTION
This is a follow-up to https://github.com/Slicer/Slicer/pull/7833#issuecomment-2204049639.

When building the `tbb` external project with MSVC 1940 (not with https://github.com/Slicer/Slicer/commit/aa313b88e79fd5f3d279a7a7c2fc01f8639c1cc7) there is a build error such as the following:
```
2>CMake Error at SuperBuild/External_tbb.cmake:85 (message):
2>  TBB does not support your Visual Studio compiler.  [MSVC_VERSION: 1940]
```