### PR TITLE
BUG: Fix saving with long node names

### DIFF
--- a/Base/QTCore/Testing/Cxx/CMakeLists.txt
+++ b/Base/QTCore/Testing/Cxx/CMakeLists.txt
@@ -133,9 +133,13 @@ if(BUILD_TESTING)
 
   # Remark: qSlicerModuleFactoryManager class is tested within Applications/SlicerApp/Testing
 
+  #-----------------------------------------------------------------------------
+  # Temporary test directory for file writing
+  set(TEMP "${CMAKE_BINARY_DIR}/Testing/Temporary")
+
   simple_test( qSlicerCoreApplicationTest1)
   set_property(TEST qSlicerCoreApplicationTest1 PROPERTY LABELS ${LIBRARY_NAME})
-  simple_test( qSlicerCoreIOManagerTest1 )
+  simple_test( qSlicerCoreIOManagerTest1 ${TEMP})
   set_property(TEST qSlicerCoreIOManagerTest1 PROPERTY LABELS ${LIBRARY_NAME})
   simple_test( qSlicerAbstractCoreModuleTest1 )
   simple_test( qSlicerLoadableModuleFactoryTest1 )

--- a/Base/QTCore/qSlicerCoreIOManager.cxx
+++ b/Base/QTCore/qSlicerCoreIOManager.cxx
@@ -482,8 +482,20 @@ QString qSlicerCoreIOManager::forceFileNameValidCharacters(const QString& filena
 
   // Remove leading and trailing spaces
   sanitizedFilename = sanitizedFilename.trimmed();
-
   return sanitizedFilename;
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerCoreIOManager::forceFileNameMaxLength(const QString& filename, int maxLength/*=-1*/)
+{
+  QString extension = this->extractKnownExtension(filename, nullptr);
+  return qSlicerCoreIOManager::forceFileNameMaxLengthExtension(filename, maxLength, extension.length());
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerCoreIOManager::forceFileNameMaxLengthExtension(const QString& filename, int extensionLength, int maxLength/*=-1*/)
+{
+  return QString::fromStdString(vtkMRMLStorageNode::ClampFileNameExtension(filename.toStdString(), maxLength, 4, extensionLength));
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerCoreIOManager.h
+++ b/Base/QTCore/qSlicerCoreIOManager.h
@@ -109,6 +109,15 @@ public:
   /// Remove characters that are likely to cause problems in a filename
   Q_INVOKABLE static QString forceFileNameValidCharacters(const QString& filename);
 
+  /// Clamp the length of a filename to a maximum number of characters.
+  /// The file extension will be detected and excluded from the specified maximum length.
+  /// \sa qSlicerCoreIOManager::stripKnownExtension()
+  Q_INVOKABLE QString forceFileNameMaxLength(const QString& filename, int maxLength=-1);
+
+  /// Clamp the length of a filename to a maximum number of characters.
+  /// The length of the filename extension must also be specified so that it is not included in the shortened section.
+  Q_INVOKABLE static QString forceFileNameMaxLengthExtension(const QString& filename, int extensionLength, int maxLength=-1);
+
   /// If \a fileName ends with an extension that is associated with \a object,
   /// then return that extension. Otherwise return an empty string.
   /// If there are multiple candidates (such as for "something.seg.nrrd" both

--- a/Base/QTGUI/qSlicerExportNodeDialog.cxx
+++ b/Base/QTGUI/qSlicerExportNodeDialog.cxx
@@ -357,8 +357,10 @@ QString qSlicerExportNodeDialogPrivate::defaultFilename(vtkMRMLNode* node, QStri
     qCritical() << Q_FUNC_INFO << "failed: Core IO manager not found.";
     return QString();
   }
-  const QString safeNodeName = qSlicerCoreIOManager::forceFileNameValidCharacters(unsafeNodeName);
-  return forceFileNameExtension(safeNodeName, extension, node);
+
+  QString safeNodeName = qSlicerCoreIOManager::forceFileNameValidCharacters(unsafeNodeName);
+  safeNodeName = qSlicerCoreIOManager::forceFileNameMaxLengthExtension(safeNodeName, 0);
+  return qSlicerExportNodeDialogPrivate::forceFileNameExtension(safeNodeName, extension, node);
 }
 
 //-----------------------------------------------------------------------------
@@ -1101,7 +1103,9 @@ QString qSlicerExportNodeDialogPrivate::recommendedFilename(vtkMRMLStorableNode*
     extension = QString();
   }
 
-  return forceFileNameExtension(this->FilenameLineEdit->text(), extension, node);
+  // If the filename is too long, suggest a shorter one.
+  QString shortenedFilename = qSlicerCoreIOManager::forceFileNameMaxLengthExtension(this->FilenameLineEdit->text(), extension.length());
+  return qSlicerExportNodeDialogPrivate::forceFileNameExtension(shortenedFilename, extension, node);
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -82,6 +82,8 @@ QString qSlicerFileNameItemDelegate::forceFileNameExtension(const QString& fileN
                                                    vtkMRMLScene* mrmlScene, const QString& nodeID)
 {
   QString strippedFileName = qSlicerCoreIOManager::forceFileNameValidCharacters(fileName);
+  strippedFileName = qSlicerCoreIOManager::forceFileNameMaxLengthExtension(strippedFileName, extension.length());
+
   if(!mrmlScene)
   {
     // no scene is set, cannot check extension
@@ -868,6 +870,23 @@ bool qSlicerSaveDataDialogPrivate::saveNodes()
         // Make sure an error message is added if saving returns with error
         snode->GetUserMessages()->AddMessage(vtkCommand::ErrorEvent,
           (qSlicerSaveDataDialog::tr("Cannot write data file: %1.").arg(file.absoluteFilePath())).toStdString());
+
+        // Add warning messages if the file name or path is too long
+        if (file.fileName().length() > vtkMRMLStorageNode::GetRecommendedFileNameLength())
+        {
+          snode->GetUserMessages()->AddMessage(vtkCommand::WarningEvent,
+            (qSlicerSaveDataDialog::tr("File name may be too long: %1.").arg(file.fileName())).toStdString());
+        }
+        // Maximum file path is 260 characters on most Windows systems. Warn the user if the path
+        // is long and therefore may fail to be saved or cause compatibility issues later.
+        // The warning limit is set to somewhat lower than the 260 limit, to add some safety margin
+        // (e.g., to avoid issues when the file is moved into another folder).
+        if (file.absoluteFilePath().length() > 200)
+        {
+          snode->GetUserMessages()->AddMessage(vtkCommand::WarningEvent,
+            (qSlicerSaveDataDialog::tr("File path may be too long: %1.").arg(file.absoluteFilePath())).toStdString());
+        }
+
         this->updateStatusIconFromStorageNode(row, success);
       }
       else

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -4565,6 +4565,7 @@ bool vtkMRMLScene::SaveStorableNodeToSlicerDataBundleDirectory(vtkMRMLStorableNo
     // Default storage node usually has empty file name (if Save dialog is not opened yet)
     // file name is encoded to handle : or / characters in the node names
     std::string fileBaseName = this->PercentEncode(std::string(storableNode->GetName()));
+    fileBaseName = storageNode->ClampFileName(fileBaseName);
     std::string extension = storageNode->GetDefaultWriteFileExtension();
     std::string storageFileName = fileBaseName + std::string(".") + extension;
     vtkDebugMacro("new file name = " << storageFileName.c_str());

--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -25,6 +25,7 @@ Version:   $Revision: 1.1.1.1 $
 // VTK includes
 #include <vtkCollection.h>
 #include <vtkCommand.h>
+#include <vtkMinimalStandardRandomSequence.h>
 #include <vtkNew.h>
 #include <vtkStringArray.h>
 #include <vtkURIHandler.h>
@@ -1593,4 +1594,59 @@ void vtkMRMLStorageNode::SetWriteFileFormat(const char* writeFileFormat)
   // Let observers know about node modification, but do not change the modified timestamp, as this is transient event
   // (we do not want the application to display a warning popup on scene close exit if write state was temporarily changed due to node write)
   this->InvokeCustomModifiedEvent(vtkCommand::ModifiedEvent);
+}
+
+//-----------------------------------------------------------------------------
+std::string vtkMRMLStorageNode::ClampFileName(const std::string& filename, int maxFileNameLength/*=-1*/, int hashLength/*=4*/)
+{
+  std::string baseName = this->GetFileNameWithoutExtension(filename.c_str());
+  std::string extension = this->GetSupportedFileExtension(filename.c_str());
+  return vtkMRMLStorageNode::ClampFileNameExtension(baseName, maxFileNameLength, hashLength, extension.length());
+}
+
+//-----------------------------------------------------------------------------
+std::string vtkMRMLStorageNode::ClampFileNameExtension(const std::string& filename, int maxFileNameLength/*=-1*/, int hashLength/*=4*/, int extensionLength/*=0*/)
+{
+  if (maxFileNameLength < 0)
+  {
+    // Use default limit
+    maxFileNameLength = vtkMRMLStorageNode::GetRecommendedFileNameLength();
+  }
+
+  // Remove extension
+  std::string baseName = filename.substr(0, filename.length() - extensionLength);
+  if (baseName.length() <= maxFileNameLength)
+  {
+    return filename;
+  }
+
+  // File is too long. Convert it into a shorter filename with the following format:
+  // <first 20 characters of the base name>_<4 character hash code>.<extension>
+  int prefixLength = maxFileNameLength - hashLength - 1; // 1 for the underscore
+  std::string prefix = baseName.substr(0, prefixLength);
+  int suffixLength = baseName.length() - prefixLength;
+  std::string suffix = baseName.substr(prefixLength, suffixLength);
+
+  std::stringstream truncatedFilenameSS;
+  truncatedFilenameSS << prefix << "_";
+
+  // Seed the random number generator with a hash of the suffix
+  std::hash<std::string> hashFunction;
+  size_t hashCodeSeed = hashFunction(suffix);
+
+  vtkNew<vtkMinimalStandardRandomSequence> randomSequence;
+  randomSequence->SetSeed(hashCodeSeed);
+
+  // Generate a random hash code from upper case letters and numbers
+  std::string hashChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  for (int i = 0; i < hashLength; ++i)
+  {
+    int index = static_cast<int>(std::floor(std::fmod(randomSequence->GetNextValue(), 1.0) * hashChars.size()));
+    truncatedFilenameSS << hashChars[index];
+  }
+
+  std::string extension = filename.substr(filename.length() - extensionLength);
+  truncatedFilenameSS << extension;
+
+  return truncatedFilenameSS.str();
 }

--- a/Libs/MRML/Core/vtkMRMLStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.h
@@ -381,6 +381,22 @@ public:
   const vtkMRMLMessageCollection *GetUserMessages() const { return this->UserMessages; }
   vtkMRMLMessageCollection *GetUserMessages() { return this->UserMessages; }
 
+  //@{
+  /// Ensures that the file name (excluding the extension) is shorter than the maximum allowed length.
+  /// If the filename is shorter than the maximum allowed length then it is returned unchanged.
+  /// If the filename is longer than the maximum allowed length then the filename is shortened by using the following format:
+  /// [first 20 characters of the base name]_[4 character hash code].[extension]
+  /// The length of the prefix is the maximum allowed length minus the length of the hash code plus one for the added underscore.
+  /// The full base name of the file will be exactly maxFileNameLength characters long.
+  /// If maxFileNameLength is negative then the recommended file name length is used.
+  /// \sa GetRecommendedFileNameLength
+  std::string ClampFileName(const std::string& filename, int maxFileNameLength=-1, int hashLength = 4);
+  static std::string ClampFileNameExtension(const std::string& filename, int maxFileNameLength=-1, int hashLength = 4, int extensionLength=0);
+  //@}
+
+  /// Get the recommended maximum length of the file name.
+  static int GetRecommendedFileNameLength() { return 25; };
+
 protected:
   vtkMRMLStorageNode();
   ~vtkMRMLStorageNode() override;


### PR DESCRIPTION
When saving nodes with long names on Windows, the file creation and writing would be unsuccessful. Since the error was at the system level, the error message would often be unhelpful for the user.

This PR clamps filename length for nodes with long names using `vtkMRMLScene::ClampFileNameLength`.

The format of the clamped string is:

```
[prefix of first 20 characters of the base name]_[4 character hash code].[extension]
```

The remaining characters after the suffix are used to seed the random number generator used to create the hash code.

Re #7901