### PR TITLE
COMP: Replace vtkStdString with std::string

### DIFF
--- a/Base/Logic/vtkSlicerScriptedLoadableModuleLogic.cxx
+++ b/Base/Logic/vtkSlicerScriptedLoadableModuleLogic.cxx
@@ -29,7 +29,6 @@
 
 // VTK includes
 #include <vtkPythonUtil.h>
-#include <vtkStdString.h>
 
 // STD includes
 #include <cstdlib>

--- a/Base/QTGUI/qSlicerNodeWriter.cxx
+++ b/Base/QTGUI/qSlicerNodeWriter.cxx
@@ -38,8 +38,10 @@
 #include <vtkMRMLMessageCollection.h>
 
 // VTK includes
-#include <vtkStdString.h>
 #include <vtkStringArray.h>
+
+// STD includes
+#include <string>
 
 //-----------------------------------------------------------------------------
 class qSlicerNodeWriterPrivate
@@ -113,7 +115,7 @@ QStringList qSlicerNodeWriter::extensions(vtkObject* object)const
     const int formatCount = snode->GetSupportedWriteFileTypes()->GetNumberOfValues();
     for (int formatIt = 0; formatIt < formatCount; ++formatIt)
     {
-      vtkStdString format =
+      std::string format =
         snode->GetSupportedWriteFileTypes()->GetValue(formatIt);
       supportedExtensions << QString::fromStdString(format);
     }

--- a/Libs/MRML/Core/vtkMRMLParser.cxx
+++ b/Libs/MRML/Core/vtkMRMLParser.cxx
@@ -25,7 +25,6 @@ Version:   $Revision: 1.8 $
 // VTK includes
 #include <vtkCollection.h>
 #include <vtkObjectFactory.h>
-#include <vtkStdString.h>
 
 // STD includes
 #include <sstream>

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
@@ -69,7 +69,7 @@ void vtkMRMLSceneViewNode::WriteXML(ostream& of, int nIndent)
 
   of << " screenshotType=\"" << this->GetScreenShotType() << "\"";
 
-  vtkStdString description = this->GetSceneViewDescription();
+  std::string description = this->GetSceneViewDescription();
   vtksys::SystemTools::ReplaceString(description,"\n","<br>");
 
   of << " sceneViewDescription=\"" << this->XMLAttributeEncodeString(description) << "\"";
@@ -130,7 +130,7 @@ void vtkMRMLSceneViewNode::ReadXMLAttributes(const char** atts)
     else if(!strcmp(attName, "sceneViewDescription"))
     {
       // can have spaces in the description, don't use stringstream
-      vtkStdString sceneViewDescription = vtkStdString(attValue);
+      std::string sceneViewDescription = std::string(attValue);
       vtksys::SystemTools::ReplaceString(sceneViewDescription,"[br]","\n");
       this->SetSceneViewDescription(sceneViewDescription);
     }
@@ -142,7 +142,7 @@ void vtkMRMLSceneViewNode::ReadXMLAttributes(const char** atts)
   // TODO: don't do this if there is a storage node already, but the problem
   // is that the storage node will get set after, so GetStorageNode returns
   // null right now
-  vtkStdString screenCapturePath;
+  std::string screenCapturePath;
   if (this->GetScene() &&
       this->GetScene()->GetRootDirectory())
   {
@@ -155,7 +155,7 @@ void vtkMRMLSceneViewNode::ReadXMLAttributes(const char** atts)
   screenCapturePath += "/";
   screenCapturePath += "ScreenCaptures/";
 
-  vtkStdString screenCaptureFilename;
+  std::string screenCaptureFilename;
   screenCaptureFilename += screenCapturePath;
   if (this->GetID())
   {
@@ -737,7 +737,7 @@ vtkMRMLStorageNode* vtkMRMLSceneViewNode::CreateDefaultStorageNode()
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLSceneViewNode::SetSceneViewDescription(const vtkStdString& newDescription)
+void vtkMRMLSceneViewNode::SetSceneViewDescription(const std::string& newDescription)
 {
   if (this->SceneViewDescription == newDescription)
   {

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.h
@@ -18,9 +18,11 @@
 #include "vtkMRMLStorableNode.h"
 
 // VTK includes
-#include <vtkStdString.h>
 class vtkCollection;
 class vtkImageData;
+
+// STD includes
+#include <string>
 
 class vtkMRMLStorageNode;
 class VTK_MRML_EXPORT vtkMRMLSceneViewNode : public vtkMRMLStorableNode
@@ -93,8 +95,8 @@ class VTK_MRML_EXPORT vtkMRMLSceneViewNode : public vtkMRMLStorableNode
   void SetAbsentStorageFileNames();
 
   /// A description of this sceneView
-  void SetSceneViewDescription(const vtkStdString& newDescription);
-  vtkGetMacro(SceneViewDescription, vtkStdString);
+  void SetSceneViewDescription(const std::string& newDescription);
+  vtkGetMacro(SceneViewDescription, std::string);
 
   /// The attached screenshot of this sceneView
   virtual void SetScreenShot(vtkImageData* newScreenShot);
@@ -142,7 +144,7 @@ protected:
   vtkMRMLScene* SnapshotScene;
 
   /// The associated Description
-  vtkStdString SceneViewDescription;
+  std::string SceneViewDescription;
 
   /// The vtkImageData of the screenshot
   vtkImageData* ScreenShot;

--- a/Libs/MRML/Core/vtkMRMLSelectionNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSelectionNode.cxx
@@ -21,7 +21,6 @@ Version:   $Revision: 1.2 $
 // VTK includes
 #include <vtkCommand.h>
 #include <vtkObjectFactory.h>
-#include <vtkStdString.h>
 
 static const char* UNIT_NODE_REFERENCE_ROLE = "unit/";
 static const char* ACTIVE_VOLUME_REFERENCE_ROLE = "ActiveVolume";

--- a/Libs/MRML/Core/vtkMRMLStreamingVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLStreamingVolumeNode.h
@@ -35,7 +35,6 @@ Care Ontario.
 // VTK includes
 #include <vtkImageData.h>
 #include <vtkObject.h>
-#include <vtkStdString.h>
 #include <vtkUnsignedCharArray.h>
 
 /// \brief MRML node for representing a single compressed video frame that can be decoded to an image representation

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLCameraDisplayableManagerTest1.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLCameraDisplayableManagerTest1.cxx
@@ -43,6 +43,7 @@
 #include <vtkWindowToImageFilter.h>
 
 // STD includes
+#include <string>
 
 #include "vtkMRMLCoreTestingMacros.h"
 
@@ -626,7 +627,7 @@ int vtkMRMLCameraDisplayableManagerTest1(int argc, char* argv[])
   // Save current scene
   vtkNew<vtkTesting> testHelper;
   testHelper->AddArguments(argc, const_cast<const char **>(argv));
-  vtkStdString savedScene = testHelper->GetTempDirectory();
+  std::string savedScene = testHelper->GetTempDirectory();
   savedScene += "/vtkMRMLCameraDisplayableManagerTest1_saved.mrml";
   scene->SetVersion("Slicer4.4.0"); // Force scene version to be the same as in the baseline scene file
   if (!scene->Commit(savedScene.c_str()))
@@ -636,7 +637,7 @@ int vtkMRMLCameraDisplayableManagerTest1(int argc, char* argv[])
   }
 
   // Compare saved scene with baseline
-  vtkStdString baselineScene = testHelper->GetDataRoot();
+  std::string baselineScene = testHelper->GetDataRoot();
   baselineScene += "/Data/vtkMRMLCameraDisplayableManagerTest1.mrml";
 
   // Read baseline scene into string
@@ -723,7 +724,7 @@ int vtkMRMLCameraDisplayableManagerTest1(int argc, char* argv[])
     windowToImageFilter->SetScale(1, 1); //set the resolution of the output image
     windowToImageFilter->Update();
 
-    vtkStdString screenshootFilename = testHelper->GetDataRoot();
+    std::string screenshootFilename = testHelper->GetDataRoot();
     screenshootFilename += "/Baseline/vtkMRMLCameraDisplayableManagerTest1.png";
     vtkNew<vtkPNGWriter> writer;
     writer->SetFileName(screenshootFilename.c_str());

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLModelDisplayableManagerTest.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLModelDisplayableManagerTest.cxx
@@ -47,6 +47,7 @@
 #include <vtkWindowToImageFilter.h>
 
 // STD includes
+#include <string>
 
 const char vtkMRMLModelDisplayableManagerTest1EventLog[] =
 "# StreamVersion 1\n";
@@ -156,7 +157,7 @@ int vtkMRMLModelDisplayableManagerTest(int argc, char* argv[])
     vtkNew<vtkTesting> testHelper;
     testHelper->AddArguments(argc, const_cast<const char **>(argv));
 
-    vtkStdString screenshootFilename = testHelper->GetDataRoot();
+    std::string screenshootFilename = testHelper->GetDataRoot();
     screenshootFilename += "/Baseline/vtkMRMLCameraDisplayableManagerTest1.png";
     vtkNew<vtkPNGWriter> writer;
     writer->SetFileName(screenshootFilename.c_str());

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLThreeDReformatDisplayableManagerTest1.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLThreeDReformatDisplayableManagerTest1.cxx
@@ -47,6 +47,7 @@
 #include <vtkWindowToImageFilter.h>
 
 // STD includes
+#include <string>
 
 #include "vtkMRMLCoreTestingMacros.h"
 
@@ -1064,7 +1065,7 @@ int vtkMRMLThreeDReformatDisplayableManagerTest1(int argc, char* argv[])
     vtkNew<vtkTesting> testHelper;
     testHelper->AddArguments(argc, const_cast<const char **>(argv));
 
-    vtkStdString screenshootFilename = testHelper->GetDataRoot();
+    std::string screenshootFilename = testHelper->GetDataRoot();
     screenshootFilename += "/Baseline/vtkMRMLThreeDReformatDisplayableManagerTest1.png";
     vtkNew<vtkPNGWriter> writer;
     writer->SetFileName(screenshootFilename.c_str());

--- a/Modules/Loadable/Annotations/GUI/qSlicerAnnotationModuleSnapShotDialog.cxx
+++ b/Modules/Loadable/Annotations/GUI/qSlicerAnnotationModuleSnapShotDialog.cxx
@@ -16,7 +16,9 @@
 
 // VTK includes
 #include <vtkImageData.h>
-#include <vtkStdString.h>
+
+// STD includes
+#include <string>
 
 //-----------------------------------------------------------------------------
 qSlicerAnnotationModuleSnapShotDialog
@@ -62,7 +64,7 @@ void qSlicerAnnotationModuleSnapShotDialog::loadNode(const char* nodeId)
   this->setData(QVariant(nodeId));
 
   // get the name..
-  vtkStdString name;
+  std::string name;
   if (this->m_Logic->GetMRMLScene()
     && this->m_Logic->GetMRMLScene()->GetNodeByID(nodeId)
     && this->m_Logic->GetMRMLScene()->GetNodeByID(nodeId)->GetName())
@@ -74,7 +76,7 @@ void qSlicerAnnotationModuleSnapShotDialog::loadNode(const char* nodeId)
   this->setNameEdit(QString::fromStdString(name));
 
   // get the description..
-  vtkStdString description = this->m_Logic->GetSnapShotDescription(nodeId);
+  std::string description = this->m_Logic->GetSnapShotDescription(nodeId);
   // ..and set it in the GUI
   this->setDescription(QString::fromStdString(description));
 
@@ -146,7 +148,7 @@ void qSlicerAnnotationModuleSnapShotDialog::accept()
   else
   {
     // this snapshot already exists
-    this->m_Logic->ModifySnapShot(vtkStdString(this->data().toString().toUtf8()),
+    this->m_Logic->ModifySnapShot(std::string(this->data().toString().toUtf8()),
                                   nameBytes.data(),
                                   descriptionBytes.data(),
                                   screenshotType,

--- a/Modules/Loadable/Annotations/Logic/vtkSlicerAnnotationModuleLogic.cxx
+++ b/Modules/Loadable/Annotations/Logic/vtkSlicerAnnotationModuleLogic.cxx
@@ -200,7 +200,7 @@ void vtkSlicerAnnotationModuleLogic::RegisterNodes()
   //---------------------------------------------------------------------------
   // Modify an existing annotation snapShot.
   //---------------------------------------------------------------------------
-  void vtkSlicerAnnotationModuleLogic::ModifySnapShot(vtkStdString id, const char* name, const char* description, int screenshotType, double scaleFactor, vtkImageData* screenshot)
+  void vtkSlicerAnnotationModuleLogic::ModifySnapShot(std::string id, const char* name, const char* description, int screenshotType, double scaleFactor, vtkImageData* screenshot)
   {
 
     if (!screenshot)
@@ -253,7 +253,7 @@ void vtkSlicerAnnotationModuleLogic::RegisterNodes()
 //---------------------------------------------------------------------------
 // Return the description of an existing Annotation snapShot node.
 //---------------------------------------------------------------------------
-vtkStdString vtkSlicerAnnotationModuleLogic::GetSnapShotName(const char* id)
+std::string vtkSlicerAnnotationModuleLogic::GetSnapShotName(const char* id)
 {
   if (!this->GetMRMLScene())
   {
@@ -284,7 +284,7 @@ vtkStdString vtkSlicerAnnotationModuleLogic::GetSnapShotName(const char* id)
 //---------------------------------------------------------------------------
 // Return the description of an existing Annotation snapShot node.
 //---------------------------------------------------------------------------
-vtkStdString vtkSlicerAnnotationModuleLogic::GetSnapShotDescription(const char* id)
+std::string vtkSlicerAnnotationModuleLogic::GetSnapShotDescription(const char* id)
 {
   if (!this->GetMRMLScene())
   {

--- a/Modules/Loadable/Annotations/Logic/vtkSlicerAnnotationModuleLogic.h
+++ b/Modules/Loadable/Annotations/Logic/vtkSlicerAnnotationModuleLogic.h
@@ -12,9 +12,6 @@ class vtkMRMLAnnotationNode;
 class vtkMRMLAnnotationPointDisplayNode;
 class vtkMRMLAnnotationTextDisplayNode;
 
-// VTK includes
-#include <vtkStdString.h>
-
 // STD includes
 #include <string>
 
@@ -40,13 +37,13 @@ public:
   void CreateSnapShot(const char* name, const char* description, int screenshotType, double scaleFactor, vtkImageData* screenshot);
 
   /// Modify an existing snapShot.
-  void ModifySnapShot(vtkStdString id, const char* name, const char* description, int screenshotType, double scaleFactor, vtkImageData* screenshot);
+  void ModifySnapShot(std::string id, const char* name, const char* description, int screenshotType, double scaleFactor, vtkImageData* screenshot);
 
   /// Return the name of an existing annotation snapShot.
-  vtkStdString GetSnapShotName(const char* id);
+  std::string GetSnapShotName(const char* id);
 
   /// Return the description of an existing annotation snapShot.
-  vtkStdString GetSnapShotDescription(const char* id);
+  std::string GetSnapShotDescription(const char* id);
 
   /// Return the screenshotType of an existing annotation snapShot.
   int GetSnapShotScreenshotType(const char* id);

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationFiducialNode.h
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationFiducialNode.h
@@ -4,9 +4,12 @@
 #include "vtkSlicerAnnotationsModuleMRMLExport.h"
 #include "vtkMRMLAnnotationControlPointsNode.h"
 
-#include <vtkStdString.h>
+// VTK includes
 class vtkStringArray;
 class vtkMRMLStorageNode;
+
+// STD includes
+#include <string>
 
 /// \brief MRML node to represent a fiducial in the Annotations module - deprecated
 ///

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationNode.cxx
@@ -436,10 +436,10 @@ void vtkMRMLAnnotationNode::SetText(int id, const char *newText,int selectedFlag
     return;
   }
 
-  vtkStdString newString;
+  std::string newString;
   if (newText)
   {
-    newString = vtkStdString(newText);
+    newString = std::string(newText);
   }
 
   // check if the same as before
@@ -500,11 +500,11 @@ int vtkMRMLAnnotationNode::AddText(const char *newText,int selectedFlag, int vis
 }
 
 //-------------------------------------------------------------------------
-vtkStdString  vtkMRMLAnnotationNode::GetText(int n)
+std::string vtkMRMLAnnotationNode::GetText(int n)
 {
   if ((this->GetNumberOfTexts() <= n) || n < 0 )
   {
-      return vtkStdString();
+      return std::string();
   }
   return this->TextList->GetValue(n);
 }

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationNode.h
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationNode.h
@@ -24,6 +24,9 @@ class vtkCellArray;
 class vtkPoints;
 class vtkStringArray;
 
+// STD includes
+#include <string>
+
 class  VTK_SLICER_ANNOTATIONS_MODULE_MRML_EXPORT vtkMRMLAnnotationNode : public vtkMRMLModelNode
 {
 public:
@@ -81,7 +84,7 @@ public:
 
   int AddText(const char *newText,int selectedFlag, int visibleFlag);
   void SetText(int id, const char *newText,int selectedFlag, int visibleFlag);
-  vtkStdString GetText(int id);
+  std::string GetText(int id);
   int DeleteText(int id);
 
   int GetNumberOfTexts();

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotNode.cxx
@@ -41,7 +41,7 @@ void vtkMRMLAnnotationSnapshotNode::WriteXML(ostream& of, int nIndent)
 
   of << " screenshotType=\"" << this->GetScreenShotType() << "\"";
 
-  vtkStdString description = this->GetSnapshotDescription();
+  std::string description = this->GetSnapshotDescription();
   vtksys::SystemTools::ReplaceString(description,"\n","[br]");
 
   of << " snapshotDescription=\"" << description << "\"";
@@ -84,7 +84,7 @@ void vtkMRMLAnnotationSnapshotNode::ReadXMLAttributes(const char** atts)
     {
       std::stringstream ss;
       ss << attValue;
-      vtkStdString sceneViewDescription;
+      std::string sceneViewDescription;
       ss >> sceneViewDescription;
 
       vtksys::SystemTools::ReplaceString(sceneViewDescription,"[br]","\n");
@@ -109,7 +109,7 @@ vtkMRMLStorageNode* vtkMRMLAnnotationSnapshotNode::CreateDefaultStorageNode()
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLAnnotationSnapshotNode::SetSnapshotDescription(const vtkStdString& newDescription)
+void vtkMRMLAnnotationSnapshotNode::SetSnapshotDescription(const std::string& newDescription)
 {
   if (this->SnapshotDescription == newDescription)
   {

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotNode.h
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotNode.h
@@ -10,10 +10,13 @@
 #include "vtkMRMLAnnotationControlPointsNode.h"
 #include "vtkMRMLAnnotationNode.h"
 
-#include <vtkStdString.h>
+// VTK includes
 class vtkImageData;
 class vtkStringArray;
 class vtkMRMLStorageNode;
+
+// STD includes
+#include <string>
 
 class  VTK_SLICER_ANNOTATIONS_MODULE_MRML_EXPORT vtkMRMLAnnotationSnapshotNode : public vtkMRMLAnnotationNode
 {
@@ -32,8 +35,8 @@ public:
 
   const char* GetIcon() override {return ":/Icons/ViewCamera.png";}
 
-  void SetSnapshotDescription(const vtkStdString& newDescription);
-  vtkGetMacro(SnapshotDescription, vtkStdString);
+  void SetSnapshotDescription(const std::string& newDescription);
+  vtkGetMacro(SnapshotDescription, std::string);
 
   void WriteXML(ostream& of, int nIndent) override;
   void ReadXMLAttributes(const char** atts) override;
@@ -72,7 +75,7 @@ protected:
   void operator=(const vtkMRMLAnnotationSnapshotNode&);
 
   /// The associated Description
-  vtkStdString SnapshotDescription;
+  std::string SnapshotDescription;
 
   /// The vtkImageData of the screenshot
   vtkImageData* ScreenShot;

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationStorageNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationStorageNode.cxx
@@ -554,7 +554,7 @@ int vtkMRMLAnnotationStorageNode::WriteAnnotationData(fstream& of, vtkMRMLAnnota
   // if change the ones being included, make sure to update the parsing in ReadData
   for (int i = 0; i < refNode->GetNumberOfTexts(); i++)
   {
-    vtkStdString nodeText = refNode->GetText(i);
+    std::string nodeText = refNode->GetText(i);
     vtkDebugMacro("WriteAnnotationData: nodeText " << i << " is " << nodeText.c_str());
     int sel = refNode->GetAnnotationAttribute(i, vtkMRMLAnnotationNode::TEXT_SELECTED);
     int vis = refNode->GetAnnotationAttribute(i, vtkMRMLAnnotationNode::TEXT_VISIBLE);

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationTextDisplayNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationTextDisplayNode.cxx
@@ -1,7 +1,6 @@
 #include <sstream>
 
 #include "vtkObjectFactory.h"
-#include <vtkStdString.h>
 
 #include "vtkMRMLAnnotationTextDisplayNode.h"
 

--- a/Modules/Loadable/Colors/MRMLDM/vtkMRMLColorLegendDisplayableManager.cxx
+++ b/Modules/Loadable/Colors/MRMLDM/vtkMRMLColorLegendDisplayableManager.cxx
@@ -46,6 +46,7 @@
 #include <algorithm>
 #include <cstring>
 #include <numeric>
+#include <string>
 
 namespace
 {
@@ -510,7 +511,7 @@ bool vtkMRMLColorLegendDisplayableManager::vtkInternal::UpdateActor(vtkMRMLColor
       size_t validIndex = it - validColorMask.begin();
       if (*it && i < numberOfValidColors)
       {
-        actor->GetLookupTable()->SetAnnotation(i++, vtkStdString(colorNode->GetColorName(validIndex)));
+        actor->GetLookupTable()->SetAnnotation(i++, std::string(colorNode->GetColorName(validIndex)));
       }
     }
     actor->SetUseAnnotationAsLabel(true);

--- a/Modules/Loadable/Markups/qSlicerMarkupsWriter.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsWriter.cxx
@@ -37,8 +37,10 @@
 #include <vtkMRMLStorageNode.h>
 
 // VTK includes
-#include <vtkStdString.h>
 #include <vtkStringArray.h>
+
+// STD includes
+#include <string>
 
 //----------------------------------------------------------------------------
 qSlicerMarkupsWriter::qSlicerMarkupsWriter(QObject* parentObject)
@@ -58,7 +60,7 @@ QStringList qSlicerMarkupsWriter::extensions(vtkObject* vtkNotUsed(object))const
   const int formatCount = jsonStorageNode->GetSupportedWriteFileTypes()->GetNumberOfValues();
   for (int formatIt = 0; formatIt < formatCount; ++formatIt)
   {
-    vtkStdString format = jsonStorageNode->GetSupportedWriteFileTypes()->GetValue(formatIt);
+    std::string format = jsonStorageNode->GetSupportedWriteFileTypes()->GetValue(formatIt);
     supportedExtensions << QString::fromStdString(format);
   }
 
@@ -66,7 +68,7 @@ QStringList qSlicerMarkupsWriter::extensions(vtkObject* vtkNotUsed(object))const
   const int fidsFormatCount = fcsvStorageNode->GetSupportedWriteFileTypes()->GetNumberOfValues();
   for (int formatIt = 0; formatIt < fidsFormatCount; ++formatIt)
   {
-    vtkStdString format = fcsvStorageNode->GetSupportedWriteFileTypes()->GetValue(formatIt);
+    std::string format = fcsvStorageNode->GetSupportedWriteFileTypes()->GetValue(formatIt);
     supportedExtensions << QString::fromStdString(format);
   }
 

--- a/Modules/Loadable/SceneViews/GUI/qSlicerSceneViewsModuleDialog.cxx
+++ b/Modules/Loadable/SceneViews/GUI/qSlicerSceneViewsModuleDialog.cxx
@@ -16,9 +16,9 @@
 
 // VTK includes
 #include <vtkImageData.h>
-#include <vtkStdString.h>
 
 // STD includes
+#include <string>
 #include <vector>
 
 //-----------------------------------------------------------------------------
@@ -68,13 +68,13 @@ void qSlicerSceneViewsModuleDialog::loadNode(const QString& nodeId)
   this->setData(QVariant(nodeId));
 
   // get the name..
-  vtkStdString name = this->m_Logic->GetSceneViewName(nodeId.toUtf8());
+  std::string name = this->m_Logic->GetSceneViewName(nodeId.toUtf8());
 
   // ..and set it in the GUI
   this->setNameEdit(QString::fromStdString(name));
 
   // get the description..
-  vtkStdString description = this->m_Logic->GetSceneViewDescription(nodeId.toUtf8());
+  std::string description = this->m_Logic->GetSceneViewDescription(nodeId.toUtf8());
 
   // ..and set it in the GUI
   this->setDescription(QString::fromStdString(description));
@@ -137,7 +137,7 @@ void qSlicerSceneViewsModuleDialog::accept()
   else
   {
     // this SceneView already exists
-    this->m_Logic->ModifySceneView(vtkStdString(this->data().toString().toUtf8()),nameBytes.data(),descriptionBytes.data()
+    this->m_Logic->ModifySceneView(std::string(this->data().toString().toUtf8()),nameBytes.data(),descriptionBytes.data()
                                    ,screenshotType,this->imageData());
     //QMessageBox::information(this, "3D Slicer SceneView updated",
     //             The SceneView was updated without changing the attached scene.");

--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
@@ -13,7 +13,6 @@
 #include <vtkSmartPointer.h>
 
 // STD includes
-#include <string>
 #include <iostream>
 #include <sstream>
 
@@ -129,7 +128,7 @@ void vtkSlicerSceneViewsModuleLogic::CreateSceneView(const char* name, const cha
     newSceneViewNode->SetName(this->GetMRMLScene()->GetUniqueNameByString("SceneView"));
   }
 
-  vtkStdString descriptionString = vtkStdString(description);
+  std::string descriptionString = std::string(description);
 
   newSceneViewNode->SetSceneViewDescription(descriptionString);
   newSceneViewNode->SetScreenShotType(screenshotType);
@@ -147,7 +146,7 @@ void vtkSlicerSceneViewsModuleLogic::CreateSceneView(const char* name, const cha
 
 //---------------------------------------------------------------------------
 void vtkSlicerSceneViewsModuleLogic::
-         ModifySceneView(vtkStdString id,
+         ModifySceneView(std::string id,
                          const char* name,
                          const char* description,
                          int vtkNotUsed(screenshotType),
@@ -184,7 +183,7 @@ void vtkSlicerSceneViewsModuleLogic::
     viewNode->SetName(this->GetMRMLScene()->GetUniqueNameByString("SceneView"));
   }
 
-  vtkStdString descriptionString = vtkStdString(description);
+  std::string descriptionString = std::string(description);
   viewNode->SetSceneViewDescription(descriptionString);
   // only the text is allowed to be modified, not the screen shot type nor the
   // screen shot image, so don't resave them
@@ -195,7 +194,7 @@ void vtkSlicerSceneViewsModuleLogic::
 }
 
 //---------------------------------------------------------------------------
-vtkStdString vtkSlicerSceneViewsModuleLogic::GetSceneViewName(const char* id)
+std::string vtkSlicerSceneViewsModuleLogic::GetSceneViewName(const char* id)
 {
   if (!this->GetMRMLScene())
   {
@@ -211,11 +210,11 @@ vtkStdString vtkSlicerSceneViewsModuleLogic::GetSceneViewName(const char* id)
     return nullptr;
   }
 
-  return vtkStdString(viewNode->GetName());
+  return std::string(viewNode->GetName());
 }
 
 //---------------------------------------------------------------------------
-vtkStdString vtkSlicerSceneViewsModuleLogic::GetSceneViewDescription(const char* id)
+std::string vtkSlicerSceneViewsModuleLogic::GetSceneViewDescription(const char* id)
 {
   if (!this->GetMRMLScene())
   {

--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.h
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.h
@@ -37,8 +37,8 @@ class vtkMRMLSceneViewNode;
 
 // VTK includes
 class vtkImageData;
-#include <vtkStdString.h>
 
+// STD includes
 #include <string>
 
 class VTK_SLICER_SCENEVIEWS_MODULE_LOGIC_EXPORT vtkSlicerSceneViewsModuleLogic :
@@ -60,13 +60,13 @@ public:
   void CreateSceneView(const char* name, const char* description, int screenshotType, vtkImageData* screenshot);
 
   /// Modify an existing sceneView.
-  void ModifySceneView(vtkStdString id, const char* name, const char* description, int screenshotType, vtkImageData* screenshot);
+  void ModifySceneView(std::string id, const char* name, const char* description, int screenshotType, vtkImageData* screenshot);
 
   /// Return the name of an existing sceneView.
-  vtkStdString GetSceneViewName(const char* id);
+  std::string GetSceneViewName(const char* id);
 
   /// Return the description of an existing sceneView.
-  vtkStdString GetSceneViewDescription(const char* id);
+  std::string GetSceneViewDescription(const char* id);
 
   /// Return the screenshotType of an existing sceneView.
   int GetSceneViewScreenshotType(const char* id);

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -88,6 +88,7 @@
 
 // STD includes
 #include <sstream>
+#include <string>
 
 //----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkSlicerSegmentationsModuleLogic);
@@ -2459,7 +2460,7 @@ void vtkSlicerSegmentationsModuleLogic::GetLabelValuesFromColorNode(vtkMRMLSegme
   labelValues->SetNumberOfValues(segmentIds->GetNumberOfValues());
   for (int i = 0; i < segmentIds->GetNumberOfValues(); ++i)
   {
-    vtkStdString segmentId = segmentIds->GetValue(i);
+    std::string segmentId = segmentIds->GetValue(i);
     const char* segmentName = segmentationNode->GetSegmentation()->GetSegment(segmentId)->GetName();
     int labelValue = colorTableNode->GetColorIndexByName(segmentName);
     if (labelValue < 0)

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.cxx
@@ -38,7 +38,6 @@
 #include <vtkMRMLStorageNode.h>
 
 // VTK includes
-#include <vtkStdString.h>
 #include <vtkStringArray.h>
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Tables/Logic/vtkSlicerTablesLogic.cxx
+++ b/Modules/Loadable/Tables/Logic/vtkSlicerTablesLogic.cxx
@@ -39,6 +39,7 @@
 #include <vtkStringArray.h>
 
 // STD includes
+#include <string>
 
 //----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkSlicerTablesLogic);
@@ -99,7 +100,7 @@ vtkMRMLTableNode* vtkSlicerTablesLogic
     vtkStringArray *tables = database->GetTables();
     for (int i=0; i<tables->GetNumberOfTuples(); i++)
     {
-      vtkStdString table = tables->GetValue(i);
+      std::string table = tables->GetValue(i);
 
       // Storage node
       vtkNew<vtkMRMLTableSQLiteStorageNode> tableStorageNode;

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumeRenderingDisplayableManagerTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumeRenderingDisplayableManagerTest1.cxx
@@ -56,6 +56,7 @@
 #include <vtkWindowToImageFilter.h>
 
 // STD includes
+#include <string>
 
 const char vtkMRMLVolumeRenderingDisplayableManagerTest1EventLog[] =
 "# StreamVersion 1\n";
@@ -208,7 +209,7 @@ int vtkMRMLVolumeRenderingDisplayableManagerTest1(int argc, char* argv[])
     vtkNew<vtkTesting> testHelper;
     testHelper->AddArguments(argc, const_cast<const char **>(argv));
 
-    vtkStdString screenshootFilename = testHelper->GetDataRoot();
+    std::string screenshootFilename = testHelper->GetDataRoot();
     screenshootFilename += "/Baseline/vtkMRMLCameraDisplayableManagerTest1.png";
     vtkNew<vtkPNGWriter> writer;
     writer->SetFileName(screenshootFilename.c_str());

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -488,7 +488,7 @@ void vtkSlicerVolumesLogic::InitializeStorageNode(
       // it's a list of uris
       int numURIs = fileList->GetNumberOfValues();
       vtkDebugMacro("Have a list of " << numURIs << " uris that go along with the archetype");
-      vtkStdString thisURI;
+      std::string thisURI;
       storageNode->ResetURIList();
       for (int n = 0; n < numURIs; n++)
       {
@@ -504,7 +504,7 @@ void vtkSlicerVolumesLogic::InitializeStorageNode(
     {
       int numFiles = fileList->GetNumberOfValues();
       vtkDebugMacro("Have a list of " << numFiles << " files that go along with the archetype");
-      vtkStdString thisFileName;
+      std::string thisFileName;
       storageNode->ResetFileNameList();
       for (int n = 0; n < numFiles; n++)
       {

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
@@ -34,6 +34,7 @@
 // STD includes
 #include <cstdlib>
 #include <list>
+#include <string>
 
 #include "vtkSlicerVolumesModuleLogicExport.h"
 


### PR DESCRIPTION
`vtkStdString`, a subclass of `std::string`, was introduced in the pre-C++11 era to produce shorter symbols in compiled libraries. It is now being deprecated in favor of using `std::string` directly (see Kitware/VTK@13466f828). This commit updates both the implementation and API by replacing `vtkStdString` with `std::string`.

Since `vtkStdString` includes a constructor that accepts an `std::string`, functions expecting `vtkStdString` parameters will seamlessly accept `std::string` as well. For example, this applies to functions associated with `vtkStringArray` class.