### PR TITLE
BUG: Fix GitHub workflow for daily updates to "nightly-main" branch

### DIFF
--- a/.github/workflows/update-slicer-preview-branch.yml
+++ b/.github/workflows/update-slicer-preview-branch.yml
@@ -29,21 +29,58 @@ permissions:
 
 jobs:
   update-slicer-preview-branch:
-    name: Update Slicer preview branch
+    permissions:
+      # Needed in publish step to update the preview branch
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: main
+          # The 'fetch-depth' option ensures that a sufficient number of commits are retrieved (250)
+          # to allow the "git rev-parse" command used below to accurately reference a commit based
+          # on time.
+          # This mitigates potential warnings that occur when there aren't enough commits fetched.
+          # We assume no more than 250 commits are made in a single day.
+          fetch-depth: 250
+
+      - name: Install time zone and daylight-saving time data
+        run: |
+          sudo apt-get -y install tzdata
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
+      - name: "Compute last preview build date"
+        id: preview
+        run: |
+          # Get the current hour in 24-hour format
+          current_hour=$(date +%H)
+          # Check if the current time is before or after 11 PM
+          if [ "$current_hour" -lt 23 ]; then
+            # If before 11 PM, return the date of the previous day
+            date=$(TZ=":US/Eastern" date -d "yesterday" +"%Y-%m-%d")
+          else
+            # If it's 11 PM or later, return today's date
+            date=$(TZ=":US/Eastern" date +"%Y-%m-%d")
+          fi
+          echo $date
+          echo "date=$date" >> $GITHUB_OUTPUT
 
       - name: "Convert dashboard start time from ET to UTC"
         id: convert
         run: |
-          time=$(TZ=":US/Eastern" date -d"23:00:00"  "+%H:%M:%S %z")
+          time=$(TZ=":US/Eastern" date -d"$DATE 23:00:00" "+%Y-%m-%d %H:%M:%S %z")
+          echo "time [$time]"
           echo "time=$time" >> $GITHUB_OUTPUT
+        env:
+          DATE: ${{ steps.preview.outputs.date }}
 
       - name: "Retrieve preview branch SHA"
         id: retrieve
         run: |
-          git rev-parse "main@{${TIME}}"
+          sha=$(TZ=":US/Eastern" git rev-list -1 --before="${TIME}" main)
+          echo "sha [$sha]"
+          echo "sha=$sha" >> $GITHUB_OUTPUT
         env:
           TIME: ${{ steps.convert.outputs.time }}
 
@@ -59,10 +96,10 @@ jobs:
             echo "::error ::Failed to retrieve SHA"
             exit 1
           fi
-          remote=https://${TOKEN}@github.com/${REPOSITORY}.git
-          git push $remote $SHA:${PREVIEW_BRANCH} --force
+          remote=https://${SLICERBOT_GITHUB_TOKEN}@github.com/${REPOSITORY}.git
+          git push $remote $SHA:refs/heads/${PREVIEW_BRANCH} --force
         env:
           SHA: ${{ steps.retrieve.outputs.sha }}
-          TOKEN: ${{ steps.app-token.outputs.token }}
+          SLICERBOT_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}
           PREVIEW_BRANCH: nightly-main


### PR DESCRIPTION
This commit fixes issues with the workflow intended to update the "nightly-main" branch daily. It incorporates changes that were originally intended in commit 656350456a ("ENH: Add GitHub workflow to update the 'nightly-main' branch daily", 2024-09-20).

While testing the initial version in the `add-update-preview-branch-workflow` branch, the branch was deliberately forced as the `main` branch in the `Slicer/jcfr` fork. This allowed testing the workflow in a near-final integration context. However, the pull request https://github.com/Slicer/Slicer/pull/7953 was mistakenly created from an out-of-date version of the `add-update-preview-branch-workflow` branch, which this follow-up commit addresses.

The confusion arose from the mistaken assumption that the original pull request[^2] had been fully tested. A comment in the pull request gave the impression that the manual testing had confirmed the workflow's correctness:

> The workflow was tested manually by running it in in `jcfr/Slicer`[^1] and
> I confirmed that the branch jcfr/Slicer@nightly-main branch was properly
> updated.
>
> [^1]: https://github.com/jcfr/Slicer/actions/workflows/update-slicer-preview-branch.yml

This commit resolves the issues and ensures proper daily updates of the "nightly-main" branch.

[^2]: https://github.com/Slicer/Slicer/pull/7953