### PR TITLE
BUG: Ensure background SeriesTime corner annotation is displayed

### DIFF
--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -70,7 +70,7 @@ class SliceAnnotations(VTKObservationMixin):
             "4-Bg-SeriesDate": {"text": "", "category": "B"},
             "5-Fg-SeriesDate": {"text": "", "category": "B"},
             "6-Bg-SeriesTime": {"text": "", "category": "C"},
-            "7-Bg-SeriesTime": {"text": "", "category": "C"},
+            "7-Fg-SeriesTime": {"text": "", "category": "C"},
             "8-Bg-SeriesDescription": {"text": "", "category": "C"},
             "9-Fg-SeriesDescription": {"text": "", "category": "C"},
         })


### PR DESCRIPTION
Fix an issue originally introduced in 169df52840 ("ENH: Fix 3943 and other enhancements for slice view annotations", 2015-02-24)