### PR TITLE
ENH: Add option to show CLI executable windows on Windows

### DIFF
--- a/Base/Python/slicer/cli.py
+++ b/Base/Python/slicer/cli.py
@@ -50,18 +50,19 @@ def setNodeParameters(node, parameters):
             print("parameter ", key, " has unsupported type ", value.__class__.__name__)
 
 
-def runSync(module, node=None, parameters=None, delete_temporary_files=True, update_display=True):
+def runSync(module, node=None, parameters=None, delete_temporary_files=True, update_display=True, hide_window=True):
     """Run a CLI synchronously, optionally given a node with optional parameters,
     returning the node (or the new one if created)
     node: existing parameter node (None by default)
     parameters: dictionary of parameters for cli (None by default)
     delete_temporary_files: remove temp files created during execution (True by default)
     update_display: show output nodes after completion
+    hide_window: whether to hide the CLI process window (Windows only, True by default).
     """
     return run(module, node=node, parameters=parameters, wait_for_completion=True, delete_temporary_files=delete_temporary_files, update_display=update_display)
 
 
-def run(module, node=None, parameters=None, wait_for_completion=False, delete_temporary_files=True, update_display=True):
+def run(module, node=None, parameters=None, wait_for_completion=False, delete_temporary_files=True, update_display=True, hide_window=True):
     """Runs a CLI, optionally given a node with optional parameters, returning
     back the node (or the new one if created)
     node: existing parameter node (None by default)
@@ -69,6 +70,7 @@ def run(module, node=None, parameters=None, wait_for_completion=False, delete_te
     wait_for_completion: block if True (False by default)
     delete_temporary_files: remove temp files created during execution (True by default)
     update_display: show output nodes after completion
+    hide_window: whether to hide the CLI process window (Windows only, True by default).
     """
     if node:
         setNodeParameters(node, parameters)
@@ -80,6 +82,7 @@ def run(module, node=None, parameters=None, wait_for_completion=False, delete_te
     logic = module.logic()
 
     logic.SetDeleteTemporaryFiles(1 if delete_temporary_files else 0)
+    logic.SetHideWindow(1 if hide_window else 0)
 
     if wait_for_completion:
         logic.ApplyAndWait(node, update_display)

--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
@@ -196,6 +196,7 @@ public:
   ModuleDescription DefaultModuleDescription;
   int DeleteTemporaryFiles;
   int AllowInMemoryTransfer;
+  int HideWindow;
 
   int RedirectModuleStreams;
 
@@ -310,6 +311,7 @@ vtkSlicerCLIModuleLogic::vtkSlicerCLIModuleLogic()
   this->Internal->DeleteTemporaryFiles = 1;
   this->Internal->AllowInMemoryTransfer = 1;
   this->Internal->RedirectModuleStreams = 1;
+  this->Internal->HideWindow = 1;
   this->Internal->RescheduleCallback =
     vtkSmartPointer<vtkSlicerCLIRescheduleCallback>::New();
   this->Internal->RescheduleCallback->SetCLIModuleLogic(this);
@@ -410,6 +412,22 @@ void vtkSlicerCLIModuleLogic::SetAllowInMemoryTransfer(int value)
 int vtkSlicerCLIModuleLogic::GetAllowInMemoryTransfer() const
 {
   return this->Internal->AllowInMemoryTransfer;
+}
+
+//----------------------------------------------------------------------------
+void vtkSlicerCLIModuleLogic::SetHideWindow(int value)
+{
+  vtkDebugMacro(<< this->GetClassName() << " (" << this << "): setting HideWindow to " << value);
+  if (this->Internal->HideWindow != value)
+  {
+    this->Internal->HideWindow = value;
+  }
+}
+
+//----------------------------------------------------------------------------
+int vtkSlicerCLIModuleLogic::GetHideWindow() const
+{
+  return this->Internal->HideWindow;
 }
 
 //----------------------------------------------------------------------------
@@ -1798,8 +1816,9 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
     itksysProcess_SetCommand(process, command);
     itksysProcess_SetOption(process,
                             itksysProcess_Option_Detach, 0);
+    // This only affects the itksys process behavior on Windows.
     itksysProcess_SetOption(process,
-                            itksysProcess_Option_HideWindow, 1);
+                            itksysProcess_Option_HideWindow, this->GetHideWindow());
     // itksysProcess_SetTimeout(process, 5.0); // 5 seconds
 
     // execute the command

--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.h
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.h
@@ -96,6 +96,10 @@ public:
   void SetAllowInMemoryTransfer(int value);
   int GetAllowInMemoryTransfer() const;
 
+  /// Control whether the CLI process window is hidden (Windows only, defaults to 1).
+  void SetHideWindow(int value);
+  int GetHideWindow() const;
+
   /// For debugging, control redirection of cout and cerr
   virtual void RedirectModuleStreamsOn();
   virtual void RedirectModuleStreamsOff();


### PR DESCRIPTION
By default, windows associated with CLI executables are hidden on Windows via `itksysProcess_Option_HideWindow = 1`. This behavior makes it impossible for CLIs that create their own windows (e.g., using `vtkWin32HardwareWindow`) to display them.

This commit introduces support for optionally showing CLI windows:
- Adds `SetHideWindow` / `GetHideWindow` methods to `vtkSlicerCLIModuleLogic`, defaulting to `true` to preserve current behavior.
- Updates `ApplyTask` to respect this flag when setting `itksysProcess_Option_HideWindow`.
- Extends the Python API in `slicer.cli.run` and `slicer.cli.runSync` to accept a new `hide_window` parameter (defaulting to `True`).

This enables use cases such as launching interactive viewers as part of CLI workflows on Windows.
