### PR TITLE
STYLE: Fix typo replacing clipingState with clippingState

### DIFF
--- a/Libs/MRML/Core/vtkMRMLClipNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLClipNode.cxx
@@ -39,7 +39,7 @@
 
 const char* vtkMRMLClipNode::ClippingNodeReferenceRole = "clipping";
 const char* vtkMRMLClipNode::ClippingNodeReferenceRef = "clippingRef";
-const char* vtkMRMLClipNode::ClippingNodeStatePropertyName = "clipingState";
+const char* vtkMRMLClipNode::ClippingNodeStatePropertyName = "clippingState";
 int DEFAULT_CLIPPING_STATE = vtkMRMLClipNode::ClipPositiveSpace;
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes typo in vtkMRMLClipNode.