### PR TITLE
BUG: Fix crash when hovering over interaction handles after scene load

### DIFF
--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager.cxx
@@ -436,12 +436,14 @@ void vtkMRMLLinearTransformsDisplayableManager::OnMRMLSceneStartClose()
 void vtkMRMLLinearTransformsDisplayableManager::OnMRMLSceneEndClose()
 {
   this->SetUpdateFromMRMLRequested(true);
+  this->RequestRender();
 }
 
 //---------------------------------------------------------------------------
 void vtkMRMLLinearTransformsDisplayableManager::OnMRMLSceneEndBatchProcess()
 {
   this->SetUpdateFromMRMLRequested(true);
+  this->RequestRender();
 }
 
 //---------------------------------------------------------------------------
@@ -551,12 +553,11 @@ bool vtkMRMLLinearTransformsDisplayableManager::ProcessInteractionEvent(vtkMRMLI
   }
 
   // Find/create active widget
-  vtkMRMLTransformHandleWidget* activeWidget = nullptr;
   double closestDistance2 = VTK_DOUBLE_MAX;
-  activeWidget = this->Internal->FindClosestWidget(eventData, closestDistance2);
+  vtkSmartPointer<vtkMRMLTransformHandleWidget> activeWidget = this->Internal->FindClosestWidget(eventData, closestDistance2);
 
   // Deactivate previous widget
-  if (this->Internal->LastActiveWidget != nullptr && this->Internal->LastActiveWidget != activeWidget)
+  if (this->Internal->LastActiveWidget != nullptr && this->Internal->LastActiveWidget != activeWidget.GetPointer())
   {
     this->Internal->LastActiveWidget->Leave(eventData);
   }


### PR DESCRIPTION
After OnMRMLSceneEndBatchProcess was called, UpdateFromMRMLRequested was called, but RequestRender was not. This meant that the widget would not be updated until the user tried to mouse over the widget. This caused a crash in ProcessInteractionEvent, since the activeWidget was deleted during processing as UpdateFromMRML was resolved.

Fixed by:
- Calling RequestRender after SetUpdateFromMRMLRequested(True) in OnMRMLSceneEndClose() and OnMRMLSceneEndBatchProcess().
- Using vtkSmartPointer for activeWidget in ProcessInteractionEvent so that the pointer to the active widget can't be made invalid.