### PR TITLE
ENH: Improve and Customize URI Argument Handling for Custom Applications

### DIFF
--- a/Applications/SlicerApp/Main.cxx
+++ b/Applications/SlicerApp/Main.cxx
@@ -47,6 +47,8 @@ int SlicerAppMain(int argc, char* argv[])
   QScopedPointer<SlicerMainWindowType> window;
   QScopedPointer<QSplashScreen> splashScreen;
 
+  app.setURIArgumentHandlingEnabled(true);
+
   int exitCode = qSlicerApplicationHelper::postInitializeApplication<SlicerMainWindowType>(
         app, splashScreen, window);
   if (exitCode != 0)

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -211,6 +211,7 @@ qSlicerCoreApplicationPrivate::qSlicerCoreApplicationPrivate(
   this->RevisionUserSettings = nullptr;
   this->ReturnCode = qSlicerCoreApplication::ExitNotRequested;
   this->CoreCommandOptions = QSharedPointer<qSlicerCoreCommandOptions>(coreCommandOptions);
+  this->URIArgumentHandlingEnabled = true;
   this->CoreIOManager = QSharedPointer<qSlicerCoreIOManager>(coreIOManager);
 #ifdef Slicer_BUILD_DICOM_SUPPORT
   this->DICOMDatabase = QSharedPointer<ctkDICOMDatabase>(new ctkDICOMDatabase);
@@ -1173,14 +1174,21 @@ void qSlicerCoreApplication::handleURIArguments(const QStringList& fileNames)
 }
 
 //-----------------------------------------------------------------------------
+CTK_GET_CPP(qSlicerCoreApplication, bool, isURIArgumentHandlingEnabled, URIArgumentHandlingEnabled);
+CTK_SET_CPP(qSlicerCoreApplication, bool, setURIArgumentHandlingEnabled, URIArgumentHandlingEnabled);
+
+//-----------------------------------------------------------------------------
 void qSlicerCoreApplication::handleCommandLineArguments()
 {
+  Q_D(qSlicerCoreApplication);
+
   qSlicerCoreCommandOptions* options = this->coreCommandOptions();
 
   QStringList unparsedArguments = options->unparsedArguments();
   if (unparsedArguments.length() > 0 &&
       options->pythonScript().isEmpty() &&
-      options->extraPythonScript().isEmpty())
+      options->extraPythonScript().isEmpty() &&
+      d->URIArgumentHandlingEnabled)
   {
     this->handleURIArguments(unparsedArguments);
   }

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -611,6 +611,17 @@ public:
   /// After processing the URLs, the remaining file paths are loaded using loadFiles().
   Q_INVOKABLE void handleURIArguments(const QStringList& fileNames);
 
+  ///@{
+  /// Set/Get if post-startup default handling of URI arguments is enabled.
+  ///
+  /// When enabled, the function `handleURIArguments()` will process command-line
+  /// arguments automatically post-startup.
+  ///
+  /// \sa handleURIArguments()
+  bool isURIArgumentHandlingEnabled() const;
+  void setURIArgumentHandlingEnabled(bool enabled);
+  ///}@
+
 public slots:
 
   /// Restart the application with the arguments passed at startup time

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -604,6 +604,13 @@ public:
   /// If returns false then calling `logUsageEvent` method has no effect.
   bool isUsageLoggingSupported() const;
 
+  /// Processes command line arguments specified as file paths or URLs.
+  ///
+  /// This function iterates through the provided list of URIs.
+  /// For each URL in the list, the signal urlReceived() is emitted.
+  /// After processing the URLs, the remaining file paths are loaded using loadFiles().
+  Q_INVOKABLE void handleURIArguments(const QStringList& fileNames);
+
 public slots:
 
   /// Restart the application with the arguments passed at startup time

--- a/Base/QTCore/qSlicerCoreApplication_p.h
+++ b/Base/QTCore/qSlicerCoreApplication_p.h
@@ -168,6 +168,9 @@ public:
   /// CoreCommandOptions - It should exist only one instance of the CoreCommandOptions
   QSharedPointer<qSlicerCoreCommandOptions>   CoreCommandOptions;
 
+  /// Post-startup default handling of URI arguments
+  bool URIArgumentHandlingEnabled;
+
   /// ErrorLogModel - It should exist only one instance of the ErrorLogModel
   QSharedPointer<ctkErrorLogAbstractModel> ErrorLogModel;
 


### PR DESCRIPTION
Introduces two enhancements to streamline and customize how URI arguments are handled in custom Slicer applications:

* Add `qSlicerCoreApplication::handleURIArguments`.
* Add the ability to enable or disable post-startup URI argument handling.
