### PR TITLE
COMP: Fix manual trigger of Doxygen build and publish through GitHub UI

### DIFF
--- a/.github/workflows/trigger-doxygen-build-and-publish.yml
+++ b/.github/workflows/trigger-doxygen-build-and-publish.yml
@@ -46,7 +46,7 @@ jobs:
 
           elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             slicer_repository=${{ github.event.inputs.slicer_repository }}
-            slicer_ref=${{ github.event.inputs.ref }}
+            slicer_ref=${{ github.event.inputs.slicer_ref }}
             preview=${{ github.event.inputs.preview }}
 
           else


### PR DESCRIPTION
Follow-up of commit e6b2ab6265d ("ENH: Add GitHub workflow to trigger Doxygen build and publish", 2025-01-17).