### PR TITLE
ENH: Add a transform plugin in subject hierarchy tree view

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
@@ -346,11 +346,6 @@ protected slots:
 
   void onCustomContextMenu(const QPoint& point);
 
-  virtual void onTransformActionSelected();
-  virtual void onTransformInteractionInViewToggled(bool show);
-  virtual void onTransformEditProperties();
-  virtual void onCreateNewTransform();
-
 protected:
   /// Set the subject hierarchy node found in the given scene. Called only internally.
   virtual void setSubjectHierarchyNode(vtkMRMLSubjectHierarchyNode* shNode);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.cxx
@@ -169,6 +169,12 @@ QList<QAction*> qSlicerSubjectHierarchyAbstractPlugin::visibilityContextMenuActi
 }
 
 //-----------------------------------------------------------------------------
+QList<QAction*> qSlicerSubjectHierarchyAbstractPlugin::transformContextMenuActions()const
+{
+  return QList<QAction*>();
+}
+
+//-----------------------------------------------------------------------------
 QList<QAction*> qSlicerSubjectHierarchyAbstractPlugin::viewContextMenuActions()const
 {
   return QList<QAction*>();
@@ -358,6 +364,7 @@ void qSlicerSubjectHierarchyAbstractPlugin::hideAllContextMenuActions()const
   QList<QAction*> allActions;
   allActions << this->sceneContextMenuActions();
   allActions << this->itemContextMenuActions();
+  allActions << this->transformContextMenuActions();
   allActions << this->visibilityContextMenuActions();
   allActions << this->viewContextMenuActions();
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
@@ -163,6 +163,15 @@ public:
   /// \param itemID Subject Hierarchy item to show the visibility context menu items for
   Q_INVOKABLE virtual void showVisibilityContextMenuActionsForItem(vtkIdType itemID) { Q_UNUSED(itemID); };
 
+  /// Get transform context menu item actions to add to tree view.
+  /// These item transform context menu actions can be shown in the
+  /// implementations of \sa showTransformContextMenuActionsForItem
+  Q_INVOKABLE virtual QList<QAction*> transformContextMenuActions() const;
+
+  /// Show transform context menu actions valid for a given subject hierarchy
+  /// item. \param itemID Subject Hierarchy item to show the transform context menu items for
+  Q_INVOKABLE virtual void showTransformContextMenuActionsForItem(vtkIdType itemID) { Q_UNUSED(itemID); };
+
   /// Get view context menu item actions that are available when right-clicking an object in the views.
   /// These item context menu actions can be shown in the implementations of \sa showViewContextMenuActionsForItem
   /// Note: The actions need object names set so that they can be included in the white list

--- a/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.h
+++ b/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.h
@@ -112,6 +112,19 @@ public:
   /// \param itemID Subject Hierarchy item to show the visibility context menu items for
   void showVisibilityContextMenuActionsForItem(vtkIdType itemID) override;
 
+  /// Get transform context menu item actions to add to tree view.
+  /// These item transform context menu actions can be shown in the
+  /// implementations of \sa showTransformContextMenuActionsForItem
+  QList<QAction *> transformContextMenuActions() const override;
+
+  /// Show context menu actions valid for given subject hierarchy item
+  void showTransformContextMenuActionsForItem(vtkIdType itemID) override;
+
+  /// Menu section where transform nodes are listed.
+  /// It can be useful for positioning menu items above or below in other plugins
+  /// using qSlicerSubjectHierarchyAbstractPlugin::setActionPosition.
+  int transformListSection() const;
+
 protected slots:
   /// Invert selected transform
   void invert();
@@ -128,6 +141,13 @@ protected slots:
   /// Toggle interaction box
   void toggleInteractionBox(bool);
   void toggleCurrentItemHandleTypeVisibility(bool);
+
+  virtual void onTransformActionSelected();
+  virtual void onTransformInteractionInViewToggled(bool show);
+  virtual void onTransformEditProperties();
+  virtual void onHardenTransformOnBranchOfCurrentItem();
+  virtual void onRemoveTransformsFromBranchOfCurrentItem();
+  virtual void onCreateNewTransform();
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyTransformsPluginPrivate> d_ptr;


### PR DESCRIPTION
Transform related functions were originally not included into a specific plugin. Thus some functionalities related to the management of plugins were not available.
Fix https://github.com/Slicer/Slicer/issues/6621
