### PR TITLE
BUG: Update "pre-commit" workflow to support reuse from private project

### DIFF
--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   check-commit-message:


### PR DESCRIPTION
Follow-up of bf50210585 ("COMP: Support reuse of "commit-message" GitHub workflow", 2024-08-19)

This ensures the "gsactions/commit-message-checker" internally using GraphQL along with the equivalent of the "Get a Pull Request" REST endpoint is granted with the expected permissions:
* "Pull requests" repository permissions (read)
* "Contents" repository permissions (read)

See https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request