### PR TITLE
DOC: Add scriptedregistration.md with an example rigid registration

### DIFF
--- a/Docs/developer_guide/script_repository.md
+++ b/Docs/developer_guide/script_repository.md
@@ -38,6 +38,9 @@ The Slicer source code has Python [scripted modules](https://github.com/Slicer/S
 ```{include} script_repository/segmentations.md
 ```
 
+```{include} script_repository/registration.md
+```
+
 ```{include} script_repository/sequences.md
 ```
 

--- a/Docs/developer_guide/script_repository/registration.md
+++ b/Docs/developer_guide/script_repository/registration.md
@@ -1,0 +1,34 @@
+## Registration
+
+### Register two images with BRAINSFit
+
+Register two brain MRI images of the same patient acquired at different timepoints using BRAINSFit ("General registration (BRAINS)" module).
+
+```python
+# Get sample input data
+import SampleData
+sampleDataLogic = SampleData.SampleDataLogic()
+fixedVolumeNode = sampleDataLogic.downloadMRBrainTumor1()
+movingVolumeNode = sampleDataLogic.downloadMRBrainTumor2()
+# Create new nodes for output
+transformedMovingVolumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode")
+transformNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTransformNode")
+
+# Run registration
+parameters = {}
+parameters["fixedVolume"] = fixedVolumeNode.GetID()
+parameters["movingVolume"] = movingVolumeNode.GetID()
+parameters["outputVolume"] = transformedMovingVolumeNode.GetID()
+parameters["linearTransform"] = transformNode.GetID()
+parameters["useRigid"] = True  # options include: "useRigid", "useAffine", "useBSpline"
+parameters["initializeTransformMode"] = "useGeometryAlign"
+parameters["samplingPercentage"] = 0.02
+cliBrainsFitRigidNode = slicer.cli.run(slicer.modules.brainsfit, None, parameters, wait_for_completion=True)
+
+# Display fused result. Computed transformNode is automatically applied to the movingVolumeNode.
+# Ctrl + left-click-and-drag up/down to change opacity in slice views.
+slicer.util.setSliceViewerLayers(fixedVolumeNode, movingVolumeNode, foregroundOpacity=0.5)
+```
+
+All parameters for BRAINSFit can be found [here](https://github.com/BRAINSia/BRAINSTools/blob/main/BRAINSFit/BRAINSFit.xml).
+The module can register any kind of images, not just brains, but for general-purpose registration extensions consider using more robust registration tools, such as SlicerElastix and SlicerANTs extensions.

--- a/Docs/user_guide/modules/index.md
+++ b/Docs/user_guide/modules/index.md
@@ -51,6 +51,7 @@ fiducialregistration.md
 landmarkregistration.md
 performmetrictest.md
 reformat.md
+scriptedregistration.md
 ```
 
 ## Segmentation


### PR DESCRIPTION
I realized there were no examples of (image) registration in the script repository, so I thought it would be helpful to create a section and add examples of scripting registrations.