### PR TITLE
COMP: Add support for codespell 2.4.0 and fix identified typos

### DIFF
--- a/Base/Logic/vtkDataIOManagerLogic.cxx
+++ b/Base/Logic/vtkDataIOManagerLogic.cxx
@@ -354,7 +354,7 @@ int vtkDataIOManagerLogic::QueueRead ( vtkMRMLNode *node )
        ( !(cm->GetEnableForceRedownload())) )
   {
     dnode->GetNthStorageNode(storageNodeIndex)->SetReadStateTransferDone();
-    vtkDebugMacro("QueueRead: the destination file is there and we're not forceing redownload");
+    vtkDebugMacro("QueueRead: the destination file is there and we're not forcing redownload");
     return 1;
   }
 

--- a/Libs/MRML/Core/vtkMRMLColorTableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableNode.cxx
@@ -1401,13 +1401,13 @@ int vtkMRMLColorTableNode::SetColors(int firstEntry, int lastEntry, const char *
   // Setting color values using the pointer returned by WritePointer()
   // works similarly to vtkLookupTable::SetTableValue().
   unsigned char* rgba = lut->WritePointer(firstEntry, lastEntry - firstEntry + 1);
-  for (int indx = firstEntry; indx <= lastEntry; indx++)
+  for (int index = firstEntry; index <= lastEntry; index++)
   {
     *(rgba++) = static_cast<unsigned char>(r * 255.0 + 0.5);
     *(rgba++) = static_cast<unsigned char>(g * 255.0 + 0.5);
     *(rgba++) = static_cast<unsigned char>(b * 255.0 + 0.5);
     *(rgba++) = static_cast<unsigned char>(a * 255.0 + 0.5);
-    this->Names[indx] = nameStr;
+    this->Names[index] = nameStr;
   }
   lut->BuildSpecialColors();
   lut->Modified();

--- a/Libs/vtkTeem/vtkTeemNRRDReader.cxx
+++ b/Libs/vtkTeem/vtkTeemNRRDReader.cxx
@@ -982,7 +982,7 @@ void vtkTeemNRRDReader::ExecuteDataWithInformation(vtkDataObject *output, vtkInf
       axmap[axi] = axi - (axi <= rangeAxisIdx[0]);
     }
     // The memory size of the input and output of nrrdAxesPermute is
-    // the same; the existing this->nrrd->data is re-used.
+    // the same; the existing this->nrrd->data is reused.
     if (nrrdCopy(ntmp, this->nrrd)
       || nrrdAxesPermute(this->nrrd, ntmp, axmap))
     {

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
@@ -52,7 +52,7 @@ class qSlicerAbstractModuleWidget;
 
 /// \brief Qt widget for editing a segment from a segmentation using Editor effects.
 ///
-/// Widget for editing segmentations that can be re-used in any module.
+/// Widget for editing segmentations that can be reused in any module.
 ///
 /// IMPORTANT: The embedding module is responsible for setting the MRML scene and the
 ///   management of the \sa vtkMRMLSegmentEditorNode parameter set node.

--- a/SuperBuild/External_OpenSSL.cmake
+++ b/SuperBuild/External_OpenSSL.cmake
@@ -213,7 +213,7 @@ ExternalProject_Execute(${proj} \"build\" make \${jflag} build_libs)
     # libraries.
     #
     # We found out that '/MD' was used by inspecting the the file 'ms/ntdll.mak'
-    # generated atfer configuring OpenSSL.
+    # generated after configuring OpenSSL.
     #
     # If you find mistake in this explanation, do not hesitate to submit a patch
     # to fix this text. Thanks.


### PR DESCRIPTION
Fix typos flagged by the `codespell.yml` workflow, which uses the `codespell-project/actions-codespell` GitHub action. This action does not pin the version of `codespell`, and a new release (2.4.0) introduced changes requiring updates to the workflow and typo fixes.

See https://github.com/codespell-project/codespell/releases/tag/v2.4.0