### PR TITLE
BUG: Fix slice view more options open by default

### DIFF
--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
@@ -420,7 +420,7 @@
         </sizepolicy>
        </property>
        <property name="checked">
-        <bool>false</bool>
+        <bool>true</bool>
        </property>
        <property name="mirrorOnExpand" stdset="0">
         <bool>true</bool>


### PR DESCRIPTION
This closes #8085.

See https://github.com/Slicer/Slicer/issues/8085#issuecomment-2532674962 for more details.

This was accidentally included in https://github.com/Slicer/Slicer/commit/bf0f921a7191415ac18b6e7015039e60b5943f91 and caused issues with the Segmentation layer confusingly not being present until the popup widget was expanded again.