### PR TITLE
BUG: Fix subject hierarchy help button tooltip's appearance in dark mode

### DIFF
--- a/Modules/Loadable/Data/Resources/UI/qSlicerDataModuleWidget.ui
+++ b/Modules/Loadable/Data/Resources/UI/qSlicerDataModuleWidget.ui
@@ -133,7 +133,7 @@
          <item>
           <widget class="QToolButton" name="HelpButton">
            <property name="styleSheet">
-            <string notr="true">border: none; hover: {border: 1px}; pressed: {border: 1px}</string>
+            <string notr="true">QToolButton {border: none; hover: {border: 1px}; pressed: {border: 1px}}</string>
            </property>
            <property name="text">
             <string/>


### PR DESCRIPTION
In dark mode, the style sheet on the HelpButton was overriding the tooltip stylesheet, making it difficult to read. Fixed by changing the HelpButton style sheet so that the changes only affected the button, and not the tooltip.

Before:
![image](https://github.com/user-attachments/assets/1b46e763-5772-4814-b9ad-238a9a2fd9c9)

After:
![image](https://github.com/user-attachments/assets/f6e8e884-e7bf-4a3b-906d-3824c0f84ff8)
