### PR TITLE
COMP: speed up Linux compilation by using precompiled headers

### DIFF
--- a/Base/CLI/CMakeLists.txt
+++ b/Base/CLI/CMakeLists.txt
@@ -107,6 +107,9 @@ if(SlicerBaseCLI_SRCS)
   set_target_properties(${lib_name} PROPERTIES LABELS ${lib_name})
   set_target_properties(${lib_name} PROPERTIES FOLDER "Core-Base")
 
+  target_precompile_headers(${lib_name} REUSE_FROM PrecompileItkHeaders)
+  target_precompile_headers(${lib_name} REUSE_FROM PrecompileVtkHeaders)
+
   # Apply user-defined properties to the library target.
   if(Slicer_LIBRARY_PROPERTIES)
     set_target_properties(${lib_name} PROPERTIES ${Slicer_LIBRARY_PROPERTIES})

--- a/Base/Logic/CMakeLists.txt
+++ b/Base/Logic/CMakeLists.txt
@@ -174,6 +174,9 @@ target_link_libraries(${lib_name} ${libs})
 set_target_properties(${lib_name} PROPERTIES LABELS ${lib_name})
 set_target_properties(${lib_name} PROPERTIES FOLDER "Core-Base")
 
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileItkHeaders)
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileVtkHeaders)
+
 # Apply user-defined properties to the library target.
 if(Slicer_LIBRARY_PROPERTIES)
   set_target_properties(${lib_name} PROPERTIES ${Slicer_LIBRARY_PROPERTIES})
@@ -212,6 +215,8 @@ if(VTK_WRAP_PYTHON)
   # Export target
   set_property(GLOBAL APPEND PROPERTY Slicer_TARGETS ${lib_name}Python)
   set_target_properties(${lib_name}Python PROPERTIES FOLDER "Core-Base")
+  target_precompile_headers(${lib_name}Python REUSE_FROM PrecompileItkHeaders)
+  target_precompile_headers(${lib_name}Python REUSE_FROM PrecompileVtkHeaders)
   if(TARGET ${lib_name}Hierarchy)
     set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER "Core-Base")
   endif()

--- a/Base/QTApp/CMakeLists.txt
+++ b/Base/QTApp/CMakeLists.txt
@@ -69,6 +69,7 @@ SlicerMacroBuildBaseQtLibrary(
   TARGET_LIBRARIES ${KIT_target_libraries}
   RESOURCES ${KIT_resources}
   WRAP_PYTHONQT
+  USE_PRECOMPILED_HEADERS
   )
 
 # --------------------------------------------------------------------------

--- a/Base/QTCLI/CMakeLists.txt
+++ b/Base/QTCLI/CMakeLists.txt
@@ -123,6 +123,7 @@ SlicerMacroBuildBaseQtLibrary(
   TARGET_LIBRARIES ${KIT_target_libraries}
   RESOURCES ${KIT_resources}
   WRAP_PYTHONQT
+  USE_PRECOMPILED_HEADERS
   )
 
 if(Slicer_BUILD_QT_DESIGNER_PLUGINS)

--- a/Base/QTCLI/DesignerPlugins/CMakeLists.txt
+++ b/Base/QTCLI/DesignerPlugins/CMakeLists.txt
@@ -37,3 +37,6 @@ ctkMacroBuildQtDesignerPlugin(
   MOC_SRCS ${${KIT}_MOC_SRCS}
   TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
   )
+
+target_precompile_headers(${PROJECT_NAME} REUSE_FROM PrecompileQtCoreHeaders)
+target_precompile_headers(${PROJECT_NAME} REUSE_FROM PrecompileQtWidgetsHeaders)

--- a/Base/QTCore/CMakeLists.txt
+++ b/Base/QTCore/CMakeLists.txt
@@ -275,6 +275,7 @@ SlicerMacroBuildBaseQtLibrary(
   TARGET_LIBRARIES ${KIT_target_libraries}
   RESOURCES ${KIT_resources}
   WRAP_PYTHONQT
+  USE_PRECOMPILED_HEADERS
   )
 
 if(Slicer_USE_PYTHONQT_WITH_OPENSSL)

--- a/Base/QTGUI/CMakeLists.txt
+++ b/Base/QTGUI/CMakeLists.txt
@@ -365,6 +365,7 @@ SlicerMacroBuildBaseQtLibrary(
   TARGET_LIBRARIES ${KIT_target_libraries}
   RESOURCES ${KIT_resources}
   WRAP_PYTHONQT
+  USE_PRECOMPILED_HEADERS
   )
 
 #-----------------------------------------------------------------------------

--- a/Base/QTGUI/DesignerPlugins/CMakeLists.txt
+++ b/Base/QTGUI/DesignerPlugins/CMakeLists.txt
@@ -55,3 +55,6 @@ ctkMacroBuildQtDesignerPlugin(
   MOC_SRCS ${${KIT}_MOC_SRCS}
   TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
   )
+
+target_precompile_headers(${PROJECT_NAME} REUSE_FROM PrecompileQtCoreHeaders)
+target_precompile_headers(${PROJECT_NAME} REUSE_FROM PrecompileQtWidgetsHeaders)

--- a/CMake/SlicerMacroBuildBaseQtLibrary.cmake
+++ b/CMake/SlicerMacroBuildBaseQtLibrary.cmake
@@ -55,6 +55,7 @@
 macro(SlicerMacroBuildBaseQtLibrary)
   set(options
     WRAP_PYTHONQT
+    USE_PRECOMPILED_HEADERS
     )
   set(oneValueArgs
     NAME
@@ -206,6 +207,11 @@ macro(SlicerMacroBuildBaseQtLibrary)
     )
   set_target_properties(${lib_name} PROPERTIES LABELS ${lib_name})
 
+  if (SLICERQTBASELIB_USE_PRECOMPILED_HEADERS)
+    target_precompile_headers(${lib_name} REUSE_FROM PrecompileQtCoreHeaders)
+    target_precompile_headers(${lib_name} REUSE_FROM PrecompileQtWidgetsHeaders)
+  endif()
+
   # Apply user-defined properties to the library target.
   if(Slicer_LIBRARY_PROPERTIES)
     set_target_properties(${lib_name} PROPERTIES ${Slicer_LIBRARY_PROPERTIES})
@@ -252,6 +258,10 @@ macro(SlicerMacroBuildBaseQtLibrary)
       INSTALL_LIB_DIR ${Slicer_INSTALL_LIB_DIR}
       )
     set_target_properties(${lib_name}PythonQt PROPERTIES FOLDER "Core-Base")
+    if (SLICERQTBASELIB_USE_PRECOMPILED_HEADERS)
+      target_precompile_headers(${lib_name}PythonQt REUSE_FROM PrecompileQtCoreHeaders)
+      target_precompile_headers(${lib_name}PythonQt REUSE_FROM PrecompileQtWidgetsHeaders)
+    endif()
   endif()
 
   # --------------------------------------------------------------------------

--- a/Libs/CMakeLists.txt
+++ b/Libs/CMakeLists.txt
@@ -12,6 +12,13 @@ set(GENERATECLP_USE_MD5 ON)
 set(dirs )
 
 list(APPEND dirs
+  PrecompileItkHeaders
+  PrecompileQtCoreHeaders
+  PrecompileQtWidgetsHeaders
+  PrecompileVtkHeaders
+  )
+
+list(APPEND dirs
   ITKFactoryRegistration
   )
 set(SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES

--- a/Libs/MRML/CLI/CMakeLists.txt
+++ b/Libs/MRML/CLI/CMakeLists.txt
@@ -90,6 +90,9 @@ set(libs
   )
 target_link_libraries(${lib_name} ${libs})
 
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileItkHeaders)
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileVtkHeaders)
+
 # Apply user-defined properties to the library target.
 if(Slicer_LIBRARY_PROPERTIES)
   set_target_properties(${lib_name} PROPERTIES ${Slicer_LIBRARY_PROPERTIES})
@@ -149,6 +152,9 @@ if(VTK_WRAP_PYTHON)
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${lib_name}Python PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    target_precompile_headers(${lib_name}Python REUSE_FROM PrecompileItkHeaders)
+    target_precompile_headers(${lib_name}Python REUSE_FROM PrecompileVtkHeaders)
+
     if(TARGET ${lib_name}Hierarchy)
       set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()

--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -314,6 +314,9 @@ if(MRML_USE_vtkTeem)
 endif()
 target_link_libraries(${lib_name} ${libs})
 
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileItkHeaders)
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileVtkHeaders)
+
 # Apply user-defined properties to the library target.
 if(Slicer_LIBRARY_PROPERTIES)
   set_target_properties(${lib_name} PROPERTIES ${Slicer_LIBRARY_PROPERTIES})
@@ -363,6 +366,8 @@ if(VTK_WRAP_PYTHON)
     KIT_INSTALL_BIN_DIR ${${PROJECT_NAME}_INSTALL_BIN_DIR}
     KIT_INSTALL_LIB_DIR ${${PROJECT_NAME}_INSTALL_LIB_DIR}
     )
+  target_precompile_headers(${lib_name}Python REUSE_FROM PrecompileItkHeaders)
+  target_precompile_headers(${lib_name}Python REUSE_FROM PrecompileVtkHeaders)
   # Export target
   export(TARGETS ${lib_name}Python APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
   # Folder

--- a/Libs/MRML/DisplayableManager/CMakeLists.txt
+++ b/Libs/MRML/DisplayableManager/CMakeLists.txt
@@ -182,6 +182,9 @@ endif()
 
 target_link_libraries(${lib_name} ${libs})
 
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileItkHeaders)
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileVtkHeaders)
+
 if(${lib_name}_AUTOINIT)
   set_property(TARGET ${lib_name}
     APPEND PROPERTY COMPILE_DEFINITIONS
@@ -248,6 +251,8 @@ if(MRMLDisplayableManager_USE_PYTHON)
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${lib_name}Python PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    target_precompile_headers(${lib_name}Python REUSE_FROM PrecompileItkHeaders)
+    target_precompile_headers(${lib_name}Python REUSE_FROM PrecompileVtkHeaders)
     if(TARGET ${lib_name}Hierarchy)
       set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()

--- a/Libs/MRML/IDImageIO/CMakeLists.txt
+++ b/Libs/MRML/IDImageIO/CMakeLists.txt
@@ -92,6 +92,8 @@ add_library(${lib_name} ${srcs})
 
 set(libs MRMLCore)
 target_link_libraries(${lib_name} ${libs})
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileItkHeaders)
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileVtkHeaders)
 
 # Apply user-defined properties to the library target.
 if(Slicer_LIBRARY_PROPERTIES)
@@ -155,6 +157,8 @@ set_target_properties(MRMLIDIOPlugin PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${MRMLIDImageIO_ITKFACTORIES_DIR}"
   )
 target_link_libraries(MRMLIDIOPlugin ${lib_name})
+target_precompile_headers(MRMLIDIOPlugin REUSE_FROM PrecompileItkHeaders)
+target_precompile_headers(MRMLIDIOPlugin REUSE_FROM PrecompileVtkHeaders)
 
 # Folder
 if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")

--- a/Libs/MRML/Logic/CMakeLists.txt
+++ b/Libs/MRML/Logic/CMakeLists.txt
@@ -99,6 +99,9 @@ set(libs
 
 target_link_libraries(${lib_name} ${libs})
 
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileItkHeaders)
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileVtkHeaders)
+
 # Apply user-defined properties to the library target.
 if(Slicer_LIBRARY_PROPERTIES)
   set_target_properties(${lib_name} PROPERTIES ${Slicer_LIBRARY_PROPERTIES})
@@ -158,6 +161,8 @@ if(VTK_WRAP_PYTHON)
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${lib_name}Python PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    target_precompile_headers(${lib_name}Python REUSE_FROM PrecompileItkHeaders)
+    target_precompile_headers(${lib_name}Python REUSE_FROM PrecompileVtkHeaders)
     if(TARGET ${lib_name}Hierarchy)
       set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()

--- a/Libs/MRML/Widgets/CMakeLists.txt
+++ b/Libs/MRML/Widgets/CMakeLists.txt
@@ -487,6 +487,10 @@ set(MRMLWidgets_LIBRARIES
 
 target_link_libraries(${lib_name} ${MRMLWidgets_LIBRARIES})
 
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileQtCoreHeaders)
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileQtWidgetsHeaders)
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileVtkHeaders)
+
 # Apply user-defined properties to the library target.
 if(Slicer_LIBRARY_PROPERTIES)
   set_target_properties(${lib_name} PROPERTIES ${Slicer_LIBRARY_PROPERTIES})
@@ -513,6 +517,10 @@ if(MRMLWidgets_WRAP_PYTHON)
     INSTALL_BIN_DIR ${Slicer_INSTALL_BIN_DIR}
     INSTALL_LIB_DIR ${Slicer_INSTALL_LIB_DIR}
     )
+  target_precompile_headers(${lib_name}PythonQt REUSE_FROM PrecompileQtCoreHeaders)
+  target_precompile_headers(${lib_name}PythonQt REUSE_FROM PrecompileQtWidgetsHeaders)
+  target_precompile_headers(${lib_name}PythonQt REUSE_FROM PrecompileVtkHeaders)
+
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${lib_name}PythonQt PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})

--- a/Libs/MRML/Widgets/DesignerPlugins/CMakeLists.txt
+++ b/Libs/MRML/Widgets/DesignerPlugins/CMakeLists.txt
@@ -177,3 +177,6 @@ ctkMacroBuildQtDesignerPlugin(
   MOC_SRCS ${${KIT}_MOC_SRCS}
   TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
   )
+
+target_precompile_headers(${PROJECT_NAME} REUSE_FROM PrecompileQtCoreHeaders)
+target_precompile_headers(${PROJECT_NAME} REUSE_FROM PrecompileQtWidgetsHeaders)

--- a/Libs/PrecompileItkHeaders/CMakeLists.txt
+++ b/Libs/PrecompileItkHeaders/CMakeLists.txt
@@ -1,0 +1,35 @@
+project(PrecompileItkHeaders)
+
+# No way found to make it work with add_library, this error appears in the project which tries to reuse the precompiled headers:
+# cmake_pch.hxx.gch: not used because `PrecompileItkHeaders_EXPORTS' not defined [-Winvalid-pch]
+add_executable(${PROJECT_NAME} PrecompileItkHeaders.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+
+set(ITK_SOURCE_DIR "${ITK_CMAKE_DIR}/..")
+
+# Do not precompile VTK/Common/Archive headers because they do not compile because of missing vtkCommonArchiveModule.h
+# Do not precompile VTK/Imaging/OpenGL2 headers because they do not compile because of missing vtkImagingOpenGL2Module.h
+file(GLOB_RECURSE precompiled_headers
+  ${ITK_SOURCE_DIR}/Modules/Core/Common/include/*.h
+  ${ITK_SOURCE_DIR}/Modules/Core/ImageFunction/include/*.h
+  ${ITK_SOURCE_DIR}/Modules/Core/Transform/include/*.h
+  ${ITK_SOURCE_DIR}/Modules/Filtering/ImageGrid/include/*.h
+  ${ITK_SOURCE_DIR}/Modules/Filtering/ImageFilterBase/include/*.h
+  ${ITK_SOURCE_DIR}/Modules/Filtering/DiffusionTensorImage/include/*.h
+  ${ITK_SOURCE_DIR}/Modules/IO/NRRD/include/*.h
+  ${ITK_SOURCE_DIR}/Modules/IO/ImageBase/include/*.h
+  ${ITK_SOURCE_DIR}/Modules/IO/SpatialObjects/include/*.h
+  ${ITK_SOURCE_DIR}/Modules/IO/TransformBase/include/*.h
+  ${ITK_SOURCE_DIR}/Modules/IO/TransformFactory/include/*.h
+)
+
+list(REMOVE_ITEM precompiled_headers ${ITK_SOURCE_DIR}/Modules/Core/Common/include/itkExceptionObject.h)
+
+cmake_path(GET ITK_CONFIG_TARGETS_FILE PARENT_PATH ITK_BUILD_DIR)
+list(APPEND precompiled_headers
+${ITK_BUILD_DIR}/Modules/ThirdParty/KWSys/src/itksys/Directory.hxx
+  ${ITK_BUILD_DIR}/Modules/ThirdParty/KWSys/src/itksys/SystemTools.hxx
+  ${ITK_BUILD_DIR}/Modules/Core/Common/itkConfigure.h
+)
+
+target_precompile_headers(${PROJECT_NAME} PUBLIC ${precompiled_headers})

--- a/Libs/PrecompileItkHeaders/PrecompileItkHeaders.cxx
+++ b/Libs/PrecompileItkHeaders/PrecompileItkHeaders.cxx
@@ -1,0 +1,4 @@
+//Empty main just to create a target
+int main() {
+  return 0;
+}

--- a/Libs/PrecompileQtCoreHeaders/CMakeLists.txt
+++ b/Libs/PrecompileQtCoreHeaders/CMakeLists.txt
@@ -1,0 +1,35 @@
+project(PrecompileQtCoreHeaders)
+
+# No way found to make it work with add_library, this error appears in the project which tries to reuse the precompiled headers:
+# cmake_pch.hxx.gch: not used because `PrecompileQtCoreHeaders_EXPORTS' not defined [-Winvalid-pch]
+add_executable(${PROJECT_NAME} PrecompileQtCoreHeaders.cxx)
+find_package(Qt5 COMPONENTS Core REQUIRED)
+target_link_libraries(${PROJECT_NAME} Qt5::Core)
+
+get_property(qt_core_lib_file_path TARGET "Qt5::Core" PROPERTY LOCATION_RELEASE)
+get_filename_component(qt_core_lib_dir ${qt_core_lib_file_path} PATH)
+set(qt_core_include_dir "${qt_core_lib_dir}/../include/QtCore")
+
+# Precompile only low level most common headers because header precompilation takes time
+set(precompiled_headers
+  "${qt_core_include_dir}/QDateTime"
+  "${qt_core_include_dir}/QDebug"
+  "${qt_core_include_dir}/QDir"
+  "${qt_core_include_dir}/QFile"
+  "${qt_core_include_dir}/QFileInfo"
+  "${qt_core_include_dir}/QHash"
+  "${qt_core_include_dir}/QList"
+  "${qt_core_include_dir}/QMap"
+  "${qt_core_include_dir}/QMetaType"
+  "${qt_core_include_dir}/QObject"
+  "${qt_core_include_dir}/QPointer"
+  "${qt_core_include_dir}/QSettings"
+  "${qt_core_include_dir}/QSharedPointer"
+  "${qt_core_include_dir}/QString"
+  "${qt_core_include_dir}/QStringList"
+  "${qt_core_include_dir}/QTimer"
+  "${qt_core_include_dir}/QUrl"
+  "${qt_core_include_dir}/QVariant"
+  )
+
+target_precompile_headers(${PROJECT_NAME} PUBLIC ${precompiled_headers})

--- a/Libs/PrecompileQtCoreHeaders/PrecompileQtCoreHeaders.cxx
+++ b/Libs/PrecompileQtCoreHeaders/PrecompileQtCoreHeaders.cxx
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/Libs/PrecompileQtWidgetsHeaders/CMakeLists.txt
+++ b/Libs/PrecompileQtWidgetsHeaders/CMakeLists.txt
@@ -1,0 +1,24 @@
+project(PrecompileQtWidgetsHeaders)
+
+# No way found to make it work with add_library, this error appears in the project which tries to reuse the precompiled headers:
+# cmake_pch.hxx.gch: not used because `PrecompileQtCoreHeaders_EXPORTS' not defined [-Winvalid-pch]
+add_executable(${PROJECT_NAME} PrecompileQtWidgetsHeaders.cxx)
+find_package(Qt5 COMPONENTS Widgets REQUIRED)
+target_link_libraries(${PROJECT_NAME} Qt5::Widgets)
+
+get_property(qt_widgets_lib_file_path TARGET "Qt5::Widgets" PROPERTY LOCATION_RELEASE)
+get_filename_component(qt_widgets_lib_dir ${qt_widgets_lib_file_path} PATH)
+set(qt_widgets_include_dir "${qt_widgets_lib_dir}/../include/QtWidgets")
+
+# Precompile only low level most common headers because header precompilation takes time
+set(precompiled_headers
+  "${qt_widgets_include_dir}/QAction"
+  "${qt_widgets_include_dir}/QApplication"
+  "${qt_widgets_include_dir}/QDialog"
+  "${qt_widgets_include_dir}/QLabel"
+  "${qt_widgets_include_dir}/QMessageBox"
+  "${qt_widgets_include_dir}/QVBoxLayout"
+  "${qt_widgets_include_dir}/QWidget"
+)
+
+target_precompile_headers(${PROJECT_NAME} PUBLIC ${precompiled_headers})

--- a/Libs/PrecompileQtWidgetsHeaders/PrecompileQtWidgetsHeaders.cxx
+++ b/Libs/PrecompileQtWidgetsHeaders/PrecompileQtWidgetsHeaders.cxx
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/Libs/PrecompileVtkHeaders/CMakeLists.txt
+++ b/Libs/PrecompileVtkHeaders/CMakeLists.txt
@@ -1,0 +1,121 @@
+project(PrecompileVtkHeaders)
+
+# No way found to make it work with add_library, this error appears in the project which tries to reuse the precompiled headers:
+# cmake_pch.hxx.gch: not used because `PrecompileVtkHeaders_EXPORTS' not defined [-Winvalid-pch]
+add_executable(${PROJECT_NAME} PrecompileVtkHeaders.cxx)
+target_link_libraries(${PROJECT_NAME} ${VTK_LIBRARIES})
+
+set(VTK_BUILD_DIR ${VTK_PREFIX_PATH})
+
+# Precompile only low level most common headers because header precompilation takes time
+set(precompiled_headers
+  "${VTK_SOURCE_DIR}/Charts/Core/vtkPlot.h"
+  "${VTK_SOURCE_DIR}/Charts/Core/vtkPlotLine.h"
+
+  "${VTK_SOURCE_DIR}/Common/Core/vtkBitArray.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkCallbackCommand.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkCollection.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkCommand.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkDataArray.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkDebugLeaks.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkDoubleArray.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkFloatArray.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkShortArray.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkSignedCharArray.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkUnsignedCharArray.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkUnsignedLongArray.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkInformation.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkInformationVector.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkIntArray.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkLookupTable.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkMath.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkMultiThreader.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkNew.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkObject.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkObjectFactory.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkPoints.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkSmartPointer.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkStdString.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkStringArray.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkVersion.h"
+  "${VTK_SOURCE_DIR}/Common/Core/vtkWeakPointer.h"
+
+  "${VTK_SOURCE_DIR}/Common/DataModel/vtkBoundingBox.h"
+  "${VTK_SOURCE_DIR}/Common/DataModel/vtkCell.h"
+  "${VTK_SOURCE_DIR}/Common/DataModel/vtkColor.h"
+  "${VTK_SOURCE_DIR}/Common/DataModel/vtkDataObject.h"
+  "${VTK_SOURCE_DIR}/Common/DataModel/vtkFieldData.h"
+  "${VTK_SOURCE_DIR}/Common/DataModel/vtkImageData.h"
+  "${VTK_SOURCE_DIR}/Common/DataModel/vtkPlane.h"
+  "${VTK_SOURCE_DIR}/Common/DataModel/vtkPlanes.h"
+  "${VTK_SOURCE_DIR}/Common/DataModel/vtkPointData.h"
+  "${VTK_SOURCE_DIR}/Common/DataModel/vtkPolyData.h"
+  "${VTK_SOURCE_DIR}/Common/DataModel/vtkTable.h"
+  "${VTK_SOURCE_DIR}/Common/DataModel/vtkUnstructuredGrid.h"
+  "${VTK_SOURCE_DIR}/Common/DataModel/vtkVector.h"
+  "${VTK_SOURCE_DIR}/Common/DataModel/vtkVoxel.h"
+
+  "${VTK_SOURCE_DIR}/Common/ExecutionModel/vtkAlgorithm.h"
+  "${VTK_SOURCE_DIR}/Common/ExecutionModel/vtkAlgorithmOutput.h"
+  "${VTK_SOURCE_DIR}/Common/ExecutionModel/vtkImageAlgorithm.h"
+  "${VTK_SOURCE_DIR}/Common/ExecutionModel/vtkStreamingDemandDrivenPipeline.h"
+  "${VTK_SOURCE_DIR}/Common/ExecutionModel/vtkTrivialProducer.h"
+
+  "${VTK_SOURCE_DIR}/Common/Math/vtkMatrix3x3.h"
+  "${VTK_SOURCE_DIR}/Common/Math/vtkMatrix4x4.h"
+
+  "${VTK_SOURCE_DIR}/Common/Misc/vtkErrorCode.h"
+
+  "${VTK_SOURCE_DIR}/Common/System/vtkTimerLog.h"
+
+  "${VTK_SOURCE_DIR}/Common/Transforms/vtkGeneralTransform.h"
+  "${VTK_SOURCE_DIR}/Common/Transforms/vtkHomogeneousTransform.h"
+  "${VTK_SOURCE_DIR}/Common/Transforms/vtkTransform.h"
+
+  "${VTK_SOURCE_DIR}/Filters/Core/vtkAppendPolyData.h"
+  "${VTK_SOURCE_DIR}/Filters/Core/vtkAssignAttribute.h"
+  "${VTK_SOURCE_DIR}/Filters/Core/vtkTriangleFilter.h"
+  "${VTK_SOURCE_DIR}/Filters/Core/vtkTubeFilter.h"
+
+  "${VTK_SOURCE_DIR}/Filters/Geometry/vtkGeometryFilter.h"
+
+  "${VTK_SOURCE_DIR}/Filters/Sources/vtkSphereSource.h"
+
+  "${VTK_SOURCE_DIR}/Imaging/Core/vtkImageAppendComponents.h"
+  "${VTK_SOURCE_DIR}/Imaging/Core/vtkImageCast.h"
+  "${VTK_SOURCE_DIR}/Imaging/Core/vtkImageChangeInformation.h"
+  "${VTK_SOURCE_DIR}/Imaging/Core/vtkImageConstantPad.h"
+  "${VTK_SOURCE_DIR}/Imaging/Core/vtkImageExtractComponents.h"
+  "${VTK_SOURCE_DIR}/Imaging/Core/vtkImageReslice.h"
+  "${VTK_SOURCE_DIR}/Imaging/Core/vtkImageThreshold.h"
+
+  "${VTK_SOURCE_DIR}/Imaging/Math/vtkImageMathematics.h"
+
+  "${VTK_SOURCE_DIR}/Imaging/Statistics/vtkImageAccumulate.h"
+
+  "${VTK_SOURCE_DIR}/Imaging/Stencil/vtkImageStencil.h"
+
+  "${VTK_SOURCE_DIR}/IO/Image/vtkPNGWriter.h"
+
+  "${VTK_SOURCE_DIR}/Rendering/Core/vtkActor.h"
+  "${VTK_SOURCE_DIR}/Rendering/Core/vtkActor2D.h"
+  "${VTK_SOURCE_DIR}/Rendering/Core/vtkCamera.h"
+  "${VTK_SOURCE_DIR}/Rendering/Core/vtkColorTransferFunction.h"
+  "${VTK_SOURCE_DIR}/Rendering/Core/vtkImageMapper.h"
+  "${VTK_SOURCE_DIR}/Rendering/Core/vtkImageMapper3D.h"
+  "${VTK_SOURCE_DIR}/Rendering/Core/vtkProperty.h"
+  "${VTK_SOURCE_DIR}/Rendering/Core/vtkProperty2D.h"
+  "${VTK_SOURCE_DIR}/Rendering/Core/vtkRenderer.h"
+  "${VTK_SOURCE_DIR}/Rendering/Core/vtkRenderWindow.h"
+  "${VTK_SOURCE_DIR}/Rendering/Core/vtkTextProperty.h"
+
+  "${VTK_SOURCE_DIR}/Utilities/Python/vtkPython.h"
+
+  "${VTK_SOURCE_DIR}/Wrapping/PythonCore/vtkPythonUtil.h"
+
+  "${VTK_BUILD_DIR}/Utilities/KWSys/vtksys/Directory.hxx"
+  "${VTK_BUILD_DIR}/Utilities/KWSys/vtksys/RegularExpression.hxx"
+  "${VTK_BUILD_DIR}/Utilities/KWSys/vtksys/SystemTools.hxx"
+  )
+
+target_precompile_headers(${PROJECT_NAME} PUBLIC ${precompiled_headers})

--- a/Libs/PrecompileVtkHeaders/PrecompileVtkHeaders.cxx
+++ b/Libs/PrecompileVtkHeaders/PrecompileVtkHeaders.cxx
@@ -1,0 +1,4 @@
+//Empty main just to create a target
+int main() {
+  return 0;
+}

--- a/Libs/RemoteIO/CMakeLists.txt
+++ b/Libs/RemoteIO/CMakeLists.txt
@@ -103,6 +103,8 @@ if(Slicer_USE_PYTHONQT_WITH_OPENSSL)
 endif()
 target_link_libraries(${lib_name} ${libs})
 
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileVtkHeaders)
+
 # Apply user-defined properties to the library target.
 if(Slicer_LIBRARY_PROPERTIES)
   set_target_properties(${lib_name} PROPERTIES ${Slicer_LIBRARY_PROPERTIES})

--- a/Libs/vtkITK/CMakeLists.txt
+++ b/Libs/vtkITK/CMakeLists.txt
@@ -168,6 +168,9 @@ set(libs
   )
 target_link_libraries(${lib_name} ${libs})
 
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileItkHeaders)
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileVtkHeaders)
+
 # Apply user-defined properties to the library target.
 if(Slicer_LIBRARY_PROPERTIES)
   set_target_properties(${lib_name} PROPERTIES ${Slicer_LIBRARY_PROPERTIES})
@@ -222,6 +225,8 @@ if(VTK_WRAP_PYTHON)
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${lib_name}Python PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    target_precompile_headers(${lib_name}Python REUSE_FROM PrecompileItkHeaders)
+    target_precompile_headers(${lib_name}Python REUSE_FROM PrecompileVtkHeaders)
     if(TARGET ${lib_name}Hierarchy)
       set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()

--- a/Libs/vtkSegmentationCore/CMakeLists.txt
+++ b/Libs/vtkSegmentationCore/CMakeLists.txt
@@ -113,6 +113,8 @@ include_directories( ${vtkSegmentationCore_INCLUDE_DIRS} )
 add_library(${PROJECT_NAME} ${vtkSegmentationCore_SRCS})
 target_link_libraries( ${PROJECT_NAME} ${vtkSegmentationCore_LIBS} )
 
+target_precompile_headers(${PROJECT_NAME} REUSE_FROM PrecompileVtkHeaders)
+
 if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND NOT WIN32)
   set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-fPIC")
 endif()
@@ -178,6 +180,7 @@ if(VTK_WRAP_PYTHON AND BUILD_SHARED_LIBS)
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${PROJECT_NAME}Python PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    target_precompile_headers(${PROJECT_NAME}Python REUSE_FROM PrecompileVtkHeaders)
     if(TARGET ${PROJECT_NAME}Hierarchy)
       set_target_properties(${PROJECT_NAME}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()

--- a/Libs/vtkTeem/CMakeLists.txt
+++ b/Libs/vtkTeem/CMakeLists.txt
@@ -103,6 +103,9 @@ set(libs
   )
 target_link_libraries(${lib_name} ${libs})
 
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileItkHeaders)
+target_precompile_headers(${lib_name} REUSE_FROM PrecompileVtkHeaders)
+
 # Apply user-defined properties to the library target.
 if(Slicer_LIBRARY_PROPERTIES)
   set_target_properties(${lib_name} PROPERTIES ${Slicer_LIBRARY_PROPERTIES})
@@ -159,6 +162,8 @@ if(VTK_WRAP_PYTHON)
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${lib_name}Python PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    target_precompile_headers(${lib_name}Python REUSE_FROM PrecompileItkHeaders)
+    target_precompile_headers(${lib_name}Python REUSE_FROM PrecompileVtkHeaders)
     if(TARGET ${lib_name}Hierarchy)
       set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()


### PR DESCRIPTION
COMP: Speed up Linux compilation by using precompiled headers

This branch was only tested on Linux Ubuntu 22.04 LTS.

It is quite easy to speed up compilation in Libs and Base thanks to
vtk, itk and qt precompiled headers.

Build test done:
- DBUILD_TESTING=OFF cmake option
- with 12 jobs for the 12 cores of my intel i7 CPU
- commands:
  cd build-dir/Slicer-Build/Libs && make clean && make -j12
  cd build-dir/Slicer-Build/Base && make clean && make -j12

Build times:
  Libs:
    without precompiled headers: 44m 28s
    with precompiled headers: 18m9s

  Base :
    without precompiled headers: 10m 35s
    with precompiled headers: 2m 54s

This branch is simply a proposal to show the benefits of precompiled headers,
do not hesitate to ask questions and propose better code.

Precompiled headers are harder to use in Modules because the target library
 and the source binary must use the same compilation flags (for instance *_EXPORTS flag must be the same)
