### PR TITLE
ENH: Generate unique segment IDs using random identifier

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
@@ -803,7 +803,7 @@ void vtkMRMLSegmentationNode::SetReferenceImageGeometryParameterFromVolumeNode(v
 //---------------------------------------------------------------------------
 std::string vtkMRMLSegmentationNode::AddSegmentFromClosedSurfaceRepresentation(vtkPolyData* polyData,
   std::string segmentName/* ="" */, double color[3] /* =nullptr */,
-  std::string vtkNotUsed(segmentId)/* ="" */)
+  std::string segmentId/* ="" */)
 {
   if (!this->Segmentation)
   {
@@ -820,7 +820,7 @@ std::string vtkMRMLSegmentationNode::AddSegmentFromClosedSurfaceRepresentation(v
     newSegment->SetColor(color);
   }
   newSegment->AddRepresentation(vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName(), polyData);
-  if (!this->Segmentation->AddSegment(newSegment.GetPointer()))
+  if (!this->Segmentation->AddSegment(newSegment.GetPointer(), segmentId))
   {
     return "";
   }
@@ -830,7 +830,7 @@ std::string vtkMRMLSegmentationNode::AddSegmentFromClosedSurfaceRepresentation(v
 //---------------------------------------------------------------------------
 std::string vtkMRMLSegmentationNode::AddSegmentFromBinaryLabelmapRepresentation(vtkOrientedImageData* imageData,
   std::string segmentName/* ="" */, double color[3] /* =nullptr */,
-  std::string vtkNotUsed(segmentId)/* ="" */)
+  std::string segmentId/* ="" */)
 {
   if (!this->Segmentation)
   {
@@ -847,7 +847,7 @@ std::string vtkMRMLSegmentationNode::AddSegmentFromBinaryLabelmapRepresentation(
     newSegment->SetColor(color);
   }
   newSegment->AddRepresentation(vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName(), imageData);
-  if (!this->Segmentation->AddSegment(newSegment.GetPointer()))
+  if (!this->Segmentation->AddSegment(newSegment.GetPointer(), segmentId))
   {
     return "";
   }

--- a/Libs/vtkSegmentationCore/CMakeLists.txt
+++ b/Libs/vtkSegmentationCore/CMakeLists.txt
@@ -4,6 +4,9 @@ project(vtkSegmentationCore)
 cmake_minimum_required(VERSION 3.16.3...3.19.7 FATAL_ERROR)
 #-----------------------------------------------------------------------------
 
+option(${PROJECT_NAME}_USE_UUID "Use UUIDs for generating segment IDs. Requires gdcm library." ON)
+mark_as_advanced(${PROJECT_NAME}_USE_UUID)
+
 # --------------------------------------------------------------------------
 # Configure headers
 # --------------------------------------------------------------------------
@@ -97,6 +100,14 @@ set(vtkSegmentationCore_INCLUDE_DIRS
 set(vtkSegmentationCore_LIBS
   ${VTK_LIBRARIES}
   )
+
+if (${PROJECT_NAME}_USE_UUID)
+  # In order to use UUIDs for segment IDs, we need to link against the gdcmMSFF library
+  # for gdcm::UIDGenerator.
+  list(APPEND vtkSegmentationCore_LIBS
+    gdcmMSFF
+    )
+endif()
 
 include_directories( ${vtkSegmentationCore_INCLUDE_DIRS} )
 add_library(${PROJECT_NAME} ${vtkSegmentationCore_SRCS})

--- a/Libs/vtkSegmentationCore/Testing/vtkSegmentationTest1.cxx
+++ b/Libs/vtkSegmentationCore/Testing/vtkSegmentationTest1.cxx
@@ -53,13 +53,13 @@ int vtkSegmentationTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
 
   // Generate sphere model
   vtkNew<vtkPolyData> spherePolyData;
-  CreateSpherePolyData(spherePolyData.GetPointer());
+  CreateSpherePolyData(spherePolyData);
 
   // Create segment
   vtkNew<vtkSegment> sphereSegment;
   sphereSegment->SetName("sphere1");
   sphereSegment->AddRepresentation(
-    vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName(), spherePolyData.GetPointer());
+    vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName(), spherePolyData);
   if (!sphereSegment->GetRepresentation(vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName()))
   {
     std::cerr << __LINE__ << ": Failed to add closed surface representation to segment!" << std::endl;
@@ -70,7 +70,7 @@ int vtkSegmentationTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
   vtkNew<vtkSegmentation> sphereSegmentation;
   sphereSegmentation->SetSourceRepresentationName(
     vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName() );
-  sphereSegmentation->AddSegment(sphereSegment.GetPointer());
+  sphereSegmentation->AddSegment(sphereSegment);
   if (sphereSegmentation->GetNumberOfSegments() != 1)
   {
     std::cerr << __LINE__ << ": Failed to add segment to segmentation!" << std::endl;
@@ -130,7 +130,7 @@ int vtkSegmentationTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
   referenceGeometryMatrix->SetElement(1,1,2.0);
   referenceGeometryMatrix->SetElement(2,2,2.0);
   int referenceGeometryExtent[6] = {0,99,0,99,0,99};
-  std::string referenceGeometryString = vtkSegmentationConverter::SerializeImageGeometry(referenceGeometryMatrix.GetPointer(), referenceGeometryExtent);
+  std::string referenceGeometryString = vtkSegmentationConverter::SerializeImageGeometry(referenceGeometryMatrix, referenceGeometryExtent);
   std::string expectedReferenceGeometryString = "2;0;0;0;0;2;0;0;0;0;2;0;0;0;0;1;0;99;0;99;0;99;";
   if (referenceGeometryString != expectedReferenceGeometryString)
   {
@@ -165,17 +165,17 @@ int vtkSegmentationTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
 
   // Add second segment
   vtkNew<vtkPolyData> spherePolyData2;
-  CreateSpherePolyData(spherePolyData2.GetPointer());
+  CreateSpherePolyData(spherePolyData2);
   vtkNew<vtkSegment> sphereSegment2;
   sphereSegment2->SetName("sphere2");
   sphereSegment2->AddRepresentation(
-    vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName(), spherePolyData2.GetPointer());
+    vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName(), spherePolyData2);
   if (!sphereSegment2->GetRepresentation(vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName()))
   {
     std::cerr << __LINE__ << ": Failed to add closed surface representation to second segment!" << std::endl;
     return EXIT_FAILURE;
   }
-  sphereSegmentation->AddSegment(sphereSegment2.GetPointer());
+  sphereSegmentation->AddSegment(sphereSegment2);
   if (sphereSegmentation->GetNumberOfSegments() != 2)
   {
     std::cerr << __LINE__ << ": Failed to add second segment to segmentation!" << std::endl;
@@ -188,7 +188,7 @@ int vtkSegmentationTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
   }
 
   // Remove segment
-  sphereSegmentation->RemoveSegment(sphereSegment2.GetPointer());
+  sphereSegmentation->RemoveSegment(sphereSegment2);
   if (sphereSegmentation->GetNumberOfSegments() != 1)
   {
     std::cerr << __LINE__ << ": Failed to remove second segment from segmentation!" << std::endl;
@@ -196,7 +196,7 @@ int vtkSegmentationTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
   }
 
   // Re-add segment
-  sphereSegmentation->AddSegment(sphereSegment2.GetPointer());
+  sphereSegmentation->AddSegment(sphereSegment2);
   if (sphereSegmentation->GetNumberOfSegments() != 2)
   {
     std::cerr << __LINE__ << ": Failed to re-add second segment to segmentation!" << std::endl;
@@ -205,11 +205,11 @@ int vtkSegmentationTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
 
   // Try to add segment with unsupported representation
   vtkNew<vtkPolyData> unsupportedPolyData;
-  CreateSpherePolyData(unsupportedPolyData.GetPointer());
+  CreateSpherePolyData(unsupportedPolyData);
   vtkNew<vtkSegment> unsupportedSegment;
   unsupportedSegment->SetName("unsupported");
-  unsupportedSegment->AddRepresentation("Unsupported", unsupportedPolyData.GetPointer());
-  sphereSegmentation->AddSegment(unsupportedSegment.GetPointer());
+  unsupportedSegment->AddRepresentation("Unsupported", unsupportedPolyData);
+  sphereSegmentation->AddSegment(unsupportedSegment);
   if (sphereSegmentation->GetNumberOfSegments() != 2)
   {
     std::cerr << __LINE__ << ": Unexpected outcome when adding segment containing unsupported representation to segmentation!" << std::endl;
@@ -222,13 +222,13 @@ int vtkSegmentationTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
 
   // Generate cube image data
   vtkNew<vtkOrientedImageData> cubeImageData;
-  CreateCubeLabelmap(cubeImageData.GetPointer());
+  CreateCubeLabelmap(cubeImageData);
 
   // Create segment
   vtkNew<vtkSegment> cubeSegment;
   cubeSegment->SetName("cube");
   cubeSegment->AddRepresentation(
-    vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName(), cubeImageData.GetPointer());
+    vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName(), cubeImageData);
   if (!cubeSegment->GetRepresentation(vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName()))
   {
     std::cerr << __LINE__ << ": Failed to add binary labelmap representation to segment!" << std::endl;
@@ -239,7 +239,7 @@ int vtkSegmentationTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
   vtkNew<vtkSegmentation> cubeSegmentation;
   cubeSegmentation->SetSourceRepresentationName(
     vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName() );
-  cubeSegmentation->AddSegment(cubeSegment.GetPointer());
+  cubeSegmentation->AddSegment(cubeSegment);
   if (cubeSegmentation->GetNumberOfSegments() != 1)
   {
     std::cerr << __LINE__ << ": Failed to add segment to second segmentation!" << std::endl;
@@ -258,12 +258,12 @@ int vtkSegmentationTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
 
   // Add segment with closed surface representation, see if it is converted to master
   vtkNew<vtkPolyData> nonMasterPolyData;
-  CreateSpherePolyData(nonMasterPolyData.GetPointer());
+  CreateSpherePolyData(nonMasterPolyData);
   vtkNew<vtkSegment> nonMasterSegment;
   nonMasterSegment->SetName("non master");
   nonMasterSegment->AddRepresentation(
-    vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName(), nonMasterPolyData.GetPointer() );
-  cubeSegmentation->AddSegment(nonMasterSegment.GetPointer());
+    vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName(), nonMasterPolyData );
+  cubeSegmentation->AddSegment(nonMasterSegment);
   if (cubeSegmentation->GetNumberOfSegments() != 2)
   {
     std::cerr << __LINE__ << ": Failed to add segment with non-source representation to segmentation!" << std::endl;
@@ -279,7 +279,8 @@ int vtkSegmentationTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
   // Copy and move segments between segmentations
 
   // Copy
-  cubeSegmentation->CopySegmentFromSegmentation(sphereSegmentation.GetPointer(), "sphere1");
+  std::string sphereSegmentID = sphereSegmentation->GetSegmentIdBySegment(sphereSegment);
+  cubeSegmentation->CopySegmentFromSegmentation(sphereSegmentation, sphereSegmentID);
   if (sphereSegmentation->GetNumberOfSegments() != 2 || cubeSegmentation->GetNumberOfSegments() != 3)
   {
     std::cerr << __LINE__ << ": Error when copying segment from one segmentation to another!" << std::endl;
@@ -287,7 +288,8 @@ int vtkSegmentationTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
   }
 
   // Move
-  sphereSegmentation->CopySegmentFromSegmentation(cubeSegmentation.GetPointer(), "cube", true);
+  std::string cubeSegmentID = cubeSegmentation->GetSegmentIdBySegment(cubeSegment);
+  sphereSegmentation->CopySegmentFromSegmentation(cubeSegmentation, cubeSegmentID, true);
   if (sphereSegmentation->GetNumberOfSegments() != 3 || cubeSegmentation->GetNumberOfSegments() != 2)
   {
     std::cerr << __LINE__ << ": Error when moving segment from one segmentation to another!" << std::endl;
@@ -348,5 +350,5 @@ void CreateCubeLabelmap(vtkOrientedImageData* imageData)
     }
   }
 
-  imageData->DeepCopy(identityImageData.GetPointer());
+  imageData->DeepCopy(identityImageData);
 }

--- a/Libs/vtkSegmentationCore/vtkSegmentation.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.h
@@ -37,10 +37,13 @@
 
 #include "vtkSegmentationCoreConfigure.h"
 
+#include <vtkSingleton.h>
+
 class vtkAbstractTransform;
 class vtkCallbackCommand;
 class vtkCollection;
 class vtkIntArray;
+class vtkMinimalStandardRandomSequence;
 class vtkSegmentationConversionPath;
 class vtkStringArray;
 
@@ -206,10 +209,14 @@ public:
   /// \return Success flag
   bool AddSegment(vtkSegment* segment, std::string segmentId = "", std::string insertBeforeSegmentId = "");
 
-  /// Generate unique segment ID. If argument is empty then a new ID will be generated in the form "Segment_",
-  /// where N is the number of segments. If argument is unique it is returned unchanged. If there is a segment
-  /// with the given name, then it is postfixed by a number to make it unique.
-  std::string GenerateUniqueSegmentID(std::string id);
+  /// Generate unique segment ID. If argument is empty then a new unique ID will be generated.
+  /// The unique generated ID is generated as a UUID derived UID
+  /// (See https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_b.2.html).
+  /// If argument is unique it is returned unchanged. If there is a segment with the given ID,
+  /// then it is postfixed by a number to make it unique.
+  /// \param id Optional segment ID to use as base for generating a unique ID
+  /// \return Unique segment ID
+  std::string GenerateUniqueSegmentID(std::string id = "");
 
   /// Remove a segment by ID
   /// \param segmentId Identifier of the segment to remove from the segmentation
@@ -517,6 +524,12 @@ public:
   static void CopySegment(vtkSegment* destination, vtkSegment* source, vtkSegment* baseline,
     std::map<vtkDataObject*, vtkDataObject*>& cachedRepresentations);
 
+  vtkSetMacro(UUIDSegmentIDs, bool);
+  vtkGetMacro(UUIDSegmentIDs, bool);
+  vtkBooleanMacro(UUIDSegmentIDs, bool);
+
+  static vtkMinimalStandardRandomSequence* GetSegmentIDRandomSequenceInstance();
+
 protected:
   bool ConvertSegmentsUsingPath(std::vector<std::string> segmentIDs, vtkSegmentationConversionPath* path, bool overwriteExisting = false);
 
@@ -560,6 +573,22 @@ protected:
   /// are no longer in the segmentation are removed
   void UpdateSourceRepresentationObservers();
 
+  /// Generate a UUID derived UID.
+  /// The form is "2.25." + a UUID converted to an integer form.
+  static std::string GenerateUUIDDerivedUID();
+
+  /// Generate a random segment ID.
+  /// The form is "S_" + random alphanumeric characters.
+  /// \param suffixLength Length of the generated ID
+  static std::string GenerateRandomSegmentID(int suffixLength, std::string validCharacters="");
+
+  /// Generate unique segment name. If argument is empty then a new name will be generated in the form "Segment_N",
+  /// where N is the number of segments. If argument is unique it is returned unchanged. If there is a segment
+  /// with the given name, then it is postfixed by a number to make it unique.
+  /// \param baseName Optional segment name to use as base for generating a unique name
+  /// \return Unique segment name
+  std::string GenerateUniqueSegmentName(std::string base);
+
 protected:
   vtkSegmentation();
   ~vtkSegmentation() override;
@@ -600,6 +629,15 @@ protected:
 
   std::set<vtkSmartPointer<vtkDataObject> > SourceRepresentationCache;
 
+  bool UUIDSegmentIDs;
+
+  /// Singleton class managing vtkMinimalStandardRandomSequence used for randomizing segment IDs
+  friend class vtkSegmentationRandomSequenceInitialize;
+
+  /// Singleton management functions.
+  static void classInitialize();
+  static void classFinalize();
+
   friend class vtkMRMLSegmentationNode;
   friend class vtkSlicerSegmentationsModuleLogic;
   friend class vtkSegmentationModifier;
@@ -609,5 +647,7 @@ private:
   vtkSegmentation(const vtkSegmentation&) = delete;
   void operator=(const vtkSegmentation&) = delete;
 };
+
+VTK_SINGLETON_DECLARE_INITIALIZER(vtkSegmentationCore_EXPORT, vtkSegmentationRandomSequence);
 
 #endif

--- a/Libs/vtkSegmentationCore/vtkSegmentationCoreConfigure.h.in
+++ b/Libs/vtkSegmentationCore/vtkSegmentationCoreConfigure.h.in
@@ -8,6 +8,8 @@
 #define vtkSegmentationCore_STATIC
 #endif
 
+#cmakedefine vtkSegmentationCore_USE_UUID
+
 #if defined(WIN32) && !defined(vtkSegmentationCore_STATIC)
 #pragma warning ( disable : 4275 )
 

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationWidgetsTest1.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationWidgetsTest1.py
@@ -72,6 +72,11 @@ class SegmentationWidgetsTest1(ScriptedLoadableModuleTest):
         displayNode = self.inputSegmentationNode.GetDisplayNode()
         self.assertIsNotNone(displayNode)
 
+        segmentIDs = self.inputSegmentationNode.GetSegmentation().GetSegmentIDs()
+        firstSegmentID = segmentIDs[0]
+        secondSegmentID = segmentIDs[1]
+        thirdSegmentID = segmentIDs[2]
+
         segmentsTableView = slicer.qMRMLSegmentsTableView()
         segmentsTableView.setMRMLScene(slicer.mrmlScene)
         segmentsTableView.setSegmentationNode(self.inputSegmentationNode)
@@ -80,7 +85,7 @@ class SegmentationWidgetsTest1(ScriptedLoadableModuleTest):
         slicer.app.processEvents()
         slicer.util.delayDisplay("All shown")
 
-        segmentsTableView.setHideSegments(["second"])
+        segmentsTableView.setHideSegments([secondSegmentID])
         self.assertEqual(len(segmentsTableView.displayedSegmentIDs()), 2)
         slicer.app.processEvents()
         slicer.util.delayDisplay("Hidden 'second'")
@@ -93,7 +98,7 @@ class SegmentationWidgetsTest1(ScriptedLoadableModuleTest):
         slicer.util.delayDisplay("All but 'third' filtered")
 
         segmentsTableView.textFilter = ""
-        firstSegment = self.inputSegmentationNode.GetSegmentation().GetSegment("first")
+        firstSegment = self.inputSegmentationNode.GetSegmentation().GetSegment(firstSegmentID)
         logic = slicer.modules.segmentations.logic()
         logic.SetSegmentStatus(firstSegment, logic.InProgress)
         sortFilterProxyModel = segmentsTableView.sortFilterProxyModel()
@@ -102,18 +107,18 @@ class SegmentationWidgetsTest1(ScriptedLoadableModuleTest):
         slicer.app.processEvents()
         slicer.util.delayDisplay("'NotStarted' shown")
 
-        segmentsTableView.setSelectedSegmentIDs(["third"])
-        segmentsTableView.setHideSegments(["second"])
+        segmentsTableView.setSelectedSegmentIDs([thirdSegmentID])
+        segmentsTableView.setHideSegments([secondSegmentID])
         segmentsTableView.showOnlySelectedSegments()
-        self.assertEqual(displayNode.GetSegmentVisibility("first"), False)
-        self.assertEqual(displayNode.GetSegmentVisibility("second"), True)
-        self.assertEqual(displayNode.GetSegmentVisibility("third"), True)
+        self.assertEqual(displayNode.GetSegmentVisibility(firstSegmentID), False)
+        self.assertEqual(displayNode.GetSegmentVisibility(secondSegmentID), True)
+        self.assertEqual(displayNode.GetSegmentVisibility(thirdSegmentID), True)
         slicer.app.processEvents()
         slicer.util.delayDisplay("Show only selected segments")
 
-        displayNode.SetSegmentVisibility("first", True)
-        displayNode.SetSegmentVisibility("second", True)
-        displayNode.SetSegmentVisibility("third", True)
+        displayNode.SetSegmentVisibility(firstSegmentID, True)
+        displayNode.SetSegmentVisibility(secondSegmentID, True)
+        displayNode.SetSegmentVisibility(thirdSegmentID, True)
         segmentsTableView.filterBarVisible = False
 
         # Reset the filtering parameters in the segmentation node to avoid interference with other tests that
@@ -382,39 +387,44 @@ class SegmentationWidgetsTest1(ScriptedLoadableModuleTest):
         segmentEditorWidget.setFocus(qt.Qt.OtherFocusReason)
         segmentEditorWidget.show()
 
-        self.segmentEditorNode.SetSelectedSegmentID("first")
-        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), "first")
+        segmentIDs = self.inputSegmentationNode.GetSegmentation().GetSegmentIDs()
+        firstSegmentID = segmentIDs[0]
+        secondSegmentID = segmentIDs[1]
+        thirdSegmentID = segmentIDs[2]
+
+        self.segmentEditorNode.SetSelectedSegmentID(firstSegmentID)
+        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), firstSegmentID)
         slicer.app.processEvents()
         slicer.util.delayDisplay("First selected")
 
         segmentEditorWidget.selectNextSegment()
-        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), "second")
+        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), secondSegmentID)
         slicer.app.processEvents()
         slicer.util.delayDisplay("Next segment")
 
         segmentEditorWidget.selectPreviousSegment()
