### PR TITLE
BUG: Fix GitHub workflow authentication for "Update Preview Branch"

### DIFF
--- a/.github/workflows/update-slicer-preview-branch.yml
+++ b/.github/workflows/update-slicer-preview-branch.yml
@@ -34,9 +34,16 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        id: app-token
+        with:
+          app-id: ${{ vars.SLICER_APP_ID }}
+          private-key: ${{ secrets.SLICER_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: main
+          token: ${{ steps.app-token.outputs.token }}
           # The 'fetch-depth' option ensures that a sufficient number of commits are retrieved (250)
           # to allow the "git rev-parse" command used below to accurately reference a commit based
           # on time.
@@ -84,22 +91,13 @@ jobs:
         env:
           TIME: ${{ steps.convert.outputs.time }}
 
-      - uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
-        id: app-token
-        with:
-          app-id: ${{ vars.SLICER_APP_ID }}
-          private-key: ${{ secrets.SLICER_APP_PRIVATE_KEY }}
-
       - name: "Publish"
         run: |
           if [ -z "$SHA" ]; then
             echo "::error ::Failed to retrieve SHA"
             exit 1
           fi
-          remote=https://${SLICERBOT_GITHUB_TOKEN}@github.com/${REPOSITORY}.git
-          git push $remote $SHA:refs/heads/${PREVIEW_BRANCH} --force
+          git push origin $SHA:refs/heads/${PREVIEW_BRANCH}
         env:
           SHA: ${{ steps.retrieve.outputs.sha }}
-          SLICERBOT_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPOSITORY: ${{ github.repository }}
           PREVIEW_BRANCH: nightly-main


### PR DESCRIPTION
This commit resolves authentication issues in the "Update Preview Branch" GitHub workflow by ensuring proper credentials are used during checkout. Additionally, the following changes were made to the Slicer repository settings:
- Granted "Slicer App" permission to push to the "nightly-main" branch.
- Updated "Slicer App" permissions to allow read/write access to workflow files.

These changes follow guidelines documented at:
https://github.com/orgs/community/discussions/25305#discussioncomment-8256560

This commit builds upon 58a9a8ce41 ("BUG: Fix GitHub workflow for daily updates to 'nightly-main' branch", 2024-09-20) integrated through https://github.com/Slicer/Slicer/pull/7955, ensuring the workflow is associated with the correct credentials to resolve the following error:

```
remote: error: GH006: Protected branch update failed for refs/heads/nightly-main.
remote: You're not authorized to push to this branch.
To https://github.com/Slicer/Slicer.git
 ! [remote rejected] ... -> nightly-main (protected branch hook declined)
```

Further, permissions for the "Slicer App" were adjusted to resolve additional errors like the one below:

```
remote: error: GH013: Repository rule violations found for refs/heads/nightly-main.
remote: Refusing to allow a GitHub App to create or update workflow `.github/workflows/update-slicer-preview-branch.yml` without `workflows` permission.
To https://github.com/Slicer/Slicer.git
 ! [remote rejected] ... -> nightly-main (push declined due to repository rule violations)
```

For more details on the required permissions, refer to: https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-workflows