### PR TITLE
BUG: Fix incorrect vtkMRMLSliceDisplayNode XML attribute name

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSliceDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceDisplayNode.cxx
@@ -79,7 +79,7 @@ void vtkMRMLSliceDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBooleanMacro(intersectingSlicesRotationEnabled, IntersectingSlicesRotationEnabled);
   vtkMRMLWriteXMLIntMacro(intersectingSlicesInteractiveHandlesVisibilityMode, IntersectingSlicesInteractiveHandlesVisibilityMode);
   vtkMRMLWriteXMLIntMacro(intersectingSlicesIntersectionMode, IntersectingSlicesIntersectionMode);
-  vtkMRMLWriteXMLIntMacro(intersectingSlicesIntersectionMode, IntersectingSlicesLineThicknessMode);
+  vtkMRMLWriteXMLIntMacro(intersectingSlicesLineThicknessMode, IntersectingSlicesLineThicknessMode);
   vtkMRMLWriteXMLEndMacro();
 }
 


### PR DESCRIPTION
IntersectingSlicesLineThicknessMode was written to the xml file as intersectingSlicesIntersectionMode, causing duplicate attributes in the vtkMRMLSliceDisplayNode element.