### PR TITLE
ENH: Change log level in islands effect

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorIslandsEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorIslandsEffect.py
@@ -165,7 +165,7 @@ about each operation, hover the mouse over the option and wait for the tooltip t
         islandCount = islandMath.GetNumberOfIslands()
         islandOrigCount = islandMath.GetOriginalNumberOfIslands()
         ignoredIslands = islandOrigCount - islandCount
-        logging.info("%d islands created (%d ignored)" % (islandCount, ignoredIslands))
+        logging.debug("%d islands created (%d ignored)" % (islandCount, ignoredIslands))
 
         baseSegmentName = "Label"
         selectedSegmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()


### PR DESCRIPTION
Changing the island effect done message from info to debug. No other effect logs activity at this level, and it pollutes log when using algorithmically.
