### PR TITLE
ENH: Make terminology code finding more robust

### DIFF
--- a/Libs/vtkSegmentationCore/vtkSegmentationConverter.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentationConverter.h
@@ -185,6 +185,10 @@ protected:
   /// Source representation to target representation rule graph
   RepresentationToRepresentationToRuleMapType RulesGraph;
 
+  /// Stores conversion parameters that this software does not know.
+  /// We store these parameters here because the converter rules only store the parameters they know about.
+  vtkSmartPointer<vtkSegmentationConversionParameters> CustomConversionParameters;
+
 private:
   vtkSegmentationConverter(const vtkSegmentationConverter&) = delete;
   void operator=(const vtkSegmentationConverter&) = delete;

--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.h
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.h
@@ -56,6 +56,10 @@ public:
         , CodeValue(codeValue)
         , CodeMeaning(codeMeaning)
         { };
+      bool IsValid() const
+      {
+        return !CodingSchemeDesignator.empty() && !CodeValue.empty();
+      };
       std::string CodingSchemeDesignator;
       std::string CodeValue;
       std::string CodeMeaning; // Human readable name (not required for ID)
@@ -240,10 +244,8 @@ public:
   /// \return Flag indicating whether the attribute was found
   bool FindTypeInTerminologyBy3dSlicerLabel(std::string terminologyName, std::string slicerLabel, vtkSlicerTerminologyEntry* entry);
 
-  /// Convert terminology category object to code identifier
-  static CodeIdentifier CodeIdentifierFromTerminologyCategory(vtkSlicerTerminologyCategory* category);
-  /// Convert terminology type object to code identifier
-  static CodeIdentifier CodeIdentifierFromTerminologyType(vtkSlicerTerminologyType* type);
+  /// Convert terminology category, type, etc. object to code identifier
+  static CodeIdentifier GetCodeIdentifierFromCodedEntry(vtkCodedEntry* entry);
 
   /// Convert terminology entry VTK object to string containing identifiers
   /// Serialized terminology entry consists of the following: terminologyContextName, category (codingScheme,
@@ -267,6 +269,11 @@ public:
   /// codeValue, codeMeaning triple), type, typeModifier, anatomicContextName, anatomicRegion, anatomicRegionModifier
   ///  \return Success flag
   bool DeserializeTerminologyEntry(std::string serializedEntry, vtkSlicerTerminologyEntry* entry);
+
+  /// Get metadata (such as recommended color) from loaded terminologies.
+  /// The entry will be first searched in the terminology context that is specified in the entry,
+  /// if not found then it is searched in all the other loaded terminology contexts.
+  bool UpdateEntryFromLoadedTerminologies(vtkSlicerTerminologyEntry* entry);
 
   /// Assemble human readable info string from a terminology entry, for example for tooltips
   static std::string GetInfoStringFromTerminologyEntry(vtkSlicerTerminologyEntry* entry);

--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyType.cxx
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyType.cxx
@@ -95,8 +95,12 @@ void vtkSlicerTerminologyType::Copy(vtkCodedEntry* aType)
 
   this->Superclass::Copy(aType);
 
-  vtkSlicerTerminologyType *aTerminologyType =
-      vtkSlicerTerminologyType::SafeDownCast(aType);
+  vtkSlicerTerminologyType *aTerminologyType = vtkSlicerTerminologyType::SafeDownCast(aType);
+  if (!aTerminologyType)
+  {
+    vtkErrorMacro("Copy: Input type is not a vtkSlicerTerminologyType");
+    return;
+  }
 
   this->SetRecommendedDisplayRGBValue(aTerminologyType->GetRecommendedDisplayRGBValue());
   this->SetSlicerLabel(aTerminologyType->GetSlicerLabel());

--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyItemDelegate.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyItemDelegate.cxx
@@ -89,6 +89,8 @@ void qSlicerTerminologyItemDelegate::setEditorData(QWidget *editor, const QModel
   if (logic)
   {
     logic->DeserializeTerminologyEntry(terminologyString.toUtf8().constData(), terminologyEntry);
+    // Get default color and other metadata from loaded terminologies
+    logic->UpdateEntryFromLoadedTerminologies(terminologyEntry);
   }
 
   // Get metadata

--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
@@ -496,8 +496,8 @@ QColor qSlicerTerminologyNavigatorWidgetPrivate::recommendedColorForType(
     return QColor();
   }
   std::vector<vtkSlicerTerminologiesModuleLogic::CodeIdentifier> typeModifiers;
-  vtkSlicerTerminologiesModuleLogic::CodeIdentifier categoryId = vtkSlicerTerminologiesModuleLogic::CodeIdentifierFromTerminologyCategory(category);
-  vtkSlicerTerminologiesModuleLogic::CodeIdentifier typeId = vtkSlicerTerminologiesModuleLogic::CodeIdentifierFromTerminologyType(type);
+  vtkSlicerTerminologiesModuleLogic::CodeIdentifier categoryId = vtkSlicerTerminologiesModuleLogic::GetCodeIdentifierFromCodedEntry(category);
+  vtkSlicerTerminologiesModuleLogic::CodeIdentifier typeId = vtkSlicerTerminologiesModuleLogic::GetCodeIdentifierFromCodedEntry(type);
   logic->GetTypeModifiersInTerminologyType(terminologyName.c_str(), categoryId, typeId, typeModifiers);
   vtkNew<vtkSlicerTerminologyType> typeModifierObject;
   for (auto modifierId : typeModifiers)
@@ -1243,11 +1243,11 @@ void qSlicerTerminologyNavigatorWidget::populateTypeTable()
   {
     std::vector<vtkSlicerTerminologiesModuleLogic::CodeIdentifier> typesInCategory;
     std::vector<vtkSmartPointer<vtkSlicerTerminologyType>> typesObjectsInCategory;
-    vtkSlicerTerminologiesModuleLogic::CodeIdentifier categoryId = vtkSlicerTerminologiesModuleLogic::CodeIdentifierFromTerminologyCategory(category);
+    vtkSlicerTerminologiesModuleLogic::CodeIdentifier categoryId = vtkSlicerTerminologiesModuleLogic::GetCodeIdentifierFromCodedEntry(category);
 
     logic->FindTypesInTerminologyCategory(
       d->CurrentTerminologyName.toUtf8().constData(),
-      vtkSlicerTerminologiesModuleLogic::CodeIdentifierFromTerminologyCategory(category),
+      vtkSlicerTerminologiesModuleLogic::GetCodeIdentifierFromCodedEntry(category),
       typesInCategory, searchTerm, &typesObjectsInCategory);
 
     std::vector<vtkSlicerTerminologiesModuleLogic::CodeIdentifier>::iterator idIt;
@@ -1378,8 +1378,8 @@ void qSlicerTerminologyNavigatorWidget::populateTypeModifierComboBox()
   std::vector<vtkSlicerTerminologiesModuleLogic::CodeIdentifier> typeModifiers;
   logic->GetTypeModifiersInTerminologyType(
     d->CurrentTerminologyName.toUtf8().constData(),
-    vtkSlicerTerminologiesModuleLogic::CodeIdentifierFromTerminologyCategory(d->CurrentCategoryObject),
-    vtkSlicerTerminologiesModuleLogic::CodeIdentifierFromTerminologyType(d->CurrentTypeObject),
+    vtkSlicerTerminologiesModuleLogic::GetCodeIdentifierFromCodedEntry(d->CurrentCategoryObject),
+    vtkSlicerTerminologiesModuleLogic::GetCodeIdentifierFromCodedEntry(d->CurrentTypeObject),
     typeModifiers );
 
   int index = 1; // None modifier has index 0
@@ -1848,8 +1848,8 @@ void qSlicerTerminologyNavigatorWidget::onTypeModifierSelectionChanged(int index
       d->ComboBox_TypeModifier->itemText(index).toUtf8().constData() );
     if (!logic->GetTypeModifierInTerminologyType(
       d->CurrentTerminologyName.toUtf8().constData(),
-      vtkSlicerTerminologiesModuleLogic::CodeIdentifierFromTerminologyCategory(d->CurrentCategoryObject),
-      vtkSlicerTerminologiesModuleLogic::CodeIdentifierFromTerminologyType(d->CurrentTypeObject),
+      vtkSlicerTerminologiesModuleLogic::GetCodeIdentifierFromCodedEntry(d->CurrentCategoryObject),
+      vtkSlicerTerminologiesModuleLogic::GetCodeIdentifierFromCodedEntry(d->CurrentTypeObject),
       modifierId, modifier) )
     {
       qCritical() << Q_FUNC_INFO << ": Failed to find modifier '" << d->ComboBox_TypeModifier->itemText(index);
@@ -2155,7 +2155,7 @@ void qSlicerTerminologyNavigatorWidget::populateRegionModifierComboBox()
   std::vector<vtkSlicerTerminologiesModuleLogic::CodeIdentifier> regionModifiers;
   logic->GetRegionModifiersInAnatomicRegion(
     d->CurrentAnatomicContextName.toUtf8().constData(),
-    vtkSlicerTerminologiesModuleLogic::CodeIdentifierFromTerminologyType(d->CurrentRegionObject),
+    vtkSlicerTerminologiesModuleLogic::GetCodeIdentifierFromCodedEntry(d->CurrentRegionObject),
     regionModifiers );
 
   // Add "none" item
@@ -2412,7 +2412,7 @@ void qSlicerTerminologyNavigatorWidget::onRegionModifierSelectionChanged(int ind
       d->ComboBox_AnatomicRegionModifier->itemText(index).toUtf8().constData());
     if (!logic->GetRegionModifierInAnatomicRegion(
       d->CurrentAnatomicContextName.toUtf8().constData(),
-      vtkSlicerTerminologiesModuleLogic::CodeIdentifierFromTerminologyType(d->CurrentRegionObject),
+      vtkSlicerTerminologiesModuleLogic::GetCodeIdentifierFromCodedEntry(d->CurrentRegionObject),
       modifierId, modifier))
     {
       qCritical() << Q_FUNC_INFO << ": Failed to find modifier '" << d->ComboBox_AnatomicRegionModifier->itemText(index);


### PR DESCRIPTION
This commit makes terminology code finding more robust and removes unnecessary error messages when loading a segmentation.

- If terminology or anatomic context name is not found then we look for the codes in all available contexts.
- If codes are not available anywhere then we do not display an error when the segmentation is loaded. Only when the unavailable code is attempted to be shown in the terminology selector.
- Made behavior of vtkSlicerModuleLogic::DeserializeTerminologyEntry more clear: now it just parses the terminology string. To get metadata of a terminology entry from all loaded terminology contexts, the vtkSlicerModuleLogic::UpdateEntryFromLoadedTerminologies method can be called.
- When segmentation contained unknown segmentation conversion parameters then an error was logged and the parameter was discarded. Now unknown parameters are not discarded (to avoid unnecessary data loss) and logging of error message is no longer needed.

fixes #8002