### PR TITLE
BUG: Fix sitkUtils without MRMLIDImageIO

### DIFF
--- a/Base/Python/sitkUtils.py
+++ b/Base/Python/sitkUtils.py
@@ -1,5 +1,5 @@
 import SimpleITK as sitk
-
+import os
 import slicer
 
 __sitk__MRMLIDImageIO_Missing_Reported__ = False

--- a/Base/Python/tests/test_sitkUtils.py
+++ b/Base/Python/tests/test_sitkUtils.py
@@ -2,13 +2,21 @@ import slicer
 import sitkUtils as su
 
 import unittest
+import unittest.mock
 
 
 class SitkUtilsTests(unittest.TestCase):
     def setUp(self):
         pass
 
-    def test_SimpleITK_SlicerPushPull(self):
+    def test_SimpleITK_SlicerPushPullWithMRMLIDImageIO(self):
+        self._test_SimpleITK_SlicerPushPull()
+
+    def test_SimpleITK_SlicerPushPullWithoutMRMLIDImageIO(self):
+        with unittest.mock.patch.object(su, "IsMRMLIDImageIOAvailable", return_value=False):
+            self._test_SimpleITK_SlicerPushPull()
+
+    def _test_SimpleITK_SlicerPushPull(self):
         """Download the MRHead node"""
         import SampleData
 


### PR DESCRIPTION
A fallback mechanism was implemented to keep sitkUtils functional when Slicer's SimpleITK is replaced by a stock SimpleITK (that does not have MRMLIDImageIO). However, this mechanism did not work due to a missing import.

The missing import has been added and a test is now added to check that sitkUtils works with and without MRMLIDImageIO.

fixes #7902