### PR TITLE
Fix too frequent display of scene modification confirmation popup

### DIFF
--- a/Base/QTApp/qSlicerMainWindow_p.h
+++ b/Base/QTApp/qSlicerMainWindow_p.h
@@ -60,6 +60,7 @@ public:
   static QList<qSlicerIO::IOProperties> readRecentlyLoadedFiles();
   static void writeRecentlyLoadedFiles(const QList<qSlicerIO::IOProperties>& fileProperties);
 
+  virtual bool isSceneContentModifiedSinceRead(QString& details);
   virtual bool confirmCloseApplication();
   virtual bool confirmCloseScene();
 

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -3744,6 +3744,12 @@ bool vtkMRMLScene
     if (!storableNode->GetHideFromEditors() &&
          storableNode->GetModifiedSinceRead())
     {
+      if (!storableNode->GetStorageNode() && storableNode->GetDefaultStorageNodeClassName().empty())
+      {
+        // The storable node does not have a storage node, but it does not need one (because content is stored in the scene
+        // (for example vtkMRMLTextNode containing short text).
+        continue;
+      }
       found = true;
       if (modifiedStorableNodes)
       {

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -3708,9 +3708,9 @@ bool vtkMRMLScene::GetModifiedSinceRead(vtkCollection* modifiedNodes/*=nullptr*/
   for (this->Nodes->InitTraversal(it);
     (node = (vtkMRMLNode*)this->Nodes->GetNextItemAsObject(it));)
   {
-    if (node->IsA("vtkMRMLAbstractViewNode"))
+    if (node->IsA("vtkMRMLAbstractViewNode") || node->IsA("vtkMRMLCameraNode"))
     {
-      // We do not consider view node changes as scene change,
+      // We do not consider view and camera node changes as scene change,
       // because view nodes may change because application window is resized, etc.
       continue;
     }

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -632,7 +632,9 @@ void vtkMRMLMarkupsDisplayNode::SetActiveComponent(int componentType, int compon
   }
   this->ActiveComponents[context].Index = componentIndex;
   this->ActiveComponents[context].Type = componentType;
-  this->Modified();
+  // Let observers know about node modification, but do not change the modified timestamp, as this is transient event
+  // (we do not want the application to display a warning popup on scene close exit if the mouse has hovered over a control point)
+  this->InvokeCustomModifiedEvent(vtkCommand::ModifiedEvent);
 }
 
 //---------------------------------------------------------------------------
@@ -785,7 +787,9 @@ int vtkMRMLMarkupsDisplayNode::UpdateActiveControlPointWorld(
 
   if (activeComponentChanged)
   {
-    this->Modified();
+    // Let observers know about node modification, but do not change the modified timestamp, as this is transient event
+    // (we do not want the application to display a warning popup on scene close exit if the mouse has hovered over a control point)
+    this->InvokeCustomModifiedEvent(vtkCommand::ModifiedEvent);
   }
 
   return controlPointIndex;


### PR DESCRIPTION
When closing the scene or exiting the application a confirmation popup is often displayed that warns that the scene content is changed.

Often this popup did not seem justified (e.g., the scene has just been saved) and there was no way of telling why the popup was displayed (what exactly was modified).

This pull request adds a "Show details" option that can display the list of all modified nodes that should be saved in data files or the scene file:

![image](https://github.com/user-attachments/assets/11fc1eb0-b742-4772-92d8-ec703ebc5f95)

The pull request also contains a few fixes in detection of node modifications to avoid showing confirmation popups unnecessarily.