### PR TITLE
COMP: Resolve deprecated warning in MRML testing macro for std::string

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeTest1.cxx
@@ -41,7 +41,7 @@ int vtkMRMLSceneViewNodeTest1(int , char * [] )
 
   node1->SetAbsentStorageFileNames();
 
-  TEST_SET_GET_STRING( node1.GetPointer(), SceneViewDescription);
+  TEST_SET_GET_STD_STRING( node1.GetPointer(), SceneViewDescription);
 
   node1->SetScreenShot(nullptr);
   vtkImageData *nullImage = node1->GetScreenShot();

--- a/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h
+++ b/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h
@@ -361,6 +361,34 @@
   } \
   }
 
+// ----------------------------------------------------------------------------
+/// test a string variable on the object by calling Set/Get
+#define TEST_SET_GET_STD_STRING( object, variable ) \
+  { \
+  std::string originalString = object->Get##variable(); \
+  object->Set##variable( "testing with a const char");                  \
+  if( object->Get##variable() != "testing with a const char" ) \
+  {                                                                   \
+    std::cerr << "Error in Set/Get"#variable << " with a string literal" << std::endl; \
+    return EXIT_FAILURE;                                                \
+  }                                                                   \
+  std::string string1 = "testingIsGood"; \
+  object->Set##variable( string1 ); \
+  if( object->Get##variable() != string1 ) \
+  {   \
+    std::cerr << "Error in Set/Get"#variable << ", tried to set to " << string1 << " but got " << object->Get##variable() << std::endl; \
+    return EXIT_FAILURE; \
+  } \
+  std::string string2 = "moreTestingIsBetter"; \
+  object->Set##variable( string2 ); \
+  if( object->Get##variable() != string2 ) \
+  {   \
+    std::cerr << "Error in Set/Get"#variable << ", tried to set to " << string2 << " but got " << object->Get##variable() << std::endl; \
+    return EXIT_FAILURE; \
+  } \
+  object->Set##variable( originalString );  \
+  }
+
 #define EXERCISE_BASIC_OBJECT_METHODS( node )                                        \
   {                                                                                  \
   int result = vtkMRMLCoreTestingUtilities::ExerciseBasicObjectMethods(node);        \


### PR DESCRIPTION
This commit is follow-up of 9b8c82356b ("BUG: Revert invalid -Wdeprecated-declarations fix in TEST_SET_GET_STRING", 2023-11-24) and is intended to fix warnings like the following by adding `TEST_SET_GET_STD_STRING` MRML testing macro to explicitly test set/get of `std::string` (instead of relying on the deprecated operator const char*().

Warning fixed:

```
Slicer/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeTest1.cxx:
 In function ‘int vtkMRMLSceneViewNodeTest1(int, char**)’:
Slicer/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h:328:62:
 warning: ‘vtkStdString::operator const char*()’ is deprecated: Call `.c_str()` explicitly [-Wdeprecated-declarations]
   const char * originalStringPointer = object->Get##variable();
```

Related pull requests:
* https://github.com/Slicer/Slicer/pull/7401 
* https://github.com/Slicer/Slicer/pull/7411
* https://github.com/Slicer/Slicer/pull/7419

Related issues:
* https://github.com/Slicer/Slicer/issues/7403