### PR TITLE
ENH: Re-introduce logging of unparsed arguments to log file only

### DIFF
--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -717,6 +717,14 @@ void qSlicerApplication::handleCommandLineArguments()
     this->errorLogModel()->disableAllMsgHandler();
   }
 
+  if (options->ignoreRest() || !options->unparsedArguments().isEmpty())
+  {
+    qSlicerScopedTerminalOutputSettings currentTerminalOutputSettings(
+      this->errorLogModel(), ctkErrorLogTerminalOutput::None);
+
+    qDebug() << "Ignored arguments:" << options->unparsedArguments();
+  }
+
   this->Superclass::handleCommandLineArguments();
 
   this->setToolTipsEnabled(!options->disableToolTips());

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -185,14 +185,23 @@ struct qSlicerScopedTerminalOutputSettings
       const ctkErrorLogTerminalOutput::TerminalOutputs& terminalOutputs):
     ErrorLogModel(errorLogModel)
   {
+    if (errorLogModel == nullptr)
+    {
+      qWarning() << Q_FUNC_INFO << " failed: errorLogModel is invalid";
+      return;
+    }
     this->Saved = errorLogModel->terminalOutputs();
     errorLogModel->setTerminalOutputs(terminalOutputs);
   }
   ~qSlicerScopedTerminalOutputSettings()
   {
+    if (this->ErrorLogModel == nullptr)
+    {
+      return;
+    }
     this->ErrorLogModel->setTerminalOutputs(this->Saved);
   }
-  ctkErrorLogAbstractModel* ErrorLogModel;
+  ctkErrorLogAbstractModel* ErrorLogModel{nullptr};
   ctkErrorLogTerminalOutput::TerminalOutputs Saved;
 };
 

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -174,6 +174,29 @@ protected:
 };
 #endif
 
+namespace
+{
+
+// --------------------------------------------------------------------------
+struct qSlicerScopedTerminalOutputSettings
+{
+  qSlicerScopedTerminalOutputSettings(
+      ctkErrorLogAbstractModel* errorLogModel,
+      const ctkErrorLogTerminalOutput::TerminalOutputs& terminalOutputs):
+    ErrorLogModel(errorLogModel)
+  {
+    this->Saved = errorLogModel->terminalOutputs();
+    errorLogModel->setTerminalOutputs(terminalOutputs);
+  }
+  ~qSlicerScopedTerminalOutputSettings()
+  {
+    this->ErrorLogModel->setTerminalOutputs(this->Saved);
+  }
+  ctkErrorLogAbstractModel* ErrorLogModel;
+  ctkErrorLogTerminalOutput::TerminalOutputs Saved;
+};
+
+}
 
 //-----------------------------------------------------------------------------
 class qSlicerApplicationPrivate : public qSlicerCoreApplicationPrivate
@@ -1054,30 +1077,6 @@ void qSlicerApplication::setupFileLogging()
 
   // Set current log file path
   d->ErrorLogModel->setFilePath(currentLogFilePath);
-}
-
-namespace
-{
-
-// --------------------------------------------------------------------------
-struct qSlicerScopedTerminalOutputSettings
-{
-  qSlicerScopedTerminalOutputSettings(
-      ctkErrorLogAbstractModel* errorLogModel,
-      const ctkErrorLogTerminalOutput::TerminalOutputs& terminalOutputs):
-    ErrorLogModel(errorLogModel)
-  {
-    this->Saved = errorLogModel->terminalOutputs();
-    errorLogModel->setTerminalOutputs(terminalOutputs);
-  }
-  ~qSlicerScopedTerminalOutputSettings()
-  {
-    this->ErrorLogModel->setTerminalOutputs(this->Saved);
-  }
-  ctkErrorLogAbstractModel* ErrorLogModel;
-  ctkErrorLogTerminalOutput::TerminalOutputs Saved;
-};
-
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Reintroduces the logging of unparsed command-line arguments, now restricted to the log file as debug entries. This allows developers to access the information for debugging purposes without cluttering the terminal output.

Related pull requests:
* https://github.com/Slicer/Slicer/pull/7941