### PR TITLE
BUG: Force loading images from DICOM using right-handed coordinate system

### DIFF
--- a/Libs/MRML/Core/vtkMRMLVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeNode.cxx
@@ -1362,11 +1362,11 @@ bool vtkMRMLVolumeNode::IsIJKCoordinateSystemRightHanded(vtkMatrix4x4* ijkToRasM
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLVolumeNode::FlipIJKCoordinateSystemHandedness(vtkImageData* imageData, vtkMatrix4x4* ijkToRasMatrix)
+void vtkMRMLVolumeNode::ReverseSliceOrder(vtkImageData* imageData, vtkMatrix4x4* ijkToRasMatrix)
 {
   if (ijkToRasMatrix == nullptr)
   {
-    vtkGenericWarningMacro("vtkMRMLVolumeNode::FlipIJKCoordinateSystemHandedness failed: ijkToRasMatrix is invalid");
+    vtkGenericWarningMacro("vtkMRMLVolumeNode::ReverseSliceOrder failed: ijkToRasMatrix is invalid");
     return;
   }
   int imageDimensions[3] = { 0, 0, 0 };
@@ -1399,7 +1399,7 @@ void vtkMRMLVolumeNode::FlipIJKCoordinateSystemHandedness(vtkImageData* imageDat
       else
       {
         // There has been other data arrays, log a warning because we only flip the first one
-        vtkGenericWarningMacro("vtkMRMLVolumeNode::FlipIJKCoordinateSystemHandedness: Multiple types of point data arrays were found,"
+        vtkGenericWarningMacro("vtkMRMLVolumeNode::ReverseSliceOrder: Multiple types of point data arrays were found,"
           " only the " << vtkDataSetAttributes::GetAttributeTypeAsString(pointDataType) << " array will be flipped");
       }
     }
@@ -1453,6 +1453,6 @@ void vtkMRMLVolumeNode::SetIJKCoordinateSystemToRightHanded()
     // already right-handed
     return;
   }
-  vtkMRMLVolumeNode::FlipIJKCoordinateSystemHandedness(this->GetImageData(), ijkToRAS);
+  vtkMRMLVolumeNode::ReverseSliceOrder(this->GetImageData(), ijkToRAS);
   this->SetIJKToRASMatrix(ijkToRAS);
 }

--- a/Libs/MRML/Core/vtkMRMLVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeNode.h
@@ -262,7 +262,7 @@ public:
 
   /// Switch the IJK coordinate system handedness between left-handed and right-handed
   /// by inverting the K axis direction. The physical location of voxels do not change.
-  static void FlipIJKCoordinateSystemHandedness(vtkImageData* imageData, vtkMatrix4x4* ijkToRasMatrix);
+  static void ReverseSliceOrder(vtkImageData* imageData, vtkMatrix4x4* ijkToRasMatrix);
 
 protected:
   vtkMRMLVolumeNode();


### PR DESCRIPTION
Automatically flip left handed volumes when loading into 3D Slicer from DICOM to make them compatible with all algorithms. Fixes flipped normals in segmentation node for left handed volumes.

Renamed FlipIJKCoordinateSystemHandedness method to ReverseSliceOrder to make it explicit that flipping of handedness is achieved by reversing slice order. The method was introduced recently (no Slicer Stable Release has been created since then), therefore the old name was not deprecated but removed.

See related commit that applies this regularization when the image is read using volume storage node: https://github.com/Slicer/Slicer/commit/3802d812b1a5d855399d8a19cea0bd1705715d52

See discussion at https://discourse.slicer.org/t/dentalsegmentator-result-mesh-is-inverted/37408/9