### PR TITLE
BUG: Update LandmarkRegistration in SuperBuild.cmake

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -328,7 +328,7 @@ list_conditional_append(Slicer_BUILD_CompareVolumes Slicer_REMOTE_DEPENDENCIES C
 
 Slicer_Remote_Add(LandmarkRegistration
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/LandmarkRegistration"
-  GIT_TAG 551cee5c26266c5afaa44883e014e978cb0e9646
+  GIT_TAG aa23730ae78992cf14e858fe26ccfb213ea038ab
   OPTION_NAME Slicer_BUILD_LandmarkRegistration
   OPTION_DEPENDS "Slicer_BUILD_CompareVolumes;Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
Fixes https://github.com/Slicer/Slicer/issues/7194

Module repository was updated but superbuild hash was not.