### PR TITLE
ENH: Minor fixes made during the 5D nrrd IO development

### DIFF
--- a/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
@@ -55,32 +55,6 @@ Version:   $Revision: 1.6 $
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLVolumeArchetypeStorageNode);
 
-int ConvertVoxelVectorTypeMRMLToVTKITK(int vtkitk)
-{
-  switch (vtkitk)
-  {
-    case vtkITKImageWriter::VoxelVectorTypeUndefined: return vtkMRMLVolumeNode::VoxelVectorTypeUndefined;
-    case vtkITKImageWriter::VoxelVectorTypeSpatial: return vtkMRMLVolumeNode::VoxelVectorTypeSpatial;
-    case vtkITKImageWriter::VoxelVectorTypeColorRGB: return vtkMRMLVolumeNode::VoxelVectorTypeColorRGB;
-    case vtkITKImageWriter::VoxelVectorTypeColorRGBA: return vtkMRMLVolumeNode::VoxelVectorTypeColorRGBA;
-    default:
-      return vtkMRMLVolumeNode::VoxelVectorTypeUndefined;
-  }
-}
-
-int ConvertVoxelVectorTypeVTKITKToMRML(int vtkitk)
-{
-  switch (vtkitk)
-  {
-    case vtkMRMLVolumeNode::VoxelVectorTypeUndefined: return vtkITKImageWriter::VoxelVectorTypeUndefined;
-    case vtkMRMLVolumeNode::VoxelVectorTypeSpatial: return vtkITKImageWriter::VoxelVectorTypeSpatial;
-    case vtkMRMLVolumeNode::VoxelVectorTypeColorRGB: return vtkITKImageWriter::VoxelVectorTypeColorRGB;
-    case vtkMRMLVolumeNode::VoxelVectorTypeColorRGBA: return vtkITKImageWriter::VoxelVectorTypeColorRGBA;
-    default:
-      return vtkMRMLVolumeNode::VoxelVectorTypeUndefined;
-  }
-}
-
 //----------------------------------------------------------------------------
 vtkMRMLVolumeArchetypeStorageNode::vtkMRMLVolumeArchetypeStorageNode()
 {
@@ -184,6 +158,34 @@ void vtkMRMLVolumeArchetypeStorageNode::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "SingleFile:   " << this->SingleFile << "\n";
   os << indent << "UseOrientationFromFile:   " << this->UseOrientationFromFile << "\n";
   os << indent << "ForceRightHandedIJKCoordinateSystem:   " << (this->ForceRightHandedIJKCoordinateSystem ? "true" : "false") << "\n";
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLVolumeArchetypeStorageNode::ConvertVoxelVectorTypeMRMLToVTKITK(int mrmlType)
+{
+  switch (mrmlType)
+  {
+    case vtkMRMLVolumeNode::VoxelVectorTypeUndefined: return vtkITKImageWriter::VoxelVectorTypeUndefined;
+    case vtkMRMLVolumeNode::VoxelVectorTypeSpatial: return vtkITKImageWriter::VoxelVectorTypeSpatial;
+    case vtkMRMLVolumeNode::VoxelVectorTypeColorRGB: return vtkITKImageWriter::VoxelVectorTypeColorRGB;
+    case vtkMRMLVolumeNode::VoxelVectorTypeColorRGBA: return vtkITKImageWriter::VoxelVectorTypeColorRGBA;
+    default:
+      return vtkITKImageWriter::VoxelVectorTypeUndefined;
+  }
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLVolumeArchetypeStorageNode::ConvertVoxelVectorTypeVTKITKToMRML(int vtkitkType)
+{
+  switch (vtkitkType)
+  {
+    case vtkITKImageWriter::VoxelVectorTypeUndefined: return vtkMRMLVolumeNode::VoxelVectorTypeUndefined;
+    case vtkITKImageWriter::VoxelVectorTypeSpatial: return vtkMRMLVolumeNode::VoxelVectorTypeSpatial;
+    case vtkITKImageWriter::VoxelVectorTypeColorRGB: return vtkMRMLVolumeNode::VoxelVectorTypeColorRGB;
+    case vtkITKImageWriter::VoxelVectorTypeColorRGBA: return vtkMRMLVolumeNode::VoxelVectorTypeColorRGBA;
+    default:
+      return vtkMRMLVolumeNode::VoxelVectorTypeUndefined;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -508,7 +510,7 @@ int vtkMRMLVolumeArchetypeStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
   outputImage->ShallowCopy(ici->GetOutput());
   volNode->SetAndObserveImageData(outputImage.GetPointer());
 
-  int voxelVectorType = ConvertVoxelVectorTypeVTKITKToMRML(reader->GetVoxelVectorType());
+  int voxelVectorType = this->ConvertVoxelVectorTypeVTKITKToMRML(reader->GetVoxelVectorType());
   volNode->SetVoxelVectorType(voxelVectorType);
 
   // If voxel values store spatial vectors then we need to convert from LPS to RAS
@@ -693,7 +695,7 @@ int vtkMRMLVolumeArchetypeStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
 
     // Pass on voxel type to the writer
     int voxelVectorType = volNode->GetVoxelVectorType();
-    writer->SetVoxelVectorType(ConvertVoxelVectorTypeMRMLToVTKITK(voxelVectorType));
+    writer->SetVoxelVectorType(this->ConvertVoxelVectorTypeMRMLToVTKITK(voxelVectorType));
     // If voxel values store spatial vectors then we need to convert from LPS to RAS
     bool writeVoxelValuesAsLps = (
       voxelVectorType == vtkMRMLVolumeNode::VoxelVectorTypeSpatial
@@ -902,7 +904,7 @@ std::string vtkMRMLVolumeArchetypeStorageNode::UpdateFileList(vtkMRMLNode *refNo
 
   // Pass on voxel type to the writer
   int voxelVectorType = volNode->GetVoxelVectorType();
-  writer->SetVoxelVectorType(ConvertVoxelVectorTypeMRMLToVTKITK(voxelVectorType));
+  writer->SetVoxelVectorType(this->ConvertVoxelVectorTypeMRMLToVTKITK(voxelVectorType));
   // If voxel values store spatial vectors then we need to convert from LPS to RAS
   bool writeVoxelValuesAsLps = (
     voxelVectorType == vtkMRMLVolumeNode::VoxelVectorTypeSpatial

--- a/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.h
@@ -86,6 +86,11 @@ public:
   vtkBooleanMacro(ForceRightHandedIJKCoordinateSystem, bool);
   //@}
 
+  /// Convert voxel vector type enum from vtkITK type to MRML type
+  static int ConvertVoxelVectorTypeVTKITKToMRML(int vtkitkType);
+  /// Convert voxel vector type enum from MRML type to vtkITK type
+  static int ConvertVoxelVectorTypeMRMLToVTKITK(int mrmlType);
+
   /// Return true if the reference node is supported by the storage node
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
   bool CanWriteFromReferenceNode(vtkMRMLNode* refNode) override;

--- a/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.cxx
@@ -135,8 +135,7 @@ int vtkITKArchetypeDiffusionTensorImageReaderFile::RequestData(
   int extent[6] = {0,-1,0,-1,0,-1};
   vtkImageData* data = vtkImageData::GetData(outputVector);
   vtkInformation* outInfo = outputVector->GetInformationObject(0);
-  outInfo->Get
-    (vtkStreamingDemandDrivenPipeline::UPDATE_EXTENT(), extent);
+  outInfo->Get(vtkStreamingDemandDrivenPipeline::UPDATE_EXTENT(), extent);
   data->SetOrigin(0, 0, 0);
   data->SetSpacing(1, 1, 1);
   data->SetExtent(extent);
@@ -144,7 +143,7 @@ int vtkITKArchetypeDiffusionTensorImageReaderFile::RequestData(
   vtkNew<vtkFloatArray> tensors;
   tensors->SetName("ArchetypeReader");
 
-    // If there is only one file in the series, just use an image file reader
+  // If there is only one file in the series, just use an image file reader
   try
   {
     if (this->FileNames.size() == 1)

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx
@@ -119,17 +119,16 @@ vtkITKArchetypeImageSeriesReader::~vtkITKArchetypeImageSeriesReader()
     delete [] this->Archetype;
     this->Archetype = nullptr;
   }
- if (RasToIjkMatrix)
- {
-   this->RasToIjkMatrix->Delete();
-   this->RasToIjkMatrix = nullptr;
- }
+  if (RasToIjkMatrix)
+  {
+    this->RasToIjkMatrix->Delete();
+    this->RasToIjkMatrix = nullptr;
+  }
   if (MeasurementFrameMatrix)
   {
-   MeasurementFrameMatrix->Delete();
-   MeasurementFrameMatrix = nullptr;
+    MeasurementFrameMatrix->Delete();
+    MeasurementFrameMatrix = nullptr;
   }
-
 }
 
 //----------------------------------------------------------------------------
@@ -474,7 +473,7 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
       }
       else
 #endif
-      if( !this->GetSingleFile() )
+      if (!this->GetSingleFile())
       { // not dicom
         // check the dimensions of the archetype - if there
         // is more then one slice, use only the archetype
@@ -667,9 +666,9 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
       imageIO = imageReader->GetImageIO();
       if (imageIO.GetPointer() == nullptr)
       {
-          vtkErrorMacro( "vtkITKArchetypeImageSeriesReader::ExecuteInformation: ImageIO for file " << fileNameCollapsed.c_str() << " does not exist.");
-          this->SetErrorCode(vtkErrorCode::UnrecognizedFileTypeError);
-          return 0;
+        vtkErrorMacro( "vtkITKArchetypeImageSeriesReader::ExecuteInformation: ImageIO for file " << fileNameCollapsed.c_str() << " does not exist.");
+        this->SetErrorCode(vtkErrorCode::UnrecognizedFileTypeError);
+        return 0;
       }
     }
     else
@@ -714,7 +713,6 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
       extent[4] = region.GetIndex()[2];
       extent[5] = region.GetIndex()[2] + region.GetSize()[2] - 1;
       imageIO = seriesReader->GetImageIO();
-
     }
   }
   catch (itk::ExceptionObject& e)
@@ -1615,10 +1613,10 @@ int vtkITKArchetypeImageSeriesReader::AssembleVolumeContainingArchetype( )
       || this->IndexArchetype >= this->IndexDiffusionGradientOrientation.size()
       || this->IndexArchetype >= this->IndexImageOrientationPatient.size())
   {
-      vtkErrorMacro("AssembleVolumeContainingArchetype: index archetype "
-        << this->IndexArchetype << " is out of bounds 0-" << this->IndexSeriesInstanceUIDs.size());
-      this->SetErrorCode(vtkErrorCode::FileFormatError);
-      return 0;
+    vtkErrorMacro("AssembleVolumeContainingArchetype: index archetype "
+      << this->IndexArchetype << " is out of bounds 0-" << this->IndexSeriesInstanceUIDs.size());
+    this->SetErrorCode(vtkErrorCode::FileFormatError);
+    return 0;
   }
 
 

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.h
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.h
@@ -103,7 +103,7 @@ public:
   vtkSetMacro(FileNameSliceCount,int);
   vtkGetMacro(FileNameSliceCount,int);
 
-  ///  is the given file name a NRRD file?
+  /// Determine if the file can be read using ITK
   virtual int CanReadFile(const char* filename);
 
   ///

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesScalarReader.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesScalarReader.cxx
@@ -70,42 +70,41 @@ int vtkITKArchetypeImageSeriesScalarReader::RequestData(
 {
   if (!this->Superclass::Archetype)
   {
-      vtkErrorMacro("An Archetype must be specified.");
-      this->SetErrorCode(vtkErrorCode::NoFileNameError);
-      return 0;
+    vtkErrorMacro("An Archetype must be specified.");
+    this->SetErrorCode(vtkErrorCode::NoFileNameError);
+    return 0;
   }
 
   vtkInformation *outInfo = outputVector->GetInformationObject(0);
 
-  vtkDataObject * output = outInfo->Get(vtkDataObject::DATA_OBJECT());
-  vtkImageData *data = vtkImageData::SafeDownCast(output);
+  vtkDataObject* output = outInfo->Get(vtkDataObject::DATA_OBJECT());
+  vtkImageData* data = vtkImageData::SafeDownCast(output);
   // removed UpdateInformation: generates an error message
   //   from VTK and doesn't appear to be needed...
   //data->UpdateInformation();
   data->SetExtent(0,0,0,0,0,0);
   data->AllocateScalars(outInfo);
-  data->SetExtent(outInfo->Get(
-    vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT()));
+  data->SetExtent(outInfo->Get(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT()));
   this->SetMetaDataScalarRangeToPointDataInfo(data);
 
 #ifdef VTKITK_BUILD_DICOM_SUPPORT
 #define vtkITKExecuteDataDeclareDICOMImageIO \
-      typedef itk::ImageIOBase ImageIOType; \
-      ImageIOType::Pointer imageIO; \
-      if (this->DICOMImageIOApproach == vtkITKArchetypeImageSeriesReader::GDCM) \
-      { \
-        imageIO = itk::GDCMImageIO::New(); \
-      } \
-      else if (this->DICOMImageIOApproach == vtkITKArchetypeImageSeriesReader::DCMTK) \
-      { \
-        imageIO = itk::DCMTKImageIO::New(); \
-      } \
-      else \
-      { \
-        vtkErrorMacro(<<"vtkITKExecuteDataFromSeries: Unsupported DICOMImageIOApproach: " << this->GetDICOMImageIOApproach()); \
-        this->SetErrorCode(vtkErrorCode::UnrecognizedFileTypeError); \
-        return 0; \
-      }
+  typedef itk::ImageIOBase ImageIOType; \
+  ImageIOType::Pointer imageIO; \
+  if (this->DICOMImageIOApproach == vtkITKArchetypeImageSeriesReader::GDCM) \
+  { \
+    imageIO = itk::GDCMImageIO::New(); \
+  } \
+  else if (this->DICOMImageIOApproach == vtkITKArchetypeImageSeriesReader::DCMTK) \
+  { \
+    imageIO = itk::DCMTKImageIO::New(); \
+  } \
+  else \
+  { \
+    vtkErrorMacro(<<"vtkITKExecuteDataFromSeries: Unsupported DICOMImageIOApproach: " << this->GetDICOMImageIOApproach()); \
+    this->SetErrorCode(vtkErrorCode::UnrecognizedFileTypeError); \
+    return 0; \
+  }
 #else
 #define vtkITKExecuteDataDeclareDICOMImageIO \
   typedef itk::ImageIOBase ImageIOType; \
@@ -114,87 +113,87 @@ int vtkITKArchetypeImageSeriesScalarReader::RequestData(
 
 /// SCALAR MACRO
 #define vtkITKExecuteDataFromSeries(typeN, type) \
-    case typeN: \
-    {\
-      typedef itk::Image<type,3> image##typeN;\
-      typedef itk::ImageSource<image##typeN> FilterType; \
-      FilterType::Pointer filter; \
-      itk::ImageSeriesReader<image##typeN>::Pointer reader##typeN = \
-        itk::ImageSeriesReader<image##typeN>::New(); \
-      vtkITKExecuteDataDeclareDICOMImageIO \
-      if (this->ArchetypeIsDICOM) \
-      { \
-        reader##typeN->SetImageIO(imageIO); \
-      } \
-      itk::CStyleCommand::Pointer pcl=itk::CStyleCommand::New(); \
-      pcl->SetCallback((itk::CStyleCommand::FunctionPointer)&ReadProgressCallback); \
-      pcl->SetClientData(this); \
-      reader##typeN->AddObserver(itk::ProgressEvent(),pcl); \
-      reader##typeN->SetFileNames(this->FileNames); \
-      reader##typeN->ReleaseDataFlagOn(); \
-      if (this->UseNativeCoordinateOrientation) \
-      { \
-        filter = reader##typeN; \
-      } \
-      else \
-      { \
-        itk::OrientImageFilter<image##typeN,image##typeN>::Pointer orient##typeN = \
-            itk::OrientImageFilter<image##typeN,image##typeN>::New(); \
-        if (this->Debug) {orient##typeN->DebugOn();} \
-        orient##typeN->SetInput(reader##typeN->GetOutput()); \
-        orient##typeN->UseImageDirectionOn(); \
-        orient##typeN->SetDesiredCoordinateOrientation(this->DesiredCoordinateOrientation); \
-        filter = orient##typeN; \
-      }\
-      filter->UpdateLargestPossibleRegion(); \
-      itk::ImportImageContainer<itk::SizeValueType, type>::Pointer PixelContainer##typeN;\
-      PixelContainer##typeN = filter->GetOutput()->GetPixelContainer();\
-      void *ptr = static_cast<void *> (PixelContainer##typeN->GetBufferPointer());\
-      DownCast<type>(data->GetPointData()->GetScalars())                \
-        ->SetVoidArray(ptr, PixelContainer##typeN->Size(), 0,\
-                       vtkAOSDataArrayTemplate<type>::VTK_DATA_ARRAY_DELETE);\
-      PixelContainer##typeN->ContainerManageMemoryOff();\
+  case typeN: \
+  {\
+    typedef itk::Image<type,3> image##typeN;\
+    typedef itk::ImageSource<image##typeN> FilterType; \
+    FilterType::Pointer filter; \
+    itk::ImageSeriesReader<image##typeN>::Pointer reader##typeN = \
+      itk::ImageSeriesReader<image##typeN>::New(); \
+    vtkITKExecuteDataDeclareDICOMImageIO \
+    if (this->ArchetypeIsDICOM) \
+    { \
+      reader##typeN->SetImageIO(imageIO); \
+    } \
+    itk::CStyleCommand::Pointer pcl=itk::CStyleCommand::New(); \
+    pcl->SetCallback((itk::CStyleCommand::FunctionPointer)&ReadProgressCallback); \
+    pcl->SetClientData(this); \
+    reader##typeN->AddObserver(itk::ProgressEvent(),pcl); \
+    reader##typeN->SetFileNames(this->FileNames); \
+    reader##typeN->ReleaseDataFlagOn(); \
+    if (this->UseNativeCoordinateOrientation) \
+    { \
+      filter = reader##typeN; \
+    } \
+    else \
+    { \
+      itk::OrientImageFilter<image##typeN,image##typeN>::Pointer orient##typeN = \
+          itk::OrientImageFilter<image##typeN,image##typeN>::New(); \
+      if (this->Debug) {orient##typeN->DebugOn();} \
+      orient##typeN->SetInput(reader##typeN->GetOutput()); \
+      orient##typeN->UseImageDirectionOn(); \
+      orient##typeN->SetDesiredCoordinateOrientation(this->DesiredCoordinateOrientation); \
+      filter = orient##typeN; \
     }\
-    break
+    filter->UpdateLargestPossibleRegion(); \
+    itk::ImportImageContainer<itk::SizeValueType, type>::Pointer PixelContainer##typeN;\
+    PixelContainer##typeN = filter->GetOutput()->GetPixelContainer();\
+    void *ptr = static_cast<void *> (PixelContainer##typeN->GetBufferPointer());\
+    DownCast<type>(data->GetPointData()->GetScalars())                \
+      ->SetVoidArray(ptr, PixelContainer##typeN->Size(), 0,\
+                      vtkAOSDataArrayTemplate<type>::VTK_DATA_ARRAY_DELETE);\
+    PixelContainer##typeN->ContainerManageMemoryOff();\
+  }\
+  break
 
 #define vtkITKExecuteDataFromFile(typeN, type) \
-    case typeN: \
-    {\
-      typedef itk::Image<type,3> image2##typeN;\
-      typedef itk::ImageSource<image2##typeN> FilterType; \
-      FilterType::Pointer filter; \
-      itk::ImageFileReader<image2##typeN>::Pointer reader2##typeN = \
-            itk::ImageFileReader<image2##typeN>::New(); \
-      reader2##typeN->SetFileName(this->FileNames[0].c_str()); \
-      vtkITKExecuteDataDeclareDICOMImageIO \
-      if (this->ArchetypeIsDICOM) \
-      { \
-        reader2##typeN->SetImageIO(imageIO); \
-      } \
-      if (this->UseNativeCoordinateOrientation) \
-      { \
-        filter = reader2##typeN; \
-      } \
-      else \
-      { \
-        itk::OrientImageFilter<image2##typeN,image2##typeN>::Pointer orient2##typeN = \
-              itk::OrientImageFilter<image2##typeN,image2##typeN>::New(); \
-        if (this->Debug) {orient2##typeN->DebugOn();} \
-        orient2##typeN->SetInput(reader2##typeN->GetOutput()); \
-        orient2##typeN->UseImageDirectionOn(); \
-        orient2##typeN->SetDesiredCoordinateOrientation(this->DesiredCoordinateOrientation); \
-        filter = orient2##typeN; \
-      } \
-      filter->UpdateLargestPossibleRegion();\
-      itk::ImportImageContainer<itk::SizeValueType, type>::Pointer PixelContainer2##typeN;\
-      PixelContainer2##typeN = filter->GetOutput()->GetPixelContainer();\
-      void *ptr = static_cast<void *> (PixelContainer2##typeN->GetBufferPointer());\
-      DownCast<type>(data->GetPointData()->GetScalars())                \
-        ->SetVoidArray(ptr, PixelContainer2##typeN->Size(), 0,\
-                       vtkAOSDataArrayTemplate<type>::VTK_DATA_ARRAY_DELETE);\
-      PixelContainer2##typeN->ContainerManageMemoryOff();\
-    }\
-    break
+  case typeN: \
+  {\
+    typedef itk::Image<type,3> image2##typeN;\
+    typedef itk::ImageSource<image2##typeN> FilterType; \
+    FilterType::Pointer filter; \
+    itk::ImageFileReader<image2##typeN>::Pointer reader2##typeN = \
+          itk::ImageFileReader<image2##typeN>::New(); \
+    reader2##typeN->SetFileName(this->FileNames[0].c_str()); \
+    vtkITKExecuteDataDeclareDICOMImageIO \
+    if (this->ArchetypeIsDICOM) \
+    { \
+      reader2##typeN->SetImageIO(imageIO); \
+    } \
+    if (this->UseNativeCoordinateOrientation) \
+    { \
+      filter = reader2##typeN; \
+    } \
+    else \
+    { \
+      itk::OrientImageFilter<image2##typeN,image2##typeN>::Pointer orient2##typeN = \
+            itk::OrientImageFilter<image2##typeN,image2##typeN>::New(); \
+      if (this->Debug) {orient2##typeN->DebugOn();} \
+      orient2##typeN->SetInput(reader2##typeN->GetOutput()); \
+      orient2##typeN->UseImageDirectionOn(); \
+      orient2##typeN->SetDesiredCoordinateOrientation(this->DesiredCoordinateOrientation); \
+      filter = orient2##typeN; \
+    } \
+    filter->UpdateLargestPossibleRegion();\
+    itk::ImportImageContainer<itk::SizeValueType, type>::Pointer PixelContainer2##typeN;\
+    PixelContainer2##typeN = filter->GetOutput()->GetPixelContainer();\
+    void *ptr = static_cast<void *> (PixelContainer2##typeN->GetBufferPointer());\
+    DownCast<type>(data->GetPointData()->GetScalars())                \
+      ->SetVoidArray(ptr, PixelContainer2##typeN->Size(), 0,\
+                      vtkAOSDataArrayTemplate<type>::VTK_DATA_ARRAY_DELETE);\
+    PixelContainer2##typeN->ContainerManageMemoryOff();\
+  }\
+  break
   /// END SCALAR MACRO
 
   try
@@ -255,12 +254,12 @@ int vtkITKArchetypeImageSeriesScalarReader::RequestData(
       }
     }
   }
-    catch (itk::ExceptionObject & e)
-    {
-      vtkErrorMacro(<< "Exception from vtkITK MegaMacro: " << e << "\n");
-      this->SetErrorCode(vtkErrorCode::FileFormatError);
-      return 0;
-    }
+  catch (itk::ExceptionObject & e)
+  {
+    vtkErrorMacro(<< "Exception from vtkITK MegaMacro: " << e << "\n");
+    this->SetErrorCode(vtkErrorCode::FileFormatError);
+    return 0;
+  }
   return 1;
 }
 

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx
@@ -90,15 +90,15 @@ void vtkITKExecuteDataFromFileVector(
 // are assumed to be the same as the file extent/order.
 void vtkITKArchetypeImageSeriesVectorReaderFile::ExecuteDataWithInformation(vtkDataObject *output, vtkInformation* outInfo)
 {
-    if (!this->Superclass::Archetype)
-    {
-        vtkErrorMacro("An Archetype must be specified.");
-        this->SetErrorCode(vtkErrorCode::NoFileNameError);
-        return;
-    }
-    vtkImageData *data = this->AllocateOutputData(output, outInfo);
+  if (!this->Superclass::Archetype)
+  {
+    vtkErrorMacro("An Archetype must be specified.");
+    this->SetErrorCode(vtkErrorCode::NoFileNameError);
+    return;
+  }
+  vtkImageData *data = this->AllocateOutputData(output, outInfo);
 
-    // If there is only one file in the series, just use an image file reader
+  // If there is only one file in the series, just use an image file reader
   if (this->FileNames.size() == 1)
   {
     vtkDebugMacro("ImageSeriesVectorReaderFile: only one file: " << this->FileNames[0].c_str());
@@ -117,8 +117,8 @@ void vtkITKArchetypeImageSeriesVectorReaderFile::ExecuteDataWithInformation(vtkD
       vtkTemplateMacroCase(VTK_SIGNED_CHAR, signed char, vtkITKExecuteDataFromFileVector<VTK_TT>(this, data));
       vtkTemplateMacroCase(VTK_UNSIGNED_CHAR, unsigned char, vtkITKExecuteDataFromFileVector<VTK_TT>(this, data));
     default:
-        vtkErrorMacro(<< "UpdateFromFile: Unknown data type " << this->OutputScalarType);
-        this->SetErrorCode(vtkErrorCode::UnrecognizedFileTypeError);
+      vtkErrorMacro(<< "UpdateFromFile: Unknown data type " << this->OutputScalarType);
+      this->SetErrorCode(vtkErrorCode::UnrecognizedFileTypeError);
     }
 
     this->SetMetaDataScalarRangeToPointDataInfo(data);
@@ -131,7 +131,7 @@ void vtkITKArchetypeImageSeriesVectorReaderFile::ExecuteDataWithInformation(vtkD
   }
 }
 
-
+//----------------------------------------------------------------------------
 void vtkITKArchetypeImageSeriesVectorReaderFile::ReadProgressCallback(itk::Object* obj, const itk::EventObject&, void* data)
 {
   itk::ProcessObject::Pointer p(dynamic_cast<itk::ProcessObject *>(obj));

--- a/Libs/vtkITK/vtkITKImageWriter.cxx
+++ b/Libs/vtkITK/vtkITKImageWriter.cxx
@@ -42,13 +42,13 @@
 vtkStandardNewMacro(vtkITKImageWriter);
 
 // helper function
-template <class  TPixelType, int Dimension>
+template <class TPixelType, int Dimension>
 void ITKWriteVTKImage(vtkITKImageWriter *self, vtkImageData *inputImage, char *fileName,
-                      vtkMatrix4x4* rasToIjkMatrix, vtkMatrix4x4* MeasurementFrameMatrix=nullptr) {
+                      vtkMatrix4x4* rasToIjkMatrix, vtkMatrix4x4* measurementFrameMatrix=nullptr)
+{
+  typedef itk::Image<TPixelType, Dimension> ImageType;
 
-  typedef  itk::Image<TPixelType, Dimension> ImageType;
-
-  vtkMatrix4x4 *ijkToRasMatrix = vtkMatrix4x4::New();
+  vtkMatrix4x4* ijkToRasMatrix = vtkMatrix4x4::New();
 
   if (rasToIjkMatrix == nullptr)
   {
@@ -64,15 +64,14 @@ void ITKWriteVTKImage(vtkITKImageWriter *self, vtkImageData *inputImage, char *f
   typename ImageType::PointType origin;
   direction.SetIdentity();
 
-  double mag[3];
-  int i;
-  for (i=0; i<3; i++)
+  double mag[3] = {0.0};
+  for (int i=0; i<3; i++)
   {
     // normalize vectors
     mag[i] = 0;
     for (int j=0; j<3; j++)
     {
-      mag[i] += ijkToRasMatrix->GetElement(i,j)* ijkToRasMatrix->GetElement(i,j);
+      mag[i] += ijkToRasMatrix->GetElement(i,j) * ijkToRasMatrix->GetElement(i,j);
     }
     if (mag[i] == 0.0)
     {
@@ -81,15 +80,13 @@ void ITKWriteVTKImage(vtkITKImageWriter *self, vtkImageData *inputImage, char *f
     mag[i] = sqrt(mag[i]);
   }
 
-  for ( i=0; i<3; i++)
+  for (int i=0; i<3; i++)
   {
-    int j;
-    for (j=0; j<3; j++)
+    for (int j=0; j<3; j++)
     {
-      ijkToRasMatrix->SetElement(i, j, ijkToRasMatrix->GetElement(i,j)/mag[i]);
+      ijkToRasMatrix->SetElement(i, j, ijkToRasMatrix->GetElement(i,j) / mag[i]);
     }
   }
-
 
   // ITK image direction are in LPS space
   // convert from ijkToRas to ijkToLps
@@ -101,11 +98,10 @@ void ITKWriteVTKImage(vtkITKImageWriter *self, vtkImageData *inputImage, char *f
   vtkMatrix4x4* ijkToLpsMatrix = vtkMatrix4x4::New();
   vtkMatrix4x4::Multiply4x4(ijkToRasMatrix, rasToLpsMatrix, ijkToLpsMatrix);
 
-  for ( i=0; i<Dimension; i++)
+  for (int i=0; i<Dimension; i++)
   {
-    origin[i] =  ijkToRasMatrix->GetElement(3,i);
-    int j;
-    for (j=0; j<Dimension; j++)
+    origin[i] = ijkToRasMatrix->GetElement(3,i);
+    for (int j=0; j<Dimension; j++)
     {
       if (Dimension == 2)
       {
@@ -113,7 +109,7 @@ void ITKWriteVTKImage(vtkITKImageWriter *self, vtkImageData *inputImage, char *f
       }
       else
       {
-        direction[j][i] =  ijkToLpsMatrix->GetElement(i,j);
+        direction[j][i] = ijkToLpsMatrix->GetElement(i,j);
       }
     }
   }
@@ -129,79 +125,75 @@ void ITKWriteVTKImage(vtkITKImageWriter *self, vtkImageData *inputImage, char *f
   typedef typename itk::VTKImageImport<ImageType> ImageImportType;
   typename ImageImportType::Pointer itkImporter = ImageImportType::New();
 
-  // vtk export for  vtk image
+  // vtk export for vtk image
   vtkNew<vtkImageExport> vtkExporter;
-  vtkNew<vtkImageFlip> vtkFlip;
 
   // writer
   typedef typename itk::ImageFileWriter<ImageType> ImageWriterType;
-  typename ImageWriterType::Pointer   itkImageWriter =  ImageWriterType::New();
+  typename ImageWriterType::Pointer itkImageWriter = ImageWriterType::New();
 
-  if ( self->GetUseCompression() )
+  if (self->GetUseCompression())
   {
     itkImageWriter->UseCompressionOn();
   }
-    else
-    {
+  else
+  {
     itkImageWriter->UseCompressionOff();
-    }
-
+  }
 
   // set pipeline for the image
-  vtkFlip->SetInputData( inputImage );
-  vtkExporter->SetInputData ( inputImage );
-  vtkFlip->SetFilteredAxis(1);
-  vtkFlip->FlipAboutOriginOn();
+  vtkExporter->SetInputData(inputImage);
 
   ConnectPipelines(vtkExporter.GetPointer(), itkImporter);
 
   // write image
-  if(self->GetImageIOClassName())
+  if (self->GetImageIOClassName())
   {
     itk::LightObject::Pointer objectType =
       itk::ObjectFactoryBase::CreateInstance(self->GetImageIOClassName());
-    itk::ImageIOBase* imageIOType = dynamic_cast< itk::ImageIOBase * >(
+    itk::ImageIOBase* imageIOType = dynamic_cast<itk::ImageIOBase*>(
       objectType.GetPointer());
-    if(imageIOType){
+    if (imageIOType)
+    {
       itkImageWriter->SetImageIO(imageIOType);
     }
   }
   itkImageWriter->SetInput(itkImporter->GetOutput());
 
-  if (MeasurementFrameMatrix != nullptr)
+  if (measurementFrameMatrix != nullptr)
   {
-    typedef std::vector<std::vector<double> >    DoubleVectorType;
-    typedef itk::MetaDataObject<DoubleVectorType>     MetaDataDoubleVectorType;
-    const itk::MetaDataDictionary &        dictionary = itkImageWriter->GetMetaDataDictionary();
+    typedef std::vector<std::vector<double> > DoubleVectorType;
+    typedef itk::MetaDataObject<DoubleVectorType> MetaDataDoubleVectorType;
+    const itk::MetaDataDictionary &dictionary = itkImageWriter->GetMetaDataDictionary();
 
     itk::MetaDataDictionary::ConstIterator itr = dictionary.Begin();
     itk::MetaDataDictionary::ConstIterator end = dictionary.End();
 
-    while( itr != end )
+    while (itr != end)
     {
       // Get Measurement Frame
-      itk::MetaDataObjectBase::Pointer  entry = itr->second;
+      itk::MetaDataObjectBase::Pointer entry = itr->second;
       MetaDataDoubleVectorType::Pointer entryvalue
-        = dynamic_cast<MetaDataDoubleVectorType *>( entry.GetPointer() );
-      if( entryvalue )
+        = dynamic_cast<MetaDataDoubleVectorType*>(entry.GetPointer());
+      if (entryvalue)
       {
-        int pos = itr->first.find( "NRRD_measurement frame" );
-        if( pos != -1 )
+        int pos = itr->first.find("NRRD_measurement frame");
+        if (pos != -1)
         {
           DoubleVectorType tagvalue;
-          tagvalue.resize( 3 );
-          for( int i = 0; i < 3; i++ )
+          tagvalue.resize(3);
+          for (int i = 0; i < 3; i++)
           {
             tagvalue[i].resize( 3 );
-            for( int j = 0; j < 3; j++ )
+            for (int j = 0; j < 3; j++)
             {
-              tagvalue[i][j] = MeasurementFrameMatrix->GetElement(i, j);
+              tagvalue[i][j] = measurementFrameMatrix->GetElement(i, j);
             }
+            entryvalue->SetMetaDataObjectValue(tagvalue);
           }
-          entryvalue->SetMetaDataObjectValue( tagvalue );
         }
-      }
         ++itr;
+      }
     }
   }
 
@@ -222,7 +214,7 @@ void ITKWriteVTKImage(vtkITKImageWriter *self, vtkImageData *inputImage, char *f
 }
 
 //----------------------------------------------------------------------------
-template <class  TPixelType>
+template <class TPixelType>
 void ITKWriteVTKImage(vtkITKImageWriter *self, vtkImageData *inputImage, char *fileName,
                       vtkMatrix4x4* rasToIjkMatrix, vtkMatrix4x4* measurementFrameMatrix=nullptr)
 {
@@ -249,7 +241,6 @@ vtkITKImageWriter::vtkITKImageWriter()
   this->VoxelVectorType = vtkITKImageWriter::VoxelVectorTypeUndefined;
 }
 
-
 //----------------------------------------------------------------------------
 vtkITKImageWriter::~vtkITKImageWriter()
 {
@@ -267,7 +258,6 @@ vtkITKImageWriter::~vtkITKImageWriter()
   }
 }
 
-
 //----------------------------------------------------------------------------
 void vtkITKImageWriter::PrintSelf(ostream& os, vtkIndent indent)
 {
@@ -279,12 +269,11 @@ void vtkITKImageWriter::PrintSelf(ostream& os, vtkIndent indent)
     (this->ImageIOClassName ? this->ImageIOClassName : "(none)") << "\n";
 }
 
-
 //----------------------------------------------------------------------------
 // This function sets the name of the file.
 void vtkITKImageWriter::SetFileName(const char *name)
 {
-  if ( this->FileName && name && (!strcmp(this->FileName,name)))
+  if (this->FileName && name && (!strcmp(this->FileName,name)))
   {
     return;
   }
@@ -317,7 +306,7 @@ void vtkITKImageWriter::Write()
     vtkErrorMacro(<<"vtkITKImageWriter: No image to write");
     return;
   }
-  if ( ! this->FileName )
+  if (!this->FileName)
   {
     vtkErrorMacro(<<"vtkITKImageWriter: Please specify a FileName");
     return;

--- a/Libs/vtkITK/vtkITKImageWriter.h
+++ b/Libs/vtkITK/vtkITKImageWriter.h
@@ -47,32 +47,35 @@ public:
   /// in multiple files.
   void SetFileName(const char *);
 
-  char *GetFileName() {
+  char* GetFileName()
+  {
     return FileName;
   }
 
   ///
-  /// use compression if possible
-  vtkGetMacro (UseCompression, int);
-  vtkSetMacro (UseCompression, int);
+  /// Use compression if possible
+  vtkGetMacro(UseCompression, int);
+  vtkSetMacro(UseCompression, int);
   vtkBooleanMacro(UseCompression, int);
 
   ///
   /// Set/Get the ImageIO class name.
-  vtkGetStringMacro (ImageIOClassName);
-  vtkSetStringMacro (ImageIOClassName);
+  vtkGetStringMacro(ImageIOClassName);
+  vtkSetStringMacro(ImageIOClassName);
 
   ///
   /// The main interface which triggers the writer to start.
   void Write();
 
   /// Set orientation matrix
-  void SetRasToIJKMatrix( vtkMatrix4x4* mat) {
+  void SetRasToIJKMatrix(vtkMatrix4x4* mat)
+  {
     RasToIJKMatrix = mat;
   }
 
   /// Set orientation matrix
-  void SetMeasurementFrameMatrix( vtkMatrix4x4* mat) {
+  void SetMeasurementFrameMatrix(vtkMatrix4x4* mat)
+  {
     MeasurementFrameMatrix = mat;
   }
 


### PR DESCRIPTION
- Consolidate functions ConvertVoxelVectorTypeMRMLToVTKITK and ConvertVoxelVectorTypeVTKITKToMRML
  - The type of the enum in the functions was mixed up
  - These functions will be used in a later PR from another class (vtkMRMLVolumeSequenceStorageNode), and this paves the way to use the one function
- Remove the vtkFlip step from vtkITKImageWriter as it has no effect (not part of the pipeline)
- Minor style changes