-        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), "first")
+        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), firstSegmentID)
         slicer.app.processEvents()
         slicer.util.delayDisplay("Previous segment")
 
-        displayNode.SetSegmentVisibility("second", False)
+        displayNode.SetSegmentVisibility(secondSegmentID, False)
         segmentEditorWidget.selectNextSegment()
-        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), "third")
+        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), thirdSegmentID)
         slicer.app.processEvents()
         slicer.util.delayDisplay("Next segment (with second segment hidden)")
 
         # Trying to go out of bounds past first segment
         segmentEditorWidget.selectPreviousSegment()  # First
-        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), "first")
+        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), firstSegmentID)
         segmentEditorWidget.selectPreviousSegment()  # First
-        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), "first")
+        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), firstSegmentID)
         segmentEditorWidget.selectPreviousSegment()  # First
-        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), "first")
+        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), firstSegmentID)
         slicer.app.processEvents()
         slicer.util.delayDisplay("Multiple previous segment")
 
         # Wrap around
-        self.segmentEditorNode.SetSelectedSegmentID("third")
+        self.segmentEditorNode.SetSelectedSegmentID(thirdSegmentID)
         segmentEditorWidget.selectNextSegment()
-        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), "first")
+        self.assertEqual(self.segmentEditorNode.GetSelectedSegmentID(), firstSegmentID)
         slicer.util.delayDisplay("Wrap around segments")

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest1.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest1.py
@@ -168,7 +168,7 @@ class SegmentationsModuleTest1(unittest.TestCase):
         self.assertEqual(imageStatResult.GetScalarComponentAsDouble(3, 0, 0, 0), 5)
 
         # Remove segment from segmentation
-        self.inputSegmentationNode.GetSegmentation().RemoveSegment(self.sphereSegmentName)
+        self.inputSegmentationNode.GetSegmentation().RemoveSegment(sphereSegmentId)
         self.assertEqual(self.inputSegmentationNode.GetSegmentation().GetNumberOfSegments(), 2)
 
     # ------------------------------------------------------------------------------
@@ -249,7 +249,8 @@ class SegmentationsModuleTest1(unittest.TestCase):
         self.inputSegmentationNode.GetSegmentation().CreateRepresentation(self.binaryLabelmapReprName)
 
         # Copy segment to input segmentation
-        self.inputSegmentationNode.GetSegmentation().CopySegmentFromSegmentation(self.secondSegmentationNode.GetSegmentation(), self.sphereSegmentName)
+        sphereSegmentID = self.secondSegmentationNode.GetSegmentation().GetSegmentIdBySegment(self.sphereSegment)
+        self.inputSegmentationNode.GetSegmentation().CopySegmentFromSegmentation(self.secondSegmentationNode.GetSegmentation(), sphereSegmentID)
         self.assertEqual(self.inputSegmentationNode.GetSegmentation().GetNumberOfSegments(), 3)
 
         # Check merged labelmap
@@ -594,11 +595,11 @@ class SegmentationsModuleTest1(unittest.TestCase):
         segment.SetColor(0.0, 0.0, 1.0)
         segment.AddRepresentation(self.binaryLabelmapReprName, segmentOrientedImageData)
         segmentationNode.GetSegmentation().AddSegment(segment)
+        brainSegmentID = segmentationNode.GetSegmentation().GetSegmentIdBySegment(segment)
 
         # Check resolution before resampling
         geometryImageData = slicer.vtkOrientedImageData()
-        spacingComparisonDecimal = 3
-        segmentationNode.GetBinaryLabelmapRepresentation("Brain", geometryImageData)
+        segmentationNode.GetBinaryLabelmapRepresentation(brainSegmentID, geometryImageData)
         actualSpacing = geometryImageData.GetSpacing()
         expectedSpacing = [1, 1, 1.3]
         import numpy as np
@@ -616,7 +617,7 @@ class SegmentationsModuleTest1(unittest.TestCase):
         segmentationGeometryLogic.ResampleLabelmapsInSegmentationNode()
 
         # Check resolution after resampling
-        segmentationNode.GetBinaryLabelmapRepresentation("Brain", geometryImageData)
+        segmentationNode.GetBinaryLabelmapRepresentation(brainSegmentID, geometryImageData)
         actualSpacing = geometryImageData.GetSpacing()
         expectedSpacing = [0.5, 0.5, 0.5]
         for i in range(3):

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest2.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest2.py
@@ -211,7 +211,8 @@ class SegmentationsModuleTest2(unittest.TestCase):
         emptySegment.SetName("Segment_1")
         emptySegment.AddRepresentation(self.binaryLabelmapReprName, mergedLabelmap)
         self.segmentation.AddSegment(emptySegment)
-        self.segmentEditorNode.SetSelectedSegmentID("Segment_1")
+        segment1Id = self.segmentation.GetSegmentIdBySegment(emptySegment)
+        self.segmentEditorNode.SetSelectedSegmentID(segment1Id)
 
         startExtent = 0
         for size in islandSizes:

--- a/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
@@ -802,7 +802,7 @@ class SegmentStatisticsTest(ScriptedLoadableModuleTest):
             sphereSource.SetCenter(segmentGeometry[1], segmentGeometry[2], segmentGeometry[3])
             sphereSource.Update()
             uniqueSegmentID = segmentationNode.GetSegmentation().GenerateUniqueSegmentID("Test")
-            segmentationNode.AddSegmentFromClosedSurfaceRepresentation(sphereSource.GetOutput(), uniqueSegmentID)
+            segmentationNode.AddSegmentFromClosedSurfaceRepresentation(sphereSource.GetOutput(), "", None, uniqueSegmentID)
 
         self.delayDisplay("Compute statistics")
 
@@ -859,7 +859,7 @@ class SegmentStatisticsTest(ScriptedLoadableModuleTest):
             sphereSource.Update()
             segment = vtkSegmentationCore.vtkSegment()
             uniqueSegmentID = segmentationNode.GetSegmentation().GenerateUniqueSegmentID("Test")
-            segmentationNode.AddSegmentFromClosedSurfaceRepresentation(sphereSource.GetOutput(), uniqueSegmentID)
+            segmentationNode.AddSegmentFromClosedSurfaceRepresentation(sphereSource.GetOutput(), "", None, uniqueSegmentID)
 
         # test calculating only measurements for selected segments
         self.delayDisplay("Test calculating only measurements for individual segments")


### PR DESCRIPTION
Previously adding new segments to a segmentation would generate segment IDs of the format Segment_N unless another segment ID was specified. This commit changes the automatically generated segment IDs to use the format S_XYZ where XYZ is a unique random 16 character alphanumeric string.

This makes segment IDs more meaningful as a unique identifier since previously most segmentations would always contain the same IDs (Segment_1, Segment_1, etc.), now they will be unique across segmentations.