### PR TITLE
COMP: Fix libarchive build error when using Clang 16

### DIFF
--- a/SuperBuild/External_LibArchive.cmake
+++ b/SuperBuild/External_LibArchive.cmake
@@ -27,13 +27,13 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/libarchive/libarchive.git"
+    "${EP_GIT_PROTOCOL}://github.com/Slicer/libarchive.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "6c3301111caa75c76e1b2acb1afb2d71341932ef" # master v3.6.1
+    "14ec55f065e31fbbca23d3d96d43e07f21c6fb6d" # slicer-v3.6.1-2022-04-08-6c3301111
     QUIET
     )
 


### PR DESCRIPTION
Fix build errors caused by warnings treated as errors when using
Clang 16. The compiler reports implicit truncation for single-bit
signed bitfields that can only hold values -1 and 0.

Example error:

```
libarchive/archive_write_set_format_7zip.c:1541:13: error: implicit
truncation from 'int' to a one-bit wide bit-field changes value from 1
to -1 [-Werror,-Wsingle-bit-bitfield-constant-conversion]
                    file->dir = 1;
                              ^ ~ 
```

Affected files include:
- `libarchive/archive_write_set_format_xar.c`
- `libarchive/archive_write_set_format_iso9660.c`
- `libarchive/archive_write_set_format_7zip.c`

Cherry-picked upstream commit libarchive/libarchive@f180dca into the
`Slicer/libarchive` fork on branch `slicer-v3.6.1-2022-04-08-6c3301111`.
The external project now fetches the updated version of libarchive to
resolve this issue.