### PR TITLE
BUG: Fix backface color on Slice nodes in 3D views

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -1518,7 +1518,7 @@ void vtkMRMLModelDisplayableManager::UpdateActorProperties(vtkMRMLModelNode* mod
   modelDisplayNode->GetBackfaceColorHSVOffset(offsetHsv);
 
   double colorHsv[3];
-  vtkMath::RGBToHSV(modelDisplayNode->GetColor(), colorHsv);
+  vtkMath::RGBToHSV(actorProperties->GetColor(), colorHsv);
   double colorRgb[3];
   colorHsv[0] += offsetHsv[0];
   // wrap around hue value


### PR DESCRIPTION
Fix bug introduced in d6f6b7d.

The backface color for slice nodes in 3D was set from the display node color, causing the slice backface to be colored using the slice color. Fixed by getting the backface color from the frontface actor property instead.

Fix #8055