### PR TITLE
COMP: Improve compatibility with ITK_LEGACY_REMOVE flag 

### DIFF
--- a/Base/CLI/itkPluginUtilities.h
+++ b/Base/CLI/itkPluginUtilities.h
@@ -3,7 +3,7 @@
 
 // ITK includes
 #include <itkContinuousIndex.h>
-#include <itkImage.h>
+#include <itkCommonEnums.h>
 #include <itkImageFileReader.h>
 #include <itkPluginFilterWatcher.h>
 
@@ -15,14 +15,14 @@ namespace itk
 {
   //-----------------------------------------------------------------------------
   /// Get the PixelType and ComponentType from fileName
-  void GetImageType (std::string fileName,
-                     ImageIOBase::IOPixelType &pixelType,
-                     ImageIOBase::IOComponentType &componentType)
+  void GetImageType(std::string fileName,
+                    IOPixelEnum &pixelType,
+                    IOComponentEnum &componentType)
   {
-      typedef itk::Image<unsigned char, 3> ImageType;
-      itk::ImageFileReader<ImageType>::Pointer imageReader =
-        itk::ImageFileReader<ImageType>::New();
-      imageReader->SetFileName(fileName.c_str());
+      using ImageType = itk::Image<unsigned char, 3>;
+      using ReaderType = itk::ImageFileReader<ImageType>;
+      ReaderType::Pointer imageReader = ReaderType::New();
+      imageReader->SetFileName(fileName);
       imageReader->UpdateOutputInformation();
 
       pixelType = imageReader->GetImageIO()->GetPixelType();
@@ -31,9 +31,9 @@ namespace itk
 
   //-----------------------------------------------------------------------------
   /// Get the PixelTypes and ComponentTypes from fileNames
-  void GetImageTypes (std::vector<std::string> fileNames,
-                      std::vector<ImageIOBase::IOPixelType> &pixelTypes,
-                      std::vector<ImageIOBase::IOComponentType> &componentTypes)
+  void GetImageTypes(std::vector<std::string> fileNames,
+                     std::vector<IOPixelEnum> &pixelTypes,
+                     std::vector<IOComponentEnum> &componentTypes)
   {
     pixelTypes.clear();
     componentTypes.clear();
@@ -41,12 +41,10 @@ namespace itk
     // For each file, find the pixel and component type
     for (std::vector<std::string>::size_type i = 0; i < fileNames.size(); i++)
     {
-      ImageIOBase::IOPixelType pixelType;
-      ImageIOBase::IOComponentType componentType;
+      IOPixelEnum pixelType;
+      IOComponentEnum componentType;
 
-      GetImageType (fileNames[i],
-                    pixelType,
-                    componentType);
+      GetImageType(fileNames[i], pixelType, componentType);
       pixelTypes.push_back(pixelType);
       componentTypes.push_back(componentType);
     }

--- a/Extensions/Testing/CLIExtensionTemplate/CLIModuleTemplate/CLIModuleTemplate.cxx
+++ b/Extensions/Testing/CLIExtensionTemplate/CLIModuleTemplate/CLIModuleTemplate.cxx
@@ -55,8 +55,8 @@ int main( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Extensions/Testing/SuperBuildExtensionTemplate/SuperCLIModuleTemplate/SuperCLIModuleTemplate.cxx
+++ b/Extensions/Testing/SuperBuildExtensionTemplate/SuperCLIModuleTemplate/SuperCLIModuleTemplate.cxx
@@ -55,8 +55,8 @@ int main( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Libs/MRML/IDImageIO/itkMRMLIDImageIO.cxx
+++ b/Libs/MRML/IDImageIO/itkMRMLIDImageIO.cxx
@@ -261,50 +261,50 @@ MRMLIDImageIO
     int dataType = VTK_UNSIGNED_CHAR;
     if (this->GetNumberOfComponents() == 1)
     {
-      this->SetPixelType(SCALAR);
+      this->SetPixelType(CommonEnums::IOPixel::SCALAR);
       dataType = node->GetImageData()->GetScalarType();
     }
     else if (vtkMRMLDiffusionTensorVolumeNode::SafeDownCast(node) != nullptr)
     {
       // tensor at each voxel
-      this->SetPixelType(DIFFUSIONTENSOR3D);
+      this->SetPixelType(CommonEnums::IOPixel::DIFFUSIONTENSOR3D);
       dataType = node->GetImageData()->GetPointData()->GetTensors()->GetDataType();
     }
     else if (vtkMRMLDiffusionWeightedVolumeNode::SafeDownCast(node) != nullptr)
     {
       // raw DWI
-      this->SetPixelType(VECTOR);
+      this->SetPixelType(CommonEnums::IOPixel::VECTOR);
       dataType = node->GetImageData()->GetScalarType();
     }
     else if (vtkMRMLDiffusionImageVolumeNode::SafeDownCast(node) != nullptr)
     {
       // derived data from a diffusion weighted image, e.g. Q-ball
-      this->SetPixelType(VECTOR);
+      this->SetPixelType(CommonEnums::IOPixel::VECTOR);
       dataType = node->GetImageData()->GetPointData()->GetTensors()->GetDataType();
     }
     else
     {
       // everything else...
       // what should the mapping be for multi-component scalars?
-      this->SetPixelType(VECTOR);
+      this->SetPixelType(CommonEnums::IOPixel::VECTOR);
       dataType = node->GetImageData()->GetScalarType();
     }
-    IOComponentType componentType = UCHAR;
+    CommonEnums::IOComponent componentType = CommonEnums::IOComponent::UCHAR;
     // ComponentType
     switch (dataType)
     {
-      case VTK_FLOAT: componentType = FLOAT; break;
-      case VTK_DOUBLE: componentType = DOUBLE; break;
-      case VTK_INT: componentType = INT; break;
-      case VTK_UNSIGNED_INT: componentType = UINT; break;
-      case VTK_SHORT: componentType = SHORT; break;
-      case VTK_UNSIGNED_SHORT: componentType = USHORT; break;
-      case VTK_LONG: componentType = LONG; break;
-      case VTK_UNSIGNED_LONG: componentType = ULONG; break;
-      case VTK_CHAR: componentType = CHAR; break;
-      case VTK_UNSIGNED_CHAR: componentType = UCHAR; break;
+      case VTK_FLOAT: componentType = CommonEnums::IOComponent::FLOAT; break;
+      case VTK_DOUBLE: componentType = CommonEnums::IOComponent::DOUBLE; break;
+      case VTK_INT: componentType = CommonEnums::IOComponent::INT; break;
+      case VTK_UNSIGNED_INT: componentType = CommonEnums::IOComponent::UINT; break;
+      case VTK_SHORT: componentType = CommonEnums::IOComponent::SHORT; break;
+      case VTK_UNSIGNED_SHORT: componentType = CommonEnums::IOComponent::USHORT; break;
+      case VTK_LONG: componentType = CommonEnums::IOComponent::LONG; break;
+      case VTK_UNSIGNED_LONG: componentType = CommonEnums::IOComponent::ULONG; break;
+      case VTK_CHAR: componentType = CommonEnums::IOComponent::CHAR; break;
+      case VTK_UNSIGNED_CHAR: componentType = CommonEnums::IOComponent::UCHAR; break;
       default: itkWarningMacro("Unknown scalar type.");
-        componentType = UNKNOWNCOMPONENTTYPE;
+        componentType = CommonEnums::IOComponent::UNKNOWNCOMPONENTTYPE;
         break;
     }
     this->SetComponentType(componentType);
@@ -475,16 +475,16 @@ MRMLIDImageIO
   // ComponentType
   switch (this->GetComponentType())
   {
-  case FLOAT: *scalarType = VTK_FLOAT; break;
-  case DOUBLE: *scalarType = VTK_DOUBLE; break;
-  case INT: *scalarType = VTK_INT; break;
-  case UINT: *scalarType = VTK_UNSIGNED_INT; break;
-  case SHORT: *scalarType = VTK_SHORT; break;
-  case USHORT: *scalarType = VTK_UNSIGNED_SHORT; break;
-  case LONG: *scalarType = VTK_LONG; break;
-  case ULONG: *scalarType = VTK_UNSIGNED_LONG; break;
-  case CHAR: *scalarType = VTK_CHAR; break;
-  case UCHAR: *scalarType = VTK_UNSIGNED_CHAR; break;
+  case CommonEnums::IOComponent::FLOAT: *scalarType = VTK_FLOAT; break;
+  case CommonEnums::IOComponent::DOUBLE: *scalarType = VTK_DOUBLE; break;
+  case CommonEnums::IOComponent::INT: *scalarType = VTK_INT; break;
+  case CommonEnums::IOComponent::UINT: *scalarType = VTK_UNSIGNED_INT; break;
+  case CommonEnums::IOComponent::SHORT: *scalarType = VTK_SHORT; break;
+  case CommonEnums::IOComponent::USHORT: *scalarType = VTK_UNSIGNED_SHORT; break;
+  case CommonEnums::IOComponent::LONG: *scalarType = VTK_LONG; break;
+  case CommonEnums::IOComponent::ULONG: *scalarType = VTK_UNSIGNED_LONG; break;
+  case CommonEnums::IOComponent::CHAR: *scalarType = VTK_CHAR; break;
+  case CommonEnums::IOComponent::UCHAR: *scalarType = VTK_UNSIGNED_CHAR; break;
   default:
     // What should we do?
     itkWarningMacro("Unknown scalar type.");

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx
@@ -801,43 +801,43 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
         {
           scalarType = VTK_SHORT; // TODO - figure out why multi-file series doesn't have an imageIO
         }
-        else if (imageIO->GetComponentType() == itk::ImageIOBase::UCHAR)
+        else if (imageIO->GetComponentType() == itk::IOComponentEnum::UCHAR)
         {
           scalarType = VTK_UNSIGNED_CHAR;
         }
-        else if (imageIO->GetComponentType() == itk::ImageIOBase::CHAR)
+        else if (imageIO->GetComponentType() == itk::IOComponentEnum::CHAR)
         {
           scalarType = VTK_CHAR;
         }
-        else if (imageIO->GetComponentType() == itk::ImageIOBase::USHORT)
+        else if (imageIO->GetComponentType() == itk::IOComponentEnum::USHORT)
         {
           scalarType = VTK_UNSIGNED_SHORT;
         }
-        else if (imageIO->GetComponentType() == itk::ImageIOBase::SHORT)
+        else if (imageIO->GetComponentType() == itk::IOComponentEnum::SHORT)
         {
           scalarType = VTK_SHORT;
         }
-        else if (imageIO->GetComponentType() == itk::ImageIOBase::UINT)
+        else if (imageIO->GetComponentType() == itk::IOComponentEnum::UINT)
         {
           scalarType = VTK_UNSIGNED_INT;
         }
-        else if (imageIO->GetComponentType() == itk::ImageIOBase::INT)
+        else if (imageIO->GetComponentType() == itk::IOComponentEnum::INT)
         {
           scalarType = VTK_INT;
         }
-        else if (imageIO->GetComponentType() == itk::ImageIOBase::ULONG)
+        else if (imageIO->GetComponentType() == itk::IOComponentEnum::ULONG)
         {
           scalarType = VTK_UNSIGNED_LONG;
         }
-        else if (imageIO->GetComponentType() == itk::ImageIOBase::LONG)
+        else if (imageIO->GetComponentType() == itk::IOComponentEnum::LONG)
         {
           scalarType = VTK_LONG;
         }
-        else if (imageIO->GetComponentType() == itk::ImageIOBase::FLOAT)
+        else if (imageIO->GetComponentType() == itk::IOComponentEnum::FLOAT)
         {
           scalarType = VTK_FLOAT;
         }
-        else if (imageIO->GetComponentType() == itk::ImageIOBase::DOUBLE)
+        else if (imageIO->GetComponentType() == itk::IOComponentEnum::DOUBLE)
         {
           scalarType = VTK_DOUBLE;
         }
@@ -850,54 +850,54 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
           imageIO->SetFileName( this->FileNames[f] );
           imageIO->ReadImageInformation();
 
-          if ( imageIO->GetComponentType() == itk::ImageIOBase::UCHAR )
+          if ( imageIO->GetComponentType() == itk::IOComponentEnum::UCHAR )
           {
             min = std::numeric_limits<uint8_t>::min() < min ? std::numeric_limits<uint8_t>::min() : min;
             max = std::numeric_limits<uint8_t>::max() > max ? std::numeric_limits<uint8_t>::max() : max;
           }
-          if ( imageIO->GetComponentType() == itk::ImageIOBase::CHAR )
+          if ( imageIO->GetComponentType() == itk::IOComponentEnum::CHAR )
           {
             min = std::numeric_limits<int8_t>::min() < min ? std::numeric_limits<int8_t>::min() : min;
             max = std::numeric_limits<int8_t>::max() > max ? std::numeric_limits<int8_t>::max() : max;
           }
-          if ( imageIO->GetComponentType() == itk::ImageIOBase::USHORT )
+          if ( imageIO->GetComponentType() == itk::IOComponentEnum::USHORT )
           {
             min = std::numeric_limits<uint16_t>::min() < min ? std::numeric_limits<uint16_t>::min() : min;
             max = std::numeric_limits<uint16_t>::max() > max ? std::numeric_limits<uint16_t>::max() : max;
           }
-          if ( imageIO->GetComponentType() == itk::ImageIOBase::SHORT )
+          if ( imageIO->GetComponentType() == itk::IOComponentEnum::SHORT )
           {
             min = std::numeric_limits<int16_t>::min() < min ? std::numeric_limits<int16_t>::min() : min;
             max = std::numeric_limits<int16_t>::max() > max ? std::numeric_limits<int16_t>::max() : max;
           }
-          if ( imageIO->GetComponentType() == itk::ImageIOBase::UINT )
+          if ( imageIO->GetComponentType() == itk::IOComponentEnum::UINT )
           {
             min = std::numeric_limits<uint32_t>::min() < min ? std::numeric_limits<uint32_t>::min() : min;
             max = std::numeric_limits<uint32_t>::max() > max ? std::numeric_limits<uint32_t>::max() : max;
           }
-          if ( imageIO->GetComponentType() == itk::ImageIOBase::INT )
+          if ( imageIO->GetComponentType() == itk::IOComponentEnum::INT )
           {
             min = static_cast<double>(std::numeric_limits<int32_t>::min() < min ? std::numeric_limits<int32_t>::min() : min);
             max = static_cast<double>(std::numeric_limits<int32_t>::max() > max ? std::numeric_limits<int32_t>::max() : max);
           }
-          if ( imageIO->GetComponentType() == itk::ImageIOBase::ULONG )
+          if ( imageIO->GetComponentType() == itk::IOComponentEnum::ULONG )
           { // note that on windows ULONG is only 32 bit
             min = static_cast<double>(std::numeric_limits<uint64_t>::min() < min ? std::numeric_limits<uint64_t>::min() : min);
             max = static_cast<double>(std::numeric_limits<uint64_t>::max() > max ? std::numeric_limits<uint64_t>::max() : max);
           }
-          if ( imageIO->GetComponentType() == itk::ImageIOBase::LONG )
+          if ( imageIO->GetComponentType() == itk::IOComponentEnum::LONG )
           { // note that on windows LONG is only 32 bit
             min = static_cast<double>(std::numeric_limits<int64_t>::min() < min ? std::numeric_limits<int64_t>::min() : min);
             max = static_cast<double>(std::numeric_limits<int64_t>::max() > max ? std::numeric_limits<int64_t>::max() : max);
           }
-          if ( imageIO->GetComponentType() == itk::ImageIOBase::FLOAT )
+          if ( imageIO->GetComponentType() == itk::IOComponentEnum::FLOAT )
           {
             // use -max() as min() for both float and double as temp workaround
             // should switch to lowest() function in C++ 11 in the future
             min = -std::numeric_limits<float>::max() < min ? -std::numeric_limits<float>::max() : min;
             max = std::numeric_limits<float>::max() > max ? std::numeric_limits<float>::max() : max;
           }
-          if ( imageIO->GetComponentType() == itk::ImageIOBase::DOUBLE )
+          if ( imageIO->GetComponentType() == itk::IOComponentEnum::DOUBLE )
           {
             min = -std::numeric_limits<double>::max() < min ? -std::numeric_limits<double>::max() : min;
             max = std::numeric_limits<double>::max() > max ? std::numeric_limits<double>::max() : max;

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.h
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.h
@@ -49,7 +49,7 @@ public:
   vtkTypeMacro(vtkITKArchetypeImageSeriesReader,vtkImageAlgorithm);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  typedef itk::SpatialOrientation::ValidCoordinateOrientationFlags CoordinateOrientationCode;
+  using CoordinateOrientationCode = itk::SpatialOrientationEnums::ValidCoordinateOrientations;
 
   ///
   /// Specify the archetype filename for the series.
@@ -111,24 +111,24 @@ public:
   void SetDesiredCoordinateOrientationToAxial ()
   {
     this->DesiredCoordinateOrientation =
-      itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI;
-    ///     itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RPS;
+      CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_RAI;
+    ///     CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_RPS;
     this->UseNativeCoordinateOrientation = 0;
     this->Modified();
   }
   void SetDesiredCoordinateOrientationToCoronal ()
   {
     this->DesiredCoordinateOrientation =
-      itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RSA;
-    ///      itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RIP;
+      CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_RSA;
+    ///      CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_RIP;
     this->UseNativeCoordinateOrientation = 0;
     this->Modified();
   }
   void SetDesiredCoordinateOrientationToSagittal ()
   {
     this->DesiredCoordinateOrientation =
-      itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ASL;
-    ///      itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_AIR;
+      CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_ASL;
+    ///      CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_AIR;
     this->UseNativeCoordinateOrientation = 0;
     this->Modified();
   }

--- a/Libs/vtkITK/vtkITKLabelShapeStatistics.cxx
+++ b/Libs/vtkITK/vtkITKLabelShapeStatistics.cxx
@@ -322,7 +322,7 @@ void vtkITKLabelShapeStatisticsExecute(vtkITKLabelShapeStatistics* self, vtkImag
         vtkDoubleArray* obbOriginArray = GetArray<vtkDoubleArray>(output, "OrientedBoundingBoxOrigin", 3);
         obbOriginArray->InsertTuple3(rowIndex, boundingBoxOrigin[0], boundingBoxOrigin[1], boundingBoxOrigin[2]);
 
-        typename ShapeLabelObjectType::OrientedBoundingBoxPointType boundingBoxSize = shapeObject->GetOrientedBoundingBoxSize();
+        typename ShapeLabelObjectType::OrientedBoundingBoxSizeType boundingBoxSize = shapeObject->GetOrientedBoundingBoxSize();
         std::vector<std::string> componentNames = { "x", "y", "z" };
         vtkDoubleArray* obbSizeArray = GetArray<vtkDoubleArray>(output, "OrientedBoundingBoxSize", 3, &componentNames);
         obbSizeArray->InsertTuple3(rowIndex, boundingBoxSize[0], boundingBoxSize[1], boundingBoxSize[2]);

--- a/Modules/CLI/AddScalarVolumes/AddScalarVolumes.cxx
+++ b/Modules/CLI/AddScalarVolumes/AddScalarVolumes.cxx
@@ -103,8 +103,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/AddScalarVolumes/AddScalarVolumes.cxx
+++ b/Modules/CLI/AddScalarVolumes/AddScalarVolumes.cxx
@@ -112,37 +112,37 @@ int main( int argc, char * argv[] )
 
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
+      case itk::IOComponentEnum::UCHAR:
         return DoIt( argc, argv, static_cast<unsigned char>(0) );
         break;
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt( argc, argv, static_cast<char>(0) );
         break;
-      case itk::ImageIOBase::USHORT:
+      case itk::IOComponentEnum::USHORT:
         return DoIt( argc, argv, static_cast<unsigned short>(0) );
         break;
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt( argc, argv, static_cast<short>(0) );
         break;
-      case itk::ImageIOBase::UINT:
+      case itk::IOComponentEnum::UINT:
         return DoIt( argc, argv, static_cast<unsigned int>(0) );
         break;
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::INT:
         return DoIt( argc, argv, static_cast<int>(0) );
         break;
-      case itk::ImageIOBase::ULONG:
+      case itk::IOComponentEnum::ULONG:
         return DoIt( argc, argv, static_cast<unsigned long>(0) );
         break;
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt( argc, argv, static_cast<long>(0) );
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt( argc, argv, static_cast<float>(0) );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt( argc, argv, static_cast<double>(0) );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/CastScalarVolume/CastScalarVolume.cxx
+++ b/Modules/CLI/CastScalarVolume/CastScalarVolume.cxx
@@ -81,7 +81,7 @@ int main( int argc, char * argv[] )
     // This filter handles all types on input
     switch( componentType )
     {
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::CHAR:
         if( Type == std::string("Char") )
         {
           return DoIt( argc, argv, static_cast<char>(0), static_cast<char>(0) );
@@ -128,7 +128,7 @@ int main( int argc, char * argv[] )
           return EXIT_FAILURE;
         }
         break;
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::SHORT:
         if( Type == std::string("Char") )
         {
           return DoIt( argc, argv, static_cast<short>(0), static_cast<char>(0) );
@@ -175,7 +175,7 @@ int main( int argc, char * argv[] )
           return EXIT_FAILURE;
         }
         break;
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::INT:
         if( Type == std::string("Char") )
         {
           return DoIt( argc, argv, static_cast<int>(0), static_cast<char>(0) );
@@ -222,7 +222,7 @@ int main( int argc, char * argv[] )
           return EXIT_FAILURE;
         }
         break;
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::LONG:
         if( Type == std::string("Char") )
         {
           return DoIt( argc, argv, static_cast<long>(0), static_cast<char>(0) );
@@ -269,7 +269,7 @@ int main( int argc, char * argv[] )
           return EXIT_FAILURE;
         }
         break;
-      case itk::ImageIOBase::UCHAR:
+      case itk::IOComponentEnum::UCHAR:
         if( Type == std::string("Char") )
         {
           return DoIt( argc, argv, static_cast<unsigned char>(0), static_cast<char>(0) );
@@ -316,7 +316,7 @@ int main( int argc, char * argv[] )
           return EXIT_FAILURE;
         }
         break;
-      case itk::ImageIOBase::USHORT:
+      case itk::IOComponentEnum::USHORT:
         if( Type == std::string("Char") )
         {
           return DoIt( argc, argv, static_cast<unsigned short>(0), static_cast<char>(0) );
@@ -363,7 +363,7 @@ int main( int argc, char * argv[] )
           return EXIT_FAILURE;
         }
         break;
-      case itk::ImageIOBase::UINT:
+      case itk::IOComponentEnum::UINT:
         if( Type == std::string("Char") )
         {
           return DoIt( argc, argv, static_cast<unsigned int>(0), static_cast<char>(0) );
@@ -410,7 +410,7 @@ int main( int argc, char * argv[] )
           return EXIT_FAILURE;
         }
         break;
-      case itk::ImageIOBase::ULONG:
+      case itk::IOComponentEnum::ULONG:
         if( Type == std::string("Char") )
         {
           return DoIt( argc, argv, static_cast<unsigned long>(0), static_cast<char>(0) );
@@ -457,7 +457,7 @@ int main( int argc, char * argv[] )
           return EXIT_FAILURE;
         }
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         if( Type == std::string("Char") )
         {
           return DoIt( argc, argv, static_cast<float>(0), static_cast<char>(0) );
@@ -504,7 +504,7 @@ int main( int argc, char * argv[] )
           return EXIT_FAILURE;
         }
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         if( Type == std::string("Char") )
         {
           return DoIt( argc, argv, static_cast<double>(0), static_cast<char>(0) );
@@ -551,7 +551,7 @@ int main( int argc, char * argv[] )
           return EXIT_FAILURE;
         }
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "Unknown component type " << componentType << std::endl;
         break;

--- a/Modules/CLI/CastScalarVolume/CastScalarVolume.cxx
+++ b/Modules/CLI/CastScalarVolume/CastScalarVolume.cxx
@@ -71,8 +71,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/CheckerBoardFilter/CheckerBoardFilter.cxx
+++ b/Modules/CLI/CheckerBoardFilter/CheckerBoardFilter.cxx
@@ -100,37 +100,37 @@ int main( int argc, char * argv[] )
 
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
+      case itk::IOComponentEnum::UCHAR:
         return DoIt( argc, argv, static_cast<unsigned char>(0) );
         break;
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt( argc, argv, static_cast<char>(0) );
         break;
-      case itk::ImageIOBase::USHORT:
+      case itk::IOComponentEnum::USHORT:
         return DoIt( argc, argv, static_cast<unsigned short>(0) );
         break;
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt( argc, argv, static_cast<short>(0) );
         break;
-      case itk::ImageIOBase::UINT:
+      case itk::IOComponentEnum::UINT:
         return DoIt( argc, argv, static_cast<unsigned int>(0) );
         break;
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::INT:
         return DoIt( argc, argv, static_cast<int>(0) );
         break;
-      case itk::ImageIOBase::ULONG:
+      case itk::IOComponentEnum::ULONG:
         return DoIt( argc, argv, static_cast<unsigned long>(0) );
         break;
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt( argc, argv, static_cast<long>(0) );
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt( argc, argv, static_cast<float>(0) );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt( argc, argv, static_cast<double>(0) );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/CheckerBoardFilter/CheckerBoardFilter.cxx
+++ b/Modules/CLI/CheckerBoardFilter/CheckerBoardFilter.cxx
@@ -89,8 +89,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/CurvatureAnisotropicDiffusion/CurvatureAnisotropicDiffusion.cxx
+++ b/Modules/CLI/CurvatureAnisotropicDiffusion/CurvatureAnisotropicDiffusion.cxx
@@ -86,8 +86,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/CurvatureAnisotropicDiffusion/CurvatureAnisotropicDiffusion.cxx
+++ b/Modules/CLI/CurvatureAnisotropicDiffusion/CurvatureAnisotropicDiffusion.cxx
@@ -97,37 +97,37 @@ int main( int argc, char * argv[] )
 
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
+      case itk::IOComponentEnum::UCHAR:
         return DoIt( argc, argv, static_cast<unsigned char>(0) );
         break;
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt( argc, argv, static_cast<char>(0) );
         break;
-      case itk::ImageIOBase::USHORT:
+      case itk::IOComponentEnum::USHORT:
         return DoIt( argc, argv, static_cast<unsigned short>(0) );
         break;
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt( argc, argv, static_cast<short>(0) );
         break;
-      case itk::ImageIOBase::UINT:
+      case itk::IOComponentEnum::UINT:
         return DoIt( argc, argv, static_cast<unsigned int>(0) );
         break;
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::INT:
         return DoIt( argc, argv, static_cast<int>(0) );
         break;
-      case itk::ImageIOBase::ULONG:
+      case itk::IOComponentEnum::ULONG:
         return DoIt( argc, argv, static_cast<unsigned long>(0) );
         break;
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt( argc, argv, static_cast<long>(0) );
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt( argc, argv, static_cast<float>(0) );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt( argc, argv, static_cast<double>(0) );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/DiffusionTensorTest/DiffusionTensorTest.cxx
+++ b/Modules/CLI/DiffusionTensorTest/DiffusionTensorTest.cxx
@@ -21,8 +21,8 @@ int main( int argc, char * argv[] )
   reader->SetFileName( inputVolume.c_str() );
   reader->Update();
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   itk::GetImageType(inputVolume, pixelType, componentType);
   std::cout << "Plugin received PixelType: " << pixelType << std::endl;

--- a/Modules/CLI/GaussianBlurImageFilter/GaussianBlurImageFilter.cxx
+++ b/Modules/CLI/GaussianBlurImageFilter/GaussianBlurImageFilter.cxx
@@ -64,37 +64,37 @@ int main( int argc, char * argv[] )
     // signed types
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
+      case itk::IOComponentEnum::UCHAR:
         return DoIt( argc, argv, static_cast<unsigned char>(0) );
         break;
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt( argc, argv, static_cast<char>(0) );
         break;
-      case itk::ImageIOBase::USHORT:
+      case itk::IOComponentEnum::USHORT:
         return DoIt( argc, argv, static_cast<unsigned short>(0) );
         break;
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt( argc, argv, static_cast<short>(0) );
         break;
-      case itk::ImageIOBase::UINT:
+      case itk::IOComponentEnum::UINT:
         return DoIt( argc, argv, static_cast<unsigned int>(0) );
         break;
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::INT:
         return DoIt( argc, argv, static_cast<int>(0) );
         break;
-      case itk::ImageIOBase::ULONG:
+      case itk::IOComponentEnum::ULONG:
         return DoIt( argc, argv, static_cast<unsigned long>(0) );
         break;
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt( argc, argv, static_cast<long>(0) );
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt( argc, argv, static_cast<float>(0) );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt( argc, argv, static_cast<double>(0) );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/GaussianBlurImageFilter/GaussianBlurImageFilter.cxx
+++ b/Modules/CLI/GaussianBlurImageFilter/GaussianBlurImageFilter.cxx
@@ -53,8 +53,8 @@ int main( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/GradientAnisotropicDiffusion/GradientAnisotropicDiffusion.cxx
+++ b/Modules/CLI/GradientAnisotropicDiffusion/GradientAnisotropicDiffusion.cxx
@@ -96,37 +96,37 @@ int main( int argc, char * argv[] )
 
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
+      case itk::IOComponentEnum::UCHAR:
         return DoIt( argc, argv, static_cast<unsigned char>(0) );
         break;
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt( argc, argv, static_cast<char>(0) );
         break;
-      case itk::ImageIOBase::USHORT:
+      case itk::IOComponentEnum::USHORT:
         return DoIt( argc, argv, static_cast<unsigned short>(0) );
         break;
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt( argc, argv, static_cast<short>(0) );
         break;
-      case itk::ImageIOBase::UINT:
+      case itk::IOComponentEnum::UINT:
         return DoIt( argc, argv, static_cast<unsigned int>(0) );
         break;
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::INT:
         return DoIt( argc, argv, static_cast<int>(0) );
         break;
-      case itk::ImageIOBase::ULONG:
+      case itk::IOComponentEnum::ULONG:
         return DoIt( argc, argv, static_cast<unsigned long>(0) );
         break;
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt( argc, argv, static_cast<long>(0) );
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt( argc, argv, static_cast<float>(0) );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt( argc, argv, static_cast<double>(0) );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/GradientAnisotropicDiffusion/GradientAnisotropicDiffusion.cxx
+++ b/Modules/CLI/GradientAnisotropicDiffusion/GradientAnisotropicDiffusion.cxx
@@ -85,8 +85,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/GrayscaleFillHoleImageFilter/GrayscaleFillHoleImageFilter.cxx
+++ b/Modules/CLI/GrayscaleFillHoleImageFilter/GrayscaleFillHoleImageFilter.cxx
@@ -97,37 +97,37 @@ int main( int argc, char * argv[] )
     // This filter handles all types
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
+      case itk::IOComponentEnum::UCHAR:
         return DoIt( argc, argv, static_cast<unsigned char>(0) );
         break;
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt( argc, argv, static_cast<char>(0) );
         break;
-      case itk::ImageIOBase::USHORT:
+      case itk::IOComponentEnum::USHORT:
         return DoIt( argc, argv, static_cast<unsigned short>(0) );
         break;
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt( argc, argv, static_cast<short>(0) );
         break;
-      case itk::ImageIOBase::UINT:
+      case itk::IOComponentEnum::UINT:
         return DoIt( argc, argv, static_cast<unsigned int>(0) );
         break;
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::INT:
         return DoIt( argc, argv, static_cast<int>(0) );
         break;
-      case itk::ImageIOBase::ULONG:
+      case itk::IOComponentEnum::ULONG:
         return DoIt( argc, argv, static_cast<unsigned long>(0) );
         break;
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt( argc, argv, static_cast<long>(0) );
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt( argc, argv, static_cast<float>(0) );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt( argc, argv, static_cast<double>(0) );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/GrayscaleFillHoleImageFilter/GrayscaleFillHoleImageFilter.cxx
+++ b/Modules/CLI/GrayscaleFillHoleImageFilter/GrayscaleFillHoleImageFilter.cxx
@@ -87,8 +87,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/GrayscaleGrindPeakImageFilter/GrayscaleGrindPeakImageFilter.cxx
+++ b/Modules/CLI/GrayscaleGrindPeakImageFilter/GrayscaleGrindPeakImageFilter.cxx
@@ -98,29 +98,29 @@ int main( int argc, char * argv[] )
 
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::UCHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt( argc, argv, static_cast<unsigned char>(0) );
         break;
-      case itk::ImageIOBase::USHORT:
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::USHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt( argc, argv, static_cast<short>(0) );
         break;
-      case itk::ImageIOBase::UINT:
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::UINT:
+      case itk::IOComponentEnum::INT:
         return DoIt( argc, argv, static_cast<int>(0) );
         break;
-      case itk::ImageIOBase::ULONG:
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::ULONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt( argc, argv, static_cast<long>(0) );
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt( argc, argv, static_cast<float>(0) );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt( argc, argv, static_cast<double>(0) );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/GrayscaleGrindPeakImageFilter/GrayscaleGrindPeakImageFilter.cxx
+++ b/Modules/CLI/GrayscaleGrindPeakImageFilter/GrayscaleGrindPeakImageFilter.cxx
@@ -87,8 +87,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/HistogramMatching/HistogramMatching.cxx
+++ b/Modules/CLI/HistogramMatching/HistogramMatching.cxx
@@ -104,40 +104,40 @@ int main( int argc, char * argv[] )
     // This filter handles all types
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
+      case itk::IOComponentEnum::UCHAR:
         return DoIt<unsigned char>( argc, argv, static_cast<unsigned char>(0) );
         break;
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt<char>( argc, argv, static_cast<char>(0) );
         break;
-      case itk::ImageIOBase::USHORT:
+      case itk::IOComponentEnum::USHORT:
         return DoIt<unsigned short>( argc, argv, static_cast<unsigned short>(0) );
         break;
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt<short>( argc, argv, static_cast<short>(0) );
         break;
-      case itk::ImageIOBase::UINT:
+      case itk::IOComponentEnum::UINT:
         return DoIt<unsigned int>( argc, argv, static_cast<unsigned int>(0) );
         break;
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::INT:
         return DoIt<int>( argc, argv, static_cast<int>(0) );
         break;
-      case itk::ImageIOBase::ULONG:
+      case itk::IOComponentEnum::ULONG:
         return DoIt<unsigned long>( argc, argv, static_cast<unsigned long>(0) );
         break;
 /* A bug in ITK prevents this from working with ITK Review Statistics turned on. */
 #if defined USE_REVIEW_STATISTICS
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt<long>( argc, argv, static_cast<long>(0) );
         break;
 #endif
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt<float>( argc, argv, static_cast<float>(0) );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt<double>( argc, argv, static_cast<double>(0) );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/HistogramMatching/HistogramMatching.cxx
+++ b/Modules/CLI/HistogramMatching/HistogramMatching.cxx
@@ -94,8 +94,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/MaskScalarVolume/MaskScalarVolume.cxx
+++ b/Modules/CLI/MaskScalarVolume/MaskScalarVolume.cxx
@@ -125,37 +125,37 @@ int main( int argc, char * argv[] )
 
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
+      case itk::IOComponentEnum::UCHAR:
         return DoIt<unsigned char>( argc, argv);
         break;
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt<char>( argc, argv );
         break;
-      case itk::ImageIOBase::USHORT:
+      case itk::IOComponentEnum::USHORT:
         return DoIt<unsigned short>( argc, argv );
         break;
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt<short>( argc, argv );
         break;
-      case itk::ImageIOBase::UINT:
+      case itk::IOComponentEnum::UINT:
         return DoIt<unsigned int>( argc, argv );
         break;
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::INT:
         return DoIt<int>( argc, argv );
         break;
-      case itk::ImageIOBase::ULONG:
+      case itk::IOComponentEnum::ULONG:
         return DoIt<unsigned long>( argc, argv );
         break;
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt<long>( argc, argv );
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt<float>( argc, argv );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt<double>( argc, argv );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/MaskScalarVolume/MaskScalarVolume.cxx
+++ b/Modules/CLI/MaskScalarVolume/MaskScalarVolume.cxx
@@ -116,8 +116,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/MedianImageFilter/MedianImageFilter.cxx
+++ b/Modules/CLI/MedianImageFilter/MedianImageFilter.cxx
@@ -73,8 +73,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/MedianImageFilter/MedianImageFilter.cxx
+++ b/Modules/CLI/MedianImageFilter/MedianImageFilter.cxx
@@ -84,37 +84,37 @@ int main( int argc, char * argv[] )
 
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
+      case itk::IOComponentEnum::UCHAR:
         return DoIt( argc, argv, static_cast<unsigned char>(0) );
         break;
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt( argc, argv, static_cast<char>(0) );
         break;
-      case itk::ImageIOBase::USHORT:
+      case itk::IOComponentEnum::USHORT:
         return DoIt( argc, argv, static_cast<unsigned short>(0) );
         break;
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt( argc, argv, static_cast<short>(0) );
         break;
-      case itk::ImageIOBase::UINT:
+      case itk::IOComponentEnum::UINT:
         return DoIt( argc, argv, static_cast<unsigned int>(0) );
         break;
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::INT:
         return DoIt( argc, argv, static_cast<int>(0) );
         break;
-      case itk::ImageIOBase::ULONG:
+      case itk::IOComponentEnum::ULONG:
         return DoIt( argc, argv, static_cast<unsigned long>(0) );
         break;
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt( argc, argv, static_cast<long>(0) );
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt( argc, argv, static_cast<float>(0) );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt( argc, argv, static_cast<double>(0) );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/MultiplyScalarVolumes/MultiplyScalarVolumes.cxx
+++ b/Modules/CLI/MultiplyScalarVolumes/MultiplyScalarVolumes.cxx
@@ -110,29 +110,29 @@ int main( int argc, char * argv[] )
 
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::UCHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt( argc, argv, static_cast<char>(0) );
         break;
-      case itk::ImageIOBase::USHORT:
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::USHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt( argc, argv, static_cast<short>(0) );
         break;
-      case itk::ImageIOBase::UINT:
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::UINT:
+      case itk::IOComponentEnum::INT:
         return DoIt( argc, argv, static_cast<int>(0) );
         break;
-      case itk::ImageIOBase::ULONG:
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::ULONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt( argc, argv, static_cast<long>(0) );
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt( argc, argv, static_cast<float>(0) );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt( argc, argv, static_cast<double>(0) );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/MultiplyScalarVolumes/MultiplyScalarVolumes.cxx
+++ b/Modules/CLI/MultiplyScalarVolumes/MultiplyScalarVolumes.cxx
@@ -98,8 +98,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
+++ b/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
@@ -388,8 +388,8 @@ int main(int argc, char* * argv)
     try
     {
 
-      itk::ImageIOBase::IOPixelType     pixelType;
-      itk::ImageIOBase::IOComponentType componentType;
+      itk::IOPixelEnum     pixelType;
+      itk::IOComponentEnum componentType;
 
       itk::GetImageType(inputImageName, pixelType, componentType);
 

--- a/Modules/CLI/OrientScalarVolume/OrientScalarVolume.cxx
+++ b/Modules/CLI/OrientScalarVolume/OrientScalarVolume.cxx
@@ -175,37 +175,37 @@ int main( int argc, char * argv[] )
     // this filter produces the image of the same type as the input
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
+      case itk::IOComponentEnum::UCHAR:
         return DoIt( argc, argv, static_cast<unsigned char>(0) );
         break;
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt( argc, argv, static_cast<char>(0) );
         break;
-      case itk::ImageIOBase::USHORT:
+      case itk::IOComponentEnum::USHORT:
         return DoIt( argc, argv, static_cast<unsigned short>(0) );
         break;
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt( argc, argv, static_cast<short>(0) );
         break;
-      case itk::ImageIOBase::UINT:
+      case itk::IOComponentEnum::UINT:
         return DoIt( argc, argv, static_cast<unsigned int>(0) );
         break;
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::INT:
         return DoIt( argc, argv, static_cast<int>(0) );
         break;
-      case itk::ImageIOBase::ULONG:
+      case itk::IOComponentEnum::ULONG:
         return DoIt( argc, argv, static_cast<unsigned long>(0) );
         break;
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt( argc, argv, static_cast<long>(0) );
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt( argc, argv, static_cast<float>(0) );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt( argc, argv, static_cast<double>(0) );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/OrientScalarVolume/OrientScalarVolume.cxx
+++ b/Modules/CLI/OrientScalarVolume/OrientScalarVolume.cxx
@@ -26,66 +26,65 @@
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module
 // entry point, e.g. main()
-//
 namespace
 {
-
-//
-// Description: Map from string description to SpatialOrientation
+// Description: Map from string description to CoordinateOrientationCode
 void CreateOrientationMap(
-  std::map<std::string, itk::SpatialOrientation::ValidCoordinateOrientationFlags> & orientationMap)
+  std::map<std::string, itk::SpatialOrientationEnums::ValidCoordinateOrientations> & orientationMap)
 {
-  orientationMap["Axial"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI;
-  orientationMap["Coronal"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RSA;
-  orientationMap["Sagittal"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ASL;
-  orientationMap["RIP"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RIP;
-  orientationMap["LIP"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LIP;
-  orientationMap["RSP"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RSP;
-  orientationMap["LSP"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LSP;
-  orientationMap["RIA"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RIA;
-  orientationMap["LIA"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LIA;
-  orientationMap["RSA"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RSA;
-  orientationMap["LSA"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LSA;
-  orientationMap["IRP"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_IRP;
-  orientationMap["ILP"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ILP;
-  orientationMap["SRP"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SRP;
-  orientationMap["SLP"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SLP;
-  orientationMap["IRA"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_IRA;
-  orientationMap["ILA"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ILA;
-  orientationMap["SRA"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SRA;
-  orientationMap["SLA"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SLA;
-  orientationMap["RPI"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RPI;
-  orientationMap["LPI"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LPI;
-  orientationMap["RAI"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI;
-  orientationMap["LAI"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LAI;
-  orientationMap["RPS"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RPS;
-  orientationMap["LPS"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LPS;
-  orientationMap["RAS"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAS;
-  orientationMap["LAS"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_LAS;
-  orientationMap["PRI"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PRI;
-  orientationMap["PLI"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PLI;
-  orientationMap["ARI"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ARI;
-  orientationMap["ALI"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ALI;
-  orientationMap["PRS"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PRS;
-  orientationMap["PLS"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PLS;
-  orientationMap["ARS"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ARS;
-  orientationMap["ALS"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ALS;
-  orientationMap["IPR"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_IPR;
-  orientationMap["SPR"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SPR;
-  orientationMap["IAR"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_IAR;
-  orientationMap["SAR"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SAR;
-  orientationMap["IPL"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_IPL;
-  orientationMap["SPL"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SPL;
-  orientationMap["IAL"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_IAL;
-  orientationMap["SAL"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_SAL;
-  orientationMap["PIR"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PIR;
-  orientationMap["PSR"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PSR;
-  orientationMap["AIR"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_AIR;
-  orientationMap["ASR"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ASR;
-  orientationMap["PIL"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PIL;
-  orientationMap["PSL"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_PSL;
-  orientationMap["AIL"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_AIL;
-  orientationMap["ASL"] = itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_ASL;
+  using CoordinateOrientationCode = itk::SpatialOrientationEnums::ValidCoordinateOrientations;
+
+  orientationMap["Axial"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_RAI;
+  orientationMap["Coronal"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_RSA;
+  orientationMap["Sagittal"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_ASL;
+  orientationMap["RIP"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_RIP;
+  orientationMap["LIP"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_LIP;
+  orientationMap["RSP"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_RSP;
+  orientationMap["LSP"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_LSP;
+  orientationMap["RIA"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_RIA;
+  orientationMap["LIA"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_LIA;
+  orientationMap["RSA"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_RSA;
+  orientationMap["LSA"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_LSA;
+  orientationMap["IRP"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_IRP;
+  orientationMap["ILP"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_ILP;
+  orientationMap["SRP"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_SRP;
+  orientationMap["SLP"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_SLP;
+  orientationMap["IRA"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_IRA;
+  orientationMap["ILA"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_ILA;
+  orientationMap["SRA"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_SRA;
+  orientationMap["SLA"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_SLA;
+  orientationMap["RPI"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_RPI;
+  orientationMap["LPI"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_LPI;
+  orientationMap["RAI"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_RAI;
+  orientationMap["LAI"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_LAI;
+  orientationMap["RPS"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_RPS;
+  orientationMap["LPS"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_LPS;
+  orientationMap["RAS"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_RAS;
+  orientationMap["LAS"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_LAS;
+  orientationMap["PRI"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_PRI;
+  orientationMap["PLI"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_PLI;
+  orientationMap["ARI"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_ARI;
+  orientationMap["ALI"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_ALI;
+  orientationMap["PRS"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_PRS;
+  orientationMap["PLS"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_PLS;
+  orientationMap["ARS"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_ARS;
+  orientationMap["ALS"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_ALS;
+  orientationMap["IPR"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_IPR;
+  orientationMap["SPR"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_SPR;
+  orientationMap["IAR"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_IAR;
+  orientationMap["SAR"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_SAR;
+  orientationMap["IPL"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_IPL;
+  orientationMap["SPL"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_SPL;
+  orientationMap["IAL"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_IAL;
+  orientationMap["SAL"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_SAL;
+  orientationMap["PIR"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_PIR;
+  orientationMap["PSR"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_PSR;
+  orientationMap["AIR"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_AIR;
+  orientationMap["ASR"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_ASR;
+  orientationMap["PIL"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_PIL;
+  orientationMap["PSL"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_PSL;
+  orientationMap["AIL"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_AIL;
+  orientationMap["ASL"] = CoordinateOrientationCode::ITK_COORDINATE_ORIENTATION_ASL;
 }
 
 //
@@ -121,9 +120,9 @@ int DoIt( int argc, char * argv[], T )
                                        "Orient image",
                                        CLPProcessInformation);
 
-  std::map<std::string, itk::SpatialOrientation::ValidCoordinateOrientationFlags> orientationMap;
+  std::map<std::string, itk::SpatialOrientationEnums::ValidCoordinateOrientations> orientationMap;
   CreateOrientationMap(orientationMap);
-  std::map<std::string, itk::SpatialOrientation::ValidCoordinateOrientationFlags>::iterator o = orientationMap.find(
+  std::map<std::string, itk::SpatialOrientationEnums::ValidCoordinateOrientations>::iterator o = orientationMap.find(
       orientation);
 
   filter->SetInput( reader1->GetOutput() );

--- a/Modules/CLI/OrientScalarVolume/OrientScalarVolume.cxx
+++ b/Modules/CLI/OrientScalarVolume/OrientScalarVolume.cxx
@@ -166,8 +166,8 @@ int main( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx
+++ b/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx
@@ -518,11 +518,11 @@ SetTransform( parameters & list,
   {
     if( !list.transformsOrder.compare( "input-to-output" ) )
     {
-      transformFile->GetTransformList()->pop_back();
+      transformFile->GetModifiableTransformList()->pop_back();
     }
     else
     {
-      transformFile->GetTransformList()->pop_front();
+      transformFile->GetModifiableTransformList()->pop_front();
     }
   }
   return tensorTransform;

--- a/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx
+++ b/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx
@@ -93,8 +93,8 @@ bool VectorIsNul( std::vector<double> vec )
 
 // What pixeltype is the image
 void GetImageType( std::string fileName,
-                   itk::ImageIOBase::IOPixelType & pixelType,
-                   itk::ImageIOBase::IOComponentType & componentType )
+                   itk::IOPixelEnum & pixelType,
+                   itk::IOComponentEnum & componentType )
 {
   typedef itk::Image<unsigned char, 3> ImageType;
   itk::ImageFileReader<ImageType>::Pointer imageReader =
@@ -1140,8 +1140,8 @@ int main( int argc, char * argv[] )
   itk::TransformFactory<ThinPlateSplineTransformFloatType>::RegisterTransform();
   itk::TransformFactory<ThinPlateSplineTransformDoubleType>::RegisterTransform();
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
   // Check the input image pixel type
   GetImageType( inputVolume, pixelType, componentType );
 

--- a/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx
+++ b/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx
@@ -1147,13 +1147,13 @@ int main( int argc, char * argv[] )
 
   switch( componentType )
   {
-    case itk::ImageIOBase::FLOAT:
+    case itk::IOComponentEnum::FLOAT:
       return Do<float>( list );
       break;
-    case itk::ImageIOBase::DOUBLE:
+    case itk::IOComponentEnum::DOUBLE:
       return Do<double>( list );
       break;
-    case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+    case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
     default:
       std::cerr << "unknown component type" << std::endl;
       break;

--- a/Modules/CLI/ResampleDTIVolume/Testing/itkTestMainExtended.h
+++ b/Modules/CLI/ResampleDTIVolume/Testing/itkTestMainExtended.h
@@ -322,11 +322,11 @@ int RegressionTestImage(const char *testImageFilename,
   typedef itk::Image<unsigned char, ITK_TEST_DIMENSION_MAX>                  OutputType;
   typedef itk::Image<unsigned char, 2>                                       DiffOutputType;
 
-  itk::ImageIOBase::IOPixelType     pixelTypeBaseline;
-  itk::ImageIOBase::IOComponentType componentTypeBaseline;
+  itk::IOPixelEnum     pixelTypeBaseline;
+  itk::IOComponentEnum componentTypeBaseline;
   itk::GetImageType( baselineImageFilename, pixelTypeBaseline, componentTypeBaseline );
-  itk::ImageIOBase::IOPixelType     pixelTypeTestImage;
-  itk::ImageIOBase::IOComponentType componentTypeTestImage;
+  itk::IOPixelEnum     pixelTypeTestImage;
+  itk::IOComponentEnum componentTypeTestImage;
   itk::GetImageType( testImageFilename, pixelTypeTestImage, componentTypeTestImage );
   bool diffusion = false;
   // check if the voxels of the image are diffusion tensors

--- a/Modules/CLI/ResampleDTIVolume/Testing/itkTestMainExtended.h
+++ b/Modules/CLI/ResampleDTIVolume/Testing/itkTestMainExtended.h
@@ -330,11 +330,11 @@ int RegressionTestImage(const char *testImageFilename,
   itk::GetImageType( testImageFilename, pixelTypeTestImage, componentTypeTestImage );
   bool diffusion = false;
   // check if the voxels of the image are diffusion tensors
-  if( ( pixelTypeBaseline == itk::ImageIOBase::SYMMETRICSECONDRANKTENSOR
-        || pixelTypeBaseline == itk::ImageIOBase::DIFFUSIONTENSOR3D
+  if( ( pixelTypeBaseline == itk::IOPixelEnum::SYMMETRICSECONDRANKTENSOR
+        || pixelTypeBaseline == itk::IOPixelEnum::DIFFUSIONTENSOR3D
         )
-      && ( pixelTypeTestImage == itk::ImageIOBase::SYMMETRICSECONDRANKTENSOR
-           || pixelTypeTestImage == itk::ImageIOBase::DIFFUSIONTENSOR3D
+      && ( pixelTypeTestImage == itk::IOPixelEnum::SYMMETRICSECONDRANKTENSOR
+           || pixelTypeTestImage == itk::IOPixelEnum::DIFFUSIONTENSOR3D
            )
       )
   {

--- a/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
+++ b/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
@@ -79,8 +79,8 @@ struct parameters
 
 // To check the image voxel type
 void GetImageType( std::string fileName,
-                   itk::ImageIOBase::IOPixelType & pixelType,
-                   itk::ImageIOBase::IOComponentType & componentType
+                   itk::IOPixelEnum & pixelType,
+                   itk::IOComponentEnum & componentType
                    )
 {
   typedef itk::Image<unsigned char, 3> ImageType;
@@ -1359,8 +1359,8 @@ int main( int argc, char * argv[] )
   itk::TransformFactory<ThinPlateSplineTransformFloatType>::RegisterTransform();
   itk::TransformFactory<ThinPlateSplineTransformDoubleType>::RegisterTransform();
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
   GetImageType( list.inputVolume, pixelType, componentType );
 
   // templated over the input image voxel type

--- a/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
+++ b/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
@@ -1366,37 +1366,37 @@ int main( int argc, char * argv[] )
   // templated over the input image voxel type
   switch( componentType )
   {
-    case itk::ImageIOBase::UCHAR:
+    case itk::IOComponentEnum::UCHAR:
       return Rotate<unsigned char>( list );
       break;
-    case itk::ImageIOBase::CHAR:
+    case itk::IOComponentEnum::CHAR:
       return Rotate<char>( list );
       break;
-    case itk::ImageIOBase::USHORT:
+    case itk::IOComponentEnum::USHORT:
       return Rotate<unsigned short>( list );
       break;
-    case itk::ImageIOBase::SHORT:
+    case itk::IOComponentEnum::SHORT:
       return Rotate<short>( list );
       break;
-    case itk::ImageIOBase::UINT:
+    case itk::IOComponentEnum::UINT:
       return Rotate<unsigned int>( list );
       break;
-    case itk::ImageIOBase::INT:
+    case itk::IOComponentEnum::INT:
       return Rotate<int>( list );
       break;
-    case itk::ImageIOBase::ULONG:
+    case itk::IOComponentEnum::ULONG:
       return Rotate<unsigned long>( list );
       break;
-    case itk::ImageIOBase::LONG:
+    case itk::IOComponentEnum::LONG:
       return Rotate<long>( list );
       break;
-    case itk::ImageIOBase::FLOAT:
+    case itk::IOComponentEnum::FLOAT:
       return Rotate<float>( list );
       break;
-    case itk::ImageIOBase::DOUBLE:
+    case itk::IOComponentEnum::DOUBLE:
       return Rotate<double>( list );
       break;
-    case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+    case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
     default:
       std::cerr << "unknown component type" << std::endl;
       break;

--- a/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
+++ b/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
@@ -388,11 +388,11 @@ SetTransform( parameters & list,
   {
     if( !list.transformsOrder.compare( "input-to-output" ) )
     {
-      transformFile->GetTransformList()->pop_back();
+      transformFile->GetModifiableTransformList()->pop_back();
     }
     else
     {
-      transformFile->GetTransformList()->pop_front();
+      transformFile->GetModifiableTransformList()->pop_front();
     }
   }
   return transform;

--- a/Modules/CLI/ResampleScalarVolume/ResampleScalarVolume.cxx
+++ b/Modules/CLI/ResampleScalarVolume/ResampleScalarVolume.cxx
@@ -242,8 +242,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/ResampleScalarVolume/ResampleScalarVolume.cxx
+++ b/Modules/CLI/ResampleScalarVolume/ResampleScalarVolume.cxx
@@ -253,37 +253,37 @@ int main( int argc, char * argv[] )
 
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
+      case itk::IOComponentEnum::UCHAR:
         return DoIt( argc, argv, static_cast<unsigned char>(0) );
         break;
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt( argc, argv, static_cast<char>(0) );
         break;
-      case itk::ImageIOBase::USHORT:
+      case itk::IOComponentEnum::USHORT:
         return DoIt( argc, argv, static_cast<unsigned short>(0) );
         break;
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt( argc, argv, static_cast<short>(0) );
         break;
-      case itk::ImageIOBase::UINT:
+      case itk::IOComponentEnum::UINT:
         return DoIt( argc, argv, static_cast<unsigned int>(0) );
         break;
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::INT:
         return DoIt( argc, argv, static_cast<int>(0) );
         break;
-      case itk::ImageIOBase::ULONG:
+      case itk::IOComponentEnum::ULONG:
         return DoIt( argc, argv, static_cast<unsigned long>(0) );
         break;
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt( argc, argv, static_cast<long>(0) );
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt( argc, argv, static_cast<float>(0) );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt( argc, argv, static_cast<double>(0) );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/SubtractScalarVolumes/SubtractScalarVolumes.cxx
+++ b/Modules/CLI/SubtractScalarVolumes/SubtractScalarVolumes.cxx
@@ -105,8 +105,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/SubtractScalarVolumes/SubtractScalarVolumes.cxx
+++ b/Modules/CLI/SubtractScalarVolumes/SubtractScalarVolumes.cxx
@@ -114,37 +114,37 @@ int main( int argc, char * argv[] )
 
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
+      case itk::IOComponentEnum::UCHAR:
         return DoIt( argc, argv, static_cast<unsigned char>(0) );
         break;
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt( argc, argv, static_cast<char>(0) );
         break;
-      case itk::ImageIOBase::USHORT:
+      case itk::IOComponentEnum::USHORT:
         return DoIt( argc, argv, static_cast<unsigned short>(0) );
         break;
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt( argc, argv, static_cast<short>(0) );
         break;
-      case itk::ImageIOBase::UINT:
+      case itk::IOComponentEnum::UINT:
         return DoIt( argc, argv, static_cast<unsigned int>(0) );
         break;
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::INT:
         return DoIt( argc, argv, static_cast<int>(0) );
         break;
-      case itk::ImageIOBase::ULONG:
+      case itk::IOComponentEnum::ULONG:
         return DoIt( argc, argv, static_cast<unsigned long>(0) );
         break;
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt( argc, argv, static_cast<long>(0) );
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt( argc, argv, static_cast<float>(0) );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt( argc, argv, static_cast<double>(0) );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/TestGridTransformRegistration/TestGridTransformRegistration.cxx
+++ b/Modules/CLI/TestGridTransformRegistration/TestGridTransformRegistration.cxx
@@ -199,21 +199,21 @@ int main( int argc, char * argv[] )
 
     switch( componentType )
     {
-      case itk::ImageIOBase::CHAR:
-      case itk::ImageIOBase::UCHAR:
-      case itk::ImageIOBase::USHORT:
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::CHAR:
+      case itk::IOComponentEnum::UCHAR:
+      case itk::IOComponentEnum::USHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt( argc, argv, static_cast<short>(0) );
         break;
-      case itk::ImageIOBase::ULONG:
-      case itk::ImageIOBase::LONG:
-      case itk::ImageIOBase::UINT:
-      case itk::ImageIOBase::INT:
-      case itk::ImageIOBase::DOUBLE:
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::ULONG:
+      case itk::IOComponentEnum::LONG:
+      case itk::IOComponentEnum::UINT:
+      case itk::IOComponentEnum::INT:
+      case itk::IOComponentEnum::DOUBLE:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt( argc, argv, static_cast<float>(0) );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Modules/CLI/TestGridTransformRegistration/TestGridTransformRegistration.cxx
+++ b/Modules/CLI/TestGridTransformRegistration/TestGridTransformRegistration.cxx
@@ -188,8 +188,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/ThresholdScalarVolume/ThresholdScalarVolume.cxx
+++ b/Modules/CLI/ThresholdScalarVolume/ThresholdScalarVolume.cxx
@@ -127,8 +127,8 @@ int main( int argc, char * argv[] )
 
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {

--- a/Modules/CLI/ThresholdScalarVolume/ThresholdScalarVolume.cxx
+++ b/Modules/CLI/ThresholdScalarVolume/ThresholdScalarVolume.cxx
@@ -136,37 +136,37 @@ int main( int argc, char * argv[] )
 
     switch( componentType )
     {
-      case itk::ImageIOBase::UCHAR:
+      case itk::IOComponentEnum::UCHAR:
         return DoIt<unsigned char>( argc, argv );
         break;
-      case itk::ImageIOBase::CHAR:
+      case itk::IOComponentEnum::CHAR:
         return DoIt<char>( argc, argv );
         break;
-      case itk::ImageIOBase::USHORT:
+      case itk::IOComponentEnum::USHORT:
         return DoIt<unsigned short>( argc, argv );
         break;
-      case itk::ImageIOBase::SHORT:
+      case itk::IOComponentEnum::SHORT:
         return DoIt<short>( argc, argv );
         break;
-      case itk::ImageIOBase::UINT:
+      case itk::IOComponentEnum::UINT:
         return DoIt<unsigned int>( argc, argv );
         break;
-      case itk::ImageIOBase::INT:
+      case itk::IOComponentEnum::INT:
         return DoIt<int>( argc, argv );
         break;
-      case itk::ImageIOBase::ULONG:
+      case itk::IOComponentEnum::ULONG:
         return DoIt<unsigned long>( argc, argv );
         break;
-      case itk::ImageIOBase::LONG:
+      case itk::IOComponentEnum::LONG:
         return DoIt<long>( argc, argv );
         break;
-      case itk::ImageIOBase::FLOAT:
+      case itk::IOComponentEnum::FLOAT:
         return DoIt<float>( argc, argv );
         break;
-      case itk::ImageIOBase::DOUBLE:
+      case itk::IOComponentEnum::DOUBLE:
         return DoIt<double>( argc, argv );
         break;
-      case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
+      case itk::IOComponentEnum::UNKNOWNCOMPONENTTYPE:
       default:
         std::cout << "unknown component type" << std::endl;
         break;

--- a/Utilities/Templates/Modules/CLI/TemplateKey.cxx
+++ b/Utilities/Templates/Modules/CLI/TemplateKey.cxx
@@ -55,8 +55,8 @@ int main( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  itk::ImageIOBase::IOPixelType     pixelType;
-  itk::ImageIOBase::IOComponentType componentType;
+  itk::IOPixelEnum     pixelType;
+  itk::IOComponentEnum componentType;
 
   try
   {


### PR DESCRIPTION
I encountered the need for this change when trying to make a CLI which can be pointed to Slicer, or to ITK+SlicerExecutionModel for the purpose of configuration. My ITK build has legacy disabled, so copying `GetImageType` function inside the CLI revealed it does not compile.

We should eventually get Slicer building with `ITK_LEGACY_REMOVE` turned on, but this is a step in that direction.