### PR TITLE
COMP: Ensure setting `run_ctest_with_upload` to `FALSE` skips package upload

### DIFF
--- a/CMake/SlicerDashboardDriverScript.cmake
+++ b/CMake/SlicerDashboardDriverScript.cmake
@@ -561,8 +561,14 @@ ${ADDITIONAL_CMAKECACHE_OPTION}
         message(STATUS "Packaging and uploading Slicer to packages server ...")
         set(package_list)
         if(run_ctest_with_packages)
+
+          set(package_target "package")
+          if(run_ctest_with_upload)
+            set(package_target "packageupload")
+          endif()
+
           ctest_build(
-            TARGET packageupload
+            TARGET ${package_target}
             BUILD ${slicer_build_dir}
             APPEND
             )


### PR DESCRIPTION
Address the issue mentioned in:
 - #7825 

Moved the building of TARGET `packageupload` under the condition that `run_ctest_with_upload` is true.
The condition `run_ctest_with_packages` is already true under the situated code (the outer if condition).


closes #7825 