### PR TITLE
BUG: Fix folder display override for model nodes

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.h
@@ -160,11 +160,11 @@ protected:
   void RemoveDisplayedID(const std::string& id);
   void ClearDisplayMaps();
 
-  void UpdateMapperProperties(vtkMRMLModelNode* modelNode, vtkMRMLModelDisplayNode* displayNode,
+  void UpdateMapperProperties(vtkMRMLModelNode* modelNode, vtkMRMLDisplayNode* displayNode,
     vtkMapper* actor);
-  void UpdateActorProperties(vtkMRMLModelNode* modelNode, vtkMRMLModelDisplayNode* displayNode,
+  void UpdateActorProperties(vtkMRMLModelNode* modelNode, vtkMRMLModelDisplayNode* modelDisplayNode, vtkMRMLDisplayNode* displayNode,
     vtkActor* actor, double opacity);
-  void UpdateCapActorProperties(vtkMRMLModelNode* modelNode, vtkMRMLModelDisplayNode* displayNode,
+  void UpdateCapActorProperties(vtkMRMLModelNode* modelNode, vtkMRMLModelDisplayNode* modelDisplayNode, vtkMRMLDisplayNode* displayNode,
     vtkActor* capActor, double opacity);
 
 protected:


### PR DESCRIPTION
Folder opacity/color was broken in d6f6b7dbc2f797f8189b91b583d201dffd76d825.

Fixed by using overriding display node rather than model display node for applicable properties. Fixes failing py_nomainwindow_SubjectHierarchyFoldersTest1 test.