### PR TITLE
Use subject hierarchy tree as node selector in Volumes, Volume Rendering, Segmentations, Transforms modules

### DIFF
--- a/Libs/MRML/Widgets/qMRMLClipNodeDisplayWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLClipNodeDisplayWidget.cxx
@@ -97,7 +97,7 @@ vtkMRMLDisplayNode* qMRMLClipNodeDisplayWidget::mrmlDisplayNode() const
 //------------------------------------------------------------------------------
 void qMRMLClipNodeDisplayWidget::setMRMLDisplayNode(vtkMRMLNode* node)
 {
-  this->setMRMLDisplayNode(vtkMRMLClipNode::SafeDownCast(node));
+  this->setMRMLDisplayNode(vtkMRMLDisplayNode::SafeDownCast(node));
 }
 
 //------------------------------------------------------------------------------
@@ -109,7 +109,6 @@ void qMRMLClipNodeDisplayWidget::setMRMLDisplayNode(vtkMRMLDisplayNode* clipNode
   d->MRMLDisplayNode = clipNode;
   this->updateWidgetFromMRML();
 }
-
 
 //------------------------------------------------------------------------------
 void qMRMLClipNodeDisplayWidget::updateWidgetFromMRML()

--- a/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsModule.ui
+++ b/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsModule.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>360</width>
-    <height>909</height>
+    <width>370</width>
+    <height>946</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,43 +30,99 @@
     <number>4</number>
    </property>
    <item>
+    <widget class="ctkExpandableWidget" name="ResizableFrame_2">
+     <property name="orientations">
+      <set>Qt::Vertical</set>
+     </property>
+     <property name="sizeGripInside">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_9">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="qMRMLSubjectHierarchyTreeView" name="MRMLNodeSelector_Segmentation">
+        <property name="dragDropMode">
+         <enum>QAbstractItemView::InternalMove</enum>
+        </property>
+        <property name="indentation">
+         <number>12</number>
+        </property>
+        <property name="editMenuActionVisible">
+         <bool>false</bool>
+        </property>
+        <property name="addNodeMenuActionVisible">
+         <bool>true</bool>
+        </property>
+        <property name="multiSelection">
+         <bool>true</bool>
+        </property>
+        <property name="nodeTypes">
+         <stringlist notr="true">
+          <string>vtkMRMLSegmentationNode</string>
+         </stringlist>
+        </property>
+        <property name="hideChildNodeTypes">
+         <stringlist notr="true"/>
+        </property>
+        <property name="idColumnVisible">
+         <bool>false</bool>
+        </property>
+        <property name="colorColumnVisible">
+         <bool>false</bool>
+        </property>
+        <property name="transformColumnVisible">
+         <bool>false</bool>
+        </property>
+        <property name="pluginAllowList">
+         <stringlist notr="true">
+          <string>Segmentations</string>
+          <string>Folder</string>
+          <string>Visibility</string>
+         </stringlist>
+        </property>
+        <property name="excludeItemAttributeNamesFilter">
+         <stringlist notr="true">
+          <string>segmentID</string>
+         </stringlist>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QGridLayout" name="gridLayout_4">
      <property name="spacing">
       <number>4</number>
      </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_ActiveSegmentation">
+     <item row="0" column="1">
+      <widget class="QLabel" name="label_ReferenceVolumeName">
        <property name="text">
-        <string> Segmentation:</string>
+        <string/>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
+     <item row="0" column="0">
       <widget class="QLabel" name="label_ReferenceVolumeText">
        <property name="toolTip">
         <string>Node that was used for setting the segmentation geometry (origin, spacing, axis directions, and default extent)</string>
        </property>
        <property name="text">
         <string> Source geometry:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_Segmentation">
-       <property name="nodeTypes">
-        <stringlist notr="true">
-         <string>vtkMRMLSegmentationNode</string>
-        </stringlist>
-       </property>
-       <property name="renameEnabled">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="label_ReferenceVolumeName">
-       <property name="text">
-        <string/>
        </property>
       </widget>
      </item>
@@ -878,6 +934,11 @@
    <header>qMRMLSegmentationShow3DButton.h</header>
   </customwidget>
   <customwidget>
+   <class>qMRMLSubjectHierarchyTreeView</class>
+   <extends>QTreeView</extends>
+   <header>qMRMLSubjectHierarchyTreeView.h</header>
+  </customwidget>
+  <customwidget>
    <class>qMRMLSubjectHierarchyComboBox</class>
    <extends>ctkComboBox</extends>
    <header>qMRMLSubjectHierarchyComboBox.h</header>
@@ -923,22 +984,6 @@
   <connection>
    <sender>qSlicerSegmentationsModule</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>MRMLNodeComboBox_Segmentation</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>230</x>
-     <y>3</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>234</x>
-     <y>12</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>qSlicerSegmentationsModule</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
    <receiver>MRMLNodeComboBox_OtherSegmentationOrRepresentationNode</receiver>
    <slot>setMRMLScene(vtkMRMLScene*)</slot>
    <hints>
@@ -947,24 +992,8 @@
      <y>3</y>
     </hint>
     <hint type="destinationlabel">
-     <x>329</x>
-     <y>632</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>SegmentsTableView</sender>
-   <signal>selectionChanged(QItemSelection,QItemSelection)</signal>
-   <receiver>SegmentationDisplayNodeWidget</receiver>
-   <slot>onSegmentSelectionChanged(QItemSelection,QItemSelection)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>157</x>
-     <y>136</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>145</x>
-     <y>456</y>
+     <x>359</x>
+     <y>673</y>
     </hint>
    </hints>
   </connection>
@@ -979,8 +1008,8 @@
      <y>634</y>
     </hint>
     <hint type="destinationlabel">
-     <x>326</x>
-     <y>739</y>
+     <x>355</x>
+     <y>785</y>
     </hint>
    </hints>
   </connection>
@@ -995,8 +1024,56 @@
      <y>415</y>
     </hint>
     <hint type="destinationlabel">
-     <x>178</x>
-     <y>816</y>
+     <x>186</x>
+     <y>865</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerSegmentationsModule</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>SubjectHierarchyComboBox_ImportExport</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>262</x>
+     <y>3</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>324</x>
+     <y>758</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerSegmentationsModule</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>ColorTableNodeSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>169</x>
+     <y>431</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>354</x>
+     <y>787</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerSegmentationsModule</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>SegmentationDisplayNodeWidget</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>179</x>
+     <y>454</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>179</x>
+     <y>401</y>
     </hint>
    </hints>
   </connection>
@@ -1017,50 +1094,34 @@
    </hints>
   </connection>
   <connection>
-   <sender>qSlicerSegmentationsModule</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>SubjectHierarchyComboBox_ImportExport</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>262</x>
-     <y>3</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>275</x>
-     <y>708</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>qSlicerSegmentationsModule</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>ColorTableNodeSelector</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>169</x>
-     <y>431</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>325</x>
-     <y>741</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>qSlicerSegmentationsModule</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <sender>SegmentsTableView</sender>
+   <signal>selectionChanged(QItemSelection,QItemSelection)</signal>
    <receiver>SegmentationDisplayNodeWidget</receiver>
+   <slot>onSegmentSelectionChanged(QItemSelection,QItemSelection)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>161</x>
+     <y>276</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>145</x>
+     <y>456</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerSegmentationsModule</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>MRMLNodeSelector_Segmentation</receiver>
    <slot>setMRMLScene(vtkMRMLScene*)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>179</x>
-     <y>454</y>
+     <x>1</x>
+     <y>822</y>
     </hint>
     <hint type="destinationlabel">
-     <x>179</x>
-     <y>401</y>
+     <x>69</x>
+     <y>35</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
@@ -185,7 +185,7 @@ void qSlicerSegmentationsModuleWidget::onEnter()
   this->qvtkConnect(this->mrmlScene(), vtkMRMLScene::EndRestoreEvent,
                     this, SLOT(onMRMLSceneEndRestoreEvent()));
 
-  this->onSegmentationNodeChanged( d->MRMLNodeComboBox_Segmentation->currentNode() );
+  this->onSegmentationNodeChanged(d->MRMLNodeSelector_Segmentation->currentNode());
 
   d->populateTerminologyContextComboBox();
 }
@@ -202,7 +202,7 @@ vtkMRMLSegmentationDisplayNode* qSlicerSegmentationsModuleWidget::segmentationDi
   Q_D(qSlicerSegmentationsModuleWidget);
 
   vtkMRMLSegmentationNode* segmentationNode =  vtkMRMLSegmentationNode::SafeDownCast(
-    d->MRMLNodeComboBox_Segmentation->currentNode() );
+    d->MRMLNodeSelector_Segmentation->currentNode() );
   if (!segmentationNode)
   {
     return nullptr;
@@ -284,7 +284,7 @@ void qSlicerSegmentationsModuleWidget::updateCopyMoveButtonStates()
 
   // Set button states that copy/move from current segmentation
   vtkMRMLSegmentationNode* currentSegmentationNode =  vtkMRMLSegmentationNode::SafeDownCast(
-    d->MRMLNodeComboBox_Segmentation->currentNode() );
+    d->MRMLNodeSelector_Segmentation->currentNode() );
   if (currentSegmentationNode && currentSegmentationNode->GetSegmentation()->GetNumberOfSegments() > 0)
   {
     d->toolButton_MoveFromCurrentSegmentation->setEnabled(true);
@@ -311,13 +311,13 @@ void qSlicerSegmentationsModuleWidget::init()
   d->ImportExportTypeButtonGroup->addButton(d->radioButton_Model);
 
   // Make connections
-  connect(d->MRMLNodeComboBox_Segmentation, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
+  connect(d->MRMLNodeSelector_Segmentation, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
     this, SLOT(onSegmentationNodeChanged(vtkMRMLNode*)) );
-  connect(d->MRMLNodeComboBox_Segmentation, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
+  connect(d->MRMLNodeSelector_Segmentation, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
     d->SegmentsTableView, SLOT(setSegmentationNode(vtkMRMLNode*)) );
-  connect(d->MRMLNodeComboBox_Segmentation, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
+  connect(d->MRMLNodeSelector_Segmentation, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
     d->SegmentsTableView_Current, SLOT(setSegmentationNode(vtkMRMLNode*)) );
-  connect(d->MRMLNodeComboBox_Segmentation, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
+  connect(d->MRMLNodeSelector_Segmentation, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
     d->RepresentationsListView, SLOT(setSegmentationNode(vtkMRMLNode*)) );
 
   connect(d->SegmentsTableView, SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
@@ -349,7 +349,7 @@ void qSlicerSegmentationsModuleWidget::init()
     this, SLOT(onExportColorTableChanged()));
 
   d->ExportToFilesWidget->setSettingsKey("ExportSegmentsToFiles");
-  connect(d->MRMLNodeComboBox_Segmentation, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
+  connect(d->MRMLNodeSelector_Segmentation, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
     d->ExportToFilesWidget, SLOT(setSegmentationNode(vtkMRMLNode*)));
 
   connect(d->toolButton_MoveFromCurrentSegmentation, SIGNAL(clicked()),
@@ -423,7 +423,7 @@ void qSlicerSegmentationsModuleWidget::selectSegmentationNode(vtkMRMLSegmentatio
 {
   Q_D(qSlicerSegmentationsModuleWidget);
 
-  d->MRMLNodeComboBox_Segmentation->setCurrentNode(segmentationNode);
+  d->MRMLNodeSelector_Segmentation->setCurrentNode(segmentationNode);
 }
 
 //-----------------------------------------------------------------------------
@@ -446,7 +446,7 @@ void qSlicerSegmentationsModuleWidget::onAddSegment()
   Q_D(qSlicerSegmentationsModuleWidget);
 
   vtkMRMLSegmentationNode* currentSegmentationNode =  vtkMRMLSegmentationNode::SafeDownCast(
-    d->MRMLNodeComboBox_Segmentation->currentNode() );
+    d->MRMLNodeSelector_Segmentation->currentNode() );
   if (!currentSegmentationNode)
   {
     qWarning() << Q_FUNC_INFO << ": No segmentation selected";
@@ -491,7 +491,7 @@ void qSlicerSegmentationsModuleWidget::onEditSegmentation()
 {
   Q_D(qSlicerSegmentationsModuleWidget);
 
-  if (!d->MRMLNodeComboBox_Segmentation->currentNode())
+  if (!d->MRMLNodeSelector_Segmentation->currentNode())
   {
     qCritical() << Q_FUNC_INFO << ": Invalid segmentation";
     return;
@@ -520,7 +520,7 @@ void qSlicerSegmentationsModuleWidget::onEditSegmentation()
       qCritical() << Q_FUNC_INFO << ": MRMLNodeComboBox_Segmentation is not found in Segment Editor module";
       return;
     }
-    nodeSelector->setCurrentNode(d->MRMLNodeComboBox_Segmentation->currentNode());
+    nodeSelector->setCurrentNode(d->MRMLNodeSelector_Segmentation->currentNode());
 
     // Get segments table and select segment
     qMRMLSegmentsTableView* segmentsTable = moduleWidget->findChild<qMRMLSegmentsTableView*>("SegmentsTableView");
@@ -539,7 +539,7 @@ void qSlicerSegmentationsModuleWidget::onRemoveSelectedSegments()
   Q_D(qSlicerSegmentationsModuleWidget);
 
   vtkMRMLSegmentationNode* currentSegmentationNode =  vtkMRMLSegmentationNode::SafeDownCast(
-    d->MRMLNodeComboBox_Segmentation->currentNode() );
+    d->MRMLNodeSelector_Segmentation->currentNode() );
   if (!currentSegmentationNode)
   {
     qCritical() << Q_FUNC_INFO << ": No segmentation selected";
@@ -815,7 +815,7 @@ bool qSlicerSegmentationsModuleWidget::copySegmentsBetweenSegmentations(bool cop
   Q_D(qSlicerSegmentationsModuleWidget);
 
   vtkMRMLSegmentationNode* currentSegmentationNode =  vtkMRMLSegmentationNode::SafeDownCast(
-    d->MRMLNodeComboBox_Segmentation->currentNode() );
+    d->MRMLNodeSelector_Segmentation->currentNode() );
   if (!currentSegmentationNode)
   {
     qWarning() << Q_FUNC_INFO << ": No current segmentation is selected";
@@ -879,7 +879,7 @@ bool qSlicerSegmentationsModuleWidget::exportFromCurrentSegmentation()
   }
 
   vtkMRMLSegmentationNode* currentSegmentationNode =  vtkMRMLSegmentationNode::SafeDownCast(
-    d->MRMLNodeComboBox_Segmentation->currentNode() );
+    d->MRMLNodeSelector_Segmentation->currentNode() );
   if (!currentSegmentationNode || !currentSegmentationNode->GetSegmentation())
   {
     qWarning() << Q_FUNC_INFO << ": No segmentation selected";
@@ -1031,7 +1031,7 @@ bool qSlicerSegmentationsModuleWidget::importToCurrentSegmentation()
   Q_D(qSlicerSegmentationsModuleWidget);
 
   vtkMRMLSegmentationNode* currentSegmentationNode = vtkMRMLSegmentationNode::SafeDownCast(
-    d->MRMLNodeComboBox_Segmentation->currentNode());
+    d->MRMLNodeSelector_Segmentation->currentNode());
   if (!currentSegmentationNode)
   {
     qWarning() << Q_FUNC_INFO << ": No segmentation selected";
@@ -1175,7 +1175,7 @@ bool qSlicerSegmentationsModuleWidget::setEditedNode(
   Q_UNUSED(context);
   if (vtkMRMLSegmentationNode::SafeDownCast(node))
   {
-    d->MRMLNodeComboBox_Segmentation->setCurrentNode(node);
+    d->MRMLNodeSelector_Segmentation->setCurrentNode(node);
     return true;
   }
   return false;

--- a/Modules/Loadable/SubjectHierarchy/Widgets/DesignerPlugins/qMRMLSubjectHierarchyTreeViewPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/DesignerPlugins/qMRMLSubjectHierarchyTreeViewPlugin.cxx
@@ -49,6 +49,8 @@ QString qMRMLSubjectHierarchyTreeViewPlugin::domXml() const
     "  <property name=\"includeNodeAttributeNamesFilter\"> <stringlist notr=\"true\"/> </property>\n"
     "  <property name=\"excludeItemAttributeNamesFilter\"> <stringlist notr=\"true\"/> </property>\n"
     "  <property name=\"excludeNodeAttributeNamesFilter\"> <stringlist notr=\"true\"/> </property>\n"
+    "  <property name=\"pluginAllowList\"> <stringlist notr=\"true\"/> </property>\n"
+    "  <property name=\"pluginBlockList\"> <stringlist notr=\"true\"/> </property>\n"
     "</widget>\n"
     "</ui>\n";
 }

--- a/Modules/Loadable/Transforms/Resources/UI/qSlicerTransformsModuleWidget.ui
+++ b/Modules/Loadable/Transforms/Resources/UI/qSlicerTransformsModuleWidget.ui
@@ -37,30 +37,68 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QLabel" name="TransformNodeSelectorLabel">
-       <property name="text">
-        <string> Transform:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="qMRMLNodeComboBox" name="TransformNodeSelector">
-       <property name="nodeTypes">
-        <stringlist notr="true">
-         <string>vtkMRMLLinearTransformNode</string>
-         <string>vtkMRMLBSplineTransformNode</string>
-         <string>vtkMRMLGridTransformNode</string>
-         <string>vtkMRMLTransformNode</string>
-        </stringlist>
-       </property>
-       <property name="renameEnabled">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="ctkExpandableWidget" name="ResizableFrame">
+     <property name="orientations">
+      <set>Qt::Vertical</set>
+     </property>
+     <property name="sizeGripInside">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_9">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="qMRMLSubjectHierarchyTreeView" name="TransformNodeSelector">
+        <property name="dragDropMode">
+         <enum>QAbstractItemView::InternalMove</enum>
+        </property>
+        <property name="indentation">
+         <number>12</number>
+        </property>
+        <property name="editMenuActionVisible">
+         <bool>false</bool>
+        </property>
+        <property name="addNodeMenuActionVisible">
+         <bool>true</bool>
+        </property>
+        <property name="multiSelection">
+         <bool>true</bool>
+        </property>
+        <property name="nodeTypes">
+         <stringlist notr="true">
+          <string>vtkMRMLTransformNode</string>
+         </stringlist>
+        </property>
+        <property name="idColumnVisible">
+         <bool>false</bool>
+        </property>
+        <property name="colorColumnVisible">
+         <bool>false</bool>
+        </property>
+        <property name="pluginAllowList">
+         <stringlist notr="true">
+          <string>Transforms</string>
+          <string>Folder</string>
+          <string>Visibility</string>
+         </stringlist>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="ctkCollapsibleButton" name="InfoCollapsibleWidget">
@@ -634,28 +672,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ctkCollapsibleButton</class>
-   <extends>QWidget</extends>
-   <header>ctkCollapsibleButton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>ctkCollapsibleGroupBox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkCoordinatesWidget</class>
-   <extends>QWidget</extends>
-   <header>ctkCoordinatesWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>ctkMatrixWidget</class>
-   <extends>QWidget</extends>
-   <header>ctkMatrixWidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>qMRMLCoordinatesWidget</class>
    <extends>ctkCoordinatesWidget</extends>
    <header>qMRMLCoordinatesWidget.h</header>
@@ -681,6 +697,9 @@
    <class>qMRMLTreeView</class>
    <extends>QTreeView</extends>
    <header>qMRMLTreeView.h</header>
+   <slots>
+    <slot>setSceneModel(int)</slot>
+   </slots>
   </customwidget>
   <customwidget>
    <class>qMRMLWidget</class>
@@ -695,6 +714,11 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>qMRMLSubjectHierarchyTreeView</class>
+   <extends>QTreeView</extends>
+   <header>qMRMLSubjectHierarchyTreeView.h</header>
+  </customwidget>
+  <customwidget>
    <class>qMRMLTransformDisplayNodeWidget</class>
    <extends>qMRMLWidget</extends>
    <header>qMRMLTransformDisplayNodeWidget.h</header>
@@ -704,10 +728,39 @@
    <extends>qMRMLWidget</extends>
    <header>qMRMLTransformInfoWidget.h</header>
   </customwidget>
+  <customwidget>
+   <class>ctkCollapsibleButton</class>
+   <extends>QWidget</extends>
+   <header>ctkCollapsibleButton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>ctkCollapsibleGroupBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkCoordinatesWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkCoordinatesWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkExpandableWidget</class>
+   <extends>QFrame</extends>
+   <header>ctkExpandableWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkMatrixWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkMatrixWidget.h</header>
+  </customwidget>
  </customwidgets>
  <resources>
   <include location="../qSlicerTransformsModule.qrc"/>
   <include location="../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc"/>
+  <include location="../../../Segmentations/Widgets/Resources/qSlicerSegmentationsModuleWidgets.qrc"/>
  </resources>
  <connections>
   <connection>
@@ -722,7 +775,7 @@
     </hint>
     <hint type="destinationlabel">
      <x>169</x>
-     <y>1206</y>
+     <y>1170</y>
     </hint>
    </hints>
   </connection>
@@ -737,72 +790,8 @@
      <y>501</y>
     </hint>
     <hint type="destinationlabel">
-     <x>380</x>
-     <y>1206</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>qSlicerTransformsModuleWidget</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>TransformNodeSelector</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>293</x>
-     <y>6</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>389</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>TransformNodeSelector</sender>
-   <signal>currentNodeChanged(vtkMRMLNode*)</signal>
-   <receiver>TranslationSliders</receiver>
-   <slot>setMRMLTransformNode(vtkMRMLNode*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>336</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>163</x>
-     <y>315</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>TransformNodeSelector</sender>
-   <signal>currentNodeChanged(vtkMRMLNode*)</signal>
-   <receiver>RotationSliders</receiver>
-   <slot>setMRMLTransformNode(vtkMRMLNode*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>389</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>341</x>
-     <y>430</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>TransformNodeSelector</sender>
-   <signal>currentNodeChanged(vtkMRMLNode*)</signal>
-   <receiver>MatrixWidget</receiver>
-   <slot>setMRMLTransformNode(vtkMRMLNode*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>365</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>212</x>
-     <y>171</y>
+     <x>503</x>
+     <y>1170</y>
     </hint>
    </hints>
   </connection>
@@ -813,124 +802,12 @@
    <slot>resetUnactiveSliders()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>64</x>
-     <y>288</y>
+     <x>73</x>
+     <y>523</y>
     </hint>
     <hint type="destinationlabel">
-     <x>79</x>
-     <y>430</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>TransformNodeSelector</sender>
-   <signal>currentNodeChanged(bool)</signal>
-   <receiver>InvertPushButton</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>389</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>161</x>
-     <y>516</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>TransformNodeSelector</sender>
-   <signal>currentNodeChanged(bool)</signal>
-   <receiver>TransformToolButton</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>389</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>198</x>
-     <y>907</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>TransformNodeSelector</sender>
-   <signal>currentNodeChanged(bool)</signal>
-   <receiver>UntransformToolButton</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>389</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>198</x>
-     <y>1014</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>TransformNodeSelector</sender>
-   <signal>currentNodeChanged(bool)</signal>
-   <receiver>HardenToolButton</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>389</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>198</x>
-     <y>1014</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>TransformNodeSelector</sender>
-   <signal>currentNodeChanged(bool)</signal>
-   <receiver>TransformableTreeView</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>389</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>198</x>
-     <y>1014</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>TransformNodeSelector</sender>
-   <signal>currentNodeChanged(bool)</signal>
-   <receiver>TransformedTreeView</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>389</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>198</x>
-     <y>1014</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>TransformNodeSelector</sender>
-   <signal>currentNodeChanged(vtkMRMLNode*)</signal>
-   <receiver>TransformDisplayNodeWidget</receiver>
-   <slot>setMRMLTransformNode(vtkMRMLNode*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>240</x>
-     <y>10</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>204</x>
-     <y>758</y>
+     <x>88</x>
+     <y>640</y>
     </hint>
    </hints>
   </connection>
@@ -951,22 +828,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>TransformNodeSelector</sender>
-   <signal>currentNodeChanged(vtkMRMLNode*)</signal>
-   <receiver>TransformInfoWidget</receiver>
-   <slot>setMRMLTransformNode(vtkMRMLNode*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>240</x>
-     <y>10</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>222</x>
-     <y>59</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>qSlicerTransformsModuleWidget</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
    <receiver>TranslationSliders</receiver>
@@ -977,8 +838,8 @@
      <y>65</y>
     </hint>
     <hint type="destinationlabel">
-     <x>301</x>
-     <y>257</y>
+     <x>310</x>
+     <y>523</y>
     </hint>
    </hints>
   </connection>
@@ -993,8 +854,8 @@
      <y>611</y>
     </hint>
     <hint type="destinationlabel">
-     <x>195</x>
-     <y>59</y>
+     <x>204</x>
+     <y>215</y>
     </hint>
    </hints>
   </connection>
@@ -1009,8 +870,8 @@
      <y>816</y>
     </hint>
     <hint type="destinationlabel">
-     <x>594</x>
-     <y>1529</y>
+     <x>504</x>
+     <y>1209</y>
     </hint>
    </hints>
   </connection>
@@ -1025,24 +886,8 @@
      <y>816</y>
     </hint>
     <hint type="destinationlabel">
-     <x>594</x>
-     <y>1484</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>TransformNodeSelector</sender>
-   <signal>currentNodeChanged(bool)</signal>
-   <receiver>ConvertCollapsibleButton</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>552</x>
-     <y>17</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>461</x>
-     <y>1512</y>
+     <x>504</x>
+     <y>1206</y>
     </hint>
    </hints>
   </connection>
@@ -1057,8 +902,24 @@
      <y>611</y>
     </hint>
     <hint type="destinationlabel">
-     <x>256</x>
-     <y>724</y>
+     <x>276</x>
+     <y>699</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerTransformsModuleWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>TransformNodeSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>125</x>
+     <y>179</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>142</x>
+     <y>148</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.h
+++ b/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.h
@@ -45,6 +45,8 @@ public:
   /// Reimplemented for internal reasons
   void setMRMLScene(vtkMRMLScene* scene) override;
 
+  void enter() override;
+  void exit() override;
   bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString()) override;
 
 public slots:
@@ -64,6 +66,10 @@ protected:
   void setup() override;
 
 protected slots:
+
+  /// Called when a subject hierarchy item is modified.
+  /// Updates current item selection to reflect changes in item (such as display node creation)
+  void onSubjectHierarchyItemModified(vtkObject* caller, void* callData);
 
   void onTranslateFirstButtonPressed(bool checked);
   void onNodeSelected(vtkMRMLNode* node);

--- a/Modules/Loadable/VolumeRendering/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/CMakeLists.txt
@@ -25,11 +25,14 @@ set(MODULE_INCLUDE_DIRECTORIES
   ${CMAKE_CURRENT_SOURCE_DIR}/SubjectHierarchyPlugins
   ${CMAKE_CURRENT_BINARY_DIR}/SubjectHierarchyPlugins
   ${qSlicerSubjectHierarchyModuleWidgets_INCLUDE_DIRS}
+  ${qSlicerMarkupsModuleWidgets_INCLUDE_DIRS}
   )
 
 set(MODULE_SRCS
   qSlicer${MODULE_NAME}Module.cxx
   qSlicer${MODULE_NAME}Module.h
+  qSlicer${MODULE_NAME}ModuleWidget.cxx
+  qSlicer${MODULE_NAME}ModuleWidget.h
   qSlicer${MODULE_NAME}Reader.cxx
   qSlicer${MODULE_NAME}Reader.h
   qSlicerShaderPropertyReader.cxx
@@ -40,12 +43,14 @@ set(MODULE_SRCS
 
 set(MODULE_MOC_SRCS
   qSlicer${MODULE_NAME}Module.h
+  qSlicer${MODULE_NAME}ModuleWidget.h
   qSlicer${MODULE_NAME}Reader.h
   qSlicerShaderPropertyReader.h
   qSlicer${MODULE_NAME}SettingsPanel.h
   )
 
 set(MODULE_UI_SRCS
+  Resources/UI/qSlicer${MODULE_NAME}ModuleWidget.ui
   Resources/UI/qSlicer${MODULE_NAME}SettingsPanel.ui
   )
 
@@ -55,6 +60,7 @@ set(MODULE_TARGET_LIBRARIES
   vtkSlicer${MODULE_NAME}ModuleMRMLDisplayableManager
   qSlicer${MODULE_NAME}ModuleWidgets
   qSlicer${MODULE_NAME}SubjectHierarchyPlugins
+  qSlicerMarkupsModuleWidgets
   )
 
 set(MODULE_RESOURCES

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
@@ -6,17 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>415</width>
-    <height>689</height>
+    <width>375</width>
+    <height>775</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Volume Rendering</string>
   </property>
-  <layout class="QFormLayout" name="formLayout_2">
-   <property name="fieldGrowthPolicy">
-    <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -29,57 +26,71 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="1" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <property name="leftMargin">
-      <number>6</number>
+   <item>
+    <widget class="ctkExpandableWidget" name="ResizableFrame_2">
+     <property name="orientations">
+      <set>Qt::Vertical</set>
      </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="ctkCheckBox" name="VisibilityCheckBox">
-       <property name="text">
-        <string>Volume:</string>
-       </property>
-       <property name="indicatorIcon">
-        <iconset resource="../../../../../Libs/MRML/Widgets/Resources/qMRMLWidgets.qrc">
-         <normaloff>:/Icons/VisibleOn.png</normaloff>
-         <normalon>:/Icons/VisibleOff.png</normalon>:/Icons/VisibleOn.png</iconset>
-       </property>
-       <property name="indicatorIconSize">
-        <size>
-         <width>21</width>
-         <height>21</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="1">
-    <widget class="qMRMLNodeComboBox" name="VolumeNodeComboBox">
-     <property name="nodeTypes">
-      <stringlist notr="true">
-       <string>vtkMRMLScalarVolumeNode</string>
-      </stringlist>
-     </property>
-     <property name="hideChildNodeTypes">
-      <stringlist notr="true">
-       <string>vtkMRMLDiffusionWeightedVolumeNode</string>
-       <string>vtkMRMLDiffusionTensorVolumeNode</string>
-       <string>vtkMRMLMultiVolumeNode</string>
-      </stringlist>
-     </property>
-     <property name="addEnabled">
+     <property name="sizeGripInside">
       <bool>false</bool>
      </property>
-     <property name="renameEnabled">
-      <bool>true</bool>
-     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_10">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="qMRMLSubjectHierarchyTreeView" name="VolumeNodeSelector">
+        <property name="dragDropMode">
+         <enum>QAbstractItemView::InternalMove</enum>
+        </property>
+        <property name="indentation">
+         <number>12</number>
+        </property>
+        <property name="editMenuActionVisible">
+         <bool>false</bool>
+        </property>
+        <property name="multiSelection">
+         <bool>true</bool>
+        </property>
+        <property name="nodeTypes">
+         <stringlist notr="true">
+          <string>vtkMRMLVolumeNode</string>
+         </stringlist>
+        </property>
+        <property name="idColumnVisible">
+         <bool>false</bool>
+        </property>
+        <property name="colorColumnVisible">
+         <bool>false</bool>
+        </property>
+        <property name="transformColumnVisible">
+         <bool>false</bool>
+        </property>
+        <property name="pluginAllowList">
+         <stringlist notr="true">
+          <string>Volumes</string>
+          <string>Folder</string>
+          <string>Visibility</string>
+         </stringlist>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
+   <item>
     <widget class="ctkCollapsibleButton" name="InputsCollapsibleButton">
      <property name="enabled">
       <bool>true</bool>
@@ -166,7 +177,7 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
+   <item>
     <widget class="ctkCollapsibleButton" name="DisplayCollapsibleButton">
      <property name="text">
       <string>Display</string>
@@ -190,7 +201,32 @@
       <property name="bottomMargin">
        <number>4</number>
       </property>
-      <item row="0" column="0" colspan="2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="CropLabel_2">
+        <property name="text">
+         <string>Visibility:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="ctkCheckBox" name="VisibilityCheckBox">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="indicatorIcon">
+         <iconset resource="../../../../../Libs/MRML/Widgets/Resources/qMRMLWidgets.qrc">
+          <normaloff>:/Icons/VisibleOn.png</normaloff>
+          <normalon>:/Icons/VisibleOff.png</normalon>:/Icons/VisibleOn.png</iconset>
+        </property>
+        <property name="indicatorIconSize">
+         <size>
+          <width>21</width>
+          <height>21</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
        <widget class="qSlicerVolumeRenderingPresetComboBox" name="PresetComboBox"/>
       </item>
       <item row="2" column="0">
@@ -364,7 +400,7 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item>
     <widget class="ctkCollapsibleButton" name="AdvancedCollapsibleButton">
      <property name="enabled">
       <bool>true</bool>
@@ -394,7 +430,7 @@
       <item>
        <widget class="QTabWidget" name="AdvancedTabWidget">
         <property name="currentIndex">
-         <number>0</number>
+         <number>1</number>
         </property>
         <widget class="QWidget" name="TechniquesTab">
          <attribute name="title">
@@ -598,9 +634,87 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>5</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>qMRMLCheckableNodeComboBox</class>
+   <extends>qMRMLNodeComboBox</extends>
+   <header>qMRMLCheckableNodeComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLClipNodeWidget</class>
+   <extends>qMRMLWidget</extends>
+   <header>qMRMLClipNodeWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLDisplayNodeViewComboBox</class>
+   <extends>qMRMLCheckableNodeComboBox</extends>
+   <header>qMRMLDisplayNodeViewComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLSliderWidget</class>
+   <extends>ctkSliderWidget</extends>
+   <header>qMRMLSliderWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerWidget</class>
+   <extends>QWidget</extends>
+   <header>qSlicerWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLMarkupsROIWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLMarkupsROIWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLSubjectHierarchyTreeView</class>
+   <extends>QTreeView</extends>
+   <header>qMRMLSubjectHierarchyTreeView.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLVolumePropertyNodeWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLVolumePropertyNodeWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerVolumeRenderingPresetComboBox</class>
+   <extends>qSlicerWidget</extends>
+   <header>qSlicerVolumeRenderingPresetComboBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerGPUMemoryComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qSlicerGPUMemoryComboBox.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>ctkCheckablePushButton</class>
    <extends>ctkPushButton</extends>
@@ -629,6 +743,12 @@
    <header>ctkExpandButton.h</header>
   </customwidget>
   <customwidget>
+   <class>ctkExpandableWidget</class>
+   <extends>QFrame</extends>
+   <header>ctkExpandableWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>ctkPushButton</class>
    <extends>QPushButton</extends>
    <header>ctkPushButton.h</header>
@@ -637,60 +757,6 @@
    <class>ctkSliderWidget</class>
    <extends>QWidget</extends>
    <header>ctkSliderWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLCheckableNodeComboBox</class>
-   <extends>qMRMLNodeComboBox</extends>
-   <header>qMRMLCheckableNodeComboBox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLClipNodeWidget</class>
-   <extends>QWidget</extends>
-   <header>qMRMLClipNodeWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLDisplayNodeViewComboBox</class>
-   <extends>qMRMLCheckableNodeComboBox</extends>
-   <header>qMRMLDisplayNodeViewComboBox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLNodeComboBox</class>
-   <extends>QWidget</extends>
-   <header>qMRMLNodeComboBox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLSliderWidget</class>
-   <extends>ctkSliderWidget</extends>
-   <header>qMRMLSliderWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qSlicerWidget</class>
-   <extends>QWidget</extends>
-   <header>qSlicerWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLMarkupsROIWidget</class>
-   <extends>QWidget</extends>
-   <header>qMRMLMarkupsROIWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLVolumePropertyNodeWidget</class>
-   <extends>QWidget</extends>
-   <header>qMRMLVolumePropertyNodeWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qSlicerVolumeRenderingPresetComboBox</class>
-   <extends>qSlicerWidget</extends>
-   <header>qSlicerVolumeRenderingPresetComboBox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>qSlicerGPUMemoryComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qSlicerGPUMemoryComboBox.h</header>
-   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>
@@ -705,12 +771,12 @@
    <slot>setMRMLVolumePropertyNode(vtkMRMLNode*)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>446</x>
-     <y>66</y>
+     <x>410</x>
+     <y>92</y>
     </hint>
     <hint type="destinationlabel">
-     <x>105</x>
-     <y>305</y>
+     <x>111</x>
+     <y>674</y>
     </hint>
    </hints>
   </connection>
@@ -721,28 +787,12 @@
    <slot>setMRMLMarkupsNode(vtkMRMLNode*)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>446</x>
-     <y>63</y>
+     <x>410</x>
+     <y>87</y>
     </hint>
     <hint type="destinationlabel">
-     <x>96</x>
-     <y>296</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>VolumeNodeComboBox</sender>
-   <signal>currentNodeChanged(bool)</signal>
-   <receiver>InputsCollapsibleButton</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>154</x>
-     <y>18</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>307</x>
-     <y>64</y>
+     <x>102</x>
+     <y>557</y>
     </hint>
    </hints>
   </connection>
@@ -757,8 +807,8 @@
      <y>260</y>
     </hint>
     <hint type="destinationlabel">
-     <x>446</x>
-     <y>69</y>
+     <x>410</x>
+     <y>97</y>
     </hint>
    </hints>
   </connection>
@@ -773,8 +823,8 @@
      <y>228</y>
     </hint>
     <hint type="destinationlabel">
-     <x>446</x>
-     <y>63</y>
+     <x>410</x>
+     <y>87</y>
     </hint>
    </hints>
   </connection>
@@ -789,56 +839,8 @@
      <y>227</y>
     </hint>
     <hint type="destinationlabel">
-     <x>446</x>
-     <y>66</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>qSlicerVolumeRenderingModuleWidget</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>VolumeNodeComboBox</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>332</x>
-     <y>228</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>332</x>
-     <y>19</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>VolumeNodeComboBox</sender>
-   <signal>currentNodeChanged(bool)</signal>
-   <receiver>AdvancedCollapsibleButton</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>233</x>
-     <y>13</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>240</x>
-     <y>526</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>VolumeNodeComboBox</sender>
-   <signal>currentNodeChanged(bool)</signal>
-   <receiver>ROICropCheckBox</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>268</x>
-     <y>15</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>188</x>
-     <y>185</y>
+     <x>410</x>
+     <y>92</y>
     </hint>
    </hints>
   </connection>
@@ -849,12 +851,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>446</x>
-     <y>66</y>
+     <x>410</x>
+     <y>92</y>
     </hint>
     <hint type="destinationlabel">
-     <x>105</x>
-     <y>305</y>
+     <x>111</x>
+     <y>674</y>
     </hint>
    </hints>
   </connection>
@@ -865,28 +867,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>81</x>
-     <y>66</y>
+     <x>136</x>
+     <y>92</y>
     </hint>
     <hint type="destinationlabel">
-     <x>24</x>
-     <y>125</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>VolumeNodeComboBox</sender>
-   <signal>currentNodeChanged(bool)</signal>
-   <receiver>ROICropDisplayCheckBox</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>268</x>
-     <y>15</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>319</x>
-     <y>187</y>
+     <x>28</x>
+     <y>202</y>
     </hint>
    </hints>
   </connection>
@@ -897,28 +883,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>446</x>
-     <y>63</y>
+     <x>410</x>
+     <y>87</y>
     </hint>
     <hint type="destinationlabel">
-     <x>450</x>
-     <y>189</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>VolumeNodeComboBox</sender>
-   <signal>currentNodeChanged(bool)</signal>
-   <receiver>VisibilityCheckBox</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>109</x>
-     <y>11</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>37</x>
-     <y>18</y>
+     <x>409</x>
+     <y>235</y>
     </hint>
    </hints>
   </connection>
@@ -929,12 +899,12 @@
    <slot>setChecked(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>105</x>
-     <y>305</y>
+     <x>112</x>
+     <y>379</y>
     </hint>
     <hint type="destinationlabel">
-     <x>105</x>
-     <y>305</y>
+     <x>112</x>
+     <y>379</y>
     </hint>
    </hints>
   </connection>
@@ -945,12 +915,12 @@
    <slot>setVisible(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>105</x>
-     <y>305</y>
+     <x>407</x>
+     <y>379</y>
     </hint>
     <hint type="destinationlabel">
-     <x>105</x>
-     <y>305</y>
+     <x>313</x>
+     <y>376</y>
     </hint>
    </hints>
   </connection>
@@ -965,8 +935,8 @@
      <y>444</y>
     </hint>
     <hint type="destinationlabel">
-     <x>259</x>
-     <y>252</y>
+     <x>337</x>
+     <y>287</y>
     </hint>
    </hints>
   </connection>
@@ -981,8 +951,24 @@
      <y>444</y>
     </hint>
     <hint type="destinationlabel">
-     <x>227</x>
-     <y>409</y>
+     <x>242</x>
+     <y>295</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerVolumeRenderingModuleWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>VolumeNodeSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>1</x>
+     <y>300</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>133</x>
+     <y>18</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/VolumeRendering/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/Widgets/CMakeLists.txt
@@ -19,8 +19,6 @@ set(${KIT}_SRCS
   qSlicerPresetComboBox.cxx
   qSlicerPresetComboBox.h
   qSlicerPresetComboBox_p.h
-  qSlicer${MODULE_NAME}ModuleWidget.cxx
-  qSlicer${MODULE_NAME}ModuleWidget.h
   qSlicer${MODULE_NAME}PropertiesWidget.cxx
   qSlicer${MODULE_NAME}PropertiesWidget.h
   qSlicer${MODULE_NAME}PresetComboBox.cxx
@@ -37,7 +35,6 @@ set(${KIT}_MOC_SRCS
   qSlicerMulti${MODULE_NAME}PropertiesWidget.h
   qSlicerPresetComboBox.h
   qSlicerPresetComboBox_p.h
-  qSlicer${MODULE_NAME}ModuleWidget.h
   qSlicer${MODULE_NAME}PropertiesWidget.h
   qSlicer${MODULE_NAME}PresetComboBox.h
   qMRMLVolumePropertyNodeWidget.h
@@ -49,7 +46,6 @@ set(${KIT}_UI_SRCS
   ../Resources/UI/qSlicerCPURayCast${MODULE_NAME}PropertiesWidget.ui
   ../Resources/UI/qSlicerGPURayCast${MODULE_NAME}PropertiesWidget.ui
   ../Resources/UI/qSlicerMulti${MODULE_NAME}PropertiesWidget.ui
-  ../Resources/UI/qSlicer${MODULE_NAME}ModuleWidget.ui
   ../Resources/UI/qSlicer${MODULE_NAME}PresetComboBox.ui
   )
 
@@ -59,7 +55,6 @@ set(${KIT}_RESOURCES
 set(${KIT}_TARGET_LIBRARIES
   vtkSlicer${MODULE_NAME}ModuleLogic
   vtkSlicer${MODULE_NAME}ModuleMRML
-  qSlicerMarkupsModuleWidgets
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.cxx
@@ -90,7 +90,7 @@ void qSlicerVolumeRenderingModuleWidgetPrivate::setupUi(qSlicerVolumeRenderingMo
 {
   this->Ui_qSlicerVolumeRenderingModuleWidget::setupUi(q);
 
-  QObject::connect(this->VolumeNodeComboBox, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
+  QObject::connect(this->VolumeNodeSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
                    q, SLOT(onCurrentMRMLVolumeNodeChanged(vtkMRMLNode*)));
   // Inputs
   QObject::connect(this->VisibilityCheckBox, SIGNAL(toggled(bool)),
@@ -188,7 +188,7 @@ void qSlicerVolumeRenderingModuleWidgetPrivate::setupUi(qSlicerVolumeRenderingMo
 
   // Default values
   this->InputsCollapsibleButton->setCollapsed(true);
-  this->InputsCollapsibleButton->setEnabled(false);;
+  this->InputsCollapsibleButton->setEnabled(false);
   this->AdvancedCollapsibleButton->setCollapsed(true);
   this->AdvancedCollapsibleButton->setEnabled(false);
 
@@ -285,14 +285,14 @@ void qSlicerVolumeRenderingModuleWidget::setup()
 vtkMRMLVolumeNode* qSlicerVolumeRenderingModuleWidget::mrmlVolumeNode()const
 {
   Q_D(const qSlicerVolumeRenderingModuleWidget);
-  return vtkMRMLVolumeNode::SafeDownCast(d->VolumeNodeComboBox->currentNode());
+  return vtkMRMLVolumeNode::SafeDownCast(d->VolumeNodeSelector->currentNode());
 }
 
 // --------------------------------------------------------------------------
 void qSlicerVolumeRenderingModuleWidget::setMRMLVolumeNode(vtkMRMLNode* volumeNode)
 {
   Q_D(qSlicerVolumeRenderingModuleWidget);
-  d->VolumeNodeComboBox->setCurrentNode(volumeNode);
+  d->VolumeNodeSelector->setCurrentNode(volumeNode);
 }
 
 // --------------------------------------------------------------------------
@@ -385,6 +385,7 @@ void qSlicerVolumeRenderingModuleWidget::updateWidgetFromMRML()
   d->VisibilityCheckBox->setChecked(displayNode ? displayNode->GetVisibility() : false);
 
   // Input section
+  d->InputsCollapsibleButton->setEnabled(displayNode != nullptr);
 
   // Volume property selector
   // Update shift slider range and set transfer function extents when volume property node is modified
@@ -683,7 +684,7 @@ void qSlicerVolumeRenderingModuleWidget::onCurrentRenderingMethodChanged(int ind
   volumeRenderingLogic->ChangeVolumeRenderingMethod(renderingClassName.toUtf8());
 
   // Perform necessary setup steps for the new display node for the current volume
-  this->onCurrentMRMLVolumeNodeChanged(d->VolumeNodeComboBox->currentNode());
+  this->onCurrentMRMLVolumeNodeChanged(d->VolumeNodeSelector->currentNode());
 }
 
 // --------------------------------------------------------------------------
@@ -900,7 +901,7 @@ bool qSlicerVolumeRenderingModuleWidget::setEditedNode(vtkMRMLNode* node,
     {
       return false;
     }
-    d->VolumeNodeComboBox->setCurrentNode(displayableNode);
+    d->VolumeNodeSelector->setCurrentNode(displayableNode);
     return true;
   }
 
@@ -931,7 +932,7 @@ bool qSlicerVolumeRenderingModuleWidget::setEditedNode(vtkMRMLNode* node,
       {
         return false;
       }
-      d->VolumeNodeComboBox->setCurrentNode(displayableNode);
+      d->VolumeNodeSelector->setCurrentNode(displayableNode);
       return true;
     }
   }
@@ -955,7 +956,7 @@ bool qSlicerVolumeRenderingModuleWidget::setEditedNode(vtkMRMLNode* node,
     {
       return false;
     }
-    d->VolumeNodeComboBox->setCurrentNode(displayableNode);
+    d->VolumeNodeSelector->setCurrentNode(displayableNode);
     return true;
   }
 

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.h
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.h
@@ -26,7 +26,7 @@
 
 // Slicer includes
 #include "qSlicerAbstractModuleWidget.h"
-#include "qSlicerVolumeRenderingModuleWidgetsExport.h"
+#include "qSlicerVolumeRenderingModuleExport.h"
 
 class qSlicerVolumeRenderingPropertiesWidget;
 class qSlicerVolumeRenderingModuleWidgetPrivate;
@@ -38,7 +38,7 @@ class vtkMRMLVolumeNode;
 class vtkMRMLVolumePropertyNode;
 class vtkMRMLVolumeRenderingDisplayNode;
 
-class Q_SLICER_MODULE_VOLUMERENDERING_WIDGETS_EXPORT qSlicerVolumeRenderingModuleWidget :
+class Q_SLICER_QTMODULES_VOLUMERENDERING_EXPORT qSlicerVolumeRenderingModuleWidget :
   public qSlicerAbstractModuleWidget
 {
   Q_OBJECT

--- a/Modules/Loadable/Volumes/Resources/UI/qSlicerVolumesModuleWidget.ui
+++ b/Modules/Loadable/Volumes/Resources/UI/qSlicerVolumesModuleWidget.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>247</width>
-    <height>288</height>
+    <width>417</width>
+    <height>552</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -34,30 +34,68 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="ActiveVolumeLabel">
-       <property name="text">
-        <string> Volume: </string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="qMRMLNodeComboBox" name="ActiveVolumeNodeSelector">
-       <property name="nodeTypes">
-        <stringlist notr="true">
-         <string>vtkMRMLVolumeNode</string>
-        </stringlist>
-       </property>
-       <property name="addEnabled">
-        <bool>false</bool>
-       </property>
-       <property name="renameEnabled">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="ctkExpandableWidget" name="ResizableFrame_2">
+     <property name="orientations">
+      <set>Qt::Vertical</set>
+     </property>
+     <property name="sizeGripInside">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_10">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="qMRMLSubjectHierarchyTreeView" name="ActiveVolumeNodeSelector">
+        <property name="dragDropMode">
+         <enum>QAbstractItemView::InternalMove</enum>
+        </property>
+        <property name="indentation">
+         <number>12</number>
+        </property>
+        <property name="editMenuActionVisible">
+         <bool>false</bool>
+        </property>
+        <property name="multiSelection">
+         <bool>true</bool>
+        </property>
+        <property name="nodeTypes">
+         <stringlist notr="true">
+          <string>vtkMRMLVolumeNode</string>
+         </stringlist>
+        </property>
+        <property name="idColumnVisible">
+         <bool>false</bool>
+        </property>
+        <property name="colorColumnVisible">
+         <bool>false</bool>
+        </property>
+        <property name="transformColumnVisible">
+         <bool>false</bool>
+        </property>
+        <property name="pluginAllowList">
+         <stringlist notr="true">
+          <string>Volumes</string>
+          <string>Folder</string>
+          <string>Visibility</string>
+         </stringlist>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="ctkCollapsibleButton" name="InfoCollapsibleButton">
@@ -232,6 +270,11 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>qMRMLSubjectHierarchyTreeView</class>
+   <extends>QTreeView</extends>
+   <header>qMRMLSubjectHierarchyTreeView.h</header>
+  </customwidget>
+  <customwidget>
    <class>qSlicerVolumeDisplayWidget</class>
    <extends>qMRMLWidget</extends>
    <header>qSlicerVolumeDisplayWidget.h</header>
@@ -240,6 +283,12 @@
    <class>ctkCollapsibleButton</class>
    <extends>QWidget</extends>
    <header>ctkCollapsibleButton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkExpandableWidget</class>
+   <extends>QFrame</extends>
+   <header>ctkExpandableWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -258,24 +307,8 @@
      <y>78</y>
     </hint>
     <hint type="destinationlabel">
-     <x>118</x>
-     <y>76</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>qSlicerVolumesModuleWidget</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>ActiveVolumeNodeSelector</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>1</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>230</x>
-     <y>19</y>
+     <x>127</x>
+     <y>262</y>
     </hint>
    </hints>
   </connection>
@@ -287,11 +320,11 @@
    <hints>
     <hint type="sourcelabel">
      <x>97</x>
-     <y>568</y>
+     <y>551</y>
     </hint>
     <hint type="destinationlabel">
-     <x>179</x>
-     <y>499</y>
+     <x>171</x>
+     <y>262</y>
     </hint>
    </hints>
   </connection>
@@ -306,8 +339,24 @@
      <y>413</y>
     </hint>
     <hint type="destinationlabel">
-     <x>209</x>
-     <y>150</y>
+     <x>218</x>
+     <y>354</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerVolumesModuleWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>ActiveVolumeNodeSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>182</x>
+     <y>513</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>128</x>
+     <y>144</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
As described in https://github.com/Slicer/Slicer/issues/7533, to make it easier for users to select and show a segmentation (and hide others) the node combobox is now replaced by a subject hierarchy tree. For consistency between all top-level modules, this commit makes the same change for Transforms, Volumes, and Volume Rendering modules.

**Segmentations module:**

![image](https://github.com/user-attachments/assets/7d3bf372-6f32-4ebe-850f-f387ecc24d65)

**Volumes module:**

![image](https://github.com/user-attachments/assets/ef526ded-dbc8-4dd3-b67e-45aee293c4a2)

**Volume Rendering module:**

![image](https://github.com/user-attachments/assets/826d0d78-8bba-4e7f-901f-71bbb6d81cda)

**Transforms module:**

![image](https://github.com/user-attachments/assets/8b5bb3be-e8e5-4497-baf5-9e317dc3cd21)

New transform and segmentation nodes can be created by right-clicking on the empty area in the tree:

![image](https://github.com/user-attachments/assets/325a5577-4504-489b-ae57-e20b85620ba4)
