### PR TITLE
COMP: Remove explicit dependency of MarkupsROINode on JSON storage node

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.cxx
@@ -20,7 +20,6 @@
 
 // Markups MRML includes
 #include <vtkMRMLMarkupsROIDisplayNode.h>
-#include <vtkMRMLMarkupsROIJsonStorageNode.h>
 #include "vtkMRMLMarkupsROINode.h"
 #include "vtkMRMLMeasurementVolume.h"
 


### PR DESCRIPTION
Anticipating the relocation of Markups nodes into `Libs/MRML/Core`, this commit removes the include of `vtkMRMLMarkupsROIJsonStorageNode.h` from `vtkMRMLMarkupsROINode.cxx`.

This is consistent with how `vtkMRMLMarkupsPlaneNode` and `vtkMRMLMarkupsNode` are implemented.