### PR TITLE
ENH: Reduce bundle temp directory length when saving scene mrb

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -3858,6 +3858,20 @@ void vtkMRMLScene::TrimUndoStack()
 }
 
 //----------------------------------------------------------------------------
+std::string vtkMRMLScene::GetTemporaryBundleDirectory()
+{
+  std::stringstream ss;
+  ss << vtksys::SystemTools::GetCurrentDateTime("_tmp%Y%m%d");
+  const char validCharacters[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  int numberOfCharacters = sizeof(validCharacters) - 1;
+  for (int i = 0; i < 5; i++)
+  {
+    ss << validCharacters[rand() % numberOfCharacters];
+  }
+  return ss.str();
+}
+
+//----------------------------------------------------------------------------
 bool vtkMRMLScene::WriteToMRB(const char* filename, vtkImageData* thumbnail/*=nullptr*/, vtkMRMLMessageCollection* userMessages/*=nullptr*/)
 {
   //
@@ -3887,7 +3901,7 @@ bool vtkMRMLScene::WriteToMRB(const char* filename, vtkImageData* thumbnail/*=nu
     tempBaseDir = mrbDir;
   }
   std::stringstream tempDirStr;
-  tempDirStr << tempBaseDir << "/" << vtksys::SystemTools::GetCurrentDateTime("__BundleSaveTemp-%F_%H%M%S_") << (this->RandomGenerator() % 1000);
+  tempDirStr << tempBaseDir << "/" << this->GetTemporaryBundleDirectory();
   std::string tempDir = tempDirStr.str();
   vtkDebugMacro("Packing bundle to " << tempDir);
 
@@ -3967,7 +3981,7 @@ bool vtkMRMLScene::ReadFromMRB(const char* fullName, bool clear/*=false*/, vtkMR
     return false;
   }
   std::stringstream unpackDirStr;
-  unpackDirStr << tempBaseDir << "/" << vtksys::SystemTools::GetCurrentDateTime("__BundleLoadTemp-%F_%H%M%S_") << (this->RandomGenerator() % 1000);
+  unpackDirStr << tempBaseDir << "/" << this->GetTemporaryBundleDirectory();
   std::string unpackDir = unpackDirStr.str();
   vtkDebugMacro("Unpacking bundle to " << unpackDir);
 

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -783,6 +783,10 @@ public:
   void SetMaximumNumberOfSavedUndoStates(int stackSize);
   vtkGetMacro(MaximumNumberOfSavedUndoStates, int);
 
+  /// \brief Returns a string for the temporary directory to use for saving/reading scene files.
+  /// The directory is created from the current date/time as well as a random number 0-999.
+  std::string GetTemporaryBundleDirectory();
+
   /// \brief Write the scene to a MRML scene bundle (.mrb) file.
   /// If thumbnail image is provided then it is saved in the scene's root folder.
   /// If userMessages is not nullptr then the method may add messages to it about issues


### PR DESCRIPTION
When saving a scene that includes sequence nodes, it is easy to go over the max path length on windows. This is due to saving the mrb scenes for the sequences inside the temp directory of the full scene. This means that the path will include the same bundle temporary directory string twice in the sequence mrb path.

This commit results in a ~55% length decrease in the bundle directory path.

Previously scene temporary directories were of the format:
```__BundleSaveTemp-2024-08-20_115507_655``` (38 characters)

Now the bundle directory format is:
```20240820115507655``` (17 characters)