### PR TITLE
BUG: Fix editing of transform component values in spinbox

### DIFF
--- a/Libs/MRML/Widgets/qMRMLTransformSliders.cxx
+++ b/Libs/MRML/Widgets/qMRMLTransformSliders.cxx
@@ -458,19 +458,19 @@ void qMRMLTransformSliders::resetUnactiveSliders()
 {
   Q_D(qMRMLTransformSliders);
 
-  if (!d->ActiveSliders.contains(d->LRSlider))
+  if (!d->ActiveSliders.contains(d->LRSlider) && !d->LRSlider->isSettingValueFromSpinBox())
   {
     bool blocked = d->LRSlider->blockSignals(true);
     d->LRSlider->reset();
     d->LRSlider->blockSignals(blocked);
   }
-  if (!d->ActiveSliders.contains(d->PASlider))
+  if (!d->ActiveSliders.contains(d->PASlider) && !d->PASlider->isSettingValueFromSpinBox())
   {
     bool blocked = d->PASlider->blockSignals(true);
     d->PASlider->reset();
     d->PASlider->blockSignals(blocked);
   }
-  if (!d->ActiveSliders.contains(d->ISSlider))
+  if (!d->ActiveSliders.contains(d->ISSlider) && !d->ISSlider->isSettingValueFromSpinBox())
   {
     bool blocked = d->ISSlider->blockSignals(true);
     d->ISSlider->reset();

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "627842c05f262650bf50ff33f8fd31c7f330349a"
+    "76e21221f81a4483d58f99a4d63d76f13718fb57"
     QUIET
     )
 


### PR DESCRIPTION
In Transforms module, when rotate-first mode was enabled and edited translation components and the number of digits changed, the value that was being edited was reset. The problem was that when number of digits change then sibling widgets get a notification and they update their number of digits, too, which results in value change, which leads to resetting of all values (including the one that is being edited). Fixed by preventing resetting of the slider+spinbox for the axis that is being edited using the spinbox.

fixes #7574

---

<del>Draft pull request because it requires merging of https://github.com/commontk/CTK/pull/1219</del>
required CTK update was merged and git hash is updated in this pull request