### PR TITLE
ENH: Add API to log software usage events

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -42,6 +42,7 @@
 //  - Slicer_BUILD_DICOM_SUPPORT
 //  - Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
 //  - Slicer_BUILD_I18N_SUPPORT
+//  - Slicer_BUILD_USAGE_LOGGING_SUPPORT
 //  - Slicer_BUILD_WIN32_CONSOLE
 //  - Slicer_BUNDLE_LOCATION
 //  - Slicer_CLIMODULES_BIN_DIR
@@ -2395,4 +2396,23 @@ bool qSlicerCoreApplication::loadFiles(const QStringList& filePaths, vtkMRMLMess
 void qSlicerCoreApplication::openUrl(const QString& url)
 {
   emit urlReceived(url);
+}
+
+//------------------------------------------------------------------------------
+bool qSlicerCoreApplication::isUsageLoggingSupported() const
+{
+#ifdef Slicer_BUILD_USAGE_LOGGING_SUPPORT
+  return true;
+#else
+  return false;
+#endif
+}
+
+//------------------------------------------------------------------------------
+void qSlicerCoreApplication::logUsageEvent(const QString& component, const QString& event)
+{
+#ifdef Slicer_BUILD_USAGE_LOGGING_SUPPORT
+  Q_D(const qSlicerCoreApplication);
+  emit usageEventLogged(component, event);
+#endif
 }

--- a/CMake/vtkSlicerConfigure.h.in
+++ b/CMake/vtkSlicerConfigure.h.in
@@ -71,6 +71,7 @@
 #cmakedefine Slicer_BUILD_DICOM_SUPPORT
 #cmakedefine Slicer_BUILD_DIFFUSION_SUPPORT
 #cmakedefine Slicer_BUILD_I18N_SUPPORT
+#cmakedefine Slicer_BUILD_USAGE_LOGGING_SUPPORT
 #cmakedefine Slicer_BUILD_MULTIMEDIA_SUPPORT
 #cmakedefine Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT
 #cmakedefine Slicer_BUILD_WEBENGINE_SUPPORT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,9 @@ mark_as_superbuild(Slicer_BUILD_DIFFUSION_SUPPORT)
 option(Slicer_BUILD_I18N_SUPPORT "Build Slicer with Internationalization support" ON)
 mark_as_superbuild(Slicer_BUILD_I18N_SUPPORT)
 
+option(Slicer_BUILD_USAGE_LOGGING_SUPPORT "Build Slicer with support for software usage logging" ON)
+mark_as_superbuild(Slicer_BUILD_USAGE_LOGGING_SUPPORT)
+
 option(Slicer_BUILD_WEBENGINE_SUPPORT "Build Slicer with Qt WebEngine support" ON)
 mark_as_superbuild(Slicer_BUILD_WEBENGINE_SUPPORT)
 


### PR DESCRIPTION
The new qSlicerCoreApplication::logUsageEvent can be called by modules in Slicer core and extensions to indicate that certain software feature is used. The application itself does not process the event, just emits a 'usageEventLogged' signal, which can be connected to slots in external modules.

This API can be used for example for implementing an extension that collects usage data and computes usage statistics of various features. If no extensions are installed that processes software usage data then calling qSlicerCoreApplication::logUsageEvent has no effect.

How to test:

```
# Observe the usage event and print it if any is logged
slicer.app.connect("usageEventLogged(QString,QString)", lambda component, event: print(f"{component} -> {event}"))

# Log an event
slicer.app.logUsageEvent("TotalSegmentator", "segmentation/ct/total")
```

See related discussions at https://discourse.slicer.org/t/should-we-start-collecting-software-usage-data/30873

---

This pull request deprecates https://github.com/Slicer/Slicer/pull/7788, as we do not want to put any actual usage data recording into Slicer core, just a hook that allows implementing extensions in the future (that the user can optionally install) that can collect usage data.

@jcfr @pieper @sjh26 @jamesobutler @cpinter
