### PR TITLE
ENH: Adds loadSuccess flag to loadable Qt and VTK DICOM classes

### DIFF
--- a/Modules/Scripted/DICOMLib/Logic/vtkSlicerDICOMLoadable.cxx
+++ b/Modules/Scripted/DICOMLib/Logic/vtkSlicerDICOMLoadable.cxx
@@ -40,6 +40,7 @@ vtkSlicerDICOMLoadable::vtkSlicerDICOMLoadable()
   this->Warning = nullptr;
   this->Selected = false;
   this->Confidence = 0.5;
+  this->LoadSuccess = false;
 
   this->Files = nullptr;
   vtkSmartPointer<vtkStringArray> files = vtkSmartPointer<vtkStringArray>::New();
@@ -76,6 +77,7 @@ void vtkSlicerDICOMLoadable::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "Selected:   " << (this->Selected?"true":"false") << "\n";
   os << indent << "Confidence:   " << this->Confidence << "\n";
   os << indent << "ReferencedInstanceUIDs:   " << (this->ReferencedInstanceUIDs?"":"NULL") << "\n";
+  os << indent << "LoadSuccess:   " << (this->LoadSuccess?"true":"false") << "\n";
   if (this->ReferencedInstanceUIDs)
   {
     for (int fileIndex=0; fileIndex<this->ReferencedInstanceUIDs->GetNumberOfValues(); ++fileIndex)

--- a/Modules/Scripted/DICOMLib/Logic/vtkSlicerDICOMLoadable.h
+++ b/Modules/Scripted/DICOMLib/Logic/vtkSlicerDICOMLoadable.h
@@ -53,6 +53,10 @@ public:
   vtkSetMacro(Selected, bool);
   vtkBooleanMacro(Selected, bool);
 
+  vtkGetMacro(LoadSuccess, bool);
+  vtkSetMacro(LoadSuccess, bool);
+  vtkBooleanMacro(LoadSuccess, bool);
+
   vtkGetMacro(Confidence, double);
   vtkSetMacro(Confidence, double);
 
@@ -102,6 +106,9 @@ protected:
 
   /// List of UIDs for the DICOM instances that are referenced by this loadable
   vtkStringArray* ReferencedInstanceUIDs;
+
+  /// Flag shows that load was successful
+  bool LoadSuccess;
 };
 
 #endif

--- a/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMLoadable.cxx
+++ b/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMLoadable.cxx
@@ -55,6 +55,8 @@ public:
   double Confidence;
   /// List of UIDs for the DICOM instances that are referenced by this loadable
   QStringList ReferencedInstanceUIDs;
+  /// Flag shows that object loaded successfully
+  bool LoadSuccess;
 };
 
 //-----------------------------------------------------------------------------
@@ -68,6 +70,7 @@ qSlicerDICOMLoadablePrivate::qSlicerDICOMLoadablePrivate()
   this->Warning = QString("");
   this->Selected = false;
   this->Confidence = 0.5;
+  this->LoadSuccess = false;
 }
 
 //-----------------------------------------------------------------------------
@@ -108,6 +111,10 @@ CTK_SET_CPP(qSlicerDICOMLoadable, const bool, setSelected, Selected)
 CTK_GET_CPP(qSlicerDICOMLoadable, bool, selected, Selected)
 
 //-----------------------------------------------------------------------------
+CTK_SET_CPP(qSlicerDICOMLoadable, const bool, setLoadSuccess, LoadSuccess)
+CTK_GET_CPP(qSlicerDICOMLoadable, bool, loadSuccess, LoadSuccess)
+
+//-----------------------------------------------------------------------------
 CTK_SET_CPP(qSlicerDICOMLoadable, const double, setConfidence, Confidence)
 CTK_GET_CPP(qSlicerDICOMLoadable, double, confidence, Confidence)
 
@@ -130,6 +137,7 @@ void qSlicerDICOMLoadable::copyToVtkLoadable(vtkSlicerDICOMLoadable* vtkLoadable
   vtkLoadable->SetWarning(d->Warning.toUtf8().constData());
   vtkLoadable->SetSelected(d->Selected);
   vtkLoadable->SetConfidence(d->Confidence);
+  vtkLoadable->SetLoadSuccess(d->LoadSuccess);
 
   foreach(QString file, d->Files)
   {
@@ -157,6 +165,7 @@ void qSlicerDICOMLoadable::copyFromVtkLoadable(vtkSlicerDICOMLoadable* vtkLoadab
   d->Warning = QString(vtkLoadable->GetWarning());
   d->Selected = vtkLoadable->GetSelected();
   d->Confidence = vtkLoadable->GetConfidence();
+  d->LoadSuccess = vtkLoadable->GetLoadSuccess();
 
   vtkStringArray* filesArray = vtkLoadable->GetFiles();
   if (filesArray)

--- a/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMLoadable.h
+++ b/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMLoadable.h
@@ -51,6 +51,8 @@ class Q_SLICER_MODULE_DICOMLIB_WIDGETS_EXPORT qSlicerDICOMLoadable : public QObj
   Q_PROPERTY(QStringList files READ files WRITE setFiles)
   /// Is the object checked for loading by default
   Q_PROPERTY(bool selected READ selected WRITE setSelected)
+  /// Is the object loaded successfully
+  Q_PROPERTY(bool loadSuccess READ loadSuccess WRITE setLoadSuccess)
   /// Confidence - from 0 to 1 where 0 means low chance
   /// that the user actually wants to load their data this
   /// way up to 1, which means that the plugin is very confident
@@ -85,6 +87,9 @@ public:
 
   virtual double confidence()const;
   void setConfidence(const double newConfidence);
+
+  virtual bool loadSuccess()const;
+  void setLoadSuccess(const bool newLoadSuccess);
 
   virtual QStringList referencedInstanceUIDs()const;
   void setReferencedInstanceUIDs(const QStringList& newReferencedInstanceUIDs);


### PR DESCRIPTION
SlicerRT is unable to load DICOM-RT files successfully without it.