### PR TITLE
BUG: Fix ExtensionsIndex build

### DIFF
--- a/Extensions/CMake/SlicerBlockBuildPackageAndUploadExtensions.cmake
+++ b/Extensions/CMake/SlicerBlockBuildPackageAndUploadExtensions.cmake
@@ -146,8 +146,10 @@ foreach(EXTENSION_NAME ${EXTENSION_LIST})
       ${CMAKE_CURRENT_BINARY_DIR}/download_${proj}_wrapper_script.cmake)
     #message(STATUS "Configuring extension download wrapper script: ${download_extension_wrapper_script}")
     file(WRITE ${download_extension_wrapper_script} "
+      # command is a semicolon-separated string that cannot be used as COMMAND directly, because arguments may contain spaces
+      set(command_list \"${command}\")
       execute_process(
-        COMMAND ${command}
+        COMMAND \${command_list}
         WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\"
         RESULT_VARIABLE result
         ERROR_VARIABLE error
@@ -155,7 +157,7 @@ foreach(EXTENSION_NAME ${EXTENSION_LIST})
       # Sanitize error string to prevent false positive by Visual Studio
       set(sanitized_error \"\${error}\")
       string(REPLACE \"error:\" \"error \" sanitized_error \"\${sanitized_error}\")
-      message(STATUS \"download_${proj}_wrapper_script: Ignoring result \${result}\")
+      message(STATUS \"download_${proj}_wrapper_script: Ignoring result '\${result}'\")
       if(NOT result EQUAL 0)
         message(STATUS \"Generating '${EXTENSION_SOURCE_DIR}/CMakeLists.txt'\")
         file(MAKE_DIRECTORY \"${EXTENSION_SOURCE_DIR}\")
@@ -206,14 +208,16 @@ foreach(EXTENSION_NAME ${EXTENSION_LIST})
   set(build_error_file "${CMAKE_CURRENT_BINARY_DIR}/build_${proj}_error.txt")
   #message(STATUS "Configuring extension upload wrapper script: ${build_extension_wrapper_script}")
   file(WRITE ${build_extension_wrapper_script} "
+    # wrapper_command is a semicolon-separated string that cannot be used as COMMAND directly, because arguments may contain spaces
+    set(wrapper_command_list \"${wrapper_command}\")
     execute_process(
-      COMMAND ${wrapper_command}
+      COMMAND \${wrapper_command_list}
       WORKING_DIR \"${EXTENSION_SUPERBUILD_BINARY_DIR}\"
       OUTPUT_FILE \"${build_output_file}\"
       ERROR_FILE \"${build_error_file}\"
       RESULT_VARIABLE result
       )
-    message(STATUS \"build_${proj}_wrapper_script: Ignoring result \${result}\")
+    message(STATUS \"build_${proj}_wrapper_script: Ignoring result '\${result}'\")
     message(STATUS \"build_${proj}_output_file: ${build_output_file}\")
     message(STATUS \"build_${proj}_error_file: ${build_error_file}\")
     ")


### PR DESCRIPTION
On Windows, cmake.exe path usually contain space (e.g., "C:/Program Files/CMake/bin/cmake.exe"). If such a string is passed to execute_process as COMMAND directly then the command returns "no such file or directory" error (due to "C:/Program" is not found).

Fixed by converting the semicolon-separated string to a list and using that list as COMMAND.