### PR TITLE
BUG: Fix hanging progress popup in DICOM browser

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMBrowser.py
+++ b/Modules/Scripted/DICOMLib/DICOMBrowser.py
@@ -487,6 +487,7 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
                                                                                 lambda progressLabel, progressValue, progressDialog=progressDialog: progressCallback(progressDialog, progressLabel, progressValue),
                                                                                 self.pluginInstances)
 
+            progressDialog.setParent(None)
             progressDialog.close()
 
         if messages:
@@ -621,6 +622,7 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
 
         qt.QApplication.restoreOverrideCursor()
 
+        progressDialog.setParent(None)
         progressDialog.close()
 
         if messages:


### PR DESCRIPTION
This fixes an issue described within this forum post: https://discourse.slicer.org/t/hanging-popup-some-times-after-loading-dicom-files/6057.  There is a dialog progress popup that appears when attempting to load a DICOM file from the DICOM browser that remains on screen after the load as completed. The original post submitter only had issues intermittently. Using Slicer within [Xpra](https://github.com/Xpra-org/xpra) I was experiencing it consistently and this code change resolved the issue.