### PR TITLE
BUG: Fix translation of Python modules

### DIFF
--- a/Base/Python/slicer/i18n.py
+++ b/Base/Python/slicer/i18n.py
@@ -77,7 +77,7 @@ def tr(text):
 
     # inspect.stack() would get all the frames, which can take more than 100ms, therefore we use lower level APIs
     frame = inspect.currentframe()
-    frame.f_back  # go up in the stack one level
+    frame = frame.f_back  # go up in the stack one level
     filename = inspect.getsourcefile(frame) or inspect.getfile(frame)
 
     contextName = getContext(filename)


### PR DESCRIPTION
Context was determined incorrectly due to a recent optimization of translation speed.

fixes https://github.com/Slicer/SlicerLanguagePacks/issues/78 fixes https://github.com/Slicer/SlicerLanguagePacks/issues/79