### PR TITLE
DOC: Fixed "Edit on GitHub" link not appearing on readthedocs

### DIFF
--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -149,6 +149,18 @@ html_theme_options = {
     "includehidden": False,
 }
 
+# -- Read the Docs Specific Configuration --
+# This is needed to show "Edit on GitHub" link on the top of each page.
+# See https://about.readthedocs.com/blog/2024/07/addons-by-default/
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+# -- End of Read the Docs Specific Configuration --
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/Docs/developer_guide/modules/dicom.md
+++ b/Docs/developer_guide/modules/dicom.md
@@ -1,6 +1,6 @@
 # DICOM (Digital Imaging and Communications in Medicine)
 
-Refer to the [Slicer User Guide DICOM Section](../user_guide/modules/dicom.md) for a comprehensive overview of the DICOM standard and related features in Slicer.
+Refer to the [Slicer User Guide DICOM Section](../../user_guide/modules/dicom.md) for a comprehensive overview of the DICOM standard and related features in Slicer.
 
 The overall DICOM Implementation in 3D Slicer consists of two main bodies of code embedded within the application.
 - [CTK](https://commontk.org) code is responsible for the implementation of the DICOM database and DIMSE networking layer. The CTK code is implemented in C++ and follows the Qt style.

--- a/Docs/user_guide/modules/index.md
+++ b/Docs/user_guide/modules/index.md
@@ -51,7 +51,6 @@ fiducialregistration.md
 landmarkregistration.md
 performmetrictest.md
 reformat.md
-scriptedregistration.md
 ```
 
 ## Segmentation


### PR DESCRIPTION
Readthedocs no longer injects github project information by default, but it eeds to be enabled explicitly.
See details here: https://about.readthedocs.com/blog/2024/07/addons-by-default/

Also fixed two broken links.
