### PR TITLE
BUG: Skip "CI (Build)" workflow if any SuperBuild changes on "nightly-main"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      # Filter paths to determine whether to proceed with the build
+      - name: "Filter Paths"
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
         with:
           filters: |
@@ -37,13 +39,15 @@ jobs:
               - "Testing/**"
               - "CMakeLists.txt"
 
+      # Build Slicer if relevant paths were changed
       - name: "Build Slicer"
         id: slicer-build
         if: steps.changes.outputs.paths-to-include == 'true'
         uses: ./.github/actions/slicer-build
 
+      # Upload the Slicer package artifact if the build was successful
       - name: "Upload Slicer package"
-        if: steps.changes.outputs.paths-to-include == 'true'
+        if: ${{ steps.slicer-build.outcome == 'success' }}
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: slicer-package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,40 @@ jobs:
               - "Testing/**"
               - "CMakeLists.txt"
 
-      # Build Slicer if relevant paths were changed
+      # Retrieve changes in SuperBuild-related files relative to the 'nightly-main' branch
+      - name: "Detect SuperBuild Changes"
+        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45.0.2
+        id: superbuild-changes
+        with:
+          files: |
+            SuperBuild/External_*
+          base_sha: nightly-main
+
+      # List any SuperBuild files that were changed
+      - name: "List Changed SuperBuild Files"
+        if: steps.superbuild-changes.outputs.any_changed == 'true'
+        run: |
+          echo "Changed files:"
+          for file in ${ALL_CHANGED_FILES}; do
+            echo " $file"
+          done
+        env:
+          ALL_CHANGED_FILES: ${{ steps.superbuild-changes.outputs.all_changed_files }}
+
+      # Check prerequisites for the build
+      - name: "Check Prerequisites"
+        id: check-prereqisities
+        run: |
+          if [[ $SUPERBUILD_CHANGED == "true" ]]; then
+            echo "::warning ::Skipping Slicer build due to changes in SuperBuild files relative to 'nightly-main' branch."
+          fi
+        env:
+          SUPERBUILD_CHANGED: ${{ steps.superbuild-changes.outputs.any_changed }}
+
+      # Build Slicer if relevant paths were changed and no SuperBuild changes were detected
       - name: "Build Slicer"
         id: slicer-build
-        if: steps.changes.outputs.paths-to-include == 'true'
+        if: ${{ steps.changes.outputs.paths-to-include == 'true' && steps.superbuild-changes.outputs.any_changed == 'false' }}
         uses: ./.github/actions/slicer-build
 
       # Upload the Slicer package artifact if the build was successful


### PR DESCRIPTION
Skip the "CI (Build)" workflow if changes to `External_*.cmake` files are detected since the last Preview build. Pull request builds likely require an updated Docker image, which provides external dependencies, and building with outdated dependencies could lead to failures. To avoid this, the CI build is skipped when SuperBuild file changes may require an updated image.

Additionally, since the GitHub action `dorny/paths-filter` does not suppor specifying the `base` input for pull request events, we replaced it with the `tj-actions/changed-files` action. This resolves the warning:

> 'base' input parameter is ignored when action is triggered by pull request event"

Follow-up of https://github.com/Slicer/Slicer/pull/7942#issuecomment-2359422820