### PR TITLE
BUG: Fix segmentation Show 3D button staying disabled

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -1195,6 +1195,7 @@ void qMRMLSegmentEditorWidget::updateWidgetFromMRML()
     d->MaskingGroupBox->setEnabled(false);
     d->EffectsOptionsFrame->setEnabled(false);
     d->SourceVolumeNodeComboBox->setEnabled(false);
+    d->Show3DButton->setLocked(true);
     return;
   }
   d->SegmentationNodeComboBox->setEnabled(true);

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationShow3DButton.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationShow3DButton.cxx
@@ -59,7 +59,6 @@ public:
 };
 
 //-----------------------------------------------------------------------------
-CTK_SET_CPP(qMRMLSegmentationShow3DButton, bool, setLocked, Locked);
 CTK_GET_CPP(qMRMLSegmentationShow3DButton, bool, locked, Locked);
 
 //-----------------------------------------------------------------------------
@@ -486,4 +485,12 @@ void qMRMLSegmentationShow3DButton::onSurfaceSmoothingFactorChanged(double newSm
     }
     d->setSurfaceSmoothingFactor(newSmoothingFactor);
   }
+}
+
+//---------------------------------------------------------------------------
+void qMRMLSegmentationShow3DButton::setLocked(bool locked)
+{
+  Q_D(qMRMLSegmentationShow3DButton);
+  d->Locked = locked;
+  this->updateWidgetFromMRML();
 }


### PR DESCRIPTION
"Show 3D" button enabled/disabled state was not updated immediately when the button's "locked" state was updated. The problem was that only a member variable was set, but the button update was not triggered.

fixes https://github.com/Project-MONAI/MONAILabel/issues/1624