### PR TITLE
ENH: Improve terminology category selection

### DIFF
--- a/Modules/Loadable/Terminologies/Widgets/Resources/UI/qSlicerTerminologyNavigatorWidget.ui
+++ b/Modules/Loadable/Terminologies/Widgets/Resources/UI/qSlicerTerminologyNavigatorWidget.ui
@@ -350,7 +350,7 @@
             <bool>false</bool>
            </property>
            <property name="selectionMode">
-            <enum>QAbstractItemView::MultiSelection</enum>
+            <enum>QAbstractItemView::ExtendedSelection</enum>
            </property>
            <property name="selectionBehavior">
             <enum>QAbstractItemView::SelectRows</enum>
@@ -368,6 +368,13 @@
             <bool>false</bool>
            </attribute>
            <column/>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_SelectAllCategories">
+           <property name="text">
+            <string>Select all</string>
+           </property>
           </widget>
          </item>
         </layout>

--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
@@ -254,6 +254,8 @@ void qSlicerTerminologyNavigatorWidgetPrivate::init()
     q, SLOT(onTerminologySelectionChanged(int)) );
   QObject::connect(this->tableWidget_Category, SIGNAL(itemSelectionChanged()),
     q, SLOT(onCategorySelectionChanged()) );
+  QObject::connect(this->pushButton_SelectAllCategories, SIGNAL(clicked()),
+    q, SLOT(onSelectAllCategoriesButtonClicked()) );
   QObject::connect(this->tableWidget_Type, SIGNAL(currentItemChanged(QTableWidgetItem*,QTableWidgetItem*)),
     q, SLOT(onTypeSelected(QTableWidgetItem*,QTableWidgetItem*)) );
   QObject::connect(this->tableWidget_Type, SIGNAL(cellDoubleClicked(int,int)),
@@ -1639,6 +1641,14 @@ void qSlicerTerminologyNavigatorWidget::onCategorySelectionChanged()
   {
     d->setNameFromCurrentTerminology();
   }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerTerminologyNavigatorWidget::onSelectAllCategoriesButtonClicked()
+{
+  Q_D(qSlicerTerminologyNavigatorWidget);
+
+  d->tableWidget_Category->selectAll();
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.h
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.h
@@ -174,6 +174,7 @@ protected:
 protected slots:
   void onTerminologySelectionChanged(int);
   void onCategorySelectionChanged();
+  void onSelectAllCategoriesButtonClicked();
   void onTypeSelected(QTableWidgetItem*, QTableWidgetItem*);
   void onTypeCellDoubleClicked(int, int);
   void onTypeModifierSelectionChanged(int);


### PR DESCRIPTION
- Many users were confused and annoyed by the single-click multi-selection. This changes that style to ExtendedSelection (single-click change selection, Ctrl or Shift modifies selection)
- Add convenience button for selecting all categories again (although Ctrl+A does it as well but it is not obvious)