### PR TITLE
ENH: Support customizing interaction widget event translation

### DIFF
--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
@@ -523,6 +523,12 @@ vtkSlicerMarkupsWidget* vtkMRMLMarkupsDisplayableManager::GetWidget(vtkMRMLMarku
 }
 
 //---------------------------------------------------------------------------
+vtkSlicerMarkupsInteractionWidget* vtkMRMLMarkupsDisplayableManager::GetInteractionWidget(vtkMRMLMarkupsDisplayNode * node)
+{
+  return this->Helper->GetInteractionWidget(node);
+}
+
+//---------------------------------------------------------------------------
 /// Check if it is the correct displayableManager
 //---------------------------------------------------------------------------
 bool vtkMRMLMarkupsDisplayableManager::IsCorrectDisplayableManager()

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.h
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.h
@@ -85,6 +85,9 @@ public:
   /// Get the widget of a node.
   vtkSlicerMarkupsWidget* GetWidget(vtkMRMLMarkupsDisplayNode * node);
 
+  /// Get the interaction widget of a node.
+  vtkSlicerMarkupsInteractionWidget* GetInteractionWidget(vtkMRMLMarkupsDisplayNode * node);
+
 protected:
 
   vtkMRMLMarkupsDisplayableManager();


### PR DESCRIPTION
This adds supports for customizing interaction widget event translation specifically for Markups such as the vtkMRMLMarkupsROINode. This is necessary based on the changes made since Slicer 5.6.2 as discussed in https://github.com/Slicer/Slicer/issues/8099.

The below example exhibits the ability to remove the jump slice offset functionality upon single left-clicking on the center translation ROI handle and also on the outer scale ROI handles.

```python
import SampleData
SampleData.SampleDataLogic().downloadMRHead()
roi_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsROINode")
roi_node.SetSize(100, 100, 100)
roi_display_node = roi_node.GetDisplayNode()
sliceViewLabel = "Red"
sliceViewWidget = slicer.app.layoutManager().sliceWidget(sliceViewLabel)
displayableManager = sliceViewWidget.sliceView().displayableManagerByClassName("vtkMRMLMarkupsDisplayableManager")
interaction_widget = displayableManager.GetInteractionWidget(roi_display_node)
interaction_widget.SetEventTranslation(interaction_widget.WidgetStateOnTranslationHandle, slicer.vtkMRMLInteractionEventData.LeftButtonClickEvent, vtk.vtkEvent.NoModifier, vtk.vtkWidgetEvent.NoEvent)
interaction_widget.SetEventTranslation(interaction_widget.WidgetStateOnScaleHandle, slicer.vtkMRMLInteractionEventData.LeftButtonClickEvent, vtk.vtkEvent.NoModifier, vtk.vtkWidgetEvent.NoEvent)
```