### PR TITLE
BUG: add missing OPTIONS request handler when CORS enabled

### DIFF
--- a/Modules/Scripted/WebServer/WebServer.py
+++ b/Modules/Scripted/WebServer/WebServer.py
@@ -418,7 +418,7 @@ class SlicerHTTPServer(HTTPServer):
                     self.logMessage("Warning, we don't speak %s", version)
                     return
 
-                methods = ["GET", "POST", "PUT", "DELETE"]
+                methods = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
                 if method not in methods:
                     self.logMessage("Warning, we only handle %s" % methods)
                     return
@@ -439,7 +439,7 @@ class SlicerHTTPServer(HTTPServer):
                         highestConfidence = confidence
 
                 httpStatus = "200 OK"
-                if highestConfidenceHandler is not None and highestConfidence > 0.0:
+                if highestConfidenceHandler is not None and highestConfidence > 0.0 and method != "OPTIONS":
                     try:
                         contentType, responseBody = highestConfidenceHandler.handleRequest(method=method, uri=uri, requestBody=requestBody)
                     except Exception as e:
@@ -469,6 +469,14 @@ class SlicerHTTPServer(HTTPServer):
                     self.response += b"Cache-Control: no-cache\r\n"
                     self.response += b"\r\n"
                     self.response += responseBody
+                elif method == "OPTIONS":
+                    self.response = b"HTTP/1.1 204 No Content\r\n"
+                    self.response += b"Connection: keep-alive\r\n"
+                    if self.enableCORS:
+                        self.response += b"Access-Control-Allow-Origin: *\r\n"
+                        self.response += b"Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE, PUT\r\n"
+                        self.response += b"Access-Control-Allow-Headers: Accept\r\n"
+                        self.response += b"Access-Control-Max-Age: 86400\r\n"
                 else:
                     self.response = b"HTTP/1.1 404 Not Found\r\n"
                     self.response += b"\r\n"


### PR DESCRIPTION
This PR adds an OPTIONS request handler in the Webserver module.

This handler creates a response to preflight requests when CORS is enabled, which is required when executing cross-origin requests.

The response content was inspired from MSDN documentation at:
https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request

Relevant forum discussion:
https://discourse.slicer.org/t/using-webserver-dicomweb-interface-with-ohif-cors-enabled/39736/2

---

To test ->

1. Run a separate OHIF instance (not the built-in one) with the following datasource item in appConfig.js

```js
{...
datasource: [
{
      friendlyName: 'Slicer 3D',
      namespace: '@ohif/extension-default.dataSourcesModule.dicomweb',
      sourceName: 'slicer',
      configuration: {
        name: 'Slicer',
        wadoUriRoot: 'http://localhost:2016/dicom',
        qidoRoot: 'http://localhost:2016/dicom',
        wadoRoot: 'http://localhost:2016/dicom',
        qidoSupportsIncludeField: true,
        imageRendering: 'wadouri',
        thumbnailRendering: 'wadouri',
        enableStudyLazyLoad: true,
        supportsFuzzyMatching: true,
      },
    },
]}
```
2. In slicer, select Webserver module, advanced options, check "Enable CORS".
3. Start server
4. Navigate to your OHIF instance (eg. `http://localhost:3000?dataSources=slicer`)
5. Load a series.

Disabling CORS and restarting the server should prevent loading the series.