### PR TITLE
STYLE: Fix typo replacing Visibile with Visible

### DIFF
--- a/Libs/MRML/Core/vtkMRMLViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLViewNode.h
@@ -290,7 +290,8 @@ public:
     RenderModeFlag,
     BoxVisibleFlag,
     BoxColorFlag,
-    BoxLabelVisibileFlag,
+    BoxLabelVisibleFlag,
+    BoxLabelVisibileFlag = BoxLabelVisibleFlag, ///< \deprecated Use BoxLabelVisibleFlag instead
     BackgroundColorFlag,
     StereoTypeFlag,
     OrientationMarkerTypeFlag,

--- a/Libs/MRML/Logic/vtkMRMLViewLinkLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLViewLinkLogic.cxx
@@ -411,7 +411,7 @@ void vtkMRMLViewLinkLogic::BroadcastViewNodeEvent(vtkMRMLViewNode* viewNode)
       vNode->EndModify(wasModifying);
     }
     // Box labels visibility
-    else if (viewNode->GetInteractionFlags() == vtkMRMLViewNode::BoxLabelVisibileFlag)
+    else if (viewNode->GetInteractionFlags() == vtkMRMLViewNode::BoxLabelVisibleFlag)
     {
       vNode->SetAxisLabelsVisible(viewNode->GetAxisLabelsVisible());
     }

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -1670,15 +1670,15 @@ void qMRMLSliceControllerWidgetPrivate::onSegmentVisibilitySelectionChanged(QStr
       // the segment selector widget does not know about this segment yet, so do not update the MRML node from it
       continue;
     }
-    bool segmentVisibile = displayNode->GetSegmentVisibility(*segmentIDIt);
+    bool segmentVisible = displayNode->GetSegmentVisibility(*segmentIDIt);
     // Hide segment that is visible but its checkbox has been unchecked
-    if (segmentVisibile && !selectedSegmentIDs.contains(segmentID))
+    if (segmentVisible && !selectedSegmentIDs.contains(segmentID))
     {
       displayNode->SetSegmentVisibility(*segmentIDIt, false);
       return; // This event handler runs after each check/uncheck, so handling the first mismatch is enough
     }
     // Show segment that is not visible but its checkbox has been checked
-    else if (!segmentVisibile && selectedSegmentIDs.contains(segmentID))
+    else if (!segmentVisible && selectedSegmentIDs.contains(segmentID))
     {
       displayNode->SetSegmentVisibility(*segmentIDIt, true);
       return; // This event handler runs after each check/uncheck, so handling the first mismatch is enough

--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -447,12 +447,12 @@ void qMRMLThreeDView::resetFocalPoint()
 {
   Q_D(qMRMLThreeDView);
 
-  bool savedBoxVisibile = true;
+  bool savedBoxVisible = true;
   bool savedAxisLabelVisible = true;
   if (d->MRMLViewNode)
   {
     // Save current visibility state of Box and AxisLabel
-    savedBoxVisibile = d->MRMLViewNode->GetBoxVisible();
+    savedBoxVisible = d->MRMLViewNode->GetBoxVisible();
     savedAxisLabelVisible = d->MRMLViewNode->GetAxisLabelsVisible();
 
     int wasModifying = d->MRMLViewNode->StartModify();
@@ -479,7 +479,7 @@ void qMRMLThreeDView::resetFocalPoint()
   {
     // Restore visibility state
     int wasModifying = d->MRMLViewNode->StartModify();
-    d->MRMLViewNode->SetBoxVisible(savedBoxVisibile);
+    d->MRMLViewNode->SetBoxVisible(savedBoxVisible);
     d->MRMLViewNode->SetAxisLabelsVisible(savedAxisLabelVisible);
     d->MRMLViewNode->EndModify(wasModifying);
     // Inform the displayable manager that the view is reset, so it can

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -848,7 +848,7 @@ void qMRMLThreeDViewControllerWidget::set3DAxisLabelVisible(bool visible)
     return;
   }
 
-  d->ViewLogic->StartViewNodeInteraction(vtkMRMLViewNode::BoxLabelVisibileFlag);
+  d->ViewLogic->StartViewNodeInteraction(vtkMRMLViewNode::BoxLabelVisibleFlag);
   this->mrmlThreeDViewNode()->SetAxisLabelsVisible(visible);
   d->ViewLogic->EndViewNodeInteraction();
 }

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -1960,7 +1960,7 @@ void qSlicerMarkupsModuleWidget::onSelectionNodeActivePlaceNodeIDChanged()
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerMarkupsModuleWidget::onListVisibileInvisiblePushButtonClicked()
+void qSlicerMarkupsModuleWidget::onListVisibleInvisiblePushButtonClicked()
 {
   Q_D(qSlicerMarkupsModuleWidget);
   if (!d->MarkupsNode)

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
@@ -162,7 +162,7 @@ public slots:
   void onCreateMarkupByClass(const QString& className);
 
   /// Toggle the markups node visibility flag
-  void onListVisibileInvisiblePushButtonClicked();
+  void onListVisibleInvisiblePushButtonClicked();
 
   /// Toggle the markups node locked flag
   void onListLockedUnlockedPushButtonClicked();


### PR DESCRIPTION
Rename all occurrences of `Visibile` to `Visible` (for example `savedBoxVisibile` -> `savedBoxVisible`)