### PR TITLE
BUG: Fix copying of markup measurements

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -240,6 +240,7 @@ void vtkMRMLMarkupsNode::CopyContent(vtkMRMLNode* aSource, bool deepCopy/*=true*
     vtkSmartPointer<vtkMRMLMeasurement> measurement = this->GetMeasurement(sourceMeasurement->GetName().c_str());
     measurement = vtkSmartPointer<vtkMRMLMeasurement>::Take(sourceMeasurement->CreateInstance());
     measurement->Copy(sourceMeasurement);
+    measurement->SetInputMRMLNode(this);
     this->AddMeasurement(measurement);
   }
 }


### PR DESCRIPTION
When markup node content was copied, input node for measurements was not set correctly.

fixes #7239
