### PR TITLE
Add MRML application API for registering volume resampler

### DIFF
--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -44,10 +44,15 @@
 #include "qSlicerLoadableModuleFactory.h"
 #include "qSlicerModuleFactoryManager.h"
 #include "qSlicerModuleManager.h"
+#include "vtkSlicerApplicationLogic.h"
 #include "vtkSlicerVersionConfigure.h" // For Slicer_MAIN_PROJECT_VERSION_FULL
 
 #ifdef Slicer_USE_PYTHONQT
 # include "qSlicerScriptedLoadableModuleFactory.h"
+#endif
+
+#ifdef Slicer_BUILD_CLI_SUPPORT
+# include "vtkMRMLScalarVectorDWIVolumeResampler.h"
 #endif
 
 #include <vtkSystemInformation.h>
@@ -226,6 +231,17 @@ void qSlicerApplicationHelper::setupModuleFactoryManager(qSlicerModuleFactoryMan
   moduleFactoryManager->setModulesToIgnore(modulesToIgnore);
 
   moduleFactoryManager->setVerboseModuleDiscovery(app->commandOptions()->verboseModuleDiscovery());
+}
+
+//----------------------------------------------------------------------------
+void qSlicerApplicationHelper::registerVolumeResamplers(qSlicerApplication& app)
+{
+#ifdef Slicer_BUILD_CLI_SUPPORT
+  app.applicationLogic()->RegisterVolumeResampler(
+        "ResampleScalarVectorDWIVolume", vtkNew<vtkMRMLScalarVectorDWIVolumeResampler>().GetPointer());
+#else
+  Q_UNUSED(app);
+#endif
 }
 
 //----------------------------------------------------------------------------

--- a/Base/QTApp/qSlicerApplicationHelper.h
+++ b/Base/QTApp/qSlicerApplicationHelper.h
@@ -57,6 +57,8 @@ public:
 
   static void setupModuleFactoryManager(qSlicerModuleFactoryManager * moduleFactoryManager);
 
+  static void registerVolumeResamplers(qSlicerApplication& app);
+
   static void showMRMLEventLoggerWidget();
 
   /// Display a warning popup if rendering capabilities do not meet requirements.

--- a/Base/QTApp/qSlicerApplicationHelper.txx
+++ b/Base/QTApp/qSlicerApplicationHelper.txx
@@ -307,6 +307,8 @@ int qSlicerApplicationHelper::postInitializeApplication(
     qDebug() << "Number of loaded modules:" << moduleManager->modulesNames().count();
   }
 
+  qSlicerApplicationHelper::registerVolumeResamplers(app);
+
   splashMessage(splashScreen, QString());
 
   if (window)

--- a/Base/QTCLI/CMakeLists.txt
+++ b/Base/QTCLI/CMakeLists.txt
@@ -66,6 +66,8 @@ set(KIT_SRCS
   qSlicerCLIModuleWidget_p.h
   qSlicerCLIProgressBar.cxx
   qSlicerCLIProgressBar.h
+  vtkMRMLScalarVectorDWIVolumeResampler.cxx
+  vtkMRMLScalarVectorDWIVolumeResampler.h
   )
 
 # Headers that should run through moc

--- a/Base/QTCLI/vtkMRMLScalarVectorDWIVolumeResampler.cxx
+++ b/Base/QTCLI/vtkMRMLScalarVectorDWIVolumeResampler.cxx
@@ -44,7 +44,6 @@ bool vtkMRMLScalarVectorDWIVolumeResampler::Resample(vtkMRMLVolumeNode* inputVol
                                                      vtkMRMLTransformNode* resamplingTransform,
                                                      vtkMRMLVolumeNode* referenceVolume,
                                                      int interpolationType,
-                                                     int windowedSincFunction,
                                                      const ResamplingParameters& resamplingParameter)
 {
   // A helper RAII class to ensure a vtkMRMLNode is removed from its scene
@@ -135,28 +134,6 @@ bool vtkMRMLScalarVectorDWIVolumeResampler::Resample(vtkMRMLVolumeNode* inputVol
     cmdNode->SetParameterAsString("interpolationType", "bs");
     break;
   case vtkMRMLAbstractVolumeResampler::InterpolationTypeUndefined:
-  default:
-    break;
-  }
-
-  switch (windowedSincFunction)
-  {
-  case vtkMRMLAbstractVolumeResampler::WindowedSincFunctionHamming:
-    cmdNode->SetParameterAsString("windowFunction", "h");
-    break;
-  case vtkMRMLAbstractVolumeResampler::WindowedSincFunctionCosine:
-    cmdNode->SetParameterAsString("windowFunction", "c");
-    break;
-  case vtkMRMLAbstractVolumeResampler::WindowedSincFunctionWelch:
-    cmdNode->SetParameterAsString("windowFunction", "w");
-    break;
-  case vtkMRMLAbstractVolumeResampler::WindowedSincFunctionLanczos:
-    cmdNode->SetParameterAsString("windowFunction", "l");
-    break;
-  case vtkMRMLAbstractVolumeResampler::WindowedSincFunctionBlackman:
-    cmdNode->SetParameterAsString("windowFunction", "b");
-    break;
-  case vtkMRMLAbstractVolumeResampler::WindowedSincFunctionUndefined:
   default:
     break;
   }

--- a/Base/QTCLI/vtkMRMLScalarVectorDWIVolumeResampler.cxx
+++ b/Base/QTCLI/vtkMRMLScalarVectorDWIVolumeResampler.cxx
@@ -1,0 +1,180 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright(c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#include "vtkMRMLScalarVectorDWIVolumeResampler.h"
+
+// Slicer includes
+#include "qSlicerCLIModule.h"
+#include "qSlicerCoreApplication.h"
+#include "qSlicerModuleManager.h"
+#include "vtkSlicerCLIModuleLogic.h"
+
+// MRML includes
+#include "vtkMRMLAbstractVolumeResampler.h"
+#include "vtkMRMLCommandLineModuleNode.h"
+#include "vtkMRMLTransformNode.h"
+#include "vtkMRMLVolumeNode.h"
+
+//----------------------------------------------------------------------------
+vtkStandardNewMacro(vtkMRMLScalarVectorDWIVolumeResampler);
+
+//----------------------------------------------------------------------------
+void vtkMRMLScalarVectorDWIVolumeResampler::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLScalarVectorDWIVolumeResampler::Resample(vtkMRMLVolumeNode* inputVolume,
+                                                     vtkMRMLVolumeNode* outputVolume,
+                                                     vtkMRMLTransformNode* resamplingTransform,
+                                                     vtkMRMLVolumeNode* referenceVolume,
+                                                     int interpolationType,
+                                                     int windowedSincFunction,
+                                                     const ResamplingParameters& resamplingParameter)
+{
+  // A helper RAII class to ensure a vtkMRMLNode is removed from its scene
+  // when the enclosing scope is exited, regardless of how it is exited.
+  struct vtkMRMLNodeCleanup
+  {
+  public:
+    vtkMRMLNodeCleanup(vtkMRMLScene* scene, vtkMRMLNode* node)
+      : Scene(scene), Node(node)
+    {
+    }
+    ~vtkMRMLNodeCleanup()
+    {
+      if (this->Scene != nullptr)
+      {
+        this->Scene->RemoveNode(this->Node);
+      }
+    }
+  private:
+    vtkMRMLScene* Scene{nullptr};
+    vtkMRMLNode* Node{nullptr};
+  };
+
+  qSlicerCoreApplication* app = qSlicerCoreApplication::application();
+  if (!app
+      || !app->moduleManager()
+      || !dynamic_cast<qSlicerCLIModule*>(app->moduleManager()->module("ResampleScalarVectorDWIVolume")))
+  {
+    vtkErrorMacro("Resample: ResampleScalarVectorDWIVolume module is not available");
+    return false;
+  }
+
+  qSlicerCLIModule* cliModule =
+    dynamic_cast<qSlicerCLIModule*>(app->moduleManager()->module("ResampleScalarVectorDWIVolume"));
+
+  vtkSlicerCLIModuleLogic* cliLogic = vtkSlicerCLIModuleLogic::SafeDownCast(cliModule->cliModuleLogic());
+  if (cliLogic == nullptr)
+  {
+    vtkErrorMacro("Resample: ResampleScalarVectorDWIVolume module logic is not available");
+    return false;
+  }
+
+  // PERF: Revisit if creating and removing the node impacts performances.
+  vtkMRMLCommandLineModuleNode* cmdNode = cliLogic->CreateNodeInScene();
+  if (cmdNode == nullptr)
+  {
+    vtkErrorMacro("Resample: Failed to create ResampleScalarVectorDWIVolume node");
+    return false;
+  }
+
+  vtkMRMLNodeCleanup nodeCleanup(cliLogic->GetMRMLScene(), cmdNode);
+
+  if (inputVolume == nullptr)
+  {
+    vtkErrorMacro("Resample: Input volume node is not set");
+    return false;
+  }
+  cmdNode->SetParameterAsString("inputVolume", inputVolume->GetID());
+
+  if (outputVolume == nullptr)
+  {
+    vtkErrorMacro("Resample: Output volume node is not set");
+    return false;
+  }
+  cmdNode->SetParameterAsString("outputVolume", outputVolume->GetID());
+
+  if (resamplingTransform != nullptr)
+  {
+    cmdNode->SetParameterAsString("transformationFile", resamplingTransform->GetID());
+  }
+  if (referenceVolume != nullptr)
+  {
+    cmdNode->SetParameterAsString("referenceVolume", referenceVolume->GetID());
+  }
+
+  switch (interpolationType)
+  {
+  case vtkMRMLAbstractVolumeResampler::InterpolationTypeNearestNeighbor:
+    cmdNode->SetParameterAsString("interpolationType", "nn");
+    break;
+  case vtkMRMLAbstractVolumeResampler::InterpolationTypeLinear:
+    cmdNode->SetParameterAsString("interpolationType", "linear");
+    break;
+  case vtkMRMLAbstractVolumeResampler::InterpolationTypeWindowedSinc:
+    cmdNode->SetParameterAsString("interpolationType", "ws");
+    break;
+  case vtkMRMLAbstractVolumeResampler::InterpolationTypeBSpline:
+    cmdNode->SetParameterAsString("interpolationType", "bs");
+    break;
+  case vtkMRMLAbstractVolumeResampler::InterpolationTypeUndefined:
+  default:
+    break;
+  }
+
+  switch (windowedSincFunction)
+  {
+  case vtkMRMLAbstractVolumeResampler::WindowedSincFunctionHamming:
+    cmdNode->SetParameterAsString("windowFunction", "h");
+    break;
+  case vtkMRMLAbstractVolumeResampler::WindowedSincFunctionCosine:
+    cmdNode->SetParameterAsString("windowFunction", "c");
+    break;
+  case vtkMRMLAbstractVolumeResampler::WindowedSincFunctionWelch:
+    cmdNode->SetParameterAsString("windowFunction", "w");
+    break;
+  case vtkMRMLAbstractVolumeResampler::WindowedSincFunctionLanczos:
+    cmdNode->SetParameterAsString("windowFunction", "l");
+    break;
+  case vtkMRMLAbstractVolumeResampler::WindowedSincFunctionBlackman:
+    cmdNode->SetParameterAsString("windowFunction", "b");
+    break;
+  case vtkMRMLAbstractVolumeResampler::WindowedSincFunctionUndefined:
+  default:
+    break;
+  }
+
+  if (!resamplingParameter.empty())
+  {
+    vtkErrorMacro("Resample: resamplingParameter is not currently supported");
+    return false;
+  }
+
+  cliLogic->ApplyAndWait(cmdNode, /* updateDisplay= */ false);
+
+  bool success = cmdNode->GetStatus() == vtkMRMLCommandLineModuleNode::Completed;
+
+  if (!success)
+  {
+    vtkErrorMacro("Resample: " << cmdNode->GetErrorText());
+  }
+
+  return success;
+}

--- a/Base/QTCLI/vtkMRMLScalarVectorDWIVolumeResampler.h
+++ b/Base/QTCLI/vtkMRMLScalarVectorDWIVolumeResampler.h
@@ -1,0 +1,47 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright(c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __vtkMRMLScalarVectorDWIVolumeResampler_h
+#define __vtkMRMLScalarVectorDWIVolumeResampler_h
+
+#include "qSlicerBaseQTCLIExport.h"
+
+#include "vtkMRMLAbstractVolumeResampler.h"
+
+class Q_SLICER_BASE_QTCLI_EXPORT vtkMRMLScalarVectorDWIVolumeResampler : public vtkMRMLAbstractVolumeResampler
+{
+public:
+  static vtkMRMLScalarVectorDWIVolumeResampler *New();
+  vtkTypeMacro(vtkMRMLScalarVectorDWIVolumeResampler, vtkMRMLAbstractVolumeResampler);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  virtual bool Resample(vtkMRMLVolumeNode* inputVolume,
+                        vtkMRMLVolumeNode* outputVolume,
+                        vtkMRMLTransformNode* resamplingTransform,
+                        vtkMRMLVolumeNode* referenceVolume,
+                        int interpolationType,
+                        int windowedSincFunction,
+                        const vtkMRMLAbstractVolumeResampler::ResamplingParameters& resamplingParameter) override;
+
+protected:
+  vtkMRMLScalarVectorDWIVolumeResampler() = default;
+  ~vtkMRMLScalarVectorDWIVolumeResampler() override = default;
+  vtkMRMLScalarVectorDWIVolumeResampler(const vtkMRMLScalarVectorDWIVolumeResampler&) = delete;
+  void operator=(const vtkMRMLScalarVectorDWIVolumeResampler&) = delete;
+};
+
+#endif

--- a/Base/QTCLI/vtkMRMLScalarVectorDWIVolumeResampler.h
+++ b/Base/QTCLI/vtkMRMLScalarVectorDWIVolumeResampler.h
@@ -34,7 +34,6 @@ public:
                         vtkMRMLTransformNode* resamplingTransform,
                         vtkMRMLVolumeNode* referenceVolume,
                         int interpolationType,
-                        int windowedSincFunction,
                         const vtkMRMLAbstractVolumeResampler::ResamplingParameters& resamplingParameter) override;
 
 protected:

--- a/Libs/MRML/Logic/CMakeLists.txt
+++ b/Libs/MRML/Logic/CMakeLists.txt
@@ -63,6 +63,7 @@ endif()
 # --------------------------------------------------------------------------
 set(MRMLLogic_SRCS
   vtkMRMLAbstractLogic.cxx
+  vtkMRMLAbstractVolumeResampler.cxx
   vtkMRMLApplicationLogic.cxx
   vtkMRMLColorLogic.cxx
   vtkMRMLDisplayableHierarchyLogic.cxx

--- a/Libs/MRML/Logic/vtkMRMLAbstractVolumeResampler.cxx
+++ b/Libs/MRML/Logic/vtkMRMLAbstractVolumeResampler.cxx
@@ -1,0 +1,74 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright(c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// MRMLLogic includes
+#include "vtkMRMLAbstractVolumeResampler.h"
+
+// MRML includes
+#include <vtkMRMLVolumeNode.h>
+
+//----------------------------------------------------------------------------
+void vtkMRMLAbstractVolumeResampler::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}
+
+//----------------------------------------------------------------------------
+std::string vtkMRMLAbstractVolumeResampler::GetParameterValue(
+    const ResamplingParameters& parameters, const std::string& name)
+{
+  ResamplingParameters::const_iterator parameterIt = parameters.find(name);
+  if (parameterIt != parameters.end())
+  {
+    return parameterIt->second;
+  }
+  return std::string();
+}
+
+//----------------------------------------------------------------------------
+double vtkMRMLAbstractVolumeResampler::GetParameterValueAsDouble(
+    const ResamplingParameters& parameters, const std::string& name)
+{
+  double value = vtkVariant(vtkMRMLAbstractVolumeResampler::GetParameterValue(parameters, name)).ToDouble();
+  return value;
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLAbstractVolumeResampler::GetParameterValueAsInt(
+    const ResamplingParameters& parameters, const std::string& name)
+{
+  int value = vtkVariant(vtkMRMLAbstractVolumeResampler::GetParameterValue(parameters, name)).ToInt();
+  return value;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLAbstractVolumeResampler::SetParameterValue(ResamplingParameters& parameters, const std::string& name, const std::string& value)
+{
+  parameters[name] = value;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLAbstractVolumeResampler::SetParameterValueAsDouble(ResamplingParameters& parameters, const std::string& name, double value)
+{
+  vtkMRMLAbstractVolumeResampler::SetParameterValue(parameters, name, vtkVariant(value).ToString());
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLAbstractVolumeResampler::SetParameterValueAsInt(ResamplingParameters& parameters, const std::string& name, int value)
+{
+  vtkMRMLAbstractVolumeResampler::SetParameterValue(parameters, name, vtkVariant(value).ToString());
+}

--- a/Libs/MRML/Logic/vtkMRMLAbstractVolumeResampler.h
+++ b/Libs/MRML/Logic/vtkMRMLAbstractVolumeResampler.h
@@ -1,0 +1,93 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright(c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __vtkMRMLAbstractVolumeResampler_h
+#define __vtkMRMLAbstractVolumeResampler_h
+
+// MRMLLogic includes
+#include "vtkMRMLLogicExport.h"
+
+// MRML includes
+class vtkMRMLTransformNode;
+class vtkMRMLVectorVolumeNode;
+class vtkMRMLVolumeNode;
+
+// VTK includes
+#include <vtkObject.h>
+
+/// \brief Base class for volume resampler.
+///
+/// Sub-classes must implement actual resampling.
+class VTK_MRML_LOGIC_EXPORT vtkMRMLAbstractVolumeResampler : public vtkObject
+{
+public:
+  vtkTypeMacro(vtkMRMLAbstractVolumeResampler, vtkObject);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  enum
+  {
+    InterpolationTypeUndefined,
+    InterpolationTypeNearestNeighbor,
+    InterpolationTypeLinear,
+    InterpolationTypeWindowedSinc,
+    InterpolationTypeBSpline,
+    InterpolationType_Last // must be last
+  };
+
+  enum
+  {
+    WindowedSincFunctionUndefined,
+    WindowedSincFunctionHamming,
+    WindowedSincFunctionCosine,
+    WindowedSincFunctionWelch,
+    WindowedSincFunctionLanczos,
+    WindowedSincFunctionBlackman,
+    WindowedSincFunction_Last // must be last
+  };
+
+  typedef std::map<std::string, std::string> ResamplingParameters;
+
+  virtual bool Resample(vtkMRMLVolumeNode* inputVolume,
+                        vtkMRMLVolumeNode* outputVolume,
+                        vtkMRMLTransformNode* resamplingTransform,
+                        vtkMRMLVolumeNode* referenceVolume,
+                        int interpolationType,
+                        int windowedSincFunction,
+                        const ResamplingParameters& resamplingParameter) = 0;
+
+  /// @{
+  /// Get resampling parameter value
+  static std::string GetParameterValue(const ResamplingParameters& parameters, const std::string& name);
+  static double GetParameterValueAsDouble(const ResamplingParameters& parameters, const std::string& name);
+  static int GetParameterValueAsInt(const ResamplingParameters& parameters, const std::string& name);
+  /// }@
+
+  /// @{
+  /// Set resampling parameter value
+  static void SetParameterValue(ResamplingParameters& parameters, const std::string& name, const std::string& value);
+  static void SetParameterValueAsDouble(ResamplingParameters& parameters, const std::string& name, double value);
+  static void SetParameterValueAsInt(ResamplingParameters& parameters, const std::string& name, int value);
+  /// }@
+
+protected:
+  vtkMRMLAbstractVolumeResampler() = default;
+  ~vtkMRMLAbstractVolumeResampler() override = default;
+  vtkMRMLAbstractVolumeResampler(const vtkMRMLAbstractVolumeResampler&) = delete;
+  void operator=(const vtkMRMLAbstractVolumeResampler&) = delete;
+};
+
+#endif

--- a/Libs/MRML/Logic/vtkMRMLAbstractVolumeResampler.h
+++ b/Libs/MRML/Logic/vtkMRMLAbstractVolumeResampler.h
@@ -48,17 +48,6 @@ public:
     InterpolationType_Last // must be last
   };
 
-  enum
-  {
-    WindowedSincFunctionUndefined,
-    WindowedSincFunctionHamming,
-    WindowedSincFunctionCosine,
-    WindowedSincFunctionWelch,
-    WindowedSincFunctionLanczos,
-    WindowedSincFunctionBlackman,
-    WindowedSincFunction_Last // must be last
-  };
-
   typedef std::map<std::string, std::string> ResamplingParameters;
 
   virtual bool Resample(vtkMRMLVolumeNode* inputVolume,
@@ -66,7 +55,6 @@ public:
                         vtkMRMLTransformNode* resamplingTransform,
                         vtkMRMLVolumeNode* referenceVolume,
                         int interpolationType,
-                        int windowedSincFunction,
                         const ResamplingParameters& resamplingParameter) = 0;
 
   /// @{

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -23,6 +23,7 @@
 
 // MRMLLogic includes
 #include "vtkMRMLApplicationLogic.h"
+#include "vtkMRMLAbstractVolumeResampler.h"
 #include "vtkMRMLColorLogic.h"
 #include "vtkMRMLLogic.h"
 #include "vtkMRMLMessageCollection.h"
@@ -98,6 +99,7 @@ public:
   std::string TemporaryPath;
   std::map<std::string, vtkWeakPointer<vtkMRMLAbstractLogic> > ModuleLogicMap;
   std::map<int, std::string> FontFileNames;
+  std::map<std::string, vtkSmartPointer<vtkMRMLAbstractVolumeResampler>> Resamplers;
 };
 
 //----------------------------------------------------------------------------
@@ -1285,4 +1287,72 @@ std::string vtkMRMLApplicationLogic::GetFontsDirectory()
   filesVector.emplace_back(FONTS_DIR);
   std::string fullPath = vtksys::SystemTools::JoinPath(filesVector);
   return fullPath;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::RegisterVolumeResampler(
+    const std::string& resamplerName, vtkMRMLAbstractVolumeResampler* resampler)
+{
+  if (resamplerName.empty())
+  {
+    vtkErrorMacro("RegisterVolumeResampler: invalid sampler name.");
+    return;
+  }
+  if (this->IsVolumeResamplerRegistered(resamplerName))
+  {
+    return;
+  }
+  this->Internal->Resamplers[resamplerName] = resampler;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::UnregisterVolumeResampler(const std::string& resamplerName)
+{
+  if (!this->IsVolumeResamplerRegistered(resamplerName))
+  {
+    return;
+  }
+  this->Internal->Resamplers.erase(resamplerName);
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLApplicationLogic::IsVolumeResamplerRegistered(const std::string& resamplerName)
+{
+  return this->Internal->Resamplers.find(resamplerName) != this->Internal->Resamplers.end();
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLAbstractVolumeResampler* vtkMRMLApplicationLogic::GetVolumeResampler(const std::string& resamplerName)
+{
+  if (!this->IsVolumeResamplerRegistered(resamplerName))
+  {
+    return nullptr;
+  }
+  return this->Internal->Resamplers[resamplerName];
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLApplicationLogic::ResampleVolume(std::string& resamplerName,
+                                             vtkMRMLVolumeNode* inputVolume,
+                                             vtkMRMLVolumeNode* outputVolume,
+                                             vtkMRMLTransformNode* resamplingTransform,
+                                             vtkMRMLVolumeNode* referenceVolume,
+                                             int interpolationType,
+                                             int windowedSincFunction,
+                                             const vtkMRMLAbstractVolumeResampler::ResamplingParameters& resamplingParameters)
+{
+  vtkMRMLAbstractVolumeResampler* resampler = this->GetVolumeResampler(resamplerName);
+  if (!resampler)
+  {
+    vtkErrorMacro("ResampleVolume: resampler not registered " << resamplerName);
+    return false;
+  }
+  return resampler->Resample(
+        inputVolume,
+        outputVolume,
+        resamplingTransform,
+        referenceVolume,
+        interpolationType,
+        windowedSincFunction,
+        resamplingParameters);
 }

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -1330,27 +1330,3 @@ vtkMRMLAbstractVolumeResampler* vtkMRMLApplicationLogic::GetVolumeResampler(cons
   }
   return this->Internal->Resamplers[resamplerName];
 }
-
-//----------------------------------------------------------------------------
-bool vtkMRMLApplicationLogic::ResampleVolume(std::string& resamplerName,
-                                             vtkMRMLVolumeNode* inputVolume,
-                                             vtkMRMLVolumeNode* outputVolume,
-                                             vtkMRMLTransformNode* resamplingTransform,
-                                             vtkMRMLVolumeNode* referenceVolume,
-                                             int interpolationType,
-                                             const vtkMRMLAbstractVolumeResampler::ResamplingParameters& resamplingParameters)
-{
-  vtkMRMLAbstractVolumeResampler* resampler = this->GetVolumeResampler(resamplerName);
-  if (!resampler)
-  {
-    vtkErrorMacro("ResampleVolume: resampler not registered " << resamplerName);
-    return false;
-  }
-  return resampler->Resample(
-        inputVolume,
-        outputVolume,
-        resamplingTransform,
-        referenceVolume,
-        interpolationType,
-        resamplingParameters);
-}

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -1338,7 +1338,6 @@ bool vtkMRMLApplicationLogic::ResampleVolume(std::string& resamplerName,
                                              vtkMRMLTransformNode* resamplingTransform,
                                              vtkMRMLVolumeNode* referenceVolume,
                                              int interpolationType,
-                                             int windowedSincFunction,
                                              const vtkMRMLAbstractVolumeResampler::ResamplingParameters& resamplingParameters)
 {
   vtkMRMLAbstractVolumeResampler* resampler = this->GetVolumeResampler(resamplerName);
@@ -1353,6 +1352,5 @@ bool vtkMRMLApplicationLogic::ResampleVolume(std::string& resamplerName,
         resamplingTransform,
         referenceVolume,
         interpolationType,
-        windowedSincFunction,
         resamplingParameters);
 }

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -23,6 +23,7 @@
 
 // MRMLLogic includes
 #include "vtkMRMLAbstractLogic.h"
+#include "vtkMRMLAbstractVolumeResampler.h"
 
 #include "vtkMRMLLogicExport.h"
 #include "vtkMRMLSliceCompositeNode.h"
@@ -36,8 +37,10 @@ class vtkMRMLStorableNode;
 class vtkMRMLStorageNode;
 class vtkMRMLInteractionNode;
 class vtkMRMLMessageCollection;
+class vtkMRMLTransformNode;
 class vtkMRMLViewLogic;
 class vtkMRMLViewNode;
+class vtkMRMLVolumeNode;
 class vtkTextProperty;
 
 // VTK includes
@@ -298,6 +301,26 @@ public:
   /// Font family is set from arial/courier/times font family to custom fontfile.
   /// Font file path is set to the one specified in FontFileName property in this object.
   void UseCustomFontFile(vtkTextProperty* textProperty);
+
+  /// @{
+  /// Register/unregister resampler.
+  void RegisterVolumeResampler(const std::string& resamplerName, vtkMRMLAbstractVolumeResampler* resampler);
+  void UnregisterVolumeResampler(const std::string& resamplerName);
+  bool IsVolumeResamplerRegistered(const std::string& resamplerName);
+  vtkMRMLAbstractVolumeResampler* GetVolumeResampler(const std::string& resamplerName);
+  /// @}
+
+  /// Resample volume using the registered resampler.
+  /// \sa RegisterVolumeResampler()
+  /// \sa GetVolumeResampler()
+  bool ResampleVolume(std::string& resamplerName,
+                      vtkMRMLVolumeNode* inputVolume,
+                      vtkMRMLVolumeNode* outputVolume,
+                      vtkMRMLTransformNode* resamplingTransform,
+                      vtkMRMLVolumeNode* referenceVolume = nullptr,
+                      int interpolationType = vtkMRMLAbstractVolumeResampler::InterpolationTypeLinear,
+                      int windowedSincFunction = vtkMRMLAbstractVolumeResampler::WindowedSincFunctionCosine,
+                      const vtkMRMLAbstractVolumeResampler::ResamplingParameters& resamplingParameters = vtkMRMLAbstractVolumeResampler::ResamplingParameters());
 
 protected:
 

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -310,17 +310,6 @@ public:
   vtkMRMLAbstractVolumeResampler* GetVolumeResampler(const std::string& resamplerName);
   /// @}
 
-  /// Resample volume using the registered resampler.
-  /// \sa RegisterVolumeResampler()
-  /// \sa GetVolumeResampler()
-  bool ResampleVolume(std::string& resamplerName,
-                      vtkMRMLVolumeNode* inputVolume,
-                      vtkMRMLVolumeNode* outputVolume,
-                      vtkMRMLTransformNode* resamplingTransform,
-                      vtkMRMLVolumeNode* referenceVolume = nullptr,
-                      int interpolationType = vtkMRMLAbstractVolumeResampler::InterpolationTypeLinear,
-                      const vtkMRMLAbstractVolumeResampler::ResamplingParameters& resamplingParameters = vtkMRMLAbstractVolumeResampler::ResamplingParameters());
-
 protected:
 
   vtkMRMLApplicationLogic();

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -319,7 +319,6 @@ public:
                       vtkMRMLTransformNode* resamplingTransform,
                       vtkMRMLVolumeNode* referenceVolume = nullptr,
                       int interpolationType = vtkMRMLAbstractVolumeResampler::InterpolationTypeLinear,
-                      int windowedSincFunction = vtkMRMLAbstractVolumeResampler::WindowedSincFunctionCosine,
                       const vtkMRMLAbstractVolumeResampler::ResamplingParameters& resamplingParameters = vtkMRMLAbstractVolumeResampler::ResamplingParameters());
 
 protected:


### PR DESCRIPTION
This pull request introduces a modular and extensible framework for registering and using volume resamplers in 3D Slicer.

Key changes include:

* **Abstract Volume Resampler Framework:** A new `vtkMRMLAbstractVolumeResampler` class defines a standard interface, with utilities for managing resampling parameters.

* **Resampler Registration:** APIs in `vtkMRMLApplicationLogic` enable dynamic registration, unregistration, and querying of resamplers.

* **ResampleScalarVectorDWIVolume Integration:** The `ResampleScalarVectorDWIVolume` CLI module is now registered as a resampler, implemented via `vtkMRMLScalarVectorDWIVolumeResampler`, ensuring seamless integration and error handling.