### PR TITLE
ENH: Add GitHub workflow to trigger Doxygen build and publish

### DIFF
--- a/.github/workflows/trigger-doxygen-build-and-publish.yml
+++ b/.github/workflows/trigger-doxygen-build-and-publish.yml
@@ -1,0 +1,88 @@
+name: Trigger Doxygen Build and Publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+
+  # Allows running this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      slicer_repository:
+        description: "Slicer Repository for which to build and publish the documentation"
+        default: Slicer/Slicer
+      slicer_ref:
+        description: "Slicer Branch or tag for which to build and publish the documentation"
+        default: main
+      preview:
+        description: "Publish at https://preview.apidocs.slicer.org"
+        default: false
+        type: boolean
+
+permissions:
+  # Needed to trigger workflow run
+  actions: write
+
+jobs:
+  doxygen-build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Collect Inputs
+        id: collect_inputs
+        run: |
+          echo "EVENT_NAME [$EVENT_NAME]"
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            slicer_repository=${{ github.repository }}
+
+            github_ref=${{ github.ref }}
+            echo "github_ref [$github_ref]"
+            # Strip 'refs/heads/' or 'refs/tags/' from the start of the string
+            slicer_ref="${github_ref#refs/heads/}"
+            slicer_ref="${slicer_ref#refs/tags/}"
+
+            preview="false"
+
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            slicer_repository=${{ github.event.inputs.slicer_repository }}
+            slicer_ref=${{ github.event.inputs.ref }}
+            preview=${{ github.event.inputs.preview }}
+
+          else
+            echo "::error ::Unsupported EVENT_NAME [$EVENT_NAME]"
+            exit 1
+          fi
+
+          echo "slicer_repository [$slicer_repository]"
+          echo "slicer_repository=$slicer_repository" >> $GITHUB_OUTPUT
+
+          echo "slicer_ref [$slicer_ref]"
+          echo "slicer_ref=$slicer_ref" >> $GITHUB_OUTPUT
+
+          echo "preview [$preview]"
+          echo "preview=$preview" >> $GITHUB_OUTPUT
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+
+      - uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
+        id: app-token
+        with:
+          app-id: ${{ vars.SLICER_APP_ID }}
+          private-key: ${{ secrets.SLICER_APP_PRIVATE_KEY }}
+          owner: Slicer
+          repositories: |
+            apidocs.slicer.org
+
+      - name: Trigger Workflow
+        run: |
+          gh workflow run doxygen-build-and-publish.yml \
+                      -f slicer_repository=$SLICER_REPOSITORY \
+                      -f slicer_ref=$SLICER_REF \
+                      -f preview=$PREVIEW \
+                      --repo "Slicer/apidocs.slicer.org"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SLICER_REPOSITORY: ${{ steps.collect_inputs.outputs.slicer_repository }}
+          SLICER_REF: ${{ steps.collect_inputs.outputs.slicer_ref }}
+          PREVIEW: ${{ steps.collect_inputs.outputs.preview }}


### PR DESCRIPTION
This commit introduces the `trigger-doxygen-build-and-publish.yml` workflow, which triggers the `doxygen-build-and-publish.yml` workflow maintained in the `Slicer/apidocs.slicer.org` repository. The trigger occurs whenever the `main` branch is updated or a new tag is pushed, resulting in the build and publication of the corresponding Doxygen documentation at https://apidocs.slicer.org.

For security reasons, this workflow is not triggered by the `pull_request` event. This restriction prevents untrusted code from exploiting short-lived tokens with elevated permissions. The workflow internally configures a dummy CMake project that includes the `Utilities/Doxygen` sub-directory, which could otherwise expose sensitive information if executed with arbitrary code.

---

### Testing

| Use case | `trigger-doxygen-build-and-publish.yml` | Commit status | `doxygen-build-and-publish.yml` |
|--|--|--|--|
| `main` branch pushed | ![image](https://github.com/user-attachments/assets/17a77435-0681-4db0-a549-702d1c434927) | ![image](https://github.com/user-attachments/assets/9d6624b4-5acd-4d5b-be9d-27518d52d59e) ![image](https://github.com/user-attachments/assets/04b0e20f-f189-44c1-bcb5-34005b8a48fc) | ![image](https://github.com/user-attachments/assets/2701072f-41ac-4d54-a9ae-a0c77fbd44ff) |
| tag pushed | ![image](https://github.com/user-attachments/assets/a4a06701-9e46-44dc-8f2d-331c05602d30) | ![image](https://github.com/user-attachments/assets/84c79a19-8f8e-4fe6-977d-4aa4e9628bcd) | ![image](https://github.com/user-attachments/assets/456d9dc8-6803-4968-aad1-8e5a546e13f6) |





References:
* https://github.com/Slicer/Slicer-CI-Testing/actions/workflows/trigger-doxygen-build-and-publish.yml
* https://github.com/Slicer/apidocs.slicer.org/actions/workflows/doxygen-build-and-publish.yml


![image](https://github.com/user-attachments/assets/9f758a4f-db81-49d0-ab86-7285a39904d5)


![image](https://github.com/user-attachments/assets/b9bba80a-264c-46b9-b5e7-e7df1275025e)



