### PR TITLE
ENH: Update DCMTK from 3.6.6 to 3.6.8

### DIFF
--- a/Base/QTCore/CMakeLists.txt
+++ b/Base/QTCore/CMakeLists.txt
@@ -195,8 +195,15 @@ set(KIT_target_libraries
   )
 
 if(Slicer_BUILD_DICOM_SUPPORT)
+  # Support namespaced DCMTK targets
+  foreach(lib IN LISTS DCMTK_LIBRARIES)
+    if(TARGET "DCMTK::${lib}")
+      list(APPEND KIT_target_libraries DCMTK::${lib})
+    else()
+      list(APPEND KIT_target_libraries ${lib})
+    endif()
+  endforeach()
   list(APPEND KIT_target_libraries
-    ${DCMTK_LIBRARIES}
     CTKDICOMCore
     )
 endif()

--- a/Modules/CLI/PETStandardUptakeValueComputation/CMakeLists.txt
+++ b/Modules/CLI/PETStandardUptakeValueComputation/CMakeLists.txt
@@ -41,8 +41,14 @@ set(${MODULE_NAME}_TARGET_LIBRARIES
   MRMLCore SlicerBaseLogic SlicerBaseCLI
   ${ITK_LIBRARIES}
   ${VTK_LIBRARIES}
-  ${DCMTK_LIBRARIES}
   )
+foreach(lib IN LISTS DCMTK_LIBRARIES)
+  if(TARGET "DCMTK::${lib}")
+    list(APPEND ${MODULE_NAME}_TARGET_LIBRARIES DCMTK::${lib})
+  else()
+    list(APPEND ${MODULE_NAME}_TARGET_LIBRARIES ${lib})
+  endif()
+endforeach()
 
 #-----------------------------------------------------------------------------
 SEMMacroBuildCLI(

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "d7ce6d91322a8959b15f72d043fae685bbbd979a"
+    "82cae5781621845486bad2697aed095f04cfbe76"
     QUIET
     )
 

--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -41,7 +41,7 @@ if(NOT DEFINED DCMTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "d1fb197927fd4178b5a24e0f0dba6f8d785a8f93" # patched-DCMTK-3.6.8_20241024
+    "ea07125078cd097245867a71d8fba8b36fd92878" # patched-DCMTK-3.6.8_20241024
     QUIET
     )
 

--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -41,22 +41,7 @@ if(NOT DEFINED DCMTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    # Based of the official DCMTK release DCMTK-3.6.6
-    # * https://github.com/DCMTK/dcmtk/commit/6cb30bd7fb42190e0188afbd8cb961c62a6fb9c9
-    # * https://github.com/DCMTK/dcmtk/releases/tag/DCMTK-3.6.6
-    #
-    # with these backported patches:
-    # * Fixed extra padding created for some segmentations.
-    #   https://github.com/DCMTK/dcmtk/commit/b665e2ec2d5ce435e28da6c938736dcfa84d0da6
-    #
-    # * Made file extensions explicit for CMake CMP0115
-    #   https://github.com/DCMTK/dcmtk/commit/d090b6d7c65e52e01e436a2473dc8ba3f384efbb
-    #
-    # * Fixes for CVE-2022-2119 and CVE-2022-2120 (https://github.com/commontk/DCMTK/pull/14)
-    #   https://github.com/DCMTK/dcmtk/commit/3e996a2749a9355c9b680fa464ecfd9ab9ff567f
-    #   https://github.com/DCMTK/dcmtk/commit/f06a867513524664a1b03dfcf812d8b60fdd02cc
-    #
-    "11972eaa4ecdbf3aab0f46eff78f33d7e2b16bfe" # patched-DCMTK-3.6.6_20210115
+    "d1fb197927fd4178b5a24e0f0dba6f8d785a8f93" # patched-DCMTK-3.6.8_20241024
     QUIET
     )
 
@@ -87,9 +72,8 @@ if(NOT DEFINED DCMTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       -DDCMTK_WITH_ICONV:BOOL=OFF  # see CTK github issue #178
       -DDCMTK_WITH_SNDFILE:BOOL=OFF # see DCMQI github issue #395
       -DDCMTK_OVERWRITE_WIN32_COMPILER_FLAGS:BOOL=OFF
-      -DDCMTK_ENABLE_BUILTIN_DICTIONARY:BOOL=ON
+      -DDCMTK_DEFAULT_DICT:STRING=builtin
       -DDCMTK_ENABLE_PRIVATE_TAGS:BOOL=ON
-      -DDCMTK_WITH_ICU:BOOL=OFF
       ${EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS}
     INSTALL_COMMAND ""
     DEPENDS

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -33,7 +33,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "e18566d53a1b8a913cd460e70569e9b485137fba" # slicer-v5.4.0-2024-05-16-311b706
+    "07eb5d0d6ddd9b86de12dffa62ad3272ffc79964" # slicer-v5.4.0-2024-05-16-311b706
     QUIET
     )
 


### PR DESCRIPTION
This commit updates the DCMTK library to version 3.6.8, incorporating numerous enhancements, bug fixes, and compatibility improvements across ITK, CTK, and DCMTK itself. Notable updates include new support for recent DICOM standards (e.g., DICOM 2024b) and compatibility with cross-compiling. The upgrade also addresses several compilation warnings, improves performance, and enhances TLS support and error handling.

Additionally:

* Removed the `DCMTK_WITH_ICU` option, which became obsolete in commit DCMTK/dcmtk@b8e5fd510 ("Removed support for ICU-based charset conversion.", 2024-05-25).

* Removed the `DCMTK_ENABLE_BUILTIN_DICTIONARY` option, obsolete since  commit DCMTK/dcmtk@4ab084d3f ("Harmonize dictionary options.", 2021-09-01), and set `DCMTK_DEFAULT_DICT` instead.

* Fixed building DCMTK on Apple Silicon (DCMTK/dcmtk@5fba853b6 ("Fixed building for Apple M1.", 2021-03-25)).


----

List of ITK changes:

```
$ git shortlog e18566d53a..07eb5d0d6d --no-merges
James Butler (1):
      [Backport MR-4910] COMP: Update DCMTK targets based on new DCMTK namespace
```

----

List of CTK changes:

```
git shortlog d7ce6d91..82cae578 --no-merges
Jean-Christophe Fillion-Robin (3):
      BUG: Update DCMTK to backport fixes for CVE-2022-2119 and CVE-2022-2120
      COMP: Add explicit QByteArray to "const char*" conversion for DCMTK compatibility
      COMP: Support namespaced targets in updated DCMTK CMake exports
```

----

List of DCMTK changes:

```
$ git shortlog 11972eaa4..d1fb19792 --no-merges
Claus Stovgaard (2):
      Add DCMTK_NO_TRY_RUN for cross compiling
      Incorporate DCMTK_NO_TRY_RUN and DCMTK_ENABLE_STL

Jan Schlamelcher (13):
      Introduced a CMake option for static linking.
      Introduced CMake variable DCMTK_TLS_LIBRARY_POSTFIX.
      Documented DCMTK_TLS_LIBRARY_POSTFIX in INSTALL.
      Introduced OFdeprecated and OFdeprecated_msg.
      Introduced path separator conversion for OFpath.
      Fixed typo in previous commit.
      Enabled various compiler warnings by default.
      Fixed a stupid mistake in the previous commit.
      Added a workaround for preventing MSVC warning D9025.
      Fixed some warnings in dcmiod.
      Changed minimum required CMake version to 3.0.0.
      Various enhancements for DCMTK's CMake exports.
      Removed some dead code (CMake).

Joerg Riesmeier (382):
      Also updated GNU Autoconf files.
      Added support for another Value Type (CP-2053).
      Fixed typo and added space characters.
      Added missing object files to Makefile.
      Fixed wrong indentation.
      Removed unused variable (reported by gcc).
      Added missing "unistd" header include.
      Removed unused variable (reported by gcc).
      Made API documentation more consistent.
      Removed unused variable (reported by gcc).
      Rebuilt Makefile dependencies.
      Updated data dictionary for DICOM 2021a.
      Updated code definitions for DICOM 2021a.
      Updated Context Group classes for DICOM 2021a.
      Increased number of digits printed for FL values.
      Added support for two new Storage SOP Classes.
      Fixed typo and corrected line breaks in manpage.
      No need to convert ASCII or UTF-8 characters.
      Fixed comment on lossy JPEG vs. lossy JPEG-LS.
      Removed empty line.
      Removed outdated configure options (Autoconf).
      Added support for CP-2023.
      Added support for Patient's Size and Weight.
      Updated latest tested CMake version.
      Removed empty line from "verbatim" environment.
      Always begin condition text with a capital letter.
      Fixed issue when compiling without MT support.
      Minor changes to documentation.
      Fixed issue with findAndGetUint16Array and VR=AT.
      Fixed wrong class name in file header.
      Added typical error handling options to xml2dcm.
      Updated data dictionary for DICOM 2021b.
      Updated code definitions for DICOM 2021b.
      Added support for CID 247.
      Fixed issue caused by changed attribute name.
      Ignore missing binary value in meta header.
      Added new test case for Contour Data.
      Check whether call of saveFile() was successful.
      Added support for new Storage SOP Class.
      Added "Enhanced X-Ray Radiation Dose SR" to list.
      Modified overlay rendering for multi-frame images.
      Removed check on CMAKE_BACKWARDS_COMPATIBILITY.
      Added support for CP-1789 and CP-1998.
      Output helpful warning messages to logger.
      Added support for CP-2084.
      Removed empty line (added by previous commit).
      Fixed order of libraries to be linked.
      Added missing newline at end of file.
      Updated data dictionary for DICOM 2021c.
      Updated code definitions for DICOM 2021c.
      Added support for new Storage SOP Class.
      Added support for directory record "ANNOTATION".
      Minor fixes to syntax usage and formatting.
      Enhanced API documentation of putAndInsertXXX().
      Updated data dictionary for DICOM 2021d.
      Updated code definitions for DICOM 2021d.
      Updated Context Group classes for DICOM 2021d.
      Replaced old-style cast by OFstatic_cast().
      Fixed issue with unknown UID name.
      Check for space character in File-set ID.
      Replaced German umlaut by its transliteration.
      Removed trailing Unicode character from UID value.
      Converted non-ASCII characters to ASCII.
      Removed trailing Unicode character in manpage.
      Fixed further inconsistencies.
      Fixed typo in comment.
      Output more build options with --version.
      Removed useless typecasts from inline method.
      Added support for two new Storage SOP Classes.
      Enhanced Autoconf build system for OpenSSL checks.
      Fixed issue with findAndGetUint16Array() for OB.
      Fixed comment on Autoconf define HAVE_CXX.
      Changed order of OpenSSL libraries (Autoconf).
      Replaced OFListIterator by OFListConstIterator.
      Added missing spaces (removed by previous commit).
      Updated data dictionary for DICOM 2021e.
      Fixed Media Storage SOP Class UID in DICOMDIR.
      Updated code definitions for DICOM 2021e.
      Fixed typo.
      Removed extra space.
      Updated data dictionary for DICOM 2022a.
      Updated code definitions for DICOM 2022a.
      Removed email addresses and trailing spaces.
      Fixed spelling of attribute name in log message.
      Introduced plural form where appropriate.
      Added missing well-known frame of reference.
      Made use of DCM_PixelItemTag where appropriate.
      Updated Doxygen configuration files.
      Added check on empty Unique Keys in "strict mode".
      Extended comment on Type of Modality attribute.
      Do not set instance creator UID automatically.
      Made XML elements "date" and "time" optional.
      Do not create new document in readXML().
      Fixed typos and revised line breaks.
      Added check on missing Unique Key (strict mode).
      Specified "non-signficant characters" for VR UC.
      Removed misplaced comment character "//".
      Fixed "delimiter characters" for VR UC.
      Various minor fixes to "macros.txt".
      Fixed some outdated DIMSE Status strings.
      Replaced use of deprecated DIMSE Status Codes.
      Fixed documentation of default options.
      Minor fixes to documentation.
      Don't add Derivation Description to Icon Images.
      Fixed incorrect warning in JPEG-LS decoder.
      Made log output in this module more consistent.
      Fixed wrong VR in JSON example (see CP-2139).
      Fixed typo in comment.
      Replaced http:// by https:// in documentation.
      Updated copyright date.
      Updated data dictionary for DICOM 2022b.
      Updated code definitions for DICOM 2022b.
      Updated Context Group classes for DICOM 2022b.
      Fixed line breaks in CHANGES file.
      Also updated Autoconf's "config/configure" file.
      Fixed source code formatting.
      Removed additional CMake version check.
      Added string guard to avoid NULL ptr. derefence.
      Only call sanitizeFilename() when really needed.
      Updated Makefile dependencies.
      Added missing "dcmiod" depedendency to "dcmpstat".
      Remove created test directory with "make clean".
      Added comment on CMake policy "CMP0091" (MSVC).
      Added support for Context Groups 218 and 7551.
      Fixed issue when using option +Ca and +U8.
      Fixed issue with unwanted debug message.
      Completed support for CP-2000 (dcmsr/cmr).
      Fixed issue with misplaced \ in #error statement.
      Fixed typos found by codespell.
      Added "Rendition Selection Document" to the list.
      Fixed wrong print() output of empty concept names.
      Added missing "latin-9" to manpage documentation.
      Fixed indentation.
      Added configure tests needed by oficonv.
      Added define DCMTK_CHARSET_CONVERSION_OFICONV.
      Added support for --enable-charconv=oficonv.
      Added version number to datadir and sysconfdir.
      Added version number also to docdir.
      Updated Makefile dependencies.
      Fixed various issues in Autoconf Makefiles.
      Avoid double definition of WITH_LIBICONV.
      Added support for builtin oficonv data (Autoconf).
      Fixed page-related Doxygen commands.
      Various fixes to documentation.
      Replaced data type of string parameter.
      Fixed inconsistencies in Autoconf Makefiles.
      Fixed minor issue in syntax usage.
      Fixed issue with trailing NULL byte for UI value.
      Replace problematic character in directrory names.
      Fixed --version output when STL support enabled.
      Fixed another issue with unwanted debug message.
      Made log output more consistent within this tool.
      Made sure that "read mode" is actually used.
      Made log output more consistent with other tools.
      Simplified code by using automatic variables.
      Fixed issue when using option +Ca and +U8.
      Fixed regression test after commit a15d61db8.
      Made TCP connection timeout more configurable.
      Make target "distclean" now depends on "clean".
      Added test cases for TCP connection timeout.
      Added support for OFdeprecated to Autoconf.
      Re-added old ASC_createAssociationParameters().
      Further improved AC_CHECK_TRY_COMPILE().
      Made use of OFdepecated macro where appropriate.
      Changed order of function specifiers.
      Replaced call of deprecated function.
      Updated data dictionary for DICOM 2022c.
      Updated code definitions for DICOM 2022c.
      Updated Context Group classes for DICOM 2022c.
      Fixed typo in GNU Autoconf's configure file.
      Check MSVC version before disabling a warning.
      Added Autoconf support for new ofipc classes.
      Added configure test for <sys/un.h> header file.
      Marked deprecated functions with OFdeprecated.
      Official ANNOUNCE.367 file was incomplete.
      Added support for official UID keywords.
      Updated data dictionary for DICOM 2022d.
      Replaced tab characters by spaces.
      Fixed Doxygen markup for multi-line list entries.
      Updated code definitions for DICOM 2022d.
      Updated Context Group classes for DICOM 2022d.
      Fixed source code formatting.
      Changed name of retired Transfer Syntaxes.
      Added initial support for Supplement 225.
      Removed or replaced non-ASCII characters.
      Updated statement on 128 Presentation Contexts.
      Added complete list of Transfer Syntaxes.
      Added new Transfer Syntaxes to config file.
      Added support for fragmentable Transfer Syntaxes.
      Added support for fragmentable Transfer Syntaxes.
      Fixed various issues in manpage.
      Minor fixes in comments / documentation.
      Updated data dictionary for DICOM 2022e.
      Added support for further values to checkVM().
      Added support for new UIDs from Supplement 223.
      Added suppport for directory record "INVENTORY".
      Made sure to generate missing InstanceNumber.
      Added missing Type 2 Sequence to "INVENTORY".
      Updated list of tools using assoc. neg. profiles.
      Enhanced documentation on assoc. neg. profiles.
      Fixed wrong identation of command line parameters.
      Removed some line breaks in manpages and --help.
      Enabled support for color output on Windows OS.
      Fixed source code formatting.
      Updated data dictionary for DICOM 2023a.
      Updated code definitions for DICOM 2023a.
      Updated Context Group classes for DICOM 2023a.
      Added support for three new Storage SOP Classes.
      Various fixes after previous commit.
      Replaced "true" by "OFTrue" in API documentation.
      Added comparison operators to DcmXfer.
      Fixed major bug in read() method of DRTImage.
      Made use of term "private creator identifier".
      No useless output of transfer syntax conversion.
      Added opt. default value to dcmFindKeywordOfUID().
      Output debug information on Presentation Context.
      Fixed issue with DcmCodec::updateImageType().
      Added missing DcmItem::putAndInsertSint32Array().
      Added another constructor to DcmTag class.
      Various minor improvements to the DcmTag class.
      Added text on using options multiple times.
      Fixed typo.
      Fixed evaluation of TLS command line options.
      Updated Autoconf files for recent dcmtls changes.
      Added missing empty line.
      Updated API documentation on "DT" format.
      Fixed issues with evaluating command line options.
      Fixed wrong comment header of source file.
      Avoid double output of TLS connection details.
      Updated data dictionary for DICOM 2023b.
      Updated code definitions for DICOM 2023b.
      Added support for new Storage SOP Class.
      Updated copyright dates.
      Updated newest CMake version tested to 3.26.3.
      Added missing option --jwt to error message.
      Fixed typos in comments.
      Removed optional parameters for addSubGroup() call.
      Fixed formatting of BSD 3-Clause License text.
      Fixed typos in recently added subsection to Notes.
      Updated "dcmrt" classes based on DICOM 2023b.
      Removed source file that is no longer needed.
      The Segmentation IOD actually specifies an image.
      Enhanced comment on "Useful UID prefixes".
      Enhanced explanation of --charset-check-all.
      Updated mapping of Body Part Examined to codes.
      Fixed Doxygen commands for specifying list items.
      Updated data dictionary for DICOM 2023c.
      Updated code definitions for DICOM 2023c.
      Removed double inclusion of header file.
      Added support for new Storage SOP Classes.
      Updated reference to DICOM standard.
      Removed double inclusion of header file.
      Updated newest CMake version tested to 3.27.3.
      Updated DCMTK's URL (used for the HTML footer).
      Updated URL of DICOMscope web page.
      Updated libxml2 version number for Autoconf.
      Minor fixes and additions to ANNOUNCE file.
      Also updated version information for GNU Autoconf.
      Added comparison operator to avoid C++20 warning.
      Fixed issue with delimiters being converted.
      Fixed less useful change by last commit.
      Reverted unnecessary changes from last commit.
      Further fixes to manpages.
      Made warning messages more consistent within file.
      Added missing config file to INSTALL target.
      Removed outdated comment on odd version numbers.
      Updated data dictionary for DICOM 2023e.
      Fixed white spaces / indentation.
      Removed suffix "+" from version number (Autoconf).
      Updated code definitions for DICOM 2023e.
      Updated Context Group classes for DICOM 2023e.
      Disable warning messages on "unchecked" options.
      Moved recently added section and fixed typo.
      Added new configure test for OpenSSL (Autoconf).
      Fixed check on "shared library build".
      Create all instances on heap instead of stack.
      Updated copyright date.
      Added missing character set to XML Schema.
      Extended UID mapping table with properties.
      Made use of new dcmGetPropertiesOfUID() function.
      Minor fixes to manpage.
      Fixed issue with implementation of CP-2084.
      Removed references to specific CPs in comments.
      Fixed source code formatting.
      Fixed issue with Doxygen command @deprecated.
      Fixed typos and changed formatting.
      Minor, mainly stylistic fixes to documentation.
      Removed trailing spaces and fixed lines breaks.
      Removed historical workaround for SunCC 4.x.
      Replaced the data type of parameter "filename".
      Removed trailing spaces.
      Minor fixes to manpage.
      Updated data dictionary for DICOM 2024a.
      Updated code definitions for DICOM 2024a.
      Added support for new Storage SOP Classes.
      Added missing fragmentable Transfer Syntaxes.
      Added support for new HTJ2K Transfer Syntaxes.
      Autoconf now uses --enable-cxx11 by default.
      Cleaned up Autoconf configure tests for OpenSSL.
      Fixed typo in Makefile.
      Fixed issue with new default of C++11 support.
      Removed outdated #ifdef HAVE_xxx checks.
      Removed various historical Autoconf tests.
      Removed further outdated Autoconf tests.
      Removed "arith.h" depencency also from Autoconf.
      Updated main .gitignore file.
      Added simple logger configuration file.
      Removed unnecessary file "gmon.out".
      Removed all references to "arith" from .gitignore.
      Removed remaining references to "lzwtest.tif".
      Added note on current development version.
      Added new helpers checking the type of a VR.
      Removed further outdated Autoconf tests.
      Updated stdcxx.m4 script to the latest version.
      Fixed comment generated by stdcxx.m4 script.
      Largely revised base class for Transfer Syntaxes.
      Fixed compilation error when zlib is disabled.
      Removed further outdated Autoconf tests.
      Updated minimum required CMake version.
      Enhanced implementaton of findTagFromName().
      Renamed parameter to avoid compiler warnings.
      Various minor fixes to documentation.
      Report on missing support for color images.
      Updated data dictionary for DICOM 2024b.
      Updated code definitions for DICOM 2024b.
      Updated Context Group classes for DICOM 2024b.
      Added warning on "FIXME" comments.
      Updated information on latest CMake version.
      Marked some CMake variables as "advanced".
      Fixed wrong error handling (previous commit).
      Fixed issue with error handling (TLS support).
      Fixed crash shutting down via private SOP class.
      Removed references to ICU from documentation.
      Removed defines that were only needed for ICU.
      Replaced calls of DcmXfer::isEncapsulated().
      Deprecated DcmXfer::isEncapsulated().
      Avoid using deprecated libxml2 API.
      Added XML_PARSE_NONET flag to xmlReadFile().
      Use xmlReadFile() instead of xmlParseFile().
      Made sure that ambiguous VRs are mapped correctly.
      Fixed wrong internal VR in checkAndUpdateVR().
      Enhanced documentation of getReferencedInstances.
      Added missing Transfer Syntaxes to --accept-all.
      Added encapsulated uncompressed transfer syntax.
      Added support for encapsulated uncompressed xfer.
      Revised implementation of comparison operators.
      Updated data dictionary for DICOM 2024c.
      Updated code definitions for DICOM 2024c.
      Updated Context Group classes for DICOM 2024c.
      Use dcmGetPropertiesOfUID() for SR documents.
      Added support for new SR Storage SOP Class.
      Added "Waveform Annotation SR" to list.
      Fixed invalid array access on EXS_Unknown.
      Minor fixes after previous commit.
      Documented support of STD-GEN-BD profile.
      Removed trailing spaces.
      Fixed line breaks and typos.
      Fixed source code formatting.
      Made URL prefix for hyperlinks configurable.
      Added full support for SR IOD from Supplement 239.
      Minor fixes to formatting and API documentation.
      Removed non-ASCII characters from strings.
      Output debug messages to debug logger.
      Fixed line breaks and indendation.
      Git should ignore the new application "dcm2img".
      Added missing "configure" script in new module.
      Changed name of Status Code "0107H" (CP-2384).
      Fixed wrong module name in comment header.
      Removed outdated reference to "dcm2pnm".
      Added missing empty line.
      Added missing space character.
      Revised line breaks.
      Added documentation for new module "dcmapps".
      Fixed line break in comment.
      Updated data dictionary for DICOM 2024d.
      Updated code definitions for DICOM 2024d.
      Updated Context Group classes for DICOM 2024d.
      Added Autoconf configure test for OpenSSL 3.4.0.
      Added missing HTJ2K transfer syntaxes.
      Made HTJ2K transfer syntaxes non-fragmentable.
      Increased maximum number of proposed Xfers.
      Added support for new JPEG XL Transfer Syntaxes.

Marco Eichelberg (455):
      Added support for stdin/stdout DICOM file I/O.
      Do not redirect stderr to stdout on Windows anymore.
      Fixed stdin/stdout DICOM file I/O on Win32.
      Improved performance of DcmStdinStream.
      Fixed minor warnings reported by gcc -Wextra.
      Fixed parentheses.
      Migrated dcmsign to OpenSSL high-level APIs.
      Adapted dcmpstat to commit d588139e2.
      Updated code handling Diffie-Hellman parameters.
      Restored compatibility with OpenSSL 1.0.1.
      Fixed minor warnings related to type conversions.
      New function ASC_closeTransportConnection().
      Added hints for a better detection of OpenJPEG.
      Added missing comma to dcm2json --write-meta.
      Expanded dcm2json manpage.
      Adjusted the number of digits printed for FL and FD.
      Fixed incorrect handling of malformed JPEG bitstream.
      Fixed commit e8161b1e4.
      Fixed minor warnings reported by Visual Studio.
      Fixed include of <inttypes.h>.
      Added include needed on BSD.
      Added includes needed on Solaris.
      Added missing include.
      Added includes needed on NetBSD.
      Fixed includes for VS 2008.
      Fixed compilation of arith.cc with DCMTK_ENABLE_CXX11=ON.
      Added further missing includes
      Added support for intermediate CAs and CRLs.
      Added functions for offline certificate verification.
      Revised error handling in module dcmtls.
      Fixed minor inconsistencies.
      Added missing include.
      Fixed compilation without OpenSSL.
      Added include missing on Windows.
      Fixed warning reported by Visual Studio.
      Fix for compilation of dcmtls on Solaris.
      Modifications for LibreSSL on OpenBSD.
      Added includes needed by VS2008.
      Moved inline methods to implementation file.
      Added DCMTK_OFSTD_EXPORT to class OFFile.
      Minor changes needed on Solaris.
      Added include needed by VS2008.
      Defined cmake_minimum_required() as interval.
      Fixed LFS and vsnprintf on Windows and Solaris.
      Added includes needed on Solaris.
      Don't mask error code of association negotiation failure.
      Removed "using namespace std" statements.
      Fixed TOC-TOU race in storescp directory creation.
      Fixed warnings about possible null ptr dereference.
      Fixed configure warnings reported by CMake 3.19.
      Fixed issue in CMake scripts.
      Check if policy CMP0103 exists before setting it.
      Define __STDC_FORMAT_MACROS in oftypes.h.
      Include <cinttypes> when compiling in C++11 mode.
      Replaced DCMTK_DIAGNOSTIC_MIN_GCC_VERSION macro.
      Fixed comments.
      Fixed warnings on Solaris with SunPro compiler.
      Added error messages for unsupported include macros.
      Special handling of preprocessor warnings for MSVC.
      Set CMake CMP0115 introduced with CMake 3.20 to OLD.
      Added default in switch statement.
      Attempt to make the ofthread unit test more robust.
      Fixed minor bug in ofthread unit test.
      Added debug output to ofstd_thread semaphore test.
      Added additional check to dcmtls_scp_tls test.
      Added checks to dcmtls test cases.
      Fixed possible race condition of ofthread test.
      Fixed storescu return code issues.
      Changed default TLS profile to BCP 195 ND.
      Use random port number for dcmtls unit tests.
      Switch stdin to binary mode on Windows.
      Accept forward slash as path separator on Windows.
      Fixed previous commit.
      Accept forward slash as path separator on Windows.
      Set TLS session ID and disable session caching.
      Fixed minor warnings.
      Fixed minor warnings.
      Fixed minor warnings.
      Fixed minor warnings.
      Fixed minor warnings.
      Fixed minor warnings.
      Fixed minor warnings.
      Fixed minor warnings.
      Fixed minor warnings.
      Fixed minor warnings.
      Fixed minor warnings.
      Fixed minor warnings.
      Fixed minor warnings.
      Removed dead code that caused warnings on MSVC.
      Fixed minor warnings.
      Fixed minor warnings.
      Documented MSVC versions not supported anymore.
      Fixed issue that caused duplicate calls to the DicomImage constructor to fail when a compressed image is loadad and the result of DcmDataset::getCurrentXfer() is passed as the second parameter.
      Support "-" as special output filename.
      Moved xml2dcm functionality into a class.
      Added support for XML comment tags.
      Added support for XML import and OP output.
      Added missing linefeed.
      Fixed Makefiles.
      Fixed Makefiles.
      Fixed test for maximum supported file size.
      Fixed previous commit.
      Fixed compilation with shared libraries.
      Added explicit include for <cerrno>.
      Fixed double inclusion of libxml2.
      Fixed minor warnings.
      Send SpecificCharacterSet in BFS N-CREATE-RQ.
      Convert monochrome BMP images to MONOCHROME2.
      Added error code EC_SOPClassMismatch.
      Updated XML templates for img2dcm.
      Added multiframe support to img2dcm.
      Fixed minor warnings.
      Fixed bug in class Image2Dcm.
      Made file extensions explicit for CMake CMP0115.
      Enable compilation of DCMTK on DragonFly BSD.
      Fixed compilation on Solaris after previous commit.
      Send Illumination and RefAL only when non-empty.
      Fixed minor warning issued by gcc 10.2.1.
      Removed const qualifier in static function.
      Fixed Posix feature flags for Android build.
      Fixed warnings when compiling with OpenSSL 3.0.
      Removed definition of NEED_DARRAY macro.
      Fixed bug in SiCertificate::getCertCurveName().
      Check whether DICOM dataset contains extended chars.
      Fixed incorrect constructor call.
      Introduced configure tests for OpenSSL features.
      Added two additional configure tests needed on OpenBSD.
      Removed duplicate test.
      Enable C-GET for write protected storage areas.
      Fixed memory leak in DcmElement::getPartialValue().
      Renamed OpenSSL related feature test symbols.
      Fixed previous commit.
      Documented cross-compiling support.
      Improvements to pkg-config support.
      Fixed CMake OpenSSL feature tests.
      Added logger output for OpenSSL initialization.
      Fixed undefined behavior in handling A-ASSOCIATE-RJ.
      Removed dead code to avoid warning.
      Initialize buffer to zero.
      Corrected handling of character set for HG images.
      Updated warning message.
      Fixed indentation.
      Fixed issue with defragmentTCP() in non-blocking mode on Windows, where the WSAEWOULDBLOCK return code was not properly handled in the past.
      Added CMake option DCMTK_PORTABLE_LINUX_BINARIES.
      Replaced C_CHAR_UNSIGNED test by a compile-only one.
      Fixed further build error.
      Updated credits to include Segmed, Inc.
      Fixed various Doxygen warnings.
      Suppress warnings about attribute redeclaration.
      Fixed gcc -Wextrea warning caused by previous commit.
      Fixed warning caused by previous commit.
      Removed overly strict check in the JPEG decoder.
      Fixed typo.
      Fixed possible NULL pointer dereference.
      Removed limit of 128 presentation contexts in association negotiation configuration files for SCP use. DcmAssociationConfigurationFile::initialize() now has an additional parameter indicating SCU or SCP use, and there is a new method DcmAssociationConfiguration::isValidSCUProfile() that checks if a certain profile is suitable for SCU use.
      Fixed path traversal vulnerability.
      Updated newest CMake version tested to 3.23.1.
      Fixed infinite loop in class DcmTLSSCU.
      Added support for GL Recomm'd Display CIELab Value.
      Fixed bug in DVPSGraphicLayer::read().
      Fixed typos and layout in comments.
      Fixed RescaleType when lossy compressing CT.
      Fixed warning about uninitialized variable.
      Set CMake policy CMP0091 to OLD.
      Moved class DcmXMLParseHelper into separate library.
      Fixed Windows build after previous commit.
      Added full support for CMake policy CMP0091.
      Fixed single shared library build.
      Fixed dcmqrscp crash caused by malformed config file.
      Fixed OFStandard::getHostnameByAddress on OpenBSD.
      Fixed build of ofstd tests on Windows.
      Fixed ofstd_gethostnamebyaddress test on Cygwin.
      Ensure that libdcmxml is non-empty.
      Fixed memory leak in single process mode.
      Initial commit of BSD citrus libiconv.
      Code cleanup of oficonv.
      Further code cleanup.
      Removed citrus namespace macros.
      Removed citrus csmapper macros.
      Further code cleanup.
      Adapted CMake files for module oficonv.
      Added OFlocale_charset() function.
      Updated character set conversion mode detection.
      Added support for oficonv in OFCharacterEncoding.
      Updates and fixes for oficonv.
      Initial set of unit tests for module oficonv.
      Improved documentation.
      Moved debug output to different place.
      Adapted charset conversion tests for oficonv.
      Added configure tests needed for oficonv.
      Initial port of oficonv to Windows.
      Expanded unit tests for oficonv.
      Further code cleanup.
      Refactored oficonv unit tests.
      Added initial version of oficonv/datasrc.
      Added support for JIS X0208 (ISO-IR 87).
      Added oficonv tools mkcsmapper and mkesdb.
      Added support for JIS X0212 (ISO-IR 159).
      Removed dead code.
      Avoid creation of unneeded data files.
      Added unit tests for GB18030 character set.
      Code cleanup in oficonv module.
      Added support for ISO 8859-15 (Latin-9).
      Added CMake tests for fgetln() and strcasecmp().
      Added oficonv unit tests for ISO 8859-15.
      Added logger callback for oficonv calls.
      Removed unneeded oficonv datasrc files.
      Code cleanup.
      Moved queue implementation to include directory.
      Ported oficonv apps to Windows.
      Added test for presence of <err.h>.
      Fixed unit tests on Windows.
      Fixed function name.
      Added documentation.
      Added oficonv unit tests.
      Added binary iconv data files.
      Added function OFiconv_close_in().
      Refactored unit tests.
      Followed API change in libiconv.
      Added unit test for OF__iconv().
      Added initial unit test for OFiconvctl().
      Introduced environment variable DCMICONVPATH.
      Completed unit test for OFiconvctl().
      Use DCMICONVPATH environment variable for unit tests.
      Adapted charset conversion test for oficonv.
      Fixed OFlocale_charset() on Windows.
      Expand environment vars in DCMICONVPATH on Windows.
      Merge with latest changing in testing branch.
      Default directory macros now contain version number.
      Emulate libiconv behavior when using oficonv.
      Added possibility to embed oficonv data in library.
      Fixed compilation with Clang on FreeBSD.
      oficonv related fixes for Windows.
      Fixed minor warnings.
      Added override for configuration and data dirs.
      Added CMake option DCMTK_ENABLE_BUILTIN_OFICONV_DATA.
      Renamed CMake variable.
      Fixed oficonv compilation as shared library.
      Fixed oficonv compilation when WITH_THREADS=OFF.
      Additional fix for WITH_THREADS=OFF.
      Added support for ISO_IR 203 (ISO 8859-15).
      Added support for ISO_IR 203 in libraries and tools.
      Use installation directories more consistently.
      Initial support for compiling oficonv with autoconf.
      Fixed oficonv_data_library make target.
      Fixed oficonv_data_files make target.
      Use GNUInstallDirs directories for installation.
      Added module oficonv to DCMTK documentation.
      Improved Citrus iconv version output.
      Fixed dcm2xml after rebase to testing.
      Various fixes for oficonv.
      Further fixes for oficonv.
      Fixes for building oficonv on Android.
      Fix for DLL build without libxml2.
      Use C compiler to check for strcasestr().
      Suppress spurious MSVC warning in template code.
      Suppress warning on VS 2015.
      Use different install dirs for development version.
      Fixed single shared library build.
      Fixed single shared library build.
      Fix ignored 'deprecated' attribute warnings.
      Added dcm2json command line options.
      Added classes for handling IPC message queues.
      Added unit test for IPC message queues.
      Added detachQueue() methods to IPC classes.
      Fixed DLL build.
      Revised multi-process handling for dcmpsrcv.
      Portability fixes to ofipc classes.
      Fixed issue in iconv table lookup on Windows.
      Fixed minor warning reported by gcc.
      Fixed ofipc classes on FreeBSD.
      Fixed ofipc classes on FreeBSD, part 2.
      Fixed Windows 7 specific ofipc issue.
      Added timeout to server in ofstd_ipc unit test.
      Added ofipc dummy implementation for Android.
      More detailed error message in dcmpsrcv.
      Added cleanup signal handler to ofipc code.
      Fixed multi-process issue in dcmpsrcv.
      Added configure tests for <sys/un.h>.
      Further fix for multi-process issue in dcmpsrcv.
      Added ofipc implementation for Android.
      Fixed bug in DcmQueryRetrieveConfig::parseQuota().
      Ported recent FreeBSD commits to oficonv.
      Removed duplicate path separator.
      Added warning re dcmdjpeg +ca on lossless images.
      Added OFFile& constructor to DcmOutputFileStream.
      Fixed handling of DataSetType value in DIMSE code.
      Introduced DIMSE backward compatibility option.
      Removed obsolete code for old CMake versions.
      Prevent use of dangling pointer to freed buffer.
      Ported recent FreeBSD commits to oficonv.
      Minor code cleanup.
      Documented special filename "-" for stdin/stdout.
      Prevent redefinition of __STDC_FORMAT_MACROS macro.
      Print syntactically valid Json for compressed images.
      Suppress spurious gcc warning on MinGW.
      Fixed minor warnings reported by gcc 11.
      Suppress another spurious gcc warning on MinGW.
      Suppress further gcc warnings.
      Suppress further gcc warning.
      Added support for the new RFC 8996 TLS profiles.
      Fixed minor warnings.
      Fixed various bugs in dcmtls and updated docs.
      Fixed read routine for softcopy plut.
      Use Visual Studio compiler flags also with NMake.
      Open dump file in binary mode.
      Fixed frame size calculation for YBR_FULL_422.
      Adjusted error code for YBR_FULL_422 images.
      Fixed linking against libxml2 on Windows.
      Added option to override default cmake search logic.
      Fixed infinite loop in sendDcmDataset().
      Updated DcmSignature::initializeLibrary().
      Updated DcmSignature::initializeLibrary().
      Fixed commit #742b6378e.
      Fixed bug in CharLS code.
      Fixed bug in calculation image comparison metrics.
      Enabled ALPN support in the dcmtls module.
      Fixed minor warning.
      Fixed error code for unknown TLS ciphersuite.
      Fixed segmentation fault in xml2dcm.
      Fixed JSON output of DS elements.
      Fixed previous commit.
      Fixed bug in libxml2 detection.
      Fixed INSTALL target on Windows.
      Restored behaviour of INSTALL target on Windows.
      Updated documentation on oficonv data files.
      Fixed segmentation fault in dcmqrscp.
      Mention DCMTK_USE_WIN32_PROGRAMDATA in ANNOUNCE.
      Fixed compile issues on Debian GNU Hurd.
      Fixed ofipc on GNU Hurd.
      Fixed installation directories on Windows.
      Fixed link instructions for libtiff.
      Fixed the DCMTK_LINK_STATIC option on MacOS.
      Fixed buffer overflow in decompression codecs.
      Shortened TLS related --help output to 80 characters.
      Shortened --help output to 80 characters.
      Fixed signed/unsigned comparison.
      Added comment concerning oficonv data scripts.
      Use relative CMake installation paths.
      Fixed compilation on RHEL 6.10 / gcc 4.4.7.
      Added function ASC_setParentProcessMode().
      Call OPENSSL_init_crypto() if available.
      Added TLS support to dcmqrscp.
      Fixed OPENSSL_init_crypto() detection.
      Rebase to testing.
      Removed unnecessary include.
      Updated man page.
      Fixed compilation with OpenSSL 1.1.0.
      New implementation of OFStandard::atof().
      Minor corrections for OFStandard::atof().
      Fixed LFS64 detection.
      Describe multiframe support in img2dcm manpage.
      Removed comment.
      Disabled oficonv pass-through mode by default.
      Added TLS support to getscu.
      Removed execute bit from access rights.
      Removed obsolete code for BeOS and NeXTStep.
      Removed support for OpenSSL 1.0.2 and 1.1.0.
      Updated OpenSSL version info.
      Added destructor for csmapper area object.
      Removed support for ICONV_MAX_REUSE env variable.
      Fixed minor memory leak in oficonv.
      Sanitize aetitles for use by exec options.
      Improvements for aetitle sanitizing modification.
      Clean-up of the OpenSSL related code in DCMTK.
      Cleaned up outdated feature macros.
      Cleaned up outdated tests for header files.
      Fix for previous commit.
      Further clean-up of outdated configure tests.
      Radically simplified oflimits.h.
      Fixed bug introduced with commit #acdc98cba.
      Fixed commit #eeb7f7e4b.
      Do not try to emulate CXX11 max_digits10 limit.
      Fixed OFnumeric_limits unit tests.
      Suppress MSVC warning in unit test.
      Fixed compilation on Windows with _UNICODE defined.
      Further clean-up of outdated configure tests.
      Added initial support for compilation with C++20.
      Fixed violations of one-definition rule (ODR).
      Removed some dead code.
      Fixed two segmentation faults.
      Removed the now unused file arith.cc.
      Fixed DcmDecimalString unit tests.
      Removed configure tests for socket functions.
      Fixed bug in OF_AdjacentFind().
      Added unit tests for STL features.
      Bumped minimum CMake version required to 3.1.3.
      Revised handling of STL features at configure time.
      Fixed STL unit tests.
      Fixed warning in STL unit tests.
      Removed garbage from oficonv mapping tables.
      Fixed unit tests for previous commit.
      Fixed minor warnings.
      Fixed C++20 warnings.
      Fixed previous commit.
      Declared another variable volatile.
      Fixed Visual Studio warning.
      Fixed unchecked typecasts of DcmItem::search results.
      Fixed unchecked typecasts and fixed LUT handling.
      Replaced sprintf() by snprintf().
      Replaced sprintf() by snprintf().
      Replaced sprintf() by snprintf().
      Replaced sprintf() by snprintf().
      Replaced sprintf() by snprintf().
      Replaced sprintf() by snprintf().
      Replaced sprintf() by snprintf().
      Replaced sprintf() by snprintf().
      Fixed minor warning in C++20 build.
      Avoid dereferencing zeroth element of empty vector.
      Fixed handling of ISO_IR 13 in charset conversion.
      Removed support for ICU-based charset conversion.
      Fixed symbol conflict with libjpeg-turbo.
      Doxygen @copydoc now always refers to parent class.
      Use snprintf() instead of sprintf() if available.
      Fixed delimiter handling in non-ISO 2022 charsets.
      Added special handling for ISO_IR 13.
      Simplified code of previous commit.
      New implementation of OFStandard::ftoa().
      Fixed some ftoa unit tests.
      Added cstdio based atof and ftoa implementations.
      Removed use of std::defaultfloat, which is C++11.
      Added client-side support for IPv6.
      Fixed OFStandard::ftoa() implementation using MSVCRT.
      Allow explicit protocol selection in assoc params.
      Added IPv6 support to DCMTK's association requestors.
      Changed IP protocol version parameter to enum.
      Set compiler flags for iOS appropriately.
      Initial commit of the dcm2img command line tool.
      dcm2img now determines output format automatically.
      Implemented support for DICOM CP 2311.
      Fix reading partial objects.
      Fixed compilation with GCC 15.
      Fixed definition of ssize_t on Win64.
      Fixed minor warnings caused by previous commit.
      Fixed another minor warning.
      Reverted commit #65d4f8617.
      Do not include <cstring> in <dcmtk/ofstd/ofdefine.h>.
      Fixed minor warnings on MSVC.
      Fixed leakage of network sockets to child processes.
      Added two new helper functions to module ofstd.
      Set stdout to binary when writing image to stdout.
      Updated COPYRIGHT file.
      Removed function OFgetModulePath().
      updated COPYRIGHT.
      Fixed minor warning.
      Added helper function OFstub_main.
      Added autoconf support for dcmapps.
      Added dcmapps/docs/Makefile.in.
      Replaced deprecated command line tools by stubs.
      Check return code of fclose() when writing a file.
      Initialize m_tLayer in DcmSCPConfig copy constructor.
      Fixed compilation with libxml2 2.13.x on Windows.
      Adapted dcmsign to API change in OpenSSL 3.4.0.
      Fixed minor warning on MSVC.
      Fixed compilation with OpenSSL 1.1.1.

Mathieu Malaterre (7):
      Extend JPEG parser to allow removal of COM segment
      Expose COM removal option to img2dcm
      Remove reference to the expired LZW patent from unisys
      Indicate that the input DICOM/JPEG-LS is not conforming
      Rework un-optimized huffman table checking of symbol table
      Clarify img2dcm documentation for JPEG+APP2 vs ICC Profile
      Document mechanism to add definition in CMake

Matt McCormick (1):
      Support CMAKE_CROSSCOMPILING_EMULATOR

Michael Onken (150):
      Updated version information for 3.6.6+ development.
      Fixed extra padding created for some segmentations.
      Removed USE_STD_CXX_INLUDES.
      Try to fix build for 744a94 on some platforms.
      Try fixing C includes for old compilers.
      Replaced bzero() with memset().
      Updated dependencies.
      Fixed building for Apple M1.
      Fix for Big Endian systems. Removed retired tag.
      Fixed HL7HierarchicDesignatorMacro.
      Enforce wlmscpfs' sleeping options.
      Updated copyright date and docs.
      Fix appn/comment combination of img2dcm options.
      Removed unused function and applied formatting.
      Try fix dcmect_tests for Big Endian platform.
      Added comment.
      Harmonize dictionary options.
      Fixed possible NULL pointer dereference.
      Fixed poss. NULL pointer dereference/double free.
      Added configure support for changes in a9697d
      Fixed bug introduced in a9697d.
      Fixed documentation.
      Print warning for old cmake dictionary options.
      Remove some typos in the codebase.
      Fixed bug when adding more than 65535 frames.
      Allow up to 2^31-1 frames in segmentations.
      Fixed build errors on some systems.
      Fixed build warnings.
      Fix some binary segmentation concatenations.
      Reformatted source code.
      Forbid insertion of encapsulated Pixel Data.
      Check return value for error.
      Fixed another issue with binary seg concatenations.
      Removed debug output.
      Fix for bug introduced in 1fd08a.
      Adapted DUL constant to reflect current behaviour
      Speed up dcmseg_bigdim and only run with std::map.
      Remove debugging output introduced in last commit.
      Fixed test by removing retired attribute.
      Prepared DCMTK Release 3.6.7.
      Updated version information for 3.6.7+ development.
      Extend DcmScu for sending N-CREATE requests.
      Always return N-CREATE-RSP dataset to user.
      Various N-CREATE test fixes.
      Further changes to fix N-CREATE support tests.
      Even more changes to fix N-CREATE support tests.
      Fixed OFCHECK_MSG format, timing in N-CREATE test.
      Further N-CREATE test fixes/clarifications.
      Another fix attempt for N-CREATE tests...
      Tell server to stop before client releases assoc.
      Another N-CREATE test fix approach.
      Status string fix and more sleep() in tests.
      Use random listen port for NCREATE tests.
      Set port in config method only for NCREATE test.
      Fixed possible NULL pointer dereference.
      Updated Makefile dependencies.
      Add DcmScu support for sending N-SET requests.
      Fixed test dcmnet_scp_fail_on_disallowed_host.
      Fixed typo.
      Always propose Little Endian Implicit for storage.
      Propose Little Endian Implicit as last TS.
      Fixed possible buffer overflow.
      Allow OS to choose free port for DcmSCP.
      Use Uint16 instead of u_short.
      Check error code when loading all into memory.
      Make DcmSCU::nextMessageID protected, not private.
      Make nextMessageID() virtual.
      Refactor network init into separate method.
      Add missing include of Windows.h in dcdict.cc.
      Add support for parsing of JPEG-LS (ITU 87)
      Fixed API documentation warnings for doxygen.
      Avoid implicit cast from Uint8 to bool.
      Enhanced command line handling for img2dcm.
      Consistent use of --series-from and --study-from.
      Simpler user configuration of DCMTK_DEFAULT_DICT.
      Added Instituational Department Name as Return Key.
      Removed unused variable.
      Manually set msg ID resp. to in CANCEL request.
      Removed experimental status of DcmSCU and DcmSCP.
      Removed unused variables in tests.
      Fix signed comparison warning in some compilers.
      Presuppose C++ compiler support for C++ casts.
      Fix builds with absolute CMAKE_INSTALL_LIBDIR.
      Don't fill in Responding AE Title in request log.
      Reject wrong called AE Title if configured.
      Fixed documentation.
      Better CMake check of DCMTK_ENABLE_STL_${FEATURE}.
      Fix detection of modern C++ versions for VS.
      Fixed use-after-free bug in dcmqrsrv
      Added documentation for User Identity Negotiation.
      Added VS to list of support C++11 compilers.
      Hint that VS 2017 is expected to support C++11.
      Change log level from Warning to Info.
      Also log on info level when stopping after element.
      Removed leading spaces in dcmtk.pc.in.
      Fix detection of signed char on MSVC.
      Provide char encoding value for stdlibc (iconv).
      Better randomness for temporary filenames.
      Do not execute slow dcmnet tests per default.
      Adapt parameter definition to declaration.
      Fix read access violation for length overflow.
      Various doc. updates for pending 3.6.8 release.
      Use safe buffer length for sprintf.
      Adaptations for pending 3.6.8 release.
      Forwarded PACKAGE_DATE.
      Updated code with planned release date.
      Also updated man page with planned release date.
      Fixed last commit (release date week day).
      Created CHANGES.368 for DCMTK release 3.6.8:
      Updated version information for 3.6.8+ development.
      Build Windows binary for every pushed commit.
      Fix find_package() library variables for libtiff.
      Added missing clearData() implementation.
      If desired, ignore attribute value errors on write.
      Cleanup headers.
      Removed new lines at end of file.
      Consistent logger names and remove unused loggers.
      Fixed possible overflows when allocating memory.
      Fix compiler warning about template parameters.
      Bump action scripts used to version 4.
      Bumped two further action script versions.
      Use checkout@v4 instead of checkout@v5 (typo).
      Also bump setup-python to v5.
      Don't try to install arith.h.
      Don't install tests.
      Enable C++ standard version 11 (CXX11) per default.
      Put CMAKE_CXX_STANDARD into CMake Cache.
      Export CMAKE_CXX_STANDARD into DCMTKConfig.cmake.
      Use existing method to check for illegal groups.
      Make sure __cplusplus macro is not set too early.
      Fix comment on new method implementation.
      Refactored code for reusabiltity and consistence.
      Use more specific header files instead of dctk.h.
      Updated Makefile dependencies.
      Removed developer debug output.
      Fix C++11 OFVariant build on VS 2017.
      Guard malloced buffer to ensure they are freed.
      Removed unused header.
      Remove pixel data compression check.
      Fixed string trimming in verify() method.
      Fixed compare() method for text-based VRs.
      Fix C++20 debug build error if wchar_t is used.
      Don't use old-style C casts.
      Fix single shared lib on Ubuntu 24.
      Make movescu respect output dir with +B.
      Remove jaricom.c completely.
      Exact values for DCMTK_ENABLE_CHARSET_CONVERSION.
      Fixed DcmByteString::putOFStringAtPos.
      Remove duplicate check.
      Made Coding Scheme Designator type 1C.

Nikolas Goldhammer (4):
      Fixed confusing value of Host Type on Windows.
      Fixed a warning in the FindOpenJPEG module.
      Added flag DCMTK_USE_OWN_FINDOPENJPEG_MODULE.
      Improved detection of additional depencencies for statically linking.

Tai Chi Minh Ralph Eastwood (1):
      Add pkg-config support to DCMTK

Tingyan Xu (1):
      Added new command line tool dcm2cda.
```