### PR TITLE
BUG: Remove unneeded display of ignored arguments 

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -1116,7 +1116,6 @@ void qSlicerCoreApplication::handlePreApplicationCommandLineArguments()
   if (options->ignoreRest())
   {
     qDebug() << "Ignored arguments:" << options->unparsedArguments();
-    return;
   }
 
   if (!options->settingsDisabled() && options->keepTemporarySettings())

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -1113,11 +1113,6 @@ void qSlicerCoreApplication::handlePreApplicationCommandLineArguments()
     d->quickExit(EXIT_SUCCESS);
   }
 
-  if (options->ignoreRest())
-  {
-    qDebug() << "Ignored arguments:" << options->unparsedArguments();
-  }
-
   if (!options->settingsDisabled() && options->keepTemporarySettings())
   {
     this->showConsoleMessage("Argument '--keep-temporary-settings' requires "


### PR DESCRIPTION
Unparsed arguments may be processed after the application startup (e.g., in scripts or custom applications). Always displaying the list of ignored arguments introduces unnecessary noise in the logs.

Related issues and pull requests:
* https://github.com/Slicer/Slicer/pull/7938
* https://github.com/Slicer/Slicer/issues/7936