### PR TITLE
Control the amount of console output of the python web proxy.

### DIFF
--- a/Base/QTGUI/qSlicerWebPythonProxy.cxx
+++ b/Base/QTGUI/qSlicerWebPythonProxy.cxx
@@ -31,24 +31,24 @@
 # include "qSlicerPythonManager.h"
 #endif
 #include "qSlicerWebPythonProxy.h"
+#include "qSlicerWebPythonProxy_p.h"
+
+//------------------------------------------------------------------------------
+qSlicerWebPythonProxyPrivate::~qSlicerWebPythonProxyPrivate() = default;
+
+CTK_GET_CPP(qSlicerWebPythonProxy, bool, verbose, Verbose);
+CTK_SET_CPP(qSlicerWebPythonProxy, bool, setVerbose, Verbose);
 
 // --------------------------------------------------------------------------
-qSlicerWebPythonProxy::qSlicerWebPythonProxy(QObject *parent)
-  : QObject(parent)
-{
-  this->pythonEvaluationAllowed = false;
-}
-
-// --------------------------------------------------------------------------
-bool qSlicerWebPythonProxy::isPythonEvaluationAllowed()
+bool qSlicerWebPythonProxyPrivate::isPythonEvaluationAllowed()
 {
 #ifdef Slicer_USE_PYTHONQT
-  if (this->pythonEvaluationAllowed)
+  if (this->PythonEvaluationAllowed)
   {
     return true;
   }
 
-  qSlicerCoreApplication * app = qSlicerCoreApplication::application();
+  qSlicerCoreApplication* app = qSlicerCoreApplication::application();
   if (!app || qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))
   {
     return false;
@@ -56,11 +56,11 @@ bool qSlicerWebPythonProxy::isPythonEvaluationAllowed()
 
   ctkMessageBox* confirmationBox = new ctkMessageBox(qSlicerApplication::application()->mainWindow());
   confirmationBox->setAttribute(Qt::WA_DeleteOnClose);
-  confirmationBox->setWindowTitle(tr("Allow Python execution?"));
-  confirmationBox->setText(tr("Allow the web page to execute code using Slicer's python?"));
+  confirmationBox->setWindowTitle(qSlicerWebPythonProxy::tr("Allow Python execution?"));
+  confirmationBox->setText(qSlicerWebPythonProxy::tr("Allow the web page to execute code using Slicer's python?"));
 
-  confirmationBox->addButton(tr("Allow"), QMessageBox::AcceptRole);
-  confirmationBox->addButton(tr("Reject"), QMessageBox::RejectRole);
+  confirmationBox->addButton(qSlicerWebPythonProxy::tr("Allow"), QMessageBox::AcceptRole);
+  confirmationBox->addButton(qSlicerWebPythonProxy::tr("Reject"), QMessageBox::RejectRole);
 
   confirmationBox->setDontShowAgainVisible(true);
   confirmationBox->setDontShowAgainSettingsKey("WebEngine/AllowPythonExecution");
@@ -69,15 +69,33 @@ bool qSlicerWebPythonProxy::isPythonEvaluationAllowed()
 
   if (resultCode == QMessageBox::AcceptRole)
   {
-    this->pythonEvaluationAllowed = true;
+    this->PythonEvaluationAllowed = true;
   }
 #endif
-  return this->pythonEvaluationAllowed;
+  return this->PythonEvaluationAllowed;
 }
+
+//------------------------------------------------------------------------------
+qSlicerWebPythonProxy::qSlicerWebPythonProxy(QObject* parent)
+  : Superclass(parent)
+  , d_ptr(new qSlicerWebPythonProxyPrivate)
+{
+}
+
+//------------------------------------------------------------------------------
+qSlicerWebPythonProxy::qSlicerWebPythonProxy(qSlicerWebPythonProxyPrivate* pimpl)
+  : d_ptr(pimpl)
+{
+}
+
+//------------------------------------------------------------------------------
+qSlicerWebPythonProxy::~qSlicerWebPythonProxy() = default;
 
 // --------------------------------------------------------------------------
 QString qSlicerWebPythonProxy::evalPython(const QString &python, int mode)
 {
+  Q_D(qSlicerWebPythonProxy);
+
   ctkAbstractPythonManager::ExecuteStringMode executeStringMode{ctkAbstractPythonManager::FileInput};
   switch (mode)
   {
@@ -97,11 +115,14 @@ QString qSlicerWebPythonProxy::evalPython(const QString &python, int mode)
 
   QString result;
 #ifdef Slicer_USE_PYTHONQT
-  if (this->isPythonEvaluationAllowed())
+  if (d->isPythonEvaluationAllowed())
   {
     qSlicerPythonManager *pythonManager = qSlicerApplication::application()->pythonManager();
     result = pythonManager->executeString(python, executeStringMode).toString();
-    qDebug() << "Running " << python << " result is " << result;
+    if (this->verbose())
+    {
+      qDebug() << "Running " << python << " result is " << result;
+    }
   }
 #else
   Q_UNUSED(python);

--- a/Base/QTGUI/qSlicerWebPythonProxy.h
+++ b/Base/QTGUI/qSlicerWebPythonProxy.h
@@ -27,16 +27,20 @@
 // QtGUI includes
 #include "qSlicerBaseQTGUIExport.h"
 
+class qSlicerWebPythonProxyPrivate;
 
 class Q_SLICER_BASE_QTGUI_EXPORT qSlicerWebPythonProxy
   : public QObject
 {
   Q_OBJECT
+  Q_PROPERTY(bool verbose READ verbose WRITE setVerbose)
 
 public:
+  typedef QObject Superclass;
 
   /// Constructor
   explicit qSlicerWebPythonProxy(QObject *parent = nullptr);
+  virtual ~qSlicerWebPythonProxy();
 
   /// This enum maps to ctkAbstractPythonManager execution modes Py_eval_input,
   /// Py_file_input and Py_single_input.
@@ -54,6 +58,10 @@ public:
     };
   Q_ENUMS(EvalPythonMode);
 
+  /// Enabled detailed logging during Python evaluation.
+  bool verbose() const;
+  void setVerbose(bool value);
+
 public slots:
 
   /// Convenient function to execute python code from
@@ -70,11 +78,13 @@ public slots:
   /// \sa qSlicerWebWidget::initializeWebEngineProfile
   QString evalPython(const QString &python, int mode = FileInput);
 
-private:
-  /// Keep track of user response to avoid going through ctk dialog to check
-  bool isPythonEvaluationAllowed();
-  bool pythonEvaluationAllowed;
+protected:
+  qSlicerWebPythonProxy(qSlicerWebPythonProxyPrivate* pimpl);
+  QScopedPointer<qSlicerWebPythonProxyPrivate> d_ptr;
 
+private:
+  Q_DECLARE_PRIVATE(qSlicerWebPythonProxy);
+  Q_DISABLE_COPY(qSlicerWebPythonProxy);
 };
 
 #endif

--- a/Base/QTGUI/qSlicerWebPythonProxy_p.h
+++ b/Base/QTGUI/qSlicerWebPythonProxy_p.h
@@ -1,0 +1,28 @@
+/*=auto=========================================================================
+
+  Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+=========================================================================auto=*/
+
+#ifndef __qSlicerWebPythonProxy_p_h
+#define __qSlicerWebPythonProxy_p_h
+
+#include "qSlicerBaseQTGUIExport.h"
+
+//------------------------------------------------------------------------------
+class Q_SLICER_BASE_QTGUI_EXPORT qSlicerWebPythonProxyPrivate
+{
+public:
+  virtual ~qSlicerWebPythonProxyPrivate();
+
+  /// Keep track of user response to avoid going through ctk dialog to check
+  bool isPythonEvaluationAllowed();
+
+  bool PythonEvaluationAllowed{ false };
+  bool Verbose{ false };
+};
+
+#endif


### PR DESCRIPTION
When using SlicerEditor, long messages are often logged in the terminal, these are helpful during debugging but not in release execution. Enable/disable this logging as needed.

https://github.com/SlicerMorph/SlicerEditor/issues/43