### PR TITLE
ENH: Switch highlighted social network to LinkedIn

### DIFF
--- a/Applications/SlicerApp/qSlicerAppMainWindow.cxx
+++ b/Applications/SlicerApp/qSlicerAppMainWindow.cxx
@@ -102,9 +102,9 @@ void qSlicerAppMainWindowPrivate::setupUi(QMainWindow * mainWindow)
   helpBrowseTutorialsAction->setText(qSlicerAppMainWindow::tr("Browse Tutorials"));
   helpBrowseTutorialsAction->setToolTip(qSlicerAppMainWindow::tr("Raise the training pages in your favorite web browser"));
 
-  QAction* helpJoinUsOnTwitterAction = new QAction(mainWindow);
-  helpJoinUsOnTwitterAction->setObjectName("HelpJoinUsOnTwitterAction");
-  helpJoinUsOnTwitterAction->setText(qSlicerAppMainWindow::tr("Join Us on Twitter"));
+  QAction* helpJoinUsOnLinkedInAction = new QAction(mainWindow);
+  helpJoinUsOnLinkedInAction->setObjectName("HelpJoinUsOnLinkedInAction");
+  helpJoinUsOnLinkedInAction->setText(qSlicerAppMainWindow::tr("Join Us on LinkedIn"));
 
   QAction* helpSearchFeatureRequestsAction = new QAction(mainWindow);
   helpSearchFeatureRequestsAction->setObjectName("HelpSearchFeatureRequestsAction");
@@ -162,7 +162,7 @@ void qSlicerAppMainWindowPrivate::setupUi(QMainWindow * mainWindow)
   this->HelpMenu->addAction(helpBrowseTutorialsAction);
   this->HelpMenu->addSeparator();
   this->HelpMenu->addAction(helpVisitSlicerForumAction);
-  this->HelpMenu->addAction(helpJoinUsOnTwitterAction);
+  this->HelpMenu->addAction(helpJoinUsOnLinkedInAction);
   this->HelpMenu->addAction(helpSearchFeatureRequestsAction);
   this->HelpMenu->addAction(helpReportBugOrFeatureRequestAction);
   this->HelpMenu->addSeparator();
@@ -275,9 +275,9 @@ void qSlicerAppMainWindow::on_HelpVisitSlicerForumAction_triggered()
 }
 
 //---------------------------------------------------------------------------
-void qSlicerAppMainWindow::on_HelpJoinUsOnTwitterAction_triggered()
+void qSlicerAppMainWindow::on_HelpJoinUsOnLinkedInAction_triggered()
 {
-  QDesktopServices::openUrl(QUrl("https://twitter.com/3dslicerapp"));
+  QDesktopServices::openUrl(QUrl("https://www.linkedin.com/feed/hashtag/?keywords=3dslicer"));
 }
 
 //---------------------------------------------------------------------------

--- a/Applications/SlicerApp/qSlicerAppMainWindow.h
+++ b/Applications/SlicerApp/qSlicerAppMainWindow.h
@@ -44,7 +44,7 @@ public slots:
   void on_HelpGetHelpAction_triggered();
   void on_HelpUserInterfaceAction_triggered();
   void on_HelpVisitSlicerForumAction_triggered();
-  void on_HelpJoinUsOnTwitterAction_triggered();
+  void on_HelpJoinUsOnLinkedInAction_triggered();
   void on_HelpSearchFeatureRequestsAction_triggered();
   void on_HelpViewLicenseAction_triggered();
   void on_HelpHowToCiteAction_triggered();

--- a/Modules/Loadable/SlicerWelcome/Resources/UI/qSlicerWelcomeModuleWidget.ui
+++ b/Modules/Loadable/SlicerWelcome/Resources/UI/qSlicerWelcomeModuleWidget.ui
@@ -326,7 +326,7 @@
 &lt;li&gt;&lt;a href=&quot;https://slicer.readthedocs.io/en/latest/user_guide/getting_started.html#tutorials&quot;&gt;Browse Tutorials&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
 &lt;p&gt;&lt;b&gt;Contact Us&lt;/p&gt;
 &lt;ul&gt;&lt;li&gt;&lt;a href=&quot;https://discourse.slicer.org/&quot;&gt;Visit the Slicer Forum&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&quot;https://twitter.com/3dslicerapp&quot;&gt;Join Us on Twitter&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&quot;https://www.linkedin.com/feed/hashtag/?keywords=3dslicer&quot;&gt;Join Us on LinkedIn&lt;/a&gt;&lt;/li&gt;
 &lt;li&gt;&lt;a href=&quot;https://discourse.slicer.org/c/support/feature-requests/9&quot;&gt;Search Feature Requests&lt;/a&gt;&lt;/li&gt;
 &lt;li&gt;&lt;a href=&quot;https://slicer.readthedocs.io/en/latest/user_guide/get_help.html#i-want-to-report-a-problem&quot;&gt;Report a Bug&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;
 &lt;p&gt;&lt;b&gt;About 3D Slicer&lt;/p&gt;


### PR DESCRIPTION
The 3DSlicerApp account on X.com (formerly Twitter) has not been active since March 2023. LinkedIn continues to be a focused place for researchers to post about their work in an academic/professional setting unlike X.com that covers a wide spectrum of topics. Therefore LinkedIn may be considered more appropriate for connecting researchers to others in more helpful ways.

Previously discussed in https://discourse.slicer.org/t/social-media-presence-moving-away-from-twitter/30433/8.

See joint PR to update the Slicer website with similar change:
https://github.com/Slicer/slicer.org/pull/285