### PR TITLE
ENH: Update SlicerSurfaceToolbox to include dynamic modeler extrude tool

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -338,7 +338,7 @@ list_conditional_append(Slicer_BUILD_LandmarkRegistration Slicer_REMOTE_DEPENDEN
 
 Slicer_Remote_Add(SurfaceToolbox
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/SlicerSurfaceToolbox"
-  GIT_TAG 09d5bf61655c1f276541797f6d2593a61eabf98d
+  GIT_TAG e8b8f70930883adb6f4a227ad9d7339d20120f2c
   OPTION_NAME Slicer_BUILD_SurfaceToolbox
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
This commit updates the version of SlicerSurfaceToolbox to include:

* A new Dynamic Modeler Extrude tool.
* A fix for uniform remeshing, addressing installation issues with specific `pyacvd` versions.

Certain versions of `pyacvd` (prior to 0.3.1) required OpenCV, which caused compatibility issues on systems without OpenCV binaries installed. To ensure smooth operation, the updated SurfaceToolbox now installs a compatible `pyacvd` version if (1) The package is missing, or (2) OpenCV dependencies are unavailable. For further details, see https://discourse.slicer.org/t/surface-toolbox-of-3d-slicer-do-not-work-in-windows/40717/4

List of SlicerSurfaceToolbox changes:

```
$ git shortlog 09d5bf6..e8b8f70 --no-merges
Andras Lasso (1):
      Add Extrude tool to dynamic modeler

Mauro I. Dominguez (2):
      BUG: fix uniform remesh not working
      Add option to specify absolute extrusion length
```

Fixes #8073