### PR TITLE
ENH: Remove "Active" prefix from some node selection comboboxes

### DIFF
--- a/Docs/user_guide/modules/segmentations.md
+++ b/Docs/user_guide/modules/segmentations.md
@@ -163,7 +163,7 @@ See Script repository's [Segmentations section](../../developer_guide/script_rep
     - Set visibility and per-segment display settings, opacity, color, segment name
 - Display
     - Segmentations-wide display settings (not per-segment!): visibility, opacity (will be multiplied with per-segment opacity for display)
-    - Views: Individual views to show the active segmentation in
+    - Views: Individual views to show the selected segmentation in
     - Slice intersection thickness
     - Representation in 3D/2D views: The representation to be shown in the 3D and 2D views. Useful if there are multiple representations available, for example if we want to show the closed surface in the 3D view but the labelmap in the slice views
 - Representations
@@ -173,7 +173,7 @@ See Script repository's [Segmentations section](../../developer_guide/script_rep
         - Advanced conversion is possible (to use the non-default path or conversion parameters) by long-pressing the Create or Update button
         - Existing representations can be made master by clicking Make source. The source representation is used as source for conversions, it is the one that can be edited, and saved to disk
 - Copy/move (import/export)
-    - Left panel lists the segments in the active segmentation
+    - Left panel lists the segments in the selected segmentation
     - Right panel shows the external data container
     - The arrow buttons van be used to copy (with plus sign) or move (no plus sign) segments between the segmentation and the external node
     - New labelmap or model can be created by clicking the appropriate button on the top of the right panel

--- a/Docs/user_guide/modules/transforms.md
+++ b/Docs/user_guide/modules/transforms.md
@@ -21,7 +21,7 @@ Transform node can be created in multiple ways:
 - Method A: In Data module's Subject hierarchy tab, right-click on the "Transform" column and choose "Create new transform". This always creates a general "Transform".
 - Method B: In Data module's Subject hierarchy tab, right-click on the "Visibility" column of any transformable node and choose "Interaction" to create a parent transform and display the interaction handles (See [Interaction section](transforms.md#interaction)). This always creates a general "Transform".
 - Method C: In Data module's Transform hierarchy tab, right-click on an item and choose "Insert transform". This always creates a "Linear transform". Advantage of this method is that it is easy to build and overview hierarchy of transforms.
-- Method D: In Transforms module click on "Active transform" node selector and choose one of the "Create new..." options.
+- Method D: In Transforms module click on the "Transform" node selector and choose one of the "Create new..." options.
 
 How to choose transform type: Create "Linear transform" if you only work with linear transforms, because certain modules only allow you to select this node type as input. In other cases, it is recommended to  create the general "Transform" node. Multiple transform node types exist because earlier Slicer could only store a simple transformation in a node. Now a transform node can contain any transformation type (linear, grid, bspline, thin-plate spline, or even composite transformation - an arbitrary sequence of any transformations), therefore transform node types only differ in their name. In some modules, node selectors only accept a certain transform node type, therefore it may be necessary to create that expected transform type, but in the long term it is expected that all modules will accept the general "Transform" node type.
 
@@ -115,7 +115,7 @@ For macOS, refer to [alternate macOS keybindings](../user_interface.md#alternate
 
 ## Panels and their use
 
-Active Transform: Select the transform node to display, control and edit.
+Transform: Select the transform node to display, control and edit.
 
 ### Information
 
@@ -214,17 +214,17 @@ You can show both contours and grid or glyph representations by loading the same
 
 ### Apply transform
 
-Controls what nodes the currently selected "Active transform" is applied to.
+Controls what nodes the currently selected Transform is applied to.
 
-- Transformable: List the nodes in the scene that *do not* directly use the active transform node.
-- Transformed: List the nodes in the scene that use the active transform node.
-- Right arrow: Apply the active transform node to the selected nodes in Transformable list.
-- Left arrow: Remove the active transform node from the selected nodes in the Transformed list.
-- Harden transform: Harden active transform on the nodes selected in the Transformed list.
+- Transformable: List the nodes in the scene that *do not* directly use the selected transform node.
+- Transformed: List the nodes in the scene that use the selected transform node.
+- Right arrow: Apply the selected transform node to the selected nodes in Transformable list.
+- Left arrow: Remove the selected transform node from the selected nodes in the Transformed list.
+- Harden transform: Harden selected transform on the nodes selected in the Transformed list.
 
 ### Convert
 
-This section can sample the active transform on a grid (specified by the selected "Reference volume") and save it to a node. Depending on the type of selected "Output displacement field" node, slightly different information is exported:
+This section can sample the selected transform on a grid (specified by the selected "Reference volume") and save it to a node. Depending on the type of selected "Output displacement field" node, slightly different information is exported:
 - Scalar volume node : magnitude of displacement is saved as a scalar volume
 - Vector volume node: displacement vectors are saved as voxel values (in RAS coordinate system). When the vector volume is written to file, the image grid is saved in LPS coordinate system, but displacement values are still kept in RAS coordinate system.
 - Transform node: a grid transform is constructed. This can be used for creating an inverted displacement field that any ITK application can read. When the grid transform is written to file, both the image grid and displacement values are saved in LPS coordinate system.

--- a/Docs/user_guide/modules/volumes.md
+++ b/Docs/user_guide/modules/volumes.md
@@ -83,7 +83,7 @@ Note: Consumer file formats, such as jpg, png, and tiff are not well suited for 
 
 ## Panels and their use
 
-- Active Volume: Select the volume to display and operate on.
+- Volume: Select the volume to display and operate on.
 - Volume Information: Information about the selected volume. Some fields can be edited to correctly describe the volume, for example, when loading incompletely specified image data such as a sequence of jpeg files. Use caution however, since changing properties such as Image Spacing will impact the physical accuracy of some calculations such as Label Statistics.
   - Image Dimensions: The number of pixels in "IJK" space - this is the way the data is arranged in memory. The IJK indices (displayed in the DataProbe) go from 0 to dimension-1 in each direction.
   - Image Spacing: The physical distance between pixel centers when mapped to patient space expressed in millimeters.

--- a/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsModule.ui
+++ b/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsModule.ui
@@ -37,7 +37,7 @@
      <item row="0" column="0">
       <widget class="QLabel" name="label_ActiveSegmentation">
        <property name="text">
-        <string> Active segmentation:</string>
+        <string> Segmentation:</string>
        </property>
       </widget>
      </item>

--- a/Modules/Loadable/Transforms/Resources/UI/qSlicerTransformsModuleWidget.ui
+++ b/Modules/Loadable/Transforms/Resources/UI/qSlicerTransformsModuleWidget.ui
@@ -41,7 +41,7 @@
      <item>
       <widget class="QLabel" name="TransformNodeSelectorLabel">
        <property name="text">
-        <string>Active Transform:</string>
+        <string> Transform:</string>
        </property>
       </widget>
      </item>
@@ -420,7 +420,7 @@
         <item>
          <widget class="QToolButton" name="TransformToolButton">
           <property name="toolTip">
-           <string>Apply the active transform to the selected transformable nodes</string>
+           <string>Apply the selected transform to the selected transformable nodes</string>
           </property>
           <property name="text">
            <string>&gt;</string>
@@ -430,7 +430,7 @@
         <item>
          <widget class="QToolButton" name="UntransformToolButton">
           <property name="toolTip">
-           <string>Remove the active transform from the selected transformed nodes</string>
+           <string>Remove the selected transform from the selected transformed nodes</string>
           </property>
           <property name="text">
            <string>&lt;</string>

--- a/Modules/Loadable/Volumes/Resources/UI/qSlicerVolumesModuleWidget.ui
+++ b/Modules/Loadable/Volumes/Resources/UI/qSlicerVolumesModuleWidget.ui
@@ -38,7 +38,7 @@
      <item>
       <widget class="QLabel" name="ActiveVolumeLabel">
        <property name="text">
-        <string>Active Volume: </string>
+        <string> Volume: </string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
As discussed at Slicer hangout today.

There can be confusion that changing the selection of a combobox with label that has the prefix "Active" that it will apply changes to the scene in some way. For examplethere can be confusion that "Active Volume" in the Volume module would change which volume is showing in the layout views, however that is not the case. Changing "ActiveVolume" does not update the selection node using SetActiveVolumeID. Instead this label is just for selecting the volume node for manipulating parameters within the Volumes module widget area only.

| `main` | This PR |
|--------|----------|
|![{1FBD831B-10D1-4753-8F13-484BC0BC780C}](https://github.com/user-attachments/assets/cbe72136-188b-4097-b66b-f24cbcf96028)|![{9E4716B9-9B67-4427-AA24-A30448783FB2}](https://github.com/user-attachments/assets/86a7b647-03e6-4a54-b33d-d0c16a7d2009)|
|![{4136E032-F2B2-44CD-8471-6291582CEA4D}](https://github.com/user-attachments/assets/f3569764-efc6-467c-b204-352c7d0bc538)|![{DFA22558-5BB9-4B80-98AB-AF186D9D3E41}](https://github.com/user-attachments/assets/b8ebf0aa-277a-4388-b6df-675365cd4b92)|
|![{9BF96458-71E3-4722-B3A8-15B3F919A542}](https://github.com/user-attachments/assets/3d3107f8-f5ec-4e7b-bb05-e4bd224fa4cd)|![{BAB6801D-C447-47F2-BFDA-55ADB88A254B}](https://github.com/user-attachments/assets/4c96fc7f-5c1b-4ee7-98a3-e6f13976b20e)|

Other places in `main` already did not use the "Active" prefix or they used a subject hierarchy tree view instead of a label+combobox:
![{EC9A74DD-C93D-4A0C-B1CD-D8987B5274A7}](https://github.com/user-attachments/assets/eef3af19-5537-4c86-93e9-2bde1f266485)
