### PR TITLE
ENH: Disable compression for CLI output files

### DIFF
--- a/Modules/CLI/AddScalarVolumes/AddScalarVolumes.cxx
+++ b/Modules/CLI/AddScalarVolumes/AddScalarVolumes.cxx
@@ -91,7 +91,6 @@ int DoIt( int argc, char * argv[], T )
                                        CLPProcessInformation);
   writer->SetFileName( outputVolume.c_str() );
   writer->SetInput( filter->GetOutput() );
-  writer->SetUseCompression(1);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/CLI/CastScalarVolume/CastScalarVolume.cxx
+++ b/Modules/CLI/CastScalarVolume/CastScalarVolume.cxx
@@ -60,7 +60,6 @@ int DoIt( int argc, char * argv[], Tin, Tout )
                                        CLPProcessInformation);
   writer->SetFileName( OutputVolume.c_str() );
   writer->SetInput( filter->GetOutput() );
-  writer->SetUseCompression(1);
   writer->Update();
   return EXIT_SUCCESS;
 }

--- a/Modules/CLI/CheckerBoardFilter/CheckerBoardFilter.cxx
+++ b/Modules/CLI/CheckerBoardFilter/CheckerBoardFilter.cxx
@@ -77,7 +77,6 @@ int DoIt( int argc, char * argv[], T )
   filter->SetInput2( resample->GetOutput() );
 
   writer->SetInput( filter->GetOutput() );
-  writer->SetUseCompression(1);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/CLI/CurvatureAnisotropicDiffusion/CurvatureAnisotropicDiffusion.cxx
+++ b/Modules/CLI/CurvatureAnisotropicDiffusion/CurvatureAnisotropicDiffusion.cxx
@@ -74,7 +74,6 @@ int DoIt( int argc, char * argv[], T )
                                        CLPProcessInformation);
   writer->SetFileName( outputVolume.c_str() );
   writer->SetInput( cast->GetOutput() );
-  writer->SetUseCompression(1);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/CLI/GaussianBlurImageFilter/GaussianBlurImageFilter.cxx
+++ b/Modules/CLI/GaussianBlurImageFilter/GaussianBlurImageFilter.cxx
@@ -42,7 +42,6 @@ int DoIt( int argc, char * argv[], T )
   typename WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( outputVolume.c_str() );
   writer->SetInput( filter->GetOutput() );
-  writer->SetUseCompression(1);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/CLI/GradientAnisotropicDiffusion/GradientAnisotropicDiffusion.cxx
+++ b/Modules/CLI/GradientAnisotropicDiffusion/GradientAnisotropicDiffusion.cxx
@@ -73,7 +73,6 @@ int DoIt( int argc, char * argv[], T )
                                        CLPProcessInformation);
   writer->SetFileName( outputVolume.c_str() );
   writer->SetInput( cast->GetOutput() );
-  writer->SetUseCompression(1);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/CLI/GrayscaleFillHoleImageFilter/GrayscaleFillHoleImageFilter.cxx
+++ b/Modules/CLI/GrayscaleFillHoleImageFilter/GrayscaleFillHoleImageFilter.cxx
@@ -68,7 +68,6 @@ int DoIt( int argc, char * argv[], T )
   // Setup the input and output files
   reader->SetFileName( inputVolume.c_str() );
   writer->SetFileName( outputVolume.c_str() );
-  writer->SetUseCompression(1);
 
   // Setup the fillhole method
   fillhole->SetInput(  reader->GetOutput() );

--- a/Modules/CLI/GrayscaleGrindPeakImageFilter/GrayscaleGrindPeakImageFilter.cxx
+++ b/Modules/CLI/GrayscaleGrindPeakImageFilter/GrayscaleGrindPeakImageFilter.cxx
@@ -68,7 +68,6 @@ int DoIt( int argc, char * argv[], T )
   // Setup the input and output files
   reader->SetFileName( inputVolume.c_str() );
   writer->SetFileName( outputVolume.c_str() );
-  writer->SetUseCompression(1);
 
   // Setup the grindpeak method
   grindpeak->SetInput(  reader->GetOutput() );

--- a/Modules/CLI/HistogramMatching/HistogramMatching.cxx
+++ b/Modules/CLI/HistogramMatching/HistogramMatching.cxx
@@ -71,7 +71,6 @@ int DoIt( int argc, char * argv[], T )
   reader1->SetFileName( inputVolume.c_str() );
   reader2->SetFileName( referenceVolume.c_str() );
   writer->SetFileName( outputVolume.c_str() );
-  writer->SetUseCompression(1);
 
   // Setup the filter
   filter->SetInput( reader1->GetOutput() );

--- a/Modules/CLI/ImageLabelCombine/ImageLabelCombine.cxx
+++ b/Modules/CLI/ImageLabelCombine/ImageLabelCombine.cxx
@@ -106,7 +106,6 @@ int main( int argc, char * argv[] )
   }
 
   writer->SetInput(output);
-  writer->SetUseCompression(true);
   try
   {
     writer->Update();

--- a/Modules/CLI/LabelMapSmoothing/LabelMapSmoothing.cxx
+++ b/Modules/CLI/LabelMapSmoothing/LabelMapSmoothing.cxx
@@ -182,7 +182,6 @@ int main( int argc, char * argv[] )
 
     writer->SetInput( paster->GetOutput() );
     writer->SetFileName( outputVolume.c_str() );
-    writer->SetUseCompression(true);
     writer->Update();
 
   }

--- a/Modules/CLI/MaskScalarVolume/MaskScalarVolume.cxx
+++ b/Modules/CLI/MaskScalarVolume/MaskScalarVolume.cxx
@@ -104,7 +104,6 @@ int DoIt( int argc, char * argv[] )
                                        CLPProcessInformation);
   writer->SetFileName( OutputVolume.c_str() );
   writer->SetInput( filter->GetOutput() );
-  writer->SetUseCompression(1);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/CLI/MedianImageFilter/MedianImageFilter.cxx
+++ b/Modules/CLI/MedianImageFilter/MedianImageFilter.cxx
@@ -62,7 +62,6 @@ int DoIt( int argc, char * argv[], T )
   filter->SetRadius( indexRadius );
   filter->SetInput( reader->GetOutput() );
   writer->SetInput( filter->GetOutput() );
-  writer->SetUseCompression(1);
   writer->Update();
   return EXIT_SUCCESS;
 }

--- a/Modules/CLI/MultiplyScalarVolumes/MultiplyScalarVolumes.cxx
+++ b/Modules/CLI/MultiplyScalarVolumes/MultiplyScalarVolumes.cxx
@@ -86,7 +86,6 @@ int DoIt( int argc, char * argv[], T )
                                        CLPProcessInformation);
   writer->SetFileName( outputVolume.c_str() );
   writer->SetInput( filter->GetOutput() );
-  writer->SetUseCompression(1);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
+++ b/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
@@ -52,7 +52,6 @@ int SaveIt(ImageType::Pointer img, const char* fname)
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput( img );
   writer->SetFileName( fname );
-  writer->SetUseCompression(true);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/CLI/OrientScalarVolume/OrientScalarVolume.cxx
+++ b/Modules/CLI/OrientScalarVolume/OrientScalarVolume.cxx
@@ -152,7 +152,6 @@ int DoIt( int argc, char * argv[], T )
                                        CLPProcessInformation);
   writer->SetFileName( outputVolume.c_str() );
   writer->SetInput( change->GetOutput() );
-  writer->SetUseCompression(1);
   writer->Update();
   std::cout << "Input origin is: " << reader1->GetOutput()->GetOrigin() << std::endl;
   std::cout << "Output origin is: " << change->GetOutput()->GetOrigin()

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.txx
@@ -114,7 +114,6 @@ DiffusionTensor3DWrite<TData>
   typename WriterType::Pointer writer = WriterType::New();
   writer->SetInput( m_Input );
   writer->SetFileName( output );
-  writer->UseCompressionOn();
   writer->SetNumberOfWorkUnits(m_NumberOfThreads);
   try
   {

--- a/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
+++ b/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
@@ -1296,7 +1296,6 @@ int Rotate( parameters & list )
     typename WriterType::Pointer writer = WriterType::New();
     writer->SetInput( outputImage );
     writer->SetFileName( list.outputVolume.c_str() );
-    writer->UseCompressionOn();
     writer->Update();
   }
   catch( itk::ExceptionObject &exception )

--- a/Modules/CLI/ResampleScalarVolume/ResampleScalarVolume.cxx
+++ b/Modules/CLI/ResampleScalarVolume/ResampleScalarVolume.cxx
@@ -222,7 +222,6 @@ int DoIt( int argc, char * argv[], T )
   typename FileWriterType::Pointer seriesWriter = FileWriterType::New();
   seriesWriter->SetInput( resampler->GetOutput() );
   seriesWriter->SetFileName( OutputVolume.c_str() );
-  seriesWriter->SetUseCompression(1);
   try
   {
     seriesWriter->Update();

--- a/Modules/CLI/SimpleRegionGrowingSegmentation/SimpleRegionGrowingSegmentation.cxx
+++ b/Modules/CLI/SimpleRegionGrowingSegmentation/SimpleRegionGrowingSegmentation.cxx
@@ -74,7 +74,6 @@ int main( int argc, char *argv[] )
   confidenceConnected->SetInput( smoothing->GetOutput() );
   caster->SetInput( confidenceConnected->GetOutput() );
   writer->SetInput( caster->GetOutput() );
-  writer->SetUseCompression(true);
 
   smoothing->SetNumberOfIterations( smoothingIterations );
   smoothing->SetTimeStep( timestep );

--- a/Modules/CLI/SubtractScalarVolumes/SubtractScalarVolumes.cxx
+++ b/Modules/CLI/SubtractScalarVolumes/SubtractScalarVolumes.cxx
@@ -93,7 +93,6 @@ int DoIt( int argc, char * argv[], T )
                                        CLPProcessInformation);
   writer->SetFileName( outputVolume.c_str() );
   writer->SetInput( filter->GetOutput() );
-  writer->SetUseCompression(1);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/CLI/ThresholdScalarVolume/ThresholdScalarVolume.cxx
+++ b/Modules/CLI/ThresholdScalarVolume/ThresholdScalarVolume.cxx
@@ -115,7 +115,6 @@ int DoIt( int argc, char * argv[] )
                                        CLPProcessInformation);
   writer->SetFileName( OutputVolume.c_str() );
   writer->SetInput( lastFilter->GetOutput() );
-  writer->SetUseCompression(1);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/Modules/CLI/VotingBinaryHoleFillingImageFilter/VotingBinaryHoleFillingImageFilter.cxx
+++ b/Modules/CLI/VotingBinaryHoleFillingImageFilter/VotingBinaryHoleFillingImageFilter.cxx
@@ -73,7 +73,6 @@ int main( int argc, char * argv[] )
 
   filter->SetInput( reader->GetOutput() );
   writer->SetInput( filter->GetOutput() );
-  writer->SetUseCompression(true);
   writer->Update();
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
CLI modules are primarily used for processing and the output file is just used for temporary storage. Therefore, usually compression has no benefits, but it slows down the execution time.

If it turns out in the future that some modules would benefit from having compressed output, those modules could get an optional "--useCompression" flag, similarly to CreateDICOMSeries module.

See discussion at https://discourse.slicer.org/t/crop-volume-resample-scalar-slowness-for-large-image/34985/6