### PR TITLE
COMP: Drop support for MSVC toolset v141 aka Visual Studio 2017

### DIFF
--- a/CMake/SlicerBlockPlatformCheck.cmake
+++ b/CMake/SlicerBlockPlatformCheck.cmake
@@ -36,13 +36,10 @@ if(Slicer_PLATFORM_CHECK)
   if(WIN32)
     # See https://cmake.org/cmake/help/latest/variable/MSVC_VERSION.html
     # and https://en.wikipedia.org/wiki/Microsoft_Visual_Studio#Version_history
-    # 1910-1919 = VS 15.0 (v141 toolset) 1914 = VS 15.7
     # 1920-1929 = VS 16.0 (v142 toolset)
     # 1930-1949 = VS 17.0 (v143 toolset, see https://devblogs.microsoft.com/cppblog/msvc-toolset-minor-version-number-14-40-in-vs-2022-v17-10/)
-    # VS 15.7 was announced to officially conform with the C++ standard of C++11, C++14 and C++17
-    # https://devblogs.microsoft.com/cppblog/announcing-msvc-conforms-to-the-c-standard/
-    if(NOT MSVC_VERSION VERSION_GREATER_EQUAL 1914)
-      message(FATAL_ERROR "Microsoft Visual C/C++ toolset 141 (VS 15.7) or newer is required !")
+    if(NOT MSVC_VERSION VERSION_GREATER_EQUAL 1920)
+      message(FATAL_ERROR "Microsoft Visual C/C++ toolset 142 or newer is required !")
     endif()
   elseif(APPLE)
     # See CMake/Modules/Platform/Darwin.cmake)

--- a/Docs/developer_guide/build_instructions/windows.md
+++ b/Docs/developer_guide/build_instructions/windows.md
@@ -27,7 +27,6 @@ Slicer relies on a number of large third-party libraries (such VTK, ITK, DCMTK),
 **Other Visual Studio IDE and compiler toolset versions**
 
 - Visual Studio 2019 (v142) toolset is not tested anymore but probably still works.
-- Visual Studio 2017 (v141) toolset is not tested anymore but probably still works. Qt-5.15.2 requires v142 redistributables, so either these extra DLL files need to be added to the installation package or each user may need to install "Microsoft Visual C++ Redistributable" package.
 - Cygwin and Mingw: not tested and not recommended. Building with cygwin gcc not supported, but the cygwin shell environment can be used to run utilities such as git.
 
 :::


### PR DESCRIPTION
This should have been included in https://github.com/Slicer/Slicer/commit/acf3dd47940665869765584564b38439f73ff1d5 as ITK 5.4.0 dropped support for MSVC v141 toolset in https://github.com/InsightSoftwareConsortium/ITK/commit/140f3c249fbb20c4f4a1607e563e19ee9a9cbd78.