### PR TITLE
BUG: Fix missing Markups ROI fill in some views

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
@@ -21,6 +21,7 @@
 // VTK includes
 #include <vtkActor2D.h>
 #include <vtkCellLocator.h>
+#include <vtkCleanPolyData.h>
 #include <vtkContourTriangulator.h>
 #include <vtkCubeSource.h>
 #include <vtkCutter.h>
@@ -68,8 +69,11 @@ vtkSlicerROIRepresentation2D::vtkSlicerROIRepresentation2D()
   this->ROIOutlineCutter->SetInputConnection(this->ROIToWorldTransformFilter->GetOutputPort());
   this->ROIOutlineCutter->SetCutFunction(this->SlicePlane);
 
+  this->ROIOutlineCleaner = vtkSmartPointer<vtkCleanPolyData>::New();
+  this->ROIOutlineCleaner->SetInputConnection(this->ROIOutlineCutter->GetOutputPort());
+
   this->ROIOutlineWorldToSliceTransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
-  this->ROIOutlineWorldToSliceTransformFilter->SetInputConnection(this->ROIOutlineCutter->GetOutputPort());
+  this->ROIOutlineWorldToSliceTransformFilter->SetInputConnection(this->ROIOutlineCleaner->GetOutputPort());
   this->ROIOutlineWorldToSliceTransformFilter->SetTransform(this->WorldToSliceTransform);
 
   this->ROIOutlineMapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.h
@@ -37,6 +37,7 @@
 #include "vtkSlicerROIRepresentation3D.h"
 
 class vtkAppendPolyData;
+class vtkCleanPolyData;
 class vtkClipPolyData;
 class vtkContourTriangulator;
 class vtkCutter;
@@ -94,6 +95,7 @@ protected:
   vtkSmartPointer<vtkTransform>               ROIToWorldTransform;
   vtkSmartPointer<vtkTransformPolyDataFilter> ROIToWorldTransformFilter;
   vtkSmartPointer<vtkCutter>                  ROIOutlineCutter;
+  vtkSmartPointer<vtkCleanPolyData>           ROIOutlineCleaner;
   vtkSmartPointer<vtkTransformPolyDataFilter> ROIOutlineWorldToSliceTransformFilter;
   vtkSmartPointer<vtkContourTriangulator>     ROIIntersectionTriangulator;
 


### PR DESCRIPTION
Contour triangulation would occasionally fail in some views depending on view orientation.

This was due to a failure in vtkContourTriangulator. Adding vtkCleanPolyData before vtkContourTriangulator in the pipeline fixes the issues.

Fix #7944