### PR TITLE
BUG: Resolve interaction handles rendering issues

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.cxx
@@ -974,7 +974,7 @@ vtkMRMLInteractionWidgetRepresentation::InteractionPipeline::InteractionPipeline
   this->Mapper3D->SetResolveCoincidentTopologyToPolygonOffset();
 
   this->Property3D = vtkSmartPointer<vtkProperty>::New();
-  this->Property3D->SetPointSize(0.0);
+  this->Property3D->SetPointSize(1.e-6); // NOTE: The point size value must be greater than zero. Refer to vtkOpenGLState::vtkglPointSize(float).
   this->Property3D->SetLineWidth(2.0);
   this->Property3D->SetDiffuse(0.0);
   this->Property3D->SetAmbient(1.0);
@@ -1903,14 +1903,6 @@ void vtkMRMLInteractionWidgetRepresentation::UpdateSlicePlaneFromSliceNode()
       this->Pipeline->WorldToSliceTransform->Scale(2.0 / dimensions[1], 2.0 / dimensions[1], 2.0 / dimensions[1]);
       this->Pipeline->WorldToSliceTransform->Translate(-1.0 * dimensions[0] / dimensions[1], -1.0, 0.0);
     }
-
-    double slicePlanePosition[3] = { 0.0, 0.0, 0.0 };
-    this->Pipeline->WorldToSliceTransform->TransformPoint(slicePlanePosition, slicePlanePosition);
-    this->Pipeline->WorldToSliceTransform->Translate(0.0, 0.0, -slicePlanePosition[2] - 10*this->WidgetScale);
-    slicePlanePosition[0] = 0.0;
-    slicePlanePosition[1] = 0.0;
-    slicePlanePosition[2] = this->WidgetScale;
-    this->Pipeline->WorldToSliceTransform->TransformPoint(slicePlanePosition, slicePlanePosition);
   }
 
   // Update slice plane (for distance computation)


### PR DESCRIPTION
@Sunderlandkyl @lassoan 

This fixes two issues:
1) handle glyphs vtk rendering warning [lines](https://github.com/Slicer/Slicer/pull/7903/files#diff-eb8c3eb226772bfbd7f81c26ca0c10239a7c7260688123bcc49d09a895780964R977)
2) handles failing the rendering when unzomming a slice view. [lines](https://github.com/Slicer/Slicer/pull/7903/files#diff-eb8c3eb226772bfbd7f81c26ca0c10239a7c7260688123bcc49d09a895780964L1906-L1913)

For issue (2), adding the translation: `this->Pipeline->WorldToSliceTransform->Translate(0.0, 0.0, -slicePlanePosition[2] - 10*this->WidgetScale)` causes the interaction handles to disappear when WidgetScale is greater than 100. This might have been intentional to avoid rendering handles when unzooming a slice view beyond a certain scale. However, this introduces two problems:

A) Even though the handles are not rendered, they remain interactable, complicating user interaction. 
B) Depending on the data in the slice and the slice orientation, the handles disappear even when clicking "fit to background" in the slice controller (the only way to render it again, it is to zoom in).

After removing these lines, I did not observe any changes in the rendering or behavior of the interaction handles when WidgetScale is less than 100.

For (1) the following stack trace was observed on linux (fixed with this PR):

```
Generic Warning: In vtkOpenGLState.cxx, line 729
Error glPointSize1 OpenGL errors detected
  0 : (1281) Invalid value

 with stack trace of
0x77fa113e26d3 : ??? [(???) ???:-1]
0x77fa113dcc55 : vtksys::SystemInformation::GetProgramStack[abi:cxx11](int, int) [(libvtksys-9.2.so.1) ???:-1]
0x77fa03341495 : ??? [(???) ???:-1]
0x77fa0334454a : vtkOpenGLState::vtkglPointSize(float) [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77fa032c95e1 : vtkOpenGLPolyDataMapper::RenderPieceStart(vtkRenderer*, vtkActor*) [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77fa032ca45a : vtkOpenGLPolyDataMapper::RenderPiece(vtkRenderer*, vtkActor*) [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77f9ffb818f7 : vtkPolyDataMapper::Render(vtkRenderer*, vtkActor*) [(libvtkRendering-9.2.so.1) ???:-1]
0x77fa0320e221 : vtkOpenGLActor::Render(vtkRenderer*, vtkMapper*) [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77f9ffa19ed1 : vtkActor::RenderTranslucentPolygonalGeometry(vtkViewport*) [(libvtkRendering-9.2.so.1) ???:-1]
0x77fa14f9d583 : vtkMRMLInteractionWidgetRepresentation::RenderTranslucentPolygonalGeometry(vtkViewport*) [(libMRMLDisplayableManager.so) ???:-1]
0x77f9ffb87ff5 : vtkProp::RenderFilteredTranslucentPolygonalGeometry(vtkViewport*, vtkInformation*) [(libvtkRendering-9.2.so.1) ???:-1]
0x77fa031d5fb3 : vtkDefaultPass::RenderFilteredTranslucentPolygonalGeometry(vtkRenderState const*) [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77fa034186e7 : vtkTranslucentPass::Render(vtkRenderState const*) [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77fa031e1298 : vtkDualDepthPeelingPass::RenderTranslucentPass() [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77fa031e2d3b : vtkDualDepthPeelingPass::InitializeDepth() [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77fa031e21b3 : vtkDualDepthPeelingPass::Prepare() [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77fa031debe0 : vtkDualDepthPeelingPass::Render(vtkRenderState const*) [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77fa033156dc : vtkOpenGLRenderer::DeviceRenderTranslucentPolygonalGeometry(vtkFrameBufferObjectBase*) [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77fa03313bdd : vtkOpenGLRenderer::UpdateGeometry(vtkFrameBufferObjectBase*) [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77fa03312c1d : vtkOpenGLRenderer::DeviceRender() [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77f9ffbd62c9 : vtkRenderer::Render() [(libvtkRendering-9.2.so.1) ???:-1]
0x77f9ffbf6031 : vtkRendererCollection::Render() [(libvtkRendering-9.2.so.1) ???:-1]
0x77f9ffbb0af4 : vtkRenderWindow::DoStereoRender() [(libvtkRendering-9.2.so.1) ???:-1]
0x77f9ffbb083a : vtkRenderWindow::Render() [(libvtkRendering-9.2.so.1) ???:-1]
0x77fa0331068c : vtkOpenGLRenderWindow::Render() [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77fa031f9698 : vtkGenericOpenGLRenderWindow::Render() [(libvtkOpenGL-9.2.so.1) ???:-1]
0x77fa25e2235a : ctkVTKAbstractView::forceRender() [(libCTKVisualizationVTKWidgets.so.0.1) ???:-1]
0x77fa25e2225b : ctkVTKAbstractView::requestRender() [(libCTKVisualizationVTKWidgets.so.0.1) ???:-1]
0x77fa25e221dd : ctkVTKAbstractView::scheduleRender() [(libCTKVisualizationVTKWidgets.so.0.1) ???:-1]
0x77fa25e2254a : ctkVTKAbstractView::resumeRender() [(libCTKVisualizationVTKWidgets.so.0.1) ???:-1]
0x77fa25547a7a : qMRMLAbstractViewWidget::resumeRender() [(libqMRMLWidgets.so) ???:-1]
0x77fa25547982 : qMRMLAbstractViewWidget::setRenderPaused(bool) [(libqMRMLWidgets.so) ???:-1]
0x77fa255793a9 : qMRMLLayoutManager::setRenderPaused(bool) [(libqMRMLWidgets.so) ???:-1]
0x77fa25af1639 : qSlicerApplication::setRenderPaused(bool) [(libqSlicerBaseQTGUI.so) ???:-1]
0x77fa25af16f3 : qSlicerApplication::resumeRender() [(libqSlicerBaseQTGUI.so) ???:-1]
0x77fa25bc1814 : ??? [(???) ???:-1]
0x77fa22ed5ddf : ??? [(???) ???:-1]
0x77fa253ea26b : ctkVTKConnection::emitExecute(vtkObject*, void*, unsigned long, void*) [(libCTKVisualizationVTKCore.so.0.1) ???:-1]
0x77fa253d71f3 : ctkVTKConnectionPrivate::execute(vtkObject*, unsigned long, void*, void*) [(libCTKVisualizationVTKCore.so.0.1) ???:-1]
0x77fa253d7099 : ctkVTKConnectionPrivate::DoCallback(vtkObject*, unsigned long, void*, void*) [(libCTKVisualizationVTKCore.so.0.1) ???:-1]
0x77f9f93972d1 : vtkCallbackCommand::Execute(vtkObject*, unsigned long, void*) [(libvtkCommon-9.2.so.1) ???:-1]
0x77fa11900cb4 : vtkEventBroker::InvokeObservation(vtkObservation*, unsigned long, void*) [(libMRMLCore.so) ???:-1]
0x77fa119000dc : vtkEventBroker::ProcessEvent(vtkObservation*, vtkObject*, unsigned long, void*) [(libMRMLCore.so) ???:-1]
0x77fa119013d0 : vtkEventBroker::Callback(vtkObject*, unsigned long, void*, void*) [(libMRMLCore.so) ???:-1]
0x77f9f93972d1 : vtkCallbackCommand::Execute(vtkObject*, unsigned long, void*) [(libvtkCommon-9.2.so.1) ???:-1]
0x77f9f95f4b07 : ??? [(???) ???:-1]
0x77f9f95f5119 : vtkObject::InvokeEvent(unsigned long, void*) [(libvtkCommon-9.2.so.1) ???:-1]
0x77fa25634f55 : vtkObject::InvokeEvent(unsigned long) [(libqMRMLWidgets.so) ???:-1]
0x77fa2417626a : vtkMRMLApplicationLogic::ResumeRender() [(libMRMLLogic.so) ???:-1]
0x77fa14f85c44 : vtkMRMLSliceViewInteractorStyle::DelegateInteractionEventToDisplayableManagers(vtkEventData*) [(libMRMLDisplayableManager.so) ???:-1]
0x77fa14f82fdd : vtkMRMLViewInteractorStyle::DelegateInteractionEventToDisplayableManagers(unsigned long) [(libMRMLDisplayableManager.so) ???:-1]
0x77fa14f838bd : vtkMRMLViewInteractorStyle::CustomProcessEvents(vtkObject*, unsigned long, void*, void*) [(libMRMLDisplayableManager.so) ???:-1]
0x77f9f93972d1 : vtkCallbackCommand::Execute(vtkObject*, unsigned long, void*) [(libvtkCommon-9.2.so.1) ???:-1]
0x77f9f95f4b07 : ??? [(???) ???:-1]
0x77f9f95f5119 : vtkObject::InvokeEvent(unsigned long, void*) [(libvtkCommon-9.2.so.1) ???:-1]
0x77fa16391fe0 : QVTKInteractorAdapter::ProcessEvent(QEvent*, vtkRenderWindowInteractor*) [(libvtkGUISupportQt-9.2.so.1) ???:-1]
0x77fa16399f99 : QVTKRenderWindowAdapter::handleEvent(QEvent*) [(libvtkGUISupportQt-9.2.so.1) ???:-1]
0x77fa163964c5 : QVTKOpenGLNativeWidget::event(QEvent*) [(libvtkGUISupportQt-9.2.so.1) ???:-1]
0x77fa2436343c : QApplicationPrivate::notify_helper(QObject*, QEvent*) [(libQt5Widgets.so.5) ???:-1]
0x77fa2436a1f8 : QApplication::notify(QObject*, QEvent*) [(libQt5Widgets.so.5) ???:-1]
0x77fa25aeb9c8 : qSlicerApplication::notify(QObject*, QEvent*) [(libqSlicerBaseQTGUI.so) ???:-1]
0x77fa22e9d808 : QCoreApplication::notifyInternal2(QObject*, QEvent*) [(libQt5Core.so.5) ???:-1]
0x77fa2436953a : QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) [(libQt5Widgets.so.5) ???:-1]
0x77fa243bafe8 : ??? [(???) ???:-1]
0x77fa243bdcf3 : ??? [(???) ???:-1]
0x77fa2436343c : QApplicationPrivate::notify_helper(QObject*, QEvent*) [(libQt5Widgets.so.5) ???:-1]
0x77fa24369f20 : QApplication::notify(QObject*, QEvent*) [(libQt5Widgets.so.5) ???:-1]
0x77fa25aeb9c8 : qSlicerApplication::notify(QObject*, QEvent*) [(libqSlicerBaseQTGUI.so) ???:-1]
0x77fa22e9d808 : QCoreApplication::notifyInternal2(QObject*, QEvent*) [(libQt5Core.so.5) ???:-1]
0x77fa2376f56d : QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) [(libQt5Gui.so.5) ???:-1]
0x77fa23770955 : QGuiApplicationPrivate::processWindowSystemEvent(QWindowSystemInterfacePrivate::WindowSystemEvent*) [(libQt5Gui.so.5) ???:-1]
0x77fa2374c8ab : QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) [(libQt5Gui.so.5) ???:-1]
0x77f9f0c6569a : ??? [(???) ???:-1]
0x77fa09d145b5 : ??? [(???) ???:-1]
0x77fa09d73717 : ??? [(???) ???:-1]
0x77fa09d13a53 : g_main_context_iteration [(libglib-2.0.so.0) ???:-1]
0x77fa22ef91cc : QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) [(libQt5Core.so.5) ???:-1]
0x77fa22e9c21a : QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) [(libQt5Core.so.5) ???:-1]
0x77fa22ea51d3 : QCoreApplication::exec() [(libQt5Core.so.5) ???:-1]
0x77fa24e42eac : qSlicerCoreApplication::exec() [(libqSlicerBaseQTCore.so) ???:-1]
0x5e7599ebf50d : ??? [(???) ???:-1]
0x5e7599ebf692 : ??? [(???) ???:-1]
0x77f9f542a1ca : ??? [(???) ???:-1]
0x77f9f542a28b : __libc_start_main [(libc.so.6) ???:-1]
0x5e7599ebeda5 : ??? [(???) ???:-1]
```