### PR TITLE
Clean up includes and forward declarations in vtkSlicerMarkupsLogic

### DIFF
--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -37,7 +37,6 @@
 #include "vtkMRMLMarkupsROIDisplayNode.h"
 #include "vtkMRMLMarkupsROIJsonStorageNode.h"
 #include "vtkMRMLMarkupsROINode.h"
-#include "vtkMRMLMarkupsStorageNode.h"
 #include "vtkMRMLTableStorageNode.h"
 
 // Markups VTK widgets includes
@@ -57,7 +56,6 @@
 #include "vtkMRMLMessageCollection.h"
 #include "vtkMRMLScene.h"
 #include "vtkMRMLSelectionNode.h"
-#include "vtkMRMLSliceCompositeNode.h"
 #include "vtkMRMLSliceNode.h"
 #include "vtkMRMLSceneViewNode.h"
 #include <vtkMRMLSubjectHierarchyNode.h>
@@ -73,8 +71,6 @@
 #include "vtkMRMLAnnotationROINode.h"
 #include "vtkMRMLAnnotationRulerNode.h"
 #include "vtkMRMLAnnotationRulerStorageNode.h"
-#include "vtkMRMLAnnotationSnapshotNode.h"
-#include "vtkMRMLAnnotationSnapshotStorageNode.h"
 #include "vtkMRMLAnnotationTextDisplayNode.h"
 
 // vtkAddon includes

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -40,23 +40,14 @@
 #include "vtkMRMLMarkupsStorageNode.h"
 #include "vtkMRMLTableStorageNode.h"
 
-// Markups vtk widgets includes
+// Markups VTK widgets includes
 #include "vtkSlicerAngleWidget.h"
 #include "vtkSlicerCurveWidget.h"
 #include "vtkSlicerLineWidget.h"
+#include "vtkSlicerMarkupsInteractionWidget.h"
 #include "vtkSlicerPlaneWidget.h"
 #include "vtkSlicerPointsWidget.h"
 #include "vtkSlicerROIWidget.h"
-#include "vtkSlicerMarkupsInteractionWidget.h"
-
-// Annotation MRML includes
-#include "vtkMRMLAnnotationLineDisplayNode.h"
-#include "vtkMRMLAnnotationRulerNode.h"
-#include "vtkMRMLAnnotationROINode.h"
-#include "vtkMRMLAnnotationFiducialNode.h"
-#include "vtkMRMLAnnotationPointDisplayNode.h"
-#include "vtkMRMLAnnotationTextDisplayNode.h"
-#include "vtkMRMLAnnotationHierarchyNode.h"
 
 // MRML includes
 #include "vtkMRMLCameraNode.h"
@@ -73,18 +64,18 @@
 #include "vtkMRMLTableNode.h"
 
 // Annotation/MRML includes for legacy annotation file loading
-#include "vtkMRMLAnnotationRulerNode.h"
-#include "vtkMRMLAnnotationRulerStorageNode.h"
-#include "vtkMRMLAnnotationTextDisplayNode.h"
-#include "vtkMRMLAnnotationLineDisplayNode.h"
 #include "vtkMRMLAnnotationFiducialNode.h"
 #include "vtkMRMLAnnotationFiducialsStorageNode.h"
 #include "vtkMRMLAnnotationHierarchyNode.h"
+#include "vtkMRMLAnnotationLineDisplayNode.h"
+#include "vtkMRMLAnnotationLinesStorageNode.h"
 #include "vtkMRMLAnnotationPointDisplayNode.h"
 #include "vtkMRMLAnnotationROINode.h"
+#include "vtkMRMLAnnotationRulerNode.h"
+#include "vtkMRMLAnnotationRulerStorageNode.h"
 #include "vtkMRMLAnnotationSnapshotNode.h"
 #include "vtkMRMLAnnotationSnapshotStorageNode.h"
-#include "vtkMRMLAnnotationLinesStorageNode.h"
+#include "vtkMRMLAnnotationTextDisplayNode.h"
 
 // vtkAddon includes
 #include "vtkAddonMathUtilities.h"

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -27,32 +27,33 @@
 // Slicer includes
 #include "vtkSlicerModuleLogic.h"
 
+// Markups module includes
+class vtkSlicerMarkupsInteractionWidget;
+class vtkSlicerMarkupsWidget;
+
 // MRML includes
 #include "vtkMRMLStorageNode.h"
+class vtkMRMLMarkupsClosedCurveNode;
+class vtkMRMLMarkupsDisplayNode;
+class vtkMRMLMarkupsJsonStorageNode;
+class vtkMRMLMarkupsNode;
+class vtkMRMLMessageCollection;
+class vtkMRMLSelectionNode;
+class vtkMRMLTableNode;
 
 // VTK includes
-#include "vtkVector.h"
+#include <vtkVector.h>
+class vtkIdList;
+class vtkMatrix4x4;
+class vtkPlane;
+class vtkPoints;
+class vtkPolyData;
 
 // STD includes
 #include <cstdlib>
 #include <string>
 
 #include "vtkSlicerMarkupsModuleLogicExport.h"
-
-class vtkIdList;
-class vtkMatrix4x4;
-class vtkMRMLMarkupsNode;
-class vtkMRMLMarkupsClosedCurveNode;
-class vtkMRMLMarkupsDisplayNode;
-class vtkMRMLMarkupsJsonStorageNode;
-class vtkMRMLMessageCollection;
-class vtkMRMLSelectionNode;
-class vtkMRMLTableNode;
-class vtkPlane;
-class vtkPoints;
-class vtkPolyData;
-class vtkSlicerMarkupsInteractionWidget;
-class vtkSlicerMarkupsWidget;
 
 class VTK_SLICER_MARKUPS_MODULE_LOGIC_EXPORT vtkSlicerMarkupsLogic :
   public vtkSlicerModuleLogic


### PR DESCRIPTION
This pull request improves code maintainability by alphabetically sorting includes, removing unused forward declarations and includes, and simplifying dependencies in  `vtkSlicerMarkupsLogic`.

Removed unused includes:
* `vtkMRMLSliceCompositeNode.h`: Became obsolete after bc5d5b45fcb ("ENH: Add interactive slice intersections widget", 2021-07-06)
* `vtkMRMLMarkupsStorageNode.h`: Became obsolete after 936675ac035 ("ENH: Simplify custom markups registration and clean up code", 2021-12-15)
* `vtkMRMLAnnotationSnapshot[Storage]Node.h`: Introduced in f44849b014e ("ENH: Remove Annotations module", 2022-09-10) but never used.