### PR TITLE
COMP: Include runtime libraries to ensure compatibility in SlicerExecutionModel

### DIFF
--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -85,7 +85,7 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "0e28e41aa167b477bc4889725ca08157c152e584"
+    "91b921bd5977c3384916ba4b03705d87b26067f7"
     QUIET
     )
 


### PR DESCRIPTION
This update resolves a termination fault that occurs when running the CLI executable built with a newer MSVC runtime on systems with older runtime libraries.

By explicitly including the runtime libraries, compatibility is ensured, avoiding reliance on the system's default runtime version.

List of SlicerExecutionModel changes:

```
$ git shortlog 0e28e41aa..91b921bd5 --no-merges
James Butler (1):
      COMP: Include system runtime libraries
```