### PR TITLE
BUG: Fix self-tests by explicitly setting file loading parameters

### DIFF
--- a/Applications/SlicerApp/Testing/Python/DICOMReaders.py
+++ b/Applications/SlicerApp/Testing/Python/DICOMReaders.py
@@ -108,7 +108,7 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
                 import SampleData
 
                 dicomFilesDirectory = SampleData.downloadFromURL(
-                    fileNames=dataset["fileName"], uris=dataset["url"], checksums=dataset["checksum"])[0]
+                    fileNames=dataset["fileName"], loadFileTypes="ZipFile", uris=dataset["url"], checksums=dataset["checksum"])[0]
                 self.delayDisplay("Finished with download")
 
                 #
@@ -222,6 +222,7 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
 
         dicomFilesDirectory = SampleData.downloadFromURL(
             fileNames="deidentifiedMRHead-dcm-one-series.zip",
+            loadFileTypes="ZipFile",
             uris=TESTING_DATA_URL + "SHA256/899f3f8617ca53bad7dca0b2908478319e708b48ff41dfa64b6bac1d76529928",
             checksums="SHA256:899f3f8617ca53bad7dca0b2908478319e708b48ff41dfa64b6bac1d76529928")[0]
         self.delayDisplay("Finished with download\n")

--- a/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
+++ b/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
@@ -101,6 +101,7 @@ class JRC2013VisWidget(ScriptedLoadableModuleWidget):
 
                 SampleData.downloadFromURL(
                     fileNames="Dcmtk-db.zip",
+                    loadFileTypes="ZipFile",
                     uris=TESTING_DATA_URL + "MD5/6bfb01cf5ffb8e3af9b1c0c9556f0c6b45f0ec40305a9539ed7a9f0dcfe378e3",
                     checksums="SHA256:6bfb01cf5ffb8e3af9b1c0c9556f0c6b45f0ec40305a9539ed7a9f0dcfe378e3")[0]
 
@@ -187,6 +188,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
 
         dicomFilesDirectory = SampleData.downloadFromURL(
             fileNames="Dcmtk-db.zip",
+            loadFileTypes="ZipFile",
             uris=TESTING_DATA_URL + "MD5/7a43d121a51a631ab0df02071e5ba6ed",
             checksums="MD5:7a43d121a51a631ab0df02071e5ba6ed")[0]
 

--- a/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
@@ -223,6 +223,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
 
         extractPath = SampleData.downloadFromURL(
             fileNames="dataset3_PETCT.zip",
+            loadFileTypes="ZipFile",
             uris=TESTING_DATA_URL + "SHA256/11e81af3462076f4ca371b632e03ed435240042915c2daf07f80059b3f78f88d",
             checksums="SHA256:11e81af3462076f4ca371b632e03ed435240042915c2daf07f80059b3f78f88d")[0]
 

--- a/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
@@ -192,6 +192,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
 
         dicomFilesDirectory = SampleData.downloadFromURL(
             fileNames="dataset1_Thorax_Abdomen.zip",
+            loadFileTypes="ZipFile",
             uris=TESTING_DATA_URL + "SHA256/17a4199aad03a373dab27dc17e5bfcf84fc194d0a30975b4073e5b595d43a56a",
             checksums="SHA256:17a4199aad03a373dab27dc17e5bfcf84fc194d0a30975b4073e5b595d43a56a")[0]
 

--- a/Applications/SlicerApp/Testing/Python/ScenePerformance.py
+++ b/Applications/SlicerApp/Testing/Python/ScenePerformance.py
@@ -120,6 +120,7 @@ class ScenePerformanceLogic(ScriptedLoadableModuleLogic):
         import SampleData
         return SampleData.downloadFromURL(
             fileNames=downloadFileName,
+            loadFiles=False,
             uris=downloadURL,
             checksums=downloadFileChecksum)[0]
 

--- a/Applications/SlicerApp/Testing/Python/SlicerRestoreSceneViewCrashIssue3445.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerRestoreSceneViewCrashIssue3445.py
@@ -101,7 +101,7 @@ class SlicerRestoreSceneViewCrashIssue3445Test(ScriptedLoadableModuleTest):
 
         filePath = SampleData.downloadFromURL(
             fileNames="BrainAtlas2012.mrb",
-            loadFiles=True,
+            loadFiles=False,
             uris=TESTING_DATA_URL + "SHA256/688ebcc6f45989795be2bcdc6b8b5bfc461f1656d677ed3ddef8c313532687f1",
             checksums="SHA256:688ebcc6f45989795be2bcdc6b8b5bfc461f1656d677ed3ddef8c313532687f1")[0]
 

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
@@ -495,7 +495,7 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
         sceneFile = SampleData.downloadFromURL(
             fileNames=self.attributeFilterTestSceneFileName,
             uris=self.attributeFilterTestSceneFileUrl,
-            # loadFiles=True,
+            loadFileTypes="SceneFile",
             checksums=self.attributeFilterTestSceneChecksum)[0]
         if not os.path.exists(sceneFile):
             logging.error("Failed to download attribute filter test scene to path " + str(sceneFile))


### PR DESCRIPTION
This commit updates several self-tests to explicitly define `loadFileTypes` or `loadFiles`, as required following commit 89104423af8 ("BUG: Ensure MRB loading correctly reports loaded nodes", 2025-01-10) introduced the following pull request:
* https://github.com/Slicer/Slicer/pull/8135

Tests updated with `loadFileTypes="ZipFile"` to ensure proper handling of zip files:
- `DICOMReaders`
- `JRC2013Vis`
- `RSNAQuantTutorial`
- `RSNAVisTutorial`

The `SubjectHierarchyGenericSelfTest` was updated with `loadFileTypes="SceneFile"` to handle scene files explicitly.

Tests updated with `loadFiles=False` to disable automatic file loading:
- `ScenePerformance`
- `SlicerRestoreSceneViewCrashIssue3445`