### PR TITLE
BUG: Suppress "Populating font family aliases" warning on macOS

### DIFF
--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -22,7 +22,11 @@
 
 // Qt includes
 #include <QFont>
+#include <QtGlobal> // For Q_OS_*, QT_VERSION
 #include <QLabel>
+#if defined(Q_OS_MACOS) && (QT_VERSION < QT_VERSION_CHECK(5, 15, 10))
+# include <QLoggingCategory>
+#endif
 #include <QSettings>
 #include <QSysInfo>
 #include <QThread>
@@ -89,6 +93,11 @@ qSlicerApplicationHelper::~qSlicerApplicationHelper() = default;
 void qSlicerApplicationHelper::preInitializeApplication(
     const char* argv0, ctkProxyStyle* style)
 {
+#if defined(Q_OS_MACOS) && (QT_VERSION < QT_VERSION_CHECK(5, 15, 10))
+  // See https://github.com/Slicer/Slicer/issues/7261
+  QLoggingCategory::setFilterRules("qt.qpa.fonts=false");
+#endif
+
   vtkLogger::SetStderrVerbosity(vtkLogger::VERBOSITY_OFF);
   itk::itkFactoryRegistration();
   qMRMLWidget::preInitializeApplication();


### PR DESCRIPTION
Suppresses warnings like the following reported at application startup on macOS:
    
```
Populating font family aliases took 108 ms. Replace uses of missing font family "Courier" with one that exists to avoid this cost.
```
    
The root issue, tracked in QTBUG-98369 and QTBUG-99216, has been resolved in newer Qt versions (see qt/qtbase@64dd5a818). This commit conditionally applies a workaround to address the warning for older Qt versions.
