### PR TITLE
COMP: Update python-cmake-buildsystem anticipating python version update

### DIFF
--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -131,7 +131,7 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "bb45aa7a4cfc7a5a93bc490c6158f702d1a2226f"
+    "48aee1262ddb7f1fbc6267352880f5a446420bb7"
     QUIET
     )
 


### PR DESCRIPTION
Summary:
- Add support for building CPython 3.9.17
- Add checksums for Python 2.7.16 to 2.7.18 and 3.7.x, 3.8.x, and 3.9.x
- cmake: Fix various configuration issues and update default version to 3.9.17
- cmake: Rename `USE_SYSTEM_FFI` to `USE_SYSTEM_LibFFI` for consistency
- cmake: Fix name of `USE_SYSTEM_SQLite3` option
- cmake: Prevent rebuilds by ensuring `SRC_DIR` is always an absolute path

List of changes:

```
$ git shortlog bb45aa7a4..48aee12 --no-merges
Brett Jia (2):
      cmake: Fix name of USE_SYSTEM_SQLite3 option
      cmake: Fix use of system libmpdec (#340)

Erlend E. Aasland (2):
      README: Fix broken Ninja link
      cmake: Add missing checksums for Python 3.7.x, 3.8.x, and 3.9.x

James Butler (2):
      ci: Test latest patch release versions
      cmake: Update default version to 3.9.17

Jean-Christophe Fillion-Robin (6):
      COMP: Update CI to the latest version of GitHub actions
      cmake: Add checksums for Python 2.7.16 to 2.7.18
      ci: Test 2.7.18 version instead of 2.7.15
      ci: Fix macos build using "macos-latest" instead of obsolete "macos-10.15"
      cmake: Prevent rebuild ensuring SRC_DIR always converted to absolute path
      style: Strip trailing spaces from CMake files

Matt McCormick (1):
      cmake: sys.platform should be 'linux' instead of 'linux2'

Shakeeb Alireza (1):
      _scproxy: Fix link error when building extension as builtin on macOS

William Emerison Six (1):
      cmake: rename USE_SYSTEM_FFI to USE_SYSTEM_LibFFI
```