### PR TITLE
ENH: Add interaction widget axis labels for markups

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.h
@@ -55,6 +55,7 @@
 #include <vtkAppendPolyData.h>
 #include <vtkArrayCalculator.h>
 #include <vtkGlyph3D.h>
+#include <vtkLabeledDataMapper.h>
 #include <vtkLookupTable.h>
 #include <vtkPlane.h>
 #include <vtkPointPlacer.h>
@@ -222,6 +223,12 @@ protected:
     vtkSmartPointer<vtkPolyDataMapper>          Mapper3D;
     vtkSmartPointer<vtkProperty>                Property3D;
     vtkSmartPointer<vtkActor>                   Actor3D;
+
+    vtkNew<vtkTransformPolyDataFilter>          AxisLabelTransformFilter;
+    vtkNew<vtkTransform>                        AxisLabelTransform;
+    vtkNew<vtkLabeledDataMapper>                AxisLabelMapper;
+    vtkNew<vtkActor2D>                          AxisLabelActor;
+    vtkNew<vtkStringArray>                      AxisLabelArray;
 
     vtkSmartPointer<vtkTransform> WorldToSliceTransform;
     vtkSmartPointer<vtkTransformPolyDataFilter> WorldToSliceTransformFilter;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -3039,6 +3039,39 @@ std::string vtkMRMLMarkupsNode::GetPropertiesLabelText()
 }
 
 //---------------------------------------------------------------------------
+void vtkMRMLMarkupsNode::SetAxisLabels(const char* axisLabelX, const char* axisLabelY, const char* axisLabelZ)
+{
+  bool modified = false;
+  if (axisLabelX && this->AxisLabels[0].compare(axisLabelX))
+  {
+    this->AxisLabels[0] = std::string(axisLabelX);
+    modified = true;
+  }
+  if (axisLabelY && this->AxisLabels[1].compare(axisLabelY))
+  {
+    this->AxisLabels[1] = std::string(axisLabelY);
+    modified = true;
+  }
+  if (axisLabelZ && this->AxisLabels[2].compare(axisLabelZ))
+  {
+    this->AxisLabels[2] = std::string(axisLabelZ);
+    modified = true;
+  }
+  if (modified)
+  {
+    this->Modified();
+  }
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsNode::GetAxisLabels(std::string &axisLabelX, std::string &axisLabelY, std::string &axisLabelZ)
+{
+  axisLabelX = this->AxisLabels[0];
+  axisLabelY = this->AxisLabels[1];
+  axisLabelZ = this->AxisLabels[2];
+}
+
+//---------------------------------------------------------------------------
 int vtkMRMLMarkupsNode::GetNthControlPointIndexByPositionStatus(int pointIndex, int positionStatus)
 {
   int foundControlPoints = 0;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -702,6 +702,12 @@ public:
   /// identifies the node and provides basic information.
   virtual std::string GetPropertiesLabelText();
 
+  /// Set axis labels to show for each axis of the interaction handler.
+  virtual void SetAxisLabels(const char* axisLabelX, const char* axisLabelY, const char* axisLabelZ);
+
+  /// Get axis labels to show for each axis of the interaction handler.
+  virtual void GetAxisLabels(std::string &axisLabelX, std::string &axisLabelY, std::string &axisLabelZ);
+
   /// Utility function to get unit node from scene
   vtkMRMLUnitNode* GetUnitNode(const char* quantity);
 
@@ -1045,6 +1051,9 @@ protected:
 
   /// Flag set from SetControlPointPositionsWorld that pauses update of measurements until the update is complete.
   bool IsUpdatingPoints{false};
+
+  /// Axis labels to show for each axis of the interaction handler. Elements of the array are labels for axes X, Y, and Z.
+  std::string AxisLabels[3];
 
   friend class qSlicerMarkupsModuleWidget; // To directly access measurements
 };

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidgetRepresentation.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidgetRepresentation.cxx
@@ -139,6 +139,28 @@ void vtkSlicerMarkupsInteractionWidgetRepresentation::SetActiveComponentIndex(in
 }
 
 //----------------------------------------------------------------------
+void vtkSlicerMarkupsInteractionWidgetRepresentation::UpdateFromMRML(
+    vtkMRMLNode* caller, unsigned long event, void *callData)
+{
+  Superclass::UpdateFromMRML(caller, event, callData);
+
+  vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(caller);
+  if (markupsNode == nullptr)
+  {
+    return;
+  }
+
+  // Update axis labels
+  std::string axisLabels[4] = {""};
+  markupsNode->GetAxisLabels(axisLabels[0], axisLabels[1], axisLabels[2]);
+  for (int i = 0; i < 4; ++i)
+  {
+    this->Pipeline->AxisLabelArray->SetValue(i, axisLabels[i].c_str());
+  }
+  this->Pipeline->AxisLabelActor->SetVisibility(!axisLabels[0].empty() || !axisLabels[1].empty() || !axisLabels[2].empty());
+}
+
+//----------------------------------------------------------------------
 bool vtkSlicerMarkupsInteractionWidgetRepresentation::IsDisplayable()
 {
   vtkMRMLMarkupsDisplayNode* displayNode = this->GetDisplayNode();
@@ -245,6 +267,24 @@ void vtkSlicerMarkupsInteractionWidgetRepresentation::UpdateInteractionPipeline(
   {
     this->UpdateROIScaleHandles();
   }
+
+  //TODO: This does not have an effect for some reason
+  //// Update text properties
+  //vtkTextProperty* markupsTextProperty = displayNode->GetTextProperty();
+  //for (int i = 0; i < 4; ++i)
+  //{
+  //  vtkSmartPointer<vtkTextProperty> axisLabelTextProperty = vtkSmartPointer<vtkTextProperty>::New();
+  //  axisLabelTextProperty->SetFontSize(markupsTextProperty->GetFontSize());
+  //  axisLabelTextProperty->SetBold(markupsTextProperty->GetBold());
+  //  axisLabelTextProperty->SetShadow(markupsTextProperty->GetShadow());
+  //  axisLabelTextProperty->SetFontFamily(markupsTextProperty->GetFontFamily());
+  //  if (i < this->GetNumberOfHandles(InteractionTranslationHandle))
+  //  {
+  //    HandleInfo handleInfo = this->GetHandleInfo(InteractionTranslationHandle, i);
+  //    axisLabelTextProperty->SetColor(handleInfo.Color);
+  //  }
+  //  this->Pipeline->AxisLabelMapper->SetLabelTextProperty(axisLabelTextProperty, i);
+  //}
 }
 
 //----------------------------------------------------------------------

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidgetRepresentation.h
@@ -54,6 +54,9 @@ public:
   void PrintSelf(ostream& os, vtkIndent indent) override;
   //@}
 
+  /// Update the representation from display node
+  void UpdateFromMRML(vtkMRMLNode* caller, unsigned long event, void *callData = nullptr) override;
+
   int GetActiveComponentType() override;
   void SetActiveComponentType(int type) override;
   int GetActiveComponentIndex() override;


### PR DESCRIPTION
Usage:
m = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLMarkupsFiducialNode') m.AddControlPointWorld(0,0,0)
m.SetAxisLabels('X', 'Y', 'Z')
m.GetDisplayNode().SetHandlesInteractive(True)