### PR TITLE
Clean up includes and forward declarations in vtkMRMLSliceLogic

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -14,8 +14,8 @@
 
 // MRMLLogic includes
 #include "vtkMRMLApplicationLogic.h"
-#include "vtkMRMLSliceLogic.h"
 #include "vtkMRMLSliceLayerLogic.h"
+#include "vtkMRMLSliceLogic.h"
 
 // MRML includes
 #include <vtkEventBroker.h>

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -20,8 +20,8 @@
 // MRML includes
 #include <vtkEventBroker.h>
 #include <vtkMRMLCrosshairNode.h>
-#include <vtkMRMLDiffusionTensorVolumeSliceDisplayNode.h>
 #include <vtkMRMLGlyphableVolumeDisplayNode.h>
+#include <vtkMRMLGlyphableVolumeSliceDisplayNode.h>
 #include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLModelNode.h>
 #include <vtkMRMLProceduralColorNode.h>
@@ -38,22 +38,17 @@
 #include <vtkGeneralTransform.h>
 #include <vtkImageAppendComponents.h>
 #include <vtkImageBlend.h>
-#include <vtkImageResample.h>
 #include <vtkImageCast.h>
 #include <vtkImageData.h>
 #include <vtkImageMathematics.h>
 #include <vtkImageReslice.h>
-#include <vtkImageThreshold.h>
-#include <vtkInformation.h>
 #include <vtkMath.h>
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 #include <vtkPlaneSource.h>
-#include <vtkPolyDataCollection.h>
 #include <vtkSmartPointer.h>
 #include <vtkStringArray.h>
 #include <vtkTransform.h>
-#include <vtkVersion.h>
 
 // VTKAddon includes
 #include <vtkAddonMathUtilities.h>

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -19,9 +19,10 @@
 #include "vtkMRMLAbstractLogic.h"
 
 // STD includes
-#include <vector>
 #include <deque>
+#include <vector>
 
+// MRML includes
 class vtkMRMLDisplayNode;
 class vtkMRMLLinearTransformNode;
 class vtkMRMLModelDisplayNode;
@@ -32,17 +33,17 @@ class vtkMRMLSliceLayerLogic;
 class vtkMRMLSliceNode;
 class vtkMRMLVolumeNode;
 
+// VTK includes
 class vtkAlgorithmOutput;
 class vtkCollection;
 class vtkImageBlend;
-class vtkTransform;
 class vtkImageData;
 class vtkImageMathematics;
 class vtkImageReslice;
 class vtkTransform;
 
-struct SliceLayerInfo;
 struct BlendPipeline;
+struct SliceLayerInfo;
 
 /// \brief Slicer logic class for slice manipulation.
 ///

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -37,10 +37,8 @@ class vtkMRMLVolumeNode;
 class vtkAlgorithmOutput;
 class vtkCollection;
 class vtkImageBlend;
-class vtkImageData;
 class vtkImageMathematics;
 class vtkImageReslice;
-class vtkTransform;
 
 struct BlendPipeline;
 struct SliceLayerInfo;


### PR DESCRIPTION
This pull request improves code maintainability by alphabetically sorting includes, removing unused forward declarations and includes, and simplifying dependencies in `vtkMRMLSliceLogic`.

Removed forward declarations:
- `vtkImageData`: Became obsolete after f20a21f ("STYLE: Remove VTKv5 support", 2015-12-01).
- `vtkTransform`: Became obsolete after e339590 ("STYLE: Removed unused variable in vtkMRMLSliceLogic", 2022-03-26) and dc9683a ("STYLE: Removed unused vtkMRMLSliceLogic::ActiveSliceTransform member", 2018-05-09).

Removed unused includes:
- `vtkImageResample.h`: Originally introduced in 01ffcb5 ("ENH 9124. Added new options for displaying slice models in 3D views: [...]") to support `vtkImageResliceMask`. Later removed in 154c6d2 ("ENH: Use the latest vtkImageReslice filter instead of vtkImageResliceMask", 2015-02-03).
- `vtkImageThreshold.h`: Became obsolete after 01ffcb5 ("ENH 9124. Added new options for displaying slice models in 3D views: [...]").
- `vtkPolyDataCollection.h`: Became obsolete after 68c2fc7 ("STYLE: Remove unused slice logic (LookupTable|PolyData)Collection members", 2018-05-09).
- `vtkInformation.h`: Became obsolete after 8e5539f ("BUG: Fixed add and subtract slice blending modes", 2018-06-01).
- `vtkVersion.h`: Became obsolete after f20a21f ("STYLE: Remove VTKv5 support", 2015-12-01).
- `vtkMRMLGlyphableVolumeSliceDisplayNode.h`: Became obsolete after fff76f4 ("ENH: merged demianVolumeGlyph-Simple branch", 2008-07-30).

Updated include:
- Added explicit include for `vtkMRMLGlyphableVolumeSliceDisplayNode.h`, which is directly used in `vtkMRMLSliceLogic::GetPolyDataDisplayNodes`.