### PR TITLE
BUG: Fix reading of markup point position from integer value

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonElement.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonElement.cxx
@@ -71,7 +71,7 @@ bool vtkMRMLMarkupsJsonElement::vtkInternal::ReadVector(rapidjson::Value& item, 
   bool success = true;
   for (int i = 0; i < numberOfComponents; i++)
   {
-    if (!item[i].IsDouble())
+    if (!item[i].IsNumber())
     {
       success = false;
       continue;
@@ -142,7 +142,7 @@ bool vtkMRMLMarkupsJsonElement::GetDoubleProperty(const char* propertyName, doub
   {
     return false;
   }
-  if (!this->Internal->JsonValue[propertyName].IsDouble())
+  if (!this->Internal->JsonValue[propertyName].IsNumber())
   {
     return false;
   }
@@ -157,7 +157,7 @@ double vtkMRMLMarkupsJsonElement::GetDoubleProperty(const char* propertyName)
   {
     return 0.0;
   }
-  if (!this->Internal->JsonValue[propertyName].IsDouble())
+  if (!this->Internal->JsonValue[propertyName].IsNumber())
   {
     return 0.0;
   }
@@ -439,7 +439,7 @@ vtkDoubleArray* vtkMRMLMarkupsJsonElement::GetDoubleArrayProperty(const char* pr
     return nullptr;
   }
   rapidjson::Value& firstControlPointValue = arrayItem.GetArray()[0];
-  if (firstControlPointValue.IsDouble())
+  if (firstControlPointValue.IsNumber())
   {
     values->SetNumberOfValues(numberOfTuples);
     double* valuesPtr = values->GetPointer(0);

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -1652,7 +1652,7 @@ void vtkSlicerVolumesLogic::InitializeDefaultVolumeDisplayPresets()
       vtkErrorMacro(<< errorPrefix << " Error reading preset " << presetIndex << ". Missing required property name, id, window, level, or color.");
       continue;
     }
-    if (!preset["name"].IsString() || !preset["id"].IsString() || !preset["window"].IsDouble() || !preset["level"].IsDouble())
+    if (!preset["name"].IsString() || !preset["id"].IsString() || !preset["window"].IsNumber() || !preset["level"].IsNumber())
     {
       vtkErrorMacro(<< errorPrefix << " Error reading preset " << presetIndex << ". Wrong type for property name, id, window, or level.");
       continue;
@@ -1663,7 +1663,7 @@ void vtkSlicerVolumesLogic::InitializeDefaultVolumeDisplayPresets()
     presetObj.level = preset["level"].GetDouble();
     presetObj.window = preset["window"].GetDouble();
     presetObj.valid = true;
-    if (!preset["name"].IsString() || !preset["id"].IsString() || !preset["window"].IsDouble() || !preset["level"].IsDouble() || !preset["color"].IsString())
+    if (!preset["name"].IsString() || !preset["id"].IsString() || !preset["window"].IsNumber() || !preset["level"].IsNumber() || !preset["color"].IsString())
     {
       vtkErrorMacro(<< errorPrefix << " Error reading preset " << presetIndex << ". Wrong type for property name, id, window, or level.");
       continue;


### PR DESCRIPTION
When markup point position was defined as an integer (0) instead of float (0.0) the markup reader rejected the position value. The problem was that the code only accepted double type. Fixed by accepting any numeric type.

Fixes issue reported at https://discourse.slicer.org/t/one-control-point-out-of-many-is-read-incorrectly-into-slicer/38369
