### PR TITLE
ENH: Add option to display slice edges in 3D view

### DIFF
--- a/Base/QTGUI/Resources/UI/qSlicerSettingsViewsPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsViewsPanel.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>469</width>
-    <height>593</height>
+    <width>360</width>
+    <height>520</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,8 +24,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>449</width>
-        <height>573</height>
+        <width>340</width>
+        <height>500</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -117,6 +117,23 @@
            <widget class="ctkComboBox" name="SliceViewOrientationComboBox">
             <property name="currentIndex">
              <number>-1</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="SliceViewOrientationLabel_2">
+            <property name="text">
+             <string>Show slice edge in 3D:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="ctkCheckBox" name="SliceEdgeVisibility3DCheckBox">
+            <property name="toolTip">
+             <string>Show colored frame around the slice when displayed in 3D views.</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -304,20 +321,20 @@
            </widget>
           </item>
           <item row="7" column="1">
-           <widget class="ctkSliderWidget" name="ThreeDAmbientShadowsSizeScaleSlider">
+           <widget class="ctkSliderWidget" name="ThreeDAmbientShadowsSizeScaleSlider" native="true">
             <property name="enabled">
              <bool>false</bool>
             </property>
-            <property name="singleStep">
+            <property name="singleStep" stdset="0">
              <double>0.010000000000000</double>
             </property>
-            <property name="pageStep">
+            <property name="pageStep" stdset="0">
              <double>0.100000000000000</double>
             </property>
-            <property name="minimum">
+            <property name="minimum" stdset="0">
              <double>-3.000000000000000</double>
             </property>
-            <property name="maximum">
+            <property name="maximum" stdset="0">
              <double>3.000000000000000</double>
             </property>
            </widget>
@@ -333,26 +350,26 @@
            </widget>
           </item>
           <item row="8" column="1">
-           <widget class="ctkSliderWidget" name="ThreeDAmbientShadowsVolumeOpacityThresholdSlider">
+           <widget class="ctkSliderWidget" name="ThreeDAmbientShadowsVolumeOpacityThresholdSlider" native="true">
             <property name="enabled">
              <bool>false</bool>
             </property>
-            <property name="decimals">
+            <property name="decimals" stdset="0">
              <number>2</number>
             </property>
-            <property name="singleStep">
+            <property name="singleStep" stdset="0">
              <double>0.010000000000000</double>
             </property>
-            <property name="pageStep">
+            <property name="pageStep" stdset="0">
              <double>0.100000000000000</double>
             </property>
-            <property name="maximum">
+            <property name="maximum" stdset="0">
              <double>1.000000000000000</double>
             </property>
-            <property name="value">
+            <property name="value" stdset="0">
              <double>0.250000000000000</double>
             </property>
-            <property name="suffix">
+            <property name="suffix" stdset="0">
              <string/>
             </property>
            </widget>
@@ -368,23 +385,23 @@
            </widget>
           </item>
           <item row="10" column="1">
-           <widget class="ctkSliderWidget" name="ThreeDAmbientShadowsIntensityScaleSlider">
+           <widget class="ctkSliderWidget" name="ThreeDAmbientShadowsIntensityScaleSlider" native="true">
             <property name="enabled">
              <bool>false</bool>
             </property>
-            <property name="singleStep">
+            <property name="singleStep" stdset="0">
              <double>0.010000000000000</double>
             </property>
-            <property name="pageStep">
+            <property name="pageStep" stdset="0">
              <double>0.100000000000000</double>
             </property>
-            <property name="minimum">
+            <property name="minimum" stdset="0">
              <double>0.000000000000000</double>
             </property>
-            <property name="maximum">
+            <property name="maximum" stdset="0">
              <double>3.000000000000000</double>
             </property>
-            <property name="value">
+            <property name="value" stdset="0">
              <double>1.000000000000000</double>
             </property>
            </widget>
@@ -400,23 +417,23 @@
            </widget>
           </item>
           <item row="11" column="1">
-           <widget class="ctkSliderWidget" name="ThreeDAmbientShadowsIntensityShiftSlider">
+           <widget class="ctkSliderWidget" name="ThreeDAmbientShadowsIntensityShiftSlider" native="true">
             <property name="enabled">
              <bool>false</bool>
             </property>
-            <property name="singleStep">
+            <property name="singleStep" stdset="0">
              <double>0.010000000000000</double>
             </property>
-            <property name="pageStep">
+            <property name="pageStep" stdset="0">
              <double>0.100000000000000</double>
             </property>
-            <property name="minimum">
+            <property name="minimum" stdset="0">
              <double>0.000000000000000</double>
             </property>
-            <property name="maximum">
+            <property name="maximum" stdset="0">
              <double>1.000000000000000</double>
             </property>
-            <property name="value">
+            <property name="value" stdset="0">
              <double>0.000000000000000</double>
             </property>
            </widget>

--- a/Base/QTGUI/qSlicerSettingsViewsPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsViewsPanel.cxx
@@ -116,6 +116,11 @@ void qSlicerSettingsViewsPanelPrivate::init()
   QObject::connect(this->SliceViewOrientationComboBox, SIGNAL(activated(int)),
     q, SLOT(sliceViewOrientationChangedByUser()));
 
+  q->registerProperty("DefaultSliceView/SliceEdgeVisibility3D", this->SliceEdgeVisibility3DCheckBox,
+    /*no tr*/"checked", SIGNAL(toggled(bool)),
+    qSlicerSettingsViewsPanel::tr("Slice edge visibility in 3D views"),
+    ctkSettingsPanel::OptionRequireRestart);
+
   q->registerProperty("Default3DView/BoxVisibility", this->ThreeDBoxVisibilityCheckBox,
                       /*no tr*/"checked", SIGNAL(toggled(bool)),
                       qSlicerSettingsViewsPanel::tr("3D view cube visibility"));

--- a/Libs/MRML/Core/vtkMRMLSliceNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.cxx
@@ -103,6 +103,8 @@ vtkMRMLSliceNode::vtkMRMLSliceNode()
   this->WidgetNormalLockedToCamera = 0;
   this->UseLabelOutline = 0;
 
+  this->SliceEdgeVisibility3D = true;
+
   this->LayoutGridColumns = 1;
   this->LayoutGridRows = 1;
 
@@ -910,6 +912,7 @@ void vtkMRMLSliceNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBooleanMacro(widgetVisibility, WidgetVisible);
   vtkMRMLWriteXMLBooleanMacro(widgetOutlineVisibility, WidgetOutlineVisible);
   vtkMRMLWriteXMLBooleanMacro(useLabelOutline, UseLabelOutline);
+  vtkMRMLWriteXMLBooleanMacro(sliceEdgeVisibility3D, SliceEdgeVisibility3D);
   vtkMRMLWriteXMLIntMacro(sliceSpacingMode, SliceSpacingMode);
   vtkMRMLWriteXMLVectorMacro(prescribedSliceSpacing, PrescribedSliceSpacing, double, 3);
 
@@ -962,6 +965,7 @@ void vtkMRMLSliceNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBooleanMacro(widgetVisibility, WidgetVisible);
   vtkMRMLReadXMLBooleanMacro(widgetOutlineVisibility, WidgetOutlineVisible);
   vtkMRMLReadXMLBooleanMacro(useLabelOutline, UseLabelOutline);
+  vtkMRMLReadXMLBooleanMacro(sliceEdgeVisibility3D, SliceEdgeVisibility3D);
   vtkMRMLReadXMLStdStringMacro(orientation, Orientation);
   vtkMRMLReadXMLStringMacro(defaultOrientation, DefaultOrientation);
   vtkMRMLReadXMLStringMacro(orientationReference, OrientationReference);
@@ -1118,6 +1122,8 @@ void vtkMRMLSliceNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
   vtkMRMLCopyBooleanMacro(WidgetOutlineVisible);
   vtkMRMLCopyBooleanMacro(UseLabelOutline);
 
+  vtkMRMLCopyBooleanMacro(SliceEdgeVisibility3D);
+
   vtkMRMLCopyIntMacro(SliceResolutionMode);
 
   vtkMRMLCopyVectorMacro(FieldOfView, double, 3);
@@ -1192,6 +1198,8 @@ void vtkMRMLSliceNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBooleanMacro(WidgetVisible);
   vtkMRMLPrintBooleanMacro(WidgetOutlineVisible);
   vtkMRMLPrintBooleanMacro(UseLabelOutline);
+
+  vtkMRMLPrintBooleanMacro(SliceEdgeVisibility3D);
 
   os << indent << "Jump mode: ";
   if (this->JumpMode == CenteredJumpSlice)

--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -81,10 +81,17 @@ class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
   vtkSetMacro(SliceVisible, int);
 
   ///
+  /// Show colored slice edge in 3D views.
+  vtkGetMacro(SliceEdgeVisibility3D, bool);
+  vtkSetMacro(SliceEdgeVisibility3D, bool);
+  vtkBooleanMacro(SliceEdgeVisibility3D, bool);
+
+  ///
   /// The visibility of the slice plane widget in the 3DViewer.
   vtkGetMacro(WidgetVisible, int);
   vtkSetMacro(WidgetVisible, int);
 
+  ///
   /// The visibility of the slice plane widget outline in the 3DViewer.
   vtkGetMacro(WidgetOutlineVisible, int);
   vtkSetMacro(WidgetOutlineVisible, int);
@@ -469,6 +476,7 @@ public:
   ///    XYZOriginFlag - broadcast the XYZOrigin to all linked viewers
   ///    LabelOutlineFlag - broadcast outlining the labelmaps
   ///    SliceVisibleFlag = broadcast display of slice in 3D
+  ///    SliceEdgeVisibility3DFlag = broadcast display of slice edge in 3D
   ///    ResetOrientationFlag = broadcast a reset to default orientation to all linked viewers
   ///    UpdateSlabReconstructionThicknessFlag = broadcast updating the slab reconstruction thickness
   enum InteractionFlagType
@@ -482,10 +490,11 @@ public:
     XYZOriginFlag = 32,
     LabelOutlineFlag = 64,
     SliceVisibleFlag = 128,
-    SliceSpacingFlag = 256,
-    ResetOrientationFlag = 512,
-    RotateToBackgroundVolumePlaneFlag = 1024,
-    UpdateSlabReconstructionThicknessFlag = 2048,
+    SliceEdgeVisibility3DFlag = 256,
+    SliceSpacingFlag = 512,
+    ResetOrientationFlag = 1024,
+    RotateToBackgroundVolumePlaneFlag = 2048,
+    UpdateSlabReconstructionThicknessFlag = 4096,
   };
 
   /// Get/Set a flag indicating what parameters are being manipulated
@@ -580,6 +589,7 @@ protected:
   int WidgetOutlineVisible;
   int WidgetNormalLockedToCamera;
   int UseLabelOutline;
+  bool SliceEdgeVisibility3D;
 
   double FieldOfView[3];
   double XYZOrigin[3];

--- a/Libs/MRML/DisplayableManager/CMakeLists.txt
+++ b/Libs/MRML/DisplayableManager/CMakeLists.txt
@@ -75,6 +75,7 @@ set(DisplayableManager_SRCS
   vtkMRMLModelDisplayableManager.cxx
   vtkMRMLViewDisplayableManager.cxx
   vtkMRMLThreeDReformatDisplayableManager.cxx
+  vtkMRMLThreeDSliceEdgeDisplayableManager.cxx
 
   # DisplayableManager associated with SliceView
   vtkMRMLCrosshairDisplayableManager.cxx
@@ -114,6 +115,7 @@ set(KIT_SRCS
   vtkMRMLCameraWidget.cxx
   vtkMRMLInteractionWidget.cxx
   vtkMRMLInteractionWidgetRepresentation.cxx
+  vtkMRMLSliceEdgeWidgetRepresentation.cxx
   vtkMRMLSliceIntersectionWidget.cxx
   vtkMRMLSliceIntersectionRepresentation2D.cxx
   vtkMRMLSliceIntersectionInteractionRepresentation.cxx

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractThreeDViewDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractThreeDViewDisplayableManager.h
@@ -52,6 +52,10 @@ public:
   /// Get the MRML ID of the picked node, returns empty string if no pick
   virtual const char* GetPickedNodeID() { return nullptr; }
 
+  /// Get the view scale factor at a given position in world coordinates for a 3D view renderer.
+  static double GetViewScaleFactorAtPosition(vtkRenderer* renderer, double positionWorld[3],
+                                             vtkMRMLInteractionEventData* interactionEventData = nullptr);
+
 protected:
 
   vtkMRMLAbstractThreeDViewDisplayableManager();

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.h
@@ -332,8 +332,6 @@ protected:
   virtual void SetupInteractionPipeline();
   InteractionPipeline* Pipeline;
 
-  double GetViewScaleFactorAtPosition(double positionWorld[3]);
-
 private:
   vtkMRMLInteractionWidgetRepresentation(const vtkMRMLInteractionWidgetRepresentation&) = delete;
   void operator=(const vtkMRMLInteractionWidgetRepresentation&) = delete;

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceEdgeWidgetRepresentation.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceEdgeWidgetRepresentation.cxx
@@ -1,0 +1,365 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Davide Punzo, punzodavide@hotmail.it,
+  and development was supported in part by CI3.
+
+==============================================================================*/
+
+// VTK includes
+#include <vtkActor.h>
+#include <vtkCallbackCommand.h>
+#include <vtkCamera.h>
+#include <vtkFeatureEdges.h>
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkPolyData.h>
+#include <vtkPolyDataMapper.h>
+#include <vtkProperty.h>
+#include <vtkRenderer.h>
+#include <vtkRenderWindow.h>
+#include <vtkStripper.h>
+#include <vtkTubeFilter.h>
+
+// MRML includes
+#include <vtkMRMLAbstractThreeDViewDisplayableManager.h>
+#include <vtkMRMLInteractionEventData.h>
+#include <vtkMRMLModelNode.h>
+#include <vtkMRMLSliceNode.h>
+#include <vtkMRMLTransformNode.h>
+#include <vtkMRMLViewNode.h>
+
+#include <vtkMRMLSliceEdgeWidgetRepresentation.h>
+
+vtkStandardNewMacro(vtkMRMLSliceEdgeWidgetRepresentation);
+
+//----------------------------------------------------------------------
+vtkMRMLSliceEdgeWidgetRepresentation::vtkMRMLSliceEdgeWidgetRepresentation()
+{
+  this->ViewScaleFactorMmPerPixel = 1.0;
+  this->ScreenSizePixel = 1000;
+  this->NeedToRender = false;
+  this->AlwaysOnTop = true;
+  this->Pipeline = nullptr;
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceEdgeWidgetRepresentation::SetupSliceEdgePipeline()
+{
+  this->Pipeline = new SliceEdgePipeline();
+  this->NeedToRenderOn();
+}
+
+//----------------------------------------------------------------------
+vtkMRMLSliceEdgeWidgetRepresentation::~vtkMRMLSliceEdgeWidgetRepresentation()
+{
+  // Force deleting variables to prevent circular dependency keeping objects alive
+  if (this->Pipeline != nullptr)
+  {
+    delete this->Pipeline;
+    this->Pipeline = nullptr;
+  }
+}
+
+//-----------------------------------------------------------------------------
+void vtkMRMLSliceEdgeWidgetRepresentation::PrintSelf(ostream& os,
+                                                      vtkIndent indent)
+{
+  Superclass::PrintSelf(os, indent);
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceEdgeWidgetRepresentation::UpdateFromMRML(
+    vtkMRMLNode* vtkNotUsed(caller), unsigned long vtkNotUsed(event), void *vtkNotUsed(callData))
+{
+  if (!this->Pipeline)
+  {
+    this->SetupSliceEdgePipeline();
+  }
+
+  if (this->GetSliceNode())
+  {
+    this->UpdateSliceEdgeFromSliceNode();
+  }
+
+  if (this->Pipeline)
+  {
+    this->UpdateSliceEdgePipeline();
+  }
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceEdgeWidgetRepresentation::UpdateSliceEdgePipeline()
+{
+  if (!this->Pipeline)
+  {
+    return;
+  }
+
+  double radius = this->ViewScaleFactorMmPerPixel * this->SliceEdgeSize;
+  double previousRadius = this->Pipeline->TubeFilter->GetRadius();
+  if (fabs(radius - previousRadius) < 1e-6)
+  {
+    return;
+  }
+
+  this->Pipeline->TubeFilter->SetRadius(radius);
+  this->NeedToRenderOn();
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceEdgeWidgetRepresentation::GetActors(vtkPropCollection* pc)
+{
+  vtkProp* actor = this->GetSliceEdgeActor();
+  if (actor)
+  {
+    actor->GetActors(pc);
+  }
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceEdgeWidgetRepresentation::ReleaseGraphicsResources(vtkWindow* window)
+{
+  vtkProp* actor = this->GetSliceEdgeActor();
+  if (actor)
+  {
+    actor->ReleaseGraphicsResources(window);
+  }
+}
+
+//----------------------------------------------------------------------
+int vtkMRMLSliceEdgeWidgetRepresentation::RenderOverlay(vtkViewport* viewport)
+{
+  int count = 0;
+  vtkProp* actor = this->GetSliceEdgeActor();
+  if (this->Pipeline && actor->GetVisibility())
+  {
+    count += actor->RenderOverlay(viewport);
+  }
+  return count;
+}
+
+//----------------------------------------------------------------------
+int vtkMRMLSliceEdgeWidgetRepresentation::RenderOpaqueGeometry(vtkViewport* viewport)
+{
+  if (!this->Pipeline)
+  {
+    this->SetupSliceEdgePipeline();
+  }
+
+  int count = 0;
+  vtkProp* actor = this->GetSliceEdgeActor();
+  if (actor && actor->GetVisibility())
+  {
+    this->UpdateSliceEdgeFromSliceNode();
+    this->UpdateViewScaleFactor();
+    this->UpdateSliceEdgePipeline();
+    count += actor->RenderOpaqueGeometry(viewport);
+  }
+  return count;
+}
+
+//----------------------------------------------------------------------
+int vtkMRMLSliceEdgeWidgetRepresentation::RenderTranslucentPolygonalGeometry(vtkViewport* viewport)
+{
+  int count = 0;
+  vtkProp* actor = this->GetSliceEdgeActor();
+  if (actor && actor->GetVisibility())
+  {
+    actor->SetPropertyKeys(this->GetPropertyKeys());
+    count += actor->RenderTranslucentPolygonalGeometry(viewport);
+  }
+  return count;
+}
+
+//----------------------------------------------------------------------
+vtkTypeBool vtkMRMLSliceEdgeWidgetRepresentation::HasTranslucentPolygonalGeometry()
+{
+  vtkProp* actor = this->GetSliceEdgeActor();
+  if (actor && actor->GetVisibility() &&
+    actor->HasTranslucentPolygonalGeometry())
+  {
+    return true;
+  }
+  return false;
+}
+
+//----------------------------------------------------------------------
+vtkMRMLSliceEdgeWidgetRepresentation::SliceEdgePipeline::SliceEdgePipeline()
+{
+  this->FeatureEdges = vtkSmartPointer<vtkFeatureEdges>::New();
+  this->FeatureEdges->SetOutputPointsPrecision(vtkAlgorithm::SINGLE_PRECISION);
+  this->FeatureEdges->SetBoundaryEdges(true);
+  this->FeatureEdges->SetFeatureEdges(false);
+  this->FeatureEdges->SetNonManifoldEdges(false);
+  this->FeatureEdges->SetManifoldEdges(false);
+  this->FeatureEdges->SetColoring(false);
+
+  this->Stripper = vtkSmartPointer<vtkStripper>::New();
+  this->Stripper->SetInputConnection(FeatureEdges->GetOutputPort());
+
+  this->TubeFilter = vtkSmartPointer<vtkTubeFilter>::New();
+  this->TubeFilter->SetInputConnection(this->Stripper->GetOutputPort());
+  this->TubeFilter->SetRadius(0.75);
+  this->TubeFilter->SetNumberOfSides(12);
+
+  this->Mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+  this->Mapper->SetInputConnection(TubeFilter->GetOutputPort());
+
+  this->Actor = vtkSmartPointer<vtkActor>::New();
+  this->Actor->SetMapper(this->Mapper);
+  this->Actor->PickableOff();
+
+  vtkProperty* prop = this->Actor->GetProperty();
+  prop->SetRepresentationToSurface();
+  prop->SetAmbient(0.5);
+  prop->SetDiffuse(0.5);
+  prop->SetSpecular(0);
+  prop->SetShading(true);
+  prop->SetSpecularPower(1);
+  prop->SetOpacity(1.);
+  prop->SetEdgeVisibility(false);
+  prop->SetVertexVisibility(false);
+}
+
+//----------------------------------------------------------------------
+vtkProp* vtkMRMLSliceEdgeWidgetRepresentation::GetSliceEdgeActor()
+{
+  if (!this->Pipeline)
+  {
+    return nullptr;
+  }
+  return this->Pipeline->Actor;
+}
+
+//----------------------------------------------------------------------
+vtkPolyData* vtkMRMLSliceEdgeWidgetRepresentation::GetSliceEdgePolydata()
+{
+  if (!this->Pipeline)
+  {
+    return nullptr;
+  }
+  return this->Pipeline->TubeFilter->GetOutput();
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceEdgeWidgetRepresentation::GetSliceEdgeColor(double color[4])
+{
+  if (!this->Pipeline || !color)
+  {
+    return;
+  }
+
+  double rgb[3];
+  this->Pipeline->Actor->GetProperty()->GetColor(rgb);
+  color[0] = rgb[0];
+  color[1] = rgb[1];
+  color[2] = rgb[2];
+  color[3] = this->Pipeline->Actor->GetProperty()->GetOpacity();
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceEdgeWidgetRepresentation::setSliceNode(vtkMRMLSliceNode *sliceNode)
+{
+  if (!sliceNode || this->SliceNode == sliceNode)
+  {
+    return;
+  }
+
+  this->SliceNode = sliceNode;
+  this->UpdateSliceEdgeFromSliceNode();
+}
+
+//----------------------------------------------------------------------
+vtkMRMLSliceNode* vtkMRMLSliceEdgeWidgetRepresentation::GetSliceNode()
+{
+  return this->SliceNode;
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceEdgeWidgetRepresentation::setSliceModelNode(vtkMRMLModelNode *sliceModelNode)
+{
+  if (!this->Pipeline || this->SliceModelNode == sliceModelNode)
+  {
+    // no change
+    return;
+  }
+
+  this->SliceModelNode = sliceModelNode;
+  this->Pipeline->FeatureEdges->SetInputConnection(sliceModelNode ? sliceModelNode->GetPolyDataConnection() : nullptr);
+
+  this->NeedToRenderOn();
+}
+
+//----------------------------------------------------------------------
+vtkMRMLModelNode* vtkMRMLSliceEdgeWidgetRepresentation::GetSliceModelNode()
+{
+  return this->SliceModelNode;
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceEdgeWidgetRepresentation::UpdateSliceEdgeFromSliceNode()
+{
+  if (!this->GetSliceNode() || !this->Pipeline)
+  {
+    return;
+  }
+
+  vtkProperty* prop = this->Pipeline->Actor->GetProperty();
+  double rgb[3];
+  prop->GetColor(rgb);
+  double* layoutColor = this->GetSliceNode()->GetLayoutColor();
+  const double tolerance = 1.e-6;
+  if (fabs(layoutColor[0] - rgb[0]) < tolerance &&
+    fabs(layoutColor[1] - rgb[1]) < tolerance &&
+    fabs(layoutColor[2] - rgb[2]) < tolerance)
+  {
+    // no change
+    return;
+  }
+
+  prop->SetColor(layoutColor);
+  this->NeedToRenderOn();
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceEdgeWidgetRepresentation::UpdateViewScaleFactor()
+{
+  this->ViewScaleFactorMmPerPixel = 1.0;
+  this->ScreenSizePixel = 1000.0;
+  if (!this->Renderer || !this->Renderer->GetActiveCamera() || !this->Renderer->GetRenderWindow())
+  {
+    return;
+  }
+
+  if (this->Renderer->GetRenderWindow()->GetNeverRendered())
+  {
+    // In VR, calling GetScreenSize() without rendering can cause a crash.
+    return;
+  }
+
+  const int* screenSize = this->Renderer->GetRenderWindow()->GetScreenSize();
+  double screenSizePixel = sqrt(screenSize[0] * screenSize[0] + screenSize[1] * screenSize[1]);
+  if (screenSizePixel < 1.0)
+  {
+    // render window is not fully initialized yet
+    return;
+  }
+  this->ScreenSizePixel = screenSizePixel;
+
+  double cameraFP[3] = { 0.0 };
+  this->Renderer->GetActiveCamera()->GetFocalPoint(cameraFP);
+  this->ViewScaleFactorMmPerPixel = vtkMRMLAbstractThreeDViewDisplayableManager::
+    GetViewScaleFactorAtPosition(this->Renderer, cameraFP);
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceEdgeWidgetRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceEdgeWidgetRepresentation.h
@@ -1,0 +1,119 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Davide Punzo, punzodavide@hotmail.it,
+  and development was supported in part by CI3.
+
+==============================================================================*/
+
+#ifndef vtkMRMLSliceEdgeWidgetRepresentation_h
+#define vtkMRMLSliceEdgeWidgetRepresentation_h
+
+// MRMLDM includes
+#include "vtkMRMLDisplayableManagerExport.h"
+#include "vtkMRMLAbstractWidgetRepresentation.h"
+
+class vtkMRMLInteractionEventData;
+class vtkMRMLModelNode;
+class vtkMRMLSliceNode;
+
+class vtkActor;
+class vtkPolyDataMapper;
+class vtkFeatureEdges;
+class vtkPolyData;
+class vtkStripper;
+class vtkTubeFilter;
+
+class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLSliceEdgeWidgetRepresentation
+  : public vtkMRMLAbstractWidgetRepresentation
+{
+public:
+  /// Instantiate this class.
+  static vtkMRMLSliceEdgeWidgetRepresentation *New();
+
+  ///@{
+  /// Standard VTK class macros.
+  vtkTypeMacro(vtkMRMLSliceEdgeWidgetRepresentation, vtkMRMLAbstractWidgetRepresentation);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+  ///@}
+
+  /// Update the representation from display node
+  void UpdateFromMRML(vtkMRMLNode* caller, unsigned long event, void *callData = nullptr) override;
+
+  /// Methods to make this class behave as a vtkProp.
+  void GetActors(vtkPropCollection*) override;
+  void ReleaseGraphicsResources(vtkWindow*) override;
+  int RenderOverlay(vtkViewport* viewport) override;
+  int RenderOpaqueGeometry(vtkViewport* viewport) override;
+  int RenderTranslucentPolygonalGeometry(vtkViewport* viewport) override;
+  vtkTypeBool HasTranslucentPolygonalGeometry() override;
+
+  /// Returns the actor for the interaction widget.
+  vtkProp* GetSliceEdgeActor();
+
+  virtual void setSliceNode(vtkMRMLSliceNode* sliceNode);
+  virtual vtkMRMLSliceNode* GetSliceNode();
+
+  virtual void setSliceModelNode(vtkMRMLModelNode* sliceNode);
+  virtual vtkMRMLModelNode* GetSliceModelNode();
+
+  virtual void UpdateSliceEdgeFromSliceNode();
+  virtual void UpdateViewScaleFactor();
+  virtual void UpdateSliceEdgePipeline();
+
+  /// Get size of slice edge in world coordinate system
+  vtkGetMacro(SliceEdgeSize, double);
+
+  virtual vtkPolyData* GetSliceEdgePolydata();
+  virtual void GetSliceEdgeColor(double color[4]);
+
+  vtkGetMacro(Interacting, bool);
+
+protected:
+  vtkMRMLSliceEdgeWidgetRepresentation();
+  ~vtkMRMLSliceEdgeWidgetRepresentation() override;
+
+  class SliceEdgePipeline
+  {
+  public:
+    SliceEdgePipeline();
+    ~SliceEdgePipeline() = default;
+
+    vtkSmartPointer<vtkActor> Actor;
+    vtkSmartPointer<vtkPolyDataMapper> Mapper;
+    vtkSmartPointer<vtkFeatureEdges> FeatureEdges;
+    vtkSmartPointer<vtkStripper> Stripper;
+    vtkSmartPointer<vtkTubeFilter> TubeFilter;
+  };
+
+  double ViewScaleFactorMmPerPixel;
+  double ScreenSizePixel; // diagonal size of the screen
+
+  /// Handle size, specified in renderer world coordinate system.
+  /// For 3D views, renderer world coordinate system is the Slicer world coordinate system, so it is measured in the
+  /// scene length unit (typically millimeters).
+  double SliceEdgeSize{2.0};
+  bool Interacting{false};
+
+  virtual void SetupSliceEdgePipeline();
+  SliceEdgePipeline* Pipeline;
+  vtkWeakPointer<vtkMRMLSliceNode> SliceNode;
+  vtkWeakPointer<vtkMRMLModelNode> SliceModelNode;
+
+private:
+  vtkMRMLSliceEdgeWidgetRepresentation(const vtkMRMLSliceEdgeWidgetRepresentation&) = delete;
+  void operator=(const vtkMRMLSliceEdgeWidgetRepresentation&) = delete;
+};
+
+#endif

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.h
@@ -185,8 +185,6 @@ class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLSliceIntersectionInteractionRepr
     /// scene length unit (typically millimeters).
     double InteractionSize{ 3.0 };
 
-    double GetViewScaleFactorAtPosition(double positionWorld[3]);
-
     vtkMRMLApplicationLogic* MRMLApplicationLogic;
 
     class vtkInternal;

--- a/Libs/MRML/DisplayableManager/vtkMRMLThreeDSliceEdgeDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLThreeDSliceEdgeDisplayableManager.cxx
@@ -1,0 +1,435 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Davide Punzo, punzodavide@hotmail.it,
+  and development was supported in part by CI3.
+
+==============================================================================*/
+
+// MRMLDisplayableManager includes
+#include "vtkMRMLThreeDSliceEdgeDisplayableManager.h"
+#include "vtkMRMLCameraNode.h"
+
+// MRML includes
+#include <vtkMRMLSliceEdgeWidgetRepresentation.h>
+#include <vtkMRMLApplicationLogic.h>
+#include <vtkMRMLModelNode.h>
+#include <vtkMRMLScene.h>
+#include <vtkMRMLSliceNode.h>
+#include <vtkMRMLSliceLogic.h>
+#include <vtkMRMLViewNode.h>
+
+// VTK includes
+#include <vtkActor.h>
+#include <vtkCallbackCommand.h>
+#include <vtkCamera.h>
+#include <vtkEventBroker.h>
+#include <vtkFeatureEdges.h>
+#include <vtkNew.h>
+#include <vtkPolyDataMapper.h>
+#include <vtkProperty.h>
+#include <vtkRenderer.h>
+#include <vtkRenderWindow.h>
+#include <vtkStripper.h>
+#include <vtkTubeFilter.h>
+
+//---------------------------------------------------------------------------
+vtkStandardNewMacro(vtkMRMLThreeDSliceEdgeDisplayableManager);
+
+//---------------------------------------------------------------------------
+class vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal
+{
+public:
+  typedef std::map<std::string, vtkSmartPointer<vtkMRMLSliceEdgeWidgetRepresentation>> SliceEdgeWidgetRepresentationsType; // SliceNodeID -> Widget
+
+  vtkInternal(vtkMRMLThreeDSliceEdgeDisplayableManager* external);
+  ~vtkInternal();
+
+  // View
+  vtkMRMLViewNode* GetViewNode();
+
+  // SliceNodes
+  void AddSliceNode(vtkMRMLSliceNode* sliceNode);
+  void RemoveSliceNode(vtkMRMLSliceNode* sliceNode);
+  void RemoveAllSliceNodes();
+  void UpdateSliceNodes();
+  vtkMRMLSliceNode* GetSliceNode(vtkMRMLSliceEdgeWidgetRepresentation* rep);
+  void AddObservations(vtkMRMLSliceNode* node);
+  void RemoveObservations(vtkMRMLSliceNode* node);
+
+  // Widget
+  vtkSmartPointer<vtkMRMLSliceEdgeWidgetRepresentation> NewSliceSliceEdgeWidgetRepresentation();
+  vtkMRMLSliceEdgeWidgetRepresentation* GetSliceEdgeWidgetRepresenatation(vtkMRMLSliceNode*);
+  // return with true if rendering is required
+  void UpdateAllSliceEdgePipelines();
+  // return with true if rendering is required
+  void UpdateSliceEdgeWidgetRepresentation(vtkMRMLSliceNode*, vtkMRMLSliceEdgeWidgetRepresentation*);
+  void UpdateSliceEdgeWidgetRepresentationVisibility(vtkMRMLSliceEdgeWidgetRepresentation* rep, vtkMRMLSliceNode* sliceNode);
+  void UpdateSliceEdgeWidgetRepresentationMesh(vtkMRMLSliceEdgeWidgetRepresentation* rep, vtkMRMLSliceNode* sliceNode);
+
+  SliceEdgeWidgetRepresentationsType SliceEdgeWidgetRepresentations;
+  vtkMRMLThreeDSliceEdgeDisplayableManager* External;
+  double ViewScaleFactorMmPerPixel;
+  double ScreenSizePixel;
+};
+
+//---------------------------------------------------------------------------
+// vtkInternal methods
+
+//---------------------------------------------------------------------------
+vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::vtkInternal(
+  vtkMRMLThreeDSliceEdgeDisplayableManager* _external)
+{
+  this->External = _external;
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::~vtkInternal()
+{
+  this->RemoveAllSliceNodes();
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLViewNode* vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::GetViewNode()
+{
+  return this->External->GetMRMLViewNode();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::AddObservations(vtkMRMLSliceNode* node)
+{
+  vtkEventBroker* broker = vtkEventBroker::GetInstance();
+  vtkEventBroker::ObservationVector observations;
+  if (!broker->GetObservationExist(node, vtkCommand::ModifiedEvent,
+    this->External, this->External->GetMRMLNodesCallbackCommand()))
+  {
+    broker->AddObservation(node, vtkCommand::ModifiedEvent,
+      this->External, this->External->GetMRMLNodesCallbackCommand());
+  }
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::RemoveObservations(vtkMRMLSliceNode* node)
+{
+  vtkEventBroker* broker = vtkEventBroker::GetInstance();
+  vtkEventBroker::ObservationVector observations;
+  observations = broker->GetObservations(
+    node, vtkCommand::ModifiedEvent, this->External, this->External->GetMRMLNodesCallbackCommand());
+  broker->RemoveObservations(observations);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::AddSliceNode(vtkMRMLSliceNode* sliceNode)
+{
+  if (!sliceNode)
+  {
+    return;
+  }
+
+  std::string sliceNodeID = sliceNode->GetID();
+  auto widgetRepIt = this->SliceEdgeWidgetRepresentations.find(sliceNodeID);
+  if (widgetRepIt == this->SliceEdgeWidgetRepresentations.end())
+  {
+    // We associate the node with the widget if an instantiation is called.
+    // We add the sliceNode without instantiating the widget first.
+    this->AddObservations(sliceNode);
+    this->SliceEdgeWidgetRepresentations[sliceNodeID] = nullptr;
+  }
+
+  this->UpdateSliceEdgeWidgetRepresentation(sliceNode, nullptr);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::RemoveSliceNode(vtkMRMLSliceNode* sliceNode)
+{
+  if (!sliceNode)
+  {
+    return;
+  }
+  std::string sliceNodeID = sliceNode->GetID();
+  this->RemoveObservations(sliceNode);
+  // The manager has the responsibility to delete the rep.
+  auto widgetRepIt = this->SliceEdgeWidgetRepresentations.find(sliceNodeID);
+  if (widgetRepIt != this->SliceEdgeWidgetRepresentations.end())
+  {
+    vtkMRMLSliceEdgeWidgetRepresentation* rep = widgetRepIt->second;
+    vtkRenderer* renderer = this->External->GetRenderer();
+    if (renderer && rep && renderer->HasViewProp(rep))
+    {
+      renderer->RemoveViewProp(rep);
+      this->External->RequestRender();
+    }
+    this->SliceEdgeWidgetRepresentations.erase(widgetRepIt);
+  }
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::RemoveAllSliceNodes()
+{
+  this->RemoveObservations(nullptr);
+  for (auto sliceNodeIDToWidgetRep : this->SliceEdgeWidgetRepresentations)
+  {
+    vtkMRMLSliceEdgeWidgetRepresentation* rep = sliceNodeIDToWidgetRep.second;
+    vtkRenderer* renderer = this->External->GetRenderer();
+    if (renderer && rep && renderer->HasViewProp(rep))
+    {
+      renderer->RemoveViewProp(rep);
+      this->External->RequestRender();
+    }
+  }
+  this->SliceEdgeWidgetRepresentations.clear();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::UpdateSliceNodes()
+{
+  if (this->External->GetMRMLScene() == nullptr)
+  {
+    this->RemoveAllSliceNodes();
+    return;
+  }
+
+  vtkMRMLNode* node;
+  vtkCollectionSimpleIterator it;
+  vtkCollection* scene = this->External->GetMRMLScene()->GetNodes();
+  for (scene->InitTraversal(it);
+       (node = vtkMRMLNode::SafeDownCast(scene->GetNextItemAsObject(it))) ;)
+  {
+    vtkMRMLSliceNode* sliceNode = vtkMRMLSliceNode::SafeDownCast(node);
+    if (sliceNode)
+    {
+      this->AddSliceNode(sliceNode);
+    }
+  }
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLSliceNode* vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::GetSliceNode(vtkMRMLSliceEdgeWidgetRepresentation* rep)
+{
+  if (!rep || !this->External->GetMRMLScene())
+  {
+    return nullptr;
+  }
+
+  // Get the slice node
+  vtkMRMLSliceNode* sliceNode = nullptr;
+  for (auto sliceNodeIDToWidgetRep : this->SliceEdgeWidgetRepresentations)
+  {
+    if (sliceNodeIDToWidgetRep.second.Get() == rep)
+    {
+      return vtkMRMLSliceNode::SafeDownCast(this->External->GetMRMLScene()->GetNodeByID(sliceNodeIDToWidgetRep.first));
+    }
+  }
+
+  return nullptr;
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::UpdateSliceEdgeWidgetRepresentationVisibility(
+  vtkMRMLSliceEdgeWidgetRepresentation* rep, vtkMRMLSliceNode* sliceNode)
+{
+  if (!rep || !sliceNode)
+  {
+    return;
+  }
+  vtkRenderer* renderer = this->External->GetRenderer();
+  if (!renderer)
+  {
+    return;
+  }
+
+  bool show =
+    sliceNode->IsDisplayableInThreeDView(this->External->GetMRMLViewNode()->GetID())
+    && sliceNode->GetSliceVisible() && sliceNode->GetSliceEdgeVisibility3D();
+
+  bool isShown = renderer->HasViewProp(rep);
+  if (show == isShown)
+  {
+    // no change
+    return;
+  }
+
+  if (show)
+  {
+    renderer->AddViewProp(rep);
+  }
+  else
+  {
+    renderer->RemoveViewProp(rep);
+  }
+
+  this->External->RequestRender();
+}
+
+//---------------------------------------------------------------------------
+vtkSmartPointer<vtkMRMLSliceEdgeWidgetRepresentation> vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::NewSliceSliceEdgeWidgetRepresentation()
+{
+  vtkSmartPointer<vtkMRMLSliceEdgeWidgetRepresentation> newRep = vtkSmartPointer<vtkMRMLSliceEdgeWidgetRepresentation>::New();
+  newRep->SetRenderer(this->External->GetRenderer());
+  newRep->SetViewNode(this->GetViewNode());
+  return newRep;
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLSliceEdgeWidgetRepresentation* vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::GetSliceEdgeWidgetRepresenatation(vtkMRMLSliceNode* sliceNode)
+{
+  if (!sliceNode)
+  {
+    return nullptr;
+  }
+  std::string nodeId = sliceNode->GetID();
+  auto it = this->SliceEdgeWidgetRepresentations.find(nodeId);
+  return (it != this->SliceEdgeWidgetRepresentations.end()) ? it->second.Get() : nullptr;
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::UpdateSliceEdgeWidgetRepresentationMesh(
+  vtkMRMLSliceEdgeWidgetRepresentation* rep, vtkMRMLSliceNode* sliceNode)
+{
+  if (!rep || !sliceNode)
+  {
+    return;
+  }
+  vtkMRMLApplicationLogic *mrmlAppLogic = this->External->GetMRMLApplicationLogic();
+  vtkMRMLSliceLogic* sliceLogic = (mrmlAppLogic ? mrmlAppLogic->GetSliceLogic(sliceNode) : nullptr);
+  vtkMRMLModelNode* sliceModelNode = (sliceLogic ? sliceLogic->GetSliceModelNode() : nullptr);
+  if (!sliceModelNode)
+  {
+    return;
+  }
+
+  rep->UpdateFromMRML(nullptr, 0);
+  rep->setSliceModelNode(sliceModelNode);
+  rep->setSliceNode(sliceNode);
+  this->External->RequestRender();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::UpdateAllSliceEdgePipelines()
+{
+  vtkMRMLScene* scene = this->External->GetMRMLScene();
+  if (!scene)
+  {
+    return;
+  }
+  bool renderRequired = false;
+  for (auto sliceNodeIDToWidgetRep : this->SliceEdgeWidgetRepresentations)
+  {
+    vtkMRMLSliceNode* sliceNode = vtkMRMLSliceNode::SafeDownCast(scene->GetNodeByID(sliceNodeIDToWidgetRep.first));
+    this->UpdateSliceEdgeWidgetRepresentation(sliceNode, sliceNodeIDToWidgetRep.second);
+  }
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::vtkInternal::UpdateSliceEdgeWidgetRepresentation(
+  vtkMRMLSliceNode* sliceNode, vtkMRMLSliceEdgeWidgetRepresentation* rep)
+{
+  if (!sliceNode || (!rep && !sliceNode->GetSliceVisible()))
+  {
+    return;
+  }
+
+  if (!rep)
+  {
+    // Instantiate widget and link it if
+    // there is no one associated to the sliceNode yet
+    vtkSmartPointer<vtkMRMLSliceEdgeWidgetRepresentation> newRep = this->NewSliceSliceEdgeWidgetRepresentation();
+    rep = newRep;
+    this->SliceEdgeWidgetRepresentations.find(sliceNode->GetID())->second = rep;
+  }
+
+  // Update rep
+  this->UpdateSliceEdgeWidgetRepresentationMesh(rep, sliceNode);
+  this->UpdateSliceEdgeWidgetRepresentationVisibility(rep, sliceNode);
+}
+
+//---------------------------------------------------------------------------
+// vtkMRMLSliceModelDisplayableManager methods
+
+//---------------------------------------------------------------------------
+vtkMRMLThreeDSliceEdgeDisplayableManager::vtkMRMLThreeDSliceEdgeDisplayableManager()
+{
+  this->Internal = new vtkInternal(this);
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLThreeDSliceEdgeDisplayableManager::~vtkMRMLThreeDSliceEdgeDisplayableManager()
+{
+  delete this->Internal;
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::UnobserveMRMLScene()
+{
+  this->Internal->RemoveAllSliceNodes();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::UpdateFromMRMLScene()
+{
+  this->Internal->UpdateSliceNodes();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::OnMRMLSceneNodeAdded(vtkMRMLNode* nodeAdded)
+{
+  if (this->GetMRMLScene()->IsBatchProcessing() ||
+      !nodeAdded->IsA("vtkMRMLSliceNode"))
+  {
+    return;
+  }
+
+  this->Internal->AddSliceNode(vtkMRMLSliceNode::SafeDownCast(nodeAdded));
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::OnMRMLSceneNodeRemoved(vtkMRMLNode* nodeRemoved)
+{
+  if (!nodeRemoved->IsA("vtkMRMLSliceNode"))
+  {
+    return;
+  }
+
+  this->Internal->RemoveSliceNode(vtkMRMLSliceNode::SafeDownCast(nodeRemoved));
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::OnMRMLNodeModified(vtkMRMLNode* node)
+{
+  vtkMRMLSliceNode* sliceNode = vtkMRMLSliceNode::SafeDownCast(node);
+  if (sliceNode)
+  {
+    vtkMRMLSliceEdgeWidgetRepresentation* rep = this->Internal->GetSliceEdgeWidgetRepresenatation(sliceNode);
+    this->Internal->UpdateSliceEdgeWidgetRepresentation(sliceNode, rep);
+  }
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::OnMRMLViewNodeModifiedEvent()
+{
+  this->Internal->UpdateAllSliceEdgePipelines();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLThreeDSliceEdgeDisplayableManager::Create()
+{
+  this->Internal->UpdateSliceNodes();
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLThreeDSliceEdgeDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLThreeDSliceEdgeDisplayableManager.h
@@ -1,0 +1,63 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Davide Punzo, punzodavide@hotmail.it,
+  and development was supported in part by CI3.
+
+==============================================================================*/
+
+#ifndef __vtkMRMLThreeDSliceEdgeDisplayableManager_h
+#define __vtkMRMLThreeDSliceEdgeDisplayableManager_h
+
+// MRMLDisplayableManager includes
+#include "vtkMRMLAbstractThreeDViewDisplayableManager.h"
+#include "vtkMRMLDisplayableManagerExport.h"
+
+/// \brief Displayable manager for showing slice edges in 3D views.
+///
+/// Responsible for any display based on the reformat widgets.
+class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLThreeDSliceEdgeDisplayableManager :
+  public vtkMRMLAbstractThreeDViewDisplayableManager
+{
+
+public:
+  static vtkMRMLThreeDSliceEdgeDisplayableManager* New();
+  vtkTypeMacro(vtkMRMLThreeDSliceEdgeDisplayableManager, vtkMRMLAbstractThreeDViewDisplayableManager);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+protected:
+  vtkMRMLThreeDSliceEdgeDisplayableManager();
+  ~vtkMRMLThreeDSliceEdgeDisplayableManager() override;
+
+  /// Initialize the displayable manager based on its associated
+  /// vtkMRMLSliceNode
+  void Create() override;
+
+  void UnobserveMRMLScene() override;
+  void UpdateFromMRMLScene() override;
+  void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
+  void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) override;
+  void OnMRMLNodeModified(vtkMRMLNode* node) override;
+  void OnMRMLViewNodeModifiedEvent() override;
+
+private:
+  vtkMRMLThreeDSliceEdgeDisplayableManager(const vtkMRMLThreeDSliceEdgeDisplayableManager&) = delete;
+  void operator=(const vtkMRMLThreeDSliceEdgeDisplayableManager&) = delete;
+
+  class vtkInternal;
+  vtkInternal* Internal;
+};
+
+#endif

--- a/Libs/MRML/Logic/vtkMRMLSliceLinkLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLinkLogic.cxx
@@ -506,6 +506,32 @@ void vtkMRMLSliceLinkLogic::BroadcastSliceNodeEvent(vtkMRMLSliceNode *sliceNode)
         }
       }
 
+      // Broadcasting the visibility of slice edge in 3D
+      if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
+        & vtkMRMLSliceNode::SliceEdgeVisibility3DFlag)
+      {
+        std::string layoutName(sliceNode->GetLayoutName() ? sliceNode->GetLayoutName() : "");
+        std::string lname(sNode->GetLayoutName() ? sNode->GetLayoutName() : "");
+        if (layoutName.find("Compare") == 0)
+        {
+          // Compare view, only broadcast to compare views
+          if (lname.find("Compare") == 0)
+          {
+            // Compare view, broadcast
+            sNode->SetSliceEdgeVisibility3D(sliceNode->GetSliceEdgeVisibility3D());
+          }
+        }
+        else
+        {
+          // Not a compare view, only broadcast to non compare views
+          if (lname.find("Compare") != 0)
+          {
+            // not a Compare view, broadcast
+            sNode->SetSliceEdgeVisibility3D(sliceNode->GetSliceEdgeVisibility3D());
+          }
+        }
+      }
+
       // Setting the slice spacing
       if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
         & vtkMRMLSliceNode::SliceSpacingFlag)

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>407</width>
+    <width>422</width>
     <height>175</height>
    </rect>
   </property>
@@ -35,7 +35,7 @@
       <bool>false</bool>
      </property>
      <property name="popupMode">
-      <enum>QToolButton::MenuButtonPopup</enum>
+      <enum>QToolButton::ToolButtonPopupMode::MenuButtonPopup</enum>
      </property>
      <property name="autoRaise">
       <bool>true</bool>
@@ -43,7 +43,7 @@
     </widget>
    </item>
    <item row="2" column="4">
-    <widget class="qMRMLNodeComboBox" name="LabelMapComboBox">
+    <widget class="qMRMLNodeComboBox" name="LabelMapComboBox" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>1</horstretch>
@@ -59,24 +59,24 @@
      <property name="toolTip">
       <string>Select the label map</string>
      </property>
-     <property name="nodeTypes">
+     <property name="nodeTypes" stdset="0">
       <stringlist notr="true">
        <string>vtkMRMLLabelMapVolumeNode</string>
       </stringlist>
      </property>
-     <property name="noneEnabled">
+     <property name="noneEnabled" stdset="0">
       <bool>true</bool>
      </property>
-     <property name="addEnabled">
+     <property name="addEnabled" stdset="0">
       <bool>false</bool>
      </property>
-     <property name="removeEnabled">
+     <property name="removeEnabled" stdset="0">
       <bool>false</bool>
      </property>
-     <property name="editEnabled">
+     <property name="editEnabled" stdset="0">
       <bool>true</bool>
      </property>
-     <property name="renameEnabled">
+     <property name="renameEnabled" stdset="0">
       <bool>true</bool>
      </property>
     </widget>
@@ -103,7 +103,7 @@
       <string/>
      </property>
      <property name="popupMode">
-      <enum>QToolButton::MenuButtonPopup</enum>
+      <enum>QToolButton::ToolButtonPopupMode::MenuButtonPopup</enum>
      </property>
      <property name="autoRaise">
       <bool>true</bool>
@@ -121,7 +121,7 @@
     </widget>
    </item>
    <item row="3" column="1" rowspan="2">
-    <widget class="ctkSliderWidget" name="ForegroundOpacitySlider">
+    <widget class="ctkSliderWidget" name="ForegroundOpacitySlider" native="true">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -131,25 +131,25 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="singleStep">
+     <property name="singleStep" stdset="0">
       <double>0.100000000000000</double>
      </property>
-     <property name="pageStep">
+     <property name="pageStep" stdset="0">
       <double>1.000000000000000</double>
      </property>
-     <property name="maximum">
+     <property name="maximum" stdset="0">
       <double>1.000000000000000</double>
      </property>
-     <property name="value">
+     <property name="value" stdset="0">
       <double>1.000000000000000</double>
      </property>
-     <property name="popupSlider">
+     <property name="popupSlider" stdset="0">
       <bool>false</bool>
      </property>
     </widget>
    </item>
    <item row="2" column="2">
-    <widget class="ctkSliderWidget" name="LabelMapOpacitySlider">
+    <widget class="ctkSliderWidget" name="LabelMapOpacitySlider" native="true">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -159,19 +159,19 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="singleStep">
+     <property name="singleStep" stdset="0">
       <double>0.100000000000000</double>
      </property>
-     <property name="pageStep">
+     <property name="pageStep" stdset="0">
       <double>1.000000000000000</double>
      </property>
-     <property name="maximum">
+     <property name="maximum" stdset="0">
       <double>1.000000000000000</double>
      </property>
     </widget>
    </item>
    <item row="3" column="4">
-    <widget class="qMRMLNodeComboBox" name="ForegroundComboBox">
+    <widget class="qMRMLNodeComboBox" name="ForegroundComboBox" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>1</horstretch>
@@ -187,24 +187,24 @@
      <property name="toolTip">
       <string>Select the foreground</string>
      </property>
-     <property name="nodeTypes">
+     <property name="nodeTypes" stdset="0">
       <stringlist notr="true">
        <string>vtkMRMLVolumeNode</string>
       </stringlist>
      </property>
-     <property name="noneEnabled">
+     <property name="noneEnabled" stdset="0">
       <bool>true</bool>
      </property>
-     <property name="addEnabled">
+     <property name="addEnabled" stdset="0">
       <bool>false</bool>
      </property>
-     <property name="removeEnabled">
+     <property name="removeEnabled" stdset="0">
       <bool>false</bool>
      </property>
-     <property name="editEnabled">
+     <property name="editEnabled" stdset="0">
       <bool>true</bool>
      </property>
-     <property name="renameEnabled">
+     <property name="renameEnabled" stdset="0">
       <bool>true</bool>
      </property>
     </widget>
@@ -220,7 +220,7 @@
     </widget>
    </item>
    <item row="1" column="2">
-    <widget class="ctkSliderWidget" name="SegmentationOpacitySlider">
+    <widget class="ctkSliderWidget" name="SegmentationOpacitySlider" native="true">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -230,19 +230,19 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="singleStep">
+     <property name="singleStep" stdset="0">
       <double>0.100000000000000</double>
      </property>
-     <property name="pageStep">
+     <property name="pageStep" stdset="0">
       <double>1.000000000000000</double>
      </property>
-     <property name="maximum">
+     <property name="maximum" stdset="0">
       <double>1.000000000000000</double>
      </property>
     </widget>
    </item>
    <item row="1" column="4">
-    <widget class="qMRMLSegmentSelectorWidget" name="SegmentSelectorWidget">
+    <widget class="qMRMLSegmentSelectorWidget" name="SegmentSelectorWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>1</horstretch>
@@ -255,22 +255,22 @@
        <height>0</height>
       </size>
      </property>
-     <property name="editEnabled">
+     <property name="editEnabled" stdset="0">
       <bool>true</bool>
      </property>
-     <property name="multiSelection">
+     <property name="multiSelection" stdset="0">
       <bool>true</bool>
      </property>
-     <property name="horizontalLayout">
+     <property name="horizontalLayout" stdset="0">
       <bool>false</bool>
      </property>
-     <property name="selectNodeUponCreation">
+     <property name="selectNodeUponCreation" stdset="0">
       <bool>true</bool>
      </property>
     </widget>
    </item>
    <item row="4" column="2">
-    <widget class="ctkSliderWidget" name="BackgroundOpacitySlider">
+    <widget class="ctkSliderWidget" name="BackgroundOpacitySlider" native="true">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -280,19 +280,19 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="singleStep">
+     <property name="singleStep" stdset="0">
       <double>0.100000000000000</double>
      </property>
-     <property name="pageStep">
+     <property name="pageStep" stdset="0">
       <double>1.000000000000000</double>
      </property>
-     <property name="maximum">
+     <property name="maximum" stdset="0">
       <double>1.000000000000000</double>
      </property>
-     <property name="value">
+     <property name="value" stdset="0">
       <double>1.000000000000000</double>
      </property>
-     <property name="popupSlider">
+     <property name="popupSlider" stdset="0">
       <bool>true</bool>
      </property>
     </widget>
@@ -303,7 +303,7 @@
       <bool>false</bool>
      </property>
      <property name="popupMode">
-      <enum>QToolButton::DelayedPopup</enum>
+      <enum>QToolButton::ToolButtonPopupMode::DelayedPopup</enum>
      </property>
      <property name="autoRaise">
       <bool>true</bool>
@@ -311,7 +311,7 @@
     </widget>
    </item>
    <item row="4" column="4">
-    <widget class="qMRMLNodeComboBox" name="BackgroundComboBox">
+    <widget class="qMRMLNodeComboBox" name="BackgroundComboBox" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>1</horstretch>
@@ -327,24 +327,24 @@
      <property name="toolTip">
       <string>Select the background</string>
      </property>
-     <property name="nodeTypes">
+     <property name="nodeTypes" stdset="0">
       <stringlist notr="true">
        <string>vtkMRMLVolumeNode</string>
       </stringlist>
      </property>
-     <property name="noneEnabled">
+     <property name="noneEnabled" stdset="0">
       <bool>true</bool>
      </property>
-     <property name="addEnabled">
+     <property name="addEnabled" stdset="0">
       <bool>false</bool>
      </property>
-     <property name="removeEnabled">
+     <property name="removeEnabled" stdset="0">
       <bool>false</bool>
      </property>
-     <property name="editEnabled">
+     <property name="editEnabled" stdset="0">
       <bool>true</bool>
      </property>
-     <property name="renameEnabled">
+     <property name="renameEnabled" stdset="0">
       <bool>true</bool>
      </property>
     </widget>
@@ -420,9 +420,9 @@
         </sizepolicy>
        </property>
        <property name="checked">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
-       <property name="mirrorOnExpand">
+       <property name="mirrorOnExpand" stdset="0">
         <bool>true</bool>
        </property>
       </widget>
@@ -481,7 +481,7 @@
            <bool>false</bool>
           </property>
           <property name="popupMode">
-           <enum>QToolButton::MenuButtonPopup</enum>
+           <enum>QToolButton::ToolButtonPopupMode::MenuButtonPopup</enum>
           </property>
           <property name="autoRaise">
            <bool>true</bool>
@@ -506,7 +506,7 @@
            <string>Slice orientation (Axial, Sagittal, Coronal, Reformat).</string>
           </property>
           <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContents</enum>
+           <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
           </property>
           <item>
            <property name="text">
@@ -540,7 +540,7 @@
             <normaloff>:/Icons/LayoutLightboxView.png</normaloff>:/Icons/LayoutLightboxView.png</iconset>
           </property>
           <property name="popupMode">
-           <enum>QToolButton::InstantPopup</enum>
+           <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
           </property>
           <property name="autoRaise">
            <bool>true</bool>
@@ -572,7 +572,7 @@
             <normaloff>:/Icons/SlicesComposite.png</normaloff>:/Icons/SlicesComposite.png</iconset>
           </property>
           <property name="popupMode">
-           <enum>QToolButton::InstantPopup</enum>
+           <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
           </property>
           <property name="autoRaise">
            <bool>true</bool>
@@ -592,7 +592,7 @@
             <normaloff>:/Icons/SlicerAutomaticSliceSpacing.png</normaloff>:/Icons/SlicerAutomaticSliceSpacing.png</iconset>
           </property>
           <property name="popupMode">
-           <enum>QToolButton::InstantPopup</enum>
+           <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
           </property>
           <property name="autoRaise">
            <bool>true</bool>
@@ -620,7 +620,7 @@
             <normaloff>:/Icons/OrientationMarker.png</normaloff>:/Icons/OrientationMarker.png</iconset>
           </property>
           <property name="popupMode">
-           <enum>QToolButton::InstantPopup</enum>
+           <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
           </property>
           <property name="autoRaise">
            <bool>true</bool>
@@ -637,7 +637,7 @@
             <normaloff>:/Icons/Ruler.png</normaloff>:/Icons/Ruler.png</iconset>
           </property>
           <property name="popupMode">
-           <enum>QToolButton::InstantPopup</enum>
+           <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
           </property>
           <property name="autoRaise">
            <bool>true</bool>
@@ -654,7 +654,7 @@
             <normaloff>:/Icons/SlabReconstruction.png</normaloff>:/Icons/SlabReconstruction.png</iconset>
           </property>
           <property name="popupMode">
-           <enum>QToolButton::InstantPopup</enum>
+           <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
           </property>
           <property name="autoRaise">
            <bool>true</bool>
@@ -671,7 +671,7 @@
             <normaloff>:/Icons/SliceMoreOptions.png</normaloff>:/Icons/SliceMoreOptions.png</iconset>
           </property>
           <property name="popupMode">
-           <enum>QToolButton::InstantPopup</enum>
+           <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
           </property>
           <property name="autoRaise">
            <bool>true</bool>
@@ -679,20 +679,20 @@
          </widget>
         </item>
         <item>
-         <widget class="ctkDynamicSpacer" name="DynamicSpacer">
-          <property name="activeSizePolicy">
+         <widget class="ctkDynamicSpacer" name="DynamicSpacer" native="true">
+          <property name="activeSizePolicy" stdset="0">
            <sizepolicy hsizetype="Minimum" vsizetype="Ignored">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="inactiveSizePolicy">
+          <property name="inactiveSizePolicy" stdset="0">
            <sizepolicy hsizetype="Expanding" vsizetype="Ignored">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="active">
+          <property name="active" stdset="0">
            <bool>true</bool>
           </property>
          </widget>
@@ -1305,6 +1305,25 @@
     <string>Control if the layers blending would clip the rendering to the background volume</string>
    </property>
   </action>
+  <action name="actionSliceEdgeVisibility3D">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../qMRMLWidgets.qrc">
+     <normaloff>:/Icons/VisibleOff.png</normaloff>
+     <normalon>:/Icons/VisibleOn.png</normalon>:/Icons/VisibleOff.png</iconset>
+   </property>
+   <property name="text">
+    <string>Show slice edge</string>
+   </property>
+   <property name="toolTip">
+    <string>Show slice edge in the 3D view</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -1322,6 +1341,7 @@
    <class>qMRMLSegmentSelectorWidget</class>
    <extends>qMRMLWidget</extends>
    <header>qMRMLSegmentSelectorWidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>ctkComboBox</class>
@@ -1351,6 +1371,7 @@
   </customwidget>
  </customwidgets>
  <resources>
+  <include location="../qMRMLWidgets.qrc"/>
   <include location="../qMRMLWidgets.qrc"/>
  </resources>
  <connections>

--- a/Libs/MRML/Widgets/Testing/qMRMLThreeDViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLThreeDViewTest1.cxx
@@ -53,7 +53,8 @@ int qMRMLThreeDViewTest1(int argc, char * argv [] )
                   << "vtkMRMLModelDisplayableManager"
                   << "vtkMRMLThreeDReformatDisplayableManager"
                   << "vtkMRMLOrientationMarkerDisplayableManager"
-                  << "vtkMRMLRulerDisplayableManager";
+                  << "vtkMRMLRulerDisplayableManager"
+                  << "vtkMRMLThreeDSliceEdgeDisplayableManager";
   vtkNew<vtkCollection> collection;
   view.getDisplayableManagers(collection.GetPointer());
   int numManagers = collection->GetNumberOfItems();

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -187,6 +187,8 @@ void qMRMLSliceControllerWidgetPrivate::setupPopupUi()
 
   QObject::connect(this->actionShow_in_3D, SIGNAL(toggled(bool)),
                    q, SLOT(setSliceVisible(bool)));
+  QObject::connect(this->actionSliceEdgeVisibility3D, SIGNAL(triggered(bool)),
+                   q, SLOT(setSliceEdgeVisibility3D(bool)));
   QObject::connect(this->actionFit_to_window, SIGNAL(triggered()),
                    q, SLOT(fitSliceToBackground()));
   QObject::connect(this->actionRotate_to_volume_plane, SIGNAL(triggered()),
@@ -726,6 +728,9 @@ void qMRMLSliceControllerWidgetPrivate::setupSliceModelMenu()
   originSliceModelAction->setDefaultWidget(originSliceModel);
   originSliceModelMenu->addAction(originSliceModelAction);
   this->SliceModelMenu->addMenu(originSliceModelMenu);
+
+  this->SliceModelMenu->addSeparator();
+  this->SliceModelMenu->addAction(this->actionSliceEdgeVisibility3D);
 }
 
 // --------------------------------------------------------------------------
@@ -1005,6 +1010,8 @@ void qMRMLSliceControllerWidgetPrivate::updateWidgetFromMRMLSliceNode()
   wasBlocked = this->SliceModelOriginYSpinBox->blockSignals(true);
   this->SliceModelOriginYSpinBox->setValue(UVWOrigin[1]);
   this->SliceModelOriginYSpinBox->blockSignals(wasBlocked);
+
+  this->actionSliceEdgeVisibility3D->setChecked(sliceNode->GetSliceEdgeVisibility3D());
 
   // OrientationMarker (check the selected option)
   QAction* action = qobject_cast<QAction*>(this->OrientationMarkerTypesMapper->mapping(sliceNode->GetOrientationMarkerType()));
@@ -2092,6 +2099,21 @@ void qMRMLSliceControllerWidget::setSliceVisible(bool visible)
 }
 
 //---------------------------------------------------------------------------
+void qMRMLSliceControllerWidget::setSliceEdgeVisibility3D(bool visible)
+{
+  Q_D(qMRMLSliceControllerWidget);
+
+  if (!this->mrmlSliceNode() || !d->MRMLSliceCompositeNode || !this->mrmlScene())
+  {
+    return;
+  }
+
+  d->SliceLogic->StartSliceNodeInteraction(vtkMRMLSliceNode::SliceEdgeVisibility3DFlag);
+  this->mrmlSliceNode()->SetSliceEdgeVisibility3D(visible);
+  d->SliceLogic->EndSliceNodeInteraction();
+}
+
+//---------------------------------------------------------------------------
 bool qMRMLSliceControllerWidget::isLinked()const
 {
   Q_D(const qMRMLSliceControllerWidget);
@@ -2635,6 +2657,7 @@ void qMRMLSliceControllerWidget::setSliceModelDimensionX(int dimension)
 {
   this->setSliceModelDimension(0,dimension);
 }
+
 // --------------------------------------------------------------------------
 void qMRMLSliceControllerWidget::setSliceModelDimensionY(int dimension)
 {

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.h
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.h
@@ -188,6 +188,9 @@ public slots:
   /// Set slice visible.
   void setSliceVisible(bool visible);
 
+  /// Set slice edge visible.
+  void setSliceEdgeVisibility3D(bool visible);
+
   /// Link/Unlink the slice controls across all slice viewer
   void setSliceLink(bool linked);
 

--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -133,6 +133,7 @@ void qMRMLThreeDViewPrivate::initDisplayableManagers()
                       << "vtkMRMLViewDisplayableManager"
                       << "vtkMRMLModelDisplayableManager"
                       << "vtkMRMLThreeDReformatDisplayableManager"
+                      << "vtkMRMLThreeDSliceEdgeDisplayableManager"
                       << "vtkMRMLCrosshairDisplayableManager3D"
                       << "vtkMRMLOrientationMarkerDisplayableManager"
                       << "vtkMRMLRulerDisplayableManager";

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -94,8 +94,6 @@ protected:
   vtkSlicerMarkupsWidgetRepresentation3D();
   ~vtkSlicerMarkupsWidgetRepresentation3D() override;
 
-  double GetViewScaleFactorAtPosition(double positionWorld[3], vtkMRMLInteractionEventData* interactionEventData = nullptr);
-
   void UpdateViewScaleFactor() override;
 
   void UpdateControlPointSize() override;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.cxx
@@ -42,6 +42,7 @@
 #include <vtkTubeFilter.h>
 
 // MRML includes
+#include "vtkMRMLAbstractThreeDViewDisplayableManager.h"
 #include "vtkMRMLInteractionEventData.h"
 #include "vtkMRMLMarkupsPlaneDisplayNode.h"
 #include "vtkMRMLMarkupsPlaneNode.h"
@@ -511,7 +512,8 @@ void vtkSlicerPlaneRepresentation3D::CanInteractWithPlane(
     this->Renderer->DisplayToWorld();
     this->Renderer->GetWorldPoint(closestPointWorld);
 
-    double pixelTolerance = this->PlaneOutlineFilter->GetRadius() / 2.0 / this->GetViewScaleFactorAtPosition(closestPointWorld)
+    double pixelTolerance = this->PlaneOutlineFilter->GetRadius() / 2.0 / vtkMRMLAbstractThreeDViewDisplayableManager::
+      GetViewScaleFactorAtPosition(this->Renderer, closestPointWorld)
       + this->PickingTolerance * this->GetScreenScaleFactor();
     if (dist2Display < pixelTolerance * pixelTolerance && dist2Display < closestDistance2)
     {

--- a/Modules/Loadable/ViewControllers/qSlicerViewControllersModule.cxx
+++ b/Modules/Loadable/ViewControllers/qSlicerViewControllersModule.cxx
@@ -244,6 +244,10 @@ void qSlicerViewControllersModule::readDefaultSliceViewSettings(vtkMRMLSliceNode
       vtkMRMLSliceNode::AddDefaultSliceOrientationPresets(this->mrmlScene(), true);
     }
   }
+  if (settings.contains("SliceEdgeVisibility3D"))
+  {
+    defaultViewNode->SetSliceEdgeVisibility3D(settings.value("SliceEdgeVisibility3D").toBool());
+  }
   readCommonViewSettings(defaultViewNode, settings);
 }
 
@@ -267,6 +271,8 @@ void qSlicerViewControllersModule::writeDefaultSliceViewSettings(vtkMRMLSliceNod
     defaultSliceOrientation = "PatientRightIsScreenRight";
   }
   settings.setValue("Orientation", defaultSliceOrientation);
+
+  settings.setValue("SliceEdgeVisibility3D", bool(defaultViewNode->GetSliceEdgeVisibility3D()));
 
   writeCommonViewSettings(defaultViewNode, settings);
 }


### PR DESCRIPTION
- Implemented functionality to show slice edges in the 3D view.
- Added user interface controls to control the visibility of slice edges.
- Implemented linking controls to synchronize the visibility of slice edges across different views.

![image](https://github.com/user-attachments/assets/eb4afd25-4697-4b62-9028-b935dcac43d2)

Reference: https://discourse.slicer.org/t/show-slice-edges-in-3d-view/11381