### PR TITLE
STYLE: Remove unused MRMLIDImageIO API

### DIFF
--- a/Libs/MRML/IDImageIO/itkMRMLIDImageIO.cxx
+++ b/Libs/MRML/IDImageIO/itkMRMLIDImageIO.cxx
@@ -377,52 +377,6 @@ MRMLIDImageIO
 }
 
 //----------------------------------------------------------------------------
-// Read from the MRML scene
-bool
-MRMLIDImageIO
-::CanUseOwnBuffer()
-{
-  return true;
-}
-
-//----------------------------------------------------------------------------
-// Read from the MRML scene
-void
-MRMLIDImageIO
-::ReadUsingOwnBuffer()
-{
-  return;
-}
-
-//----------------------------------------------------------------------------
-// Read from the MRML scene
-void *
-MRMLIDImageIO
-::GetOwnBuffer()
-{
-  vtkMRMLVolumeNode *node;
-
-  node = this->FileNameToVolumeNodePtr( m_FileName.c_str() );
-  if (node)
-  {
-    // buffer is preallocated, memcpy the data
-    if (vtkMRMLDiffusionImageVolumeNode::SafeDownCast(node) == nullptr)
-    {
-      // Scalar, Diffusion Weighted, or Vector image
-      return node->GetImageData()->GetScalarPointer();
-    }
-    else
-    {
-      return node->GetImageData()->GetPointData()->GetTensors()->GetVoidPointer(0);
-    }
-  }
-
-  throw( "MRML Node does not contain image data." );
-
-  return static_cast< void * >( nullptr );
-}
-
-//----------------------------------------------------------------------------
 bool
 MRMLIDImageIO
 ::CanWriteFile(const char* filename)

--- a/Libs/MRML/IDImageIO/itkMRMLIDImageIO.h
+++ b/Libs/MRML/IDImageIO/itkMRMLIDImageIO.h
@@ -69,10 +69,6 @@ public:
    * file specified. */
   bool CanReadFile(const char*) override;
 
-  virtual bool CanUseOwnBuffer();
-  virtual void ReadUsingOwnBuffer();
-  virtual void * GetOwnBuffer();
-
   /** Set the spacing and dimension information for the set filename. */
   void ReadImageInformation() override;
 


### PR DESCRIPTION
This commit removes the unused virtual functions `CanUseOwnBuffer`, `ReadUsingOwnBuffer`, and `GetOwnBuffer` from `MRMLIDImageIO`. These functions were originally introduced in Slicer through commit `bc99a8cfc1` ("ENH: Modify ITK MRML image reader to re-use buffer when possible", 2010-11-15).

The API was initially added to ITK via InsightSoftwareConsortium/ITK@2ffb32de2f ("ENH: Modify ITK image reader to re-use buffer when possible", 2010-11-15) on the `Slicer4UpdatesToITKv3.20` branch, which was later merged into ITK's `release` branch in commit InsightSoftwareConsortium/ITK@d4d43abf60 ("Merge branch 'Slicer4UpdatesToITKv3.20' into release", 2011-10-24).

Despite a subsequent merge of the `release` branch back into the ITK development branch via commit InsightSoftwareConsortium/ITK@5d6212c8a1 ("Merge branch 'release'", 2011-10-24), the buffer re-use API was not retained, likely due to an "ours" merge strategy (`git checkout master && git merge -s ours release`).

Fixes #7087