### PR TITLE
ENH: Centralize retrieval of Markups Moving attributes in display node

### DIFF
--- a/Docs/developer_guide/script_repository/markups.md
+++ b/Docs/developer_guide/script_repository/markups.md
@@ -513,7 +513,7 @@ Event management of Slicer-4.11 version is still subject to change. The example 
 ```python
 def onMarkupChanged(caller,event):
   markupsNode = caller
-  sliceView = markupsNode.GetAttribute(slicer.vtkMRMLMarkupsNode.GetMovingInSliceViewAttributeName())
+  sliceView = markupsNode.GetAttribute(slicer.vtkMRMLMarkupsDisplayNode.GetMovingInSliceViewAttributeName())
   movingMarkupIndex = markupsNode.GetDisplayNode().GetActiveControlPoint()
   if movingMarkupIndex >= 0:
     pos = [0,0,0]
@@ -528,13 +528,13 @@ def onMarkupChanged(caller,event):
 
 def onMarkupStartInteraction(caller, event):
   markupsNode = caller
-  sliceView = markupsNode.GetAttribute(slicer.vtkMRMLMarkupsNode.GetMovingInSliceViewAttributeName())
+  sliceView = markupsNode.GetAttribute(slicer.vtkMRMLMarkupsDisplayNode.GetMovingInSliceViewAttributeName())
   movingMarkupIndex = markupsNode.GetDisplayNode().GetActiveControlPoint()
   logging.info("Start interaction: point ID = {0}, slice view = {1}".format(movingMarkupIndex, sliceView))
 
 def onMarkupEndInteraction(caller, event):
   markupsNode = caller
-  sliceView = markupsNode.GetAttribute(slicer.vtkMRMLMarkupsNode.GetMovingInSliceViewAttributeName())
+  sliceView = markupsNode.GetAttribute(slicer.vtkMRMLMarkupsDisplayNode.GetMovingInSliceViewAttributeName())
   movingMarkupIndex = markupsNode.GetDisplayNode().GetActiveControlPoint()
   logging.info("End interaction: point ID = {0}, slice view = {1}".format(movingMarkupIndex, sliceView))
 

--- a/Docs/developer_guide/script_repository/markups.md
+++ b/Docs/developer_guide/script_repository/markups.md
@@ -513,7 +513,7 @@ Event management of Slicer-4.11 version is still subject to change. The example 
 ```python
 def onMarkupChanged(caller,event):
   markupsNode = caller
-  sliceView = markupsNode.GetAttribute("Markups.MovingInSliceView")
+  sliceView = markupsNode.GetAttribute(slicer.vtkMRMLMarkupsNode.GetMovingInSliceViewAttributeName())
   movingMarkupIndex = markupsNode.GetDisplayNode().GetActiveControlPoint()
   if movingMarkupIndex >= 0:
     pos = [0,0,0]
@@ -528,13 +528,13 @@ def onMarkupChanged(caller,event):
 
 def onMarkupStartInteraction(caller, event):
   markupsNode = caller
-  sliceView = markupsNode.GetAttribute("Markups.MovingInSliceView")
+  sliceView = markupsNode.GetAttribute(slicer.vtkMRMLMarkupsNode.GetMovingInSliceViewAttributeName())
   movingMarkupIndex = markupsNode.GetDisplayNode().GetActiveControlPoint()
   logging.info("Start interaction: point ID = {0}, slice view = {1}".format(movingMarkupIndex, sliceView))
 
 def onMarkupEndInteraction(caller, event):
   markupsNode = caller
-  sliceView = markupsNode.GetAttribute("Markups.MovingInSliceView")
+  sliceView = markupsNode.GetAttribute(slicer.vtkMRMLMarkupsNode.GetMovingInSliceViewAttributeName())
   movingMarkupIndex = markupsNode.GetDisplayNode().GetActiveControlPoint()
   logging.info("End interaction: point ID = {0}, slice view = {1}".format(movingMarkupIndex, sliceView))
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.cxx
@@ -744,15 +744,15 @@ int vtkMRMLMarkupsDisplayNode::UpdateActiveControlPointWorld(
         layoutName = viewNode->GetLayoutName();
       }
     }
-    markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingInSliceViewAttributeName(), layoutName ? layoutName : "");
+    markupsNode->SetAttribute(vtkMRMLMarkupsDisplayNode::GetMovingInSliceViewAttributeName(), layoutName ? layoutName : "");
     std::ostringstream controlPointIndexStr;
     controlPointIndexStr << controlPointIndex;
-    markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingMarkupIndexAttributeName(), controlPointIndexStr.str().c_str());
+    markupsNode->SetAttribute(vtkMRMLMarkupsDisplayNode::GetMovingMarkupIndexAttributeName(), controlPointIndexStr.str().c_str());
   }
   else
   {
-    markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingInSliceViewAttributeName(), "");
-    markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingMarkupIndexAttributeName(), "");
+    markupsNode->SetAttribute(vtkMRMLMarkupsDisplayNode::GetMovingInSliceViewAttributeName(), "");
+    markupsNode->SetAttribute(vtkMRMLMarkupsDisplayNode::GetMovingMarkupIndexAttributeName(), "");
   }
   markupsNode->SetDisableModifiedEvent(wasDisabled);
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.cxx
@@ -744,15 +744,15 @@ int vtkMRMLMarkupsDisplayNode::UpdateActiveControlPointWorld(
         layoutName = viewNode->GetLayoutName();
       }
     }
-    markupsNode->SetAttribute("Markups.MovingInSliceView", layoutName ? layoutName : "");
+    markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingInSliceViewAttributeName(), layoutName ? layoutName : "");
     std::ostringstream controlPointIndexStr;
     controlPointIndexStr << controlPointIndex;
-    markupsNode->SetAttribute("Markups.MovingMarkupIndex", controlPointIndexStr.str().c_str());
+    markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingMarkupIndexAttributeName(), controlPointIndexStr.str().c_str());
   }
   else
   {
-    markupsNode->SetAttribute("Markups.MovingInSliceView", "");
-    markupsNode->SetAttribute("Markups.MovingMarkupIndex", "");
+    markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingInSliceViewAttributeName(), "");
+    markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingMarkupIndexAttributeName(), "");
   }
   markupsNode->SetDisableModifiedEvent(wasDisabled);
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.h
@@ -144,6 +144,12 @@ public:
   /// \param context Name of the interaction context. By default it is empty string, meaning mouse
   int GetActiveControlPoint(std::string context=vtkMRMLMarkupsDisplayNode::GetDefaultContextName());
 
+  ///@{
+  /// Constants for attribute names
+  static const char* GetMovingInSliceViewAttributeName() { return "Markups.MovingInSliceView"; }
+  static const char* GetMovingMarkupIndexAttributeName() { return "Markups.MovingMarkupIndex"; }
+  ///@}
+
   /// Set the text scale of the associated text.
   vtkGetMacro(TextScale,double);
   vtkSetMacro(TextScale,double);

--- a/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.h
@@ -145,7 +145,12 @@ public:
   int GetActiveControlPoint(std::string context=vtkMRMLMarkupsDisplayNode::GetDefaultContextName());
 
   ///@{
-  /// Constants for attribute names
+  /// Constants representing the context in which a Markups control point is being moved.
+  ///
+  /// - `Markups.MovingInSliceView` stores the layout name of the slice view where the control point is being manipulated.
+  /// - `Markups.MovingMarkupIndex` stores the index of the control point currently being moved.
+  ///
+  /// These attributes are used to track interactions with Markups nodes during user input events.
   static const char* GetMovingInSliceViewAttributeName() { return "Markups.MovingInSliceView"; }
   static const char* GetMovingMarkupIndexAttributeName() { return "Markups.MovingMarkupIndex"; }
   ///@}

--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.h
@@ -921,10 +921,6 @@ public:
     return this->ReplaceListNameInControlPointLabelFormat();
   };
 
-  // Constants for attribute names
-  static const char* GetMovingInSliceViewAttributeName() { return "Markups.MovingInSliceView"; }
-  static const char* GetMovingMarkupIndexAttributeName() { return "Markups.MovingMarkupIndex"; }
-
 protected:
   vtkMRMLMarkupsNode();
   ~vtkMRMLMarkupsNode() override;

--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.h
@@ -921,6 +921,10 @@ public:
     return this->ReplaceListNameInControlPointLabelFormat();
   };
 
+  // Constants for attribute names
+  static const char* GetMovingInSliceViewAttributeName() { return "Markups.MovingInSliceView"; }
+  static const char* GetMovingMarkupIndexAttributeName() { return "Markups.MovingMarkupIndex"; }
+
 protected:
   vtkMRMLMarkupsNode();
   ~vtkMRMLMarkupsNode() override;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -850,10 +850,10 @@ void vtkSlicerMarkupsWidget::StartWidgetInteraction(vtkMRMLInteractionEventData*
     {
       layoutName = rep->GetViewNode()->GetLayoutName();
     }
-    markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingInSliceViewAttributeName(), layoutName ? layoutName : "");
+    markupsNode->SetAttribute(vtkMRMLMarkupsDisplayNode::GetMovingInSliceViewAttributeName(), layoutName ? layoutName : "");
     std::ostringstream controlPointIndexStr;
     controlPointIndexStr << activeControlPointIndex;
-    markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingMarkupIndexAttributeName(), controlPointIndexStr.str().c_str());
+    markupsNode->SetAttribute(vtkMRMLMarkupsDisplayNode::GetMovingMarkupIndexAttributeName(), controlPointIndexStr.str().c_str());
     markupsNode->SetDisableModifiedEvent(wasDisabled);
     markupsNode->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::PointStartInteractionEvent);
   }
@@ -878,8 +878,8 @@ void vtkSlicerMarkupsWidget::EndWidgetInteraction()
   // to add a new point with a minimum number of events.
   bool wasDisabled = markupsNode->GetDisableModifiedEvent();
   markupsNode->DisableModifiedEventOn();
-  markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingInSliceViewAttributeName(), "");
-  markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingMarkupIndexAttributeName(), "");
+  markupsNode->SetAttribute(vtkMRMLMarkupsDisplayNode::GetMovingInSliceViewAttributeName(), "");
+  markupsNode->SetAttribute(vtkMRMLMarkupsDisplayNode::GetMovingMarkupIndexAttributeName(), "");
   markupsNode->SetDisableModifiedEvent(wasDisabled);
 }
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -850,10 +850,10 @@ void vtkSlicerMarkupsWidget::StartWidgetInteraction(vtkMRMLInteractionEventData*
     {
       layoutName = rep->GetViewNode()->GetLayoutName();
     }
-    markupsNode->SetAttribute("Markups.MovingInSliceView", layoutName ? layoutName : "");
+    markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingInSliceViewAttributeName(), layoutName ? layoutName : "");
     std::ostringstream controlPointIndexStr;
     controlPointIndexStr << activeControlPointIndex;
-    markupsNode->SetAttribute("Markups.MovingMarkupIndex", controlPointIndexStr.str().c_str());
+    markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingMarkupIndexAttributeName(), controlPointIndexStr.str().c_str());
     markupsNode->SetDisableModifiedEvent(wasDisabled);
     markupsNode->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::PointStartInteractionEvent);
   }
@@ -878,8 +878,8 @@ void vtkSlicerMarkupsWidget::EndWidgetInteraction()
   // to add a new point with a minimum number of events.
   bool wasDisabled = markupsNode->GetDisableModifiedEvent();
   markupsNode->DisableModifiedEventOn();
-  markupsNode->SetAttribute("Markups.MovingInSliceView", "");
-  markupsNode->SetAttribute("Markups.MovingMarkupIndex", "");
+  markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingInSliceViewAttributeName(), "");
+  markupsNode->SetAttribute(vtkMRMLMarkupsNode::GetMovingMarkupIndexAttributeName(), "");
   markupsNode->SetDisableModifiedEvent(wasDisabled);
 }
 

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
@@ -546,31 +546,31 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
 
             # Check include node attribute name filter
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
-            filteredObject.includeNodeAttributeNamesFilter = [slicer.vtkMRMLMarkupsNode.GetMovingInSliceViewAttributeName()]
+            filteredObject.includeNodeAttributeNamesFilter = [slicer.vtkMRMLMarkupsDisplayNode.GetMovingInSliceViewAttributeName()]
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 5 + expectedEmptyHierarchyItemCount)
             filteredObject.addNodeAttributeFilter("Sajt")
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
             filteredObject.includeNodeAttributeNamesFilter = []
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
             # Check attribute value filter
-            filteredObject.addNodeAttributeFilter(slicer.vtkMRMLMarkupsNode.GetMovingMarkupIndexAttributeName(), 3)
+            filteredObject.addNodeAttributeFilter(slicer.vtkMRMLMarkupsDisplayNode.GetMovingMarkupIndexAttributeName(), 3)
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 3 + expectedEmptyHierarchyItemCount)
             filteredObject.includeNodeAttributeNamesFilter = []
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
-            filteredObject.addNodeAttributeFilter(slicer.vtkMRMLMarkupsNode.GetMovingMarkupIndexAttributeName(), "3")
+            filteredObject.addNodeAttributeFilter(slicer.vtkMRMLMarkupsDisplayNode.GetMovingMarkupIndexAttributeName(), "3")
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 3 + expectedEmptyHierarchyItemCount)
             filteredObject.includeNodeAttributeNamesFilter = []
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
 
             # Check exclude node attribute name filter (overrides include node attribute name filter)
-            filteredObject.excludeNodeAttributeNamesFilter = [slicer.vtkMRMLMarkupsNode.GetMovingInSliceViewAttributeName()]
+            filteredObject.excludeNodeAttributeNamesFilter = [slicer.vtkMRMLMarkupsDisplayNode.GetMovingInSliceViewAttributeName()]
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 4 + expectedEmptyHierarchyItemCount)
             filteredObject.excludeNodeAttributeNamesFilter = []
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
             # Check if exclude indeed overrides include node attribute name filter
-            filteredObject.includeNodeAttributeNamesFilter = [slicer.vtkMRMLMarkupsNode.GetMovingMarkupIndexAttributeName()]
+            filteredObject.includeNodeAttributeNamesFilter = [slicer.vtkMRMLMarkupsDisplayNode.GetMovingMarkupIndexAttributeName()]
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
-            filteredObject.excludeNodeAttributeNamesFilter = [slicer.vtkMRMLMarkupsNode.GetMovingInSliceViewAttributeName()]
+            filteredObject.excludeNodeAttributeNamesFilter = [slicer.vtkMRMLMarkupsDisplayNode.GetMovingInSliceViewAttributeName()]
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 4 + expectedEmptyHierarchyItemCount)
             filteredObject.includeNodeAttributeNamesFilter = []
             filteredObject.excludeNodeAttributeNamesFilter = []
@@ -616,7 +616,7 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
 
             # Check attribute filtering with class name and attribute value
-            filteredObject.addNodeAttributeFilter(slicer.vtkMRMLMarkupsNode.GetMovingMarkupIndexAttributeName(), 3, True, "vtkMRMLMarkupsCurveNode")
+            filteredObject.addNodeAttributeFilter(slicer.vtkMRMLMarkupsDisplayNode.GetMovingMarkupIndexAttributeName(), 3, True, "vtkMRMLMarkupsCurveNode")
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 3 + expectedEmptyHierarchyItemCount)
             filteredObject.addNodeAttributeFilter("ParentAttribute", "", True, "vtkMRMLMarkupsAngleNode")
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 5)
@@ -625,7 +625,7 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
             filteredObject.includeNodeAttributeNamesFilter = []
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
             # Check with empty attribute value
-            filteredObject.addNodeAttributeFilter(slicer.vtkMRMLMarkupsNode.GetMovingMarkupIndexAttributeName(), "", True, "vtkMRMLMarkupsCurveNode")
+            filteredObject.addNodeAttributeFilter(slicer.vtkMRMLMarkupsDisplayNode.GetMovingMarkupIndexAttributeName(), "", True, "vtkMRMLMarkupsCurveNode")
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 4 + expectedEmptyHierarchyItemCount)
             filteredObject.includeNodeAttributeNamesFilter = []
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
@@ -546,31 +546,31 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
 
             # Check include node attribute name filter
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
-            filteredObject.includeNodeAttributeNamesFilter = ["Markups.MovingInSliceView"]
+            filteredObject.includeNodeAttributeNamesFilter = [slicer.vtkMRMLMarkupsNode.GetMovingInSliceViewAttributeName()]
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 5 + expectedEmptyHierarchyItemCount)
             filteredObject.addNodeAttributeFilter("Sajt")
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
             filteredObject.includeNodeAttributeNamesFilter = []
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
             # Check attribute value filter
-            filteredObject.addNodeAttributeFilter("Markups.MovingMarkupIndex", 3)
+            filteredObject.addNodeAttributeFilter(slicer.vtkMRMLMarkupsNode.GetMovingMarkupIndexAttributeName(), 3)
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 3 + expectedEmptyHierarchyItemCount)
             filteredObject.includeNodeAttributeNamesFilter = []
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
-            filteredObject.addNodeAttributeFilter("Markups.MovingMarkupIndex", "3")
+            filteredObject.addNodeAttributeFilter(slicer.vtkMRMLMarkupsNode.GetMovingMarkupIndexAttributeName(), "3")
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 3 + expectedEmptyHierarchyItemCount)
             filteredObject.includeNodeAttributeNamesFilter = []
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
 
             # Check exclude node attribute name filter (overrides include node attribute name filter)
-            filteredObject.excludeNodeAttributeNamesFilter = ["Markups.MovingInSliceView"]
+            filteredObject.excludeNodeAttributeNamesFilter = [slicer.vtkMRMLMarkupsNode.GetMovingInSliceViewAttributeName()]
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 4 + expectedEmptyHierarchyItemCount)
             filteredObject.excludeNodeAttributeNamesFilter = []
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
             # Check if exclude indeed overrides include node attribute name filter
-            filteredObject.includeNodeAttributeNamesFilter = ["Markups.MovingMarkupIndex"]
+            filteredObject.includeNodeAttributeNamesFilter = [slicer.vtkMRMLMarkupsNode.GetMovingMarkupIndexAttributeName()]
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
-            filteredObject.excludeNodeAttributeNamesFilter = ["Markups.MovingInSliceView"]
+            filteredObject.excludeNodeAttributeNamesFilter = [slicer.vtkMRMLMarkupsNode.GetMovingInSliceViewAttributeName()]
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 4 + expectedEmptyHierarchyItemCount)
             filteredObject.includeNodeAttributeNamesFilter = []
             filteredObject.excludeNodeAttributeNamesFilter = []
@@ -616,7 +616,7 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
 
             # Check attribute filtering with class name and attribute value
-            filteredObject.addNodeAttributeFilter("Markups.MovingMarkupIndex", 3, True, "vtkMRMLMarkupsCurveNode")
+            filteredObject.addNodeAttributeFilter(slicer.vtkMRMLMarkupsNode.GetMovingMarkupIndexAttributeName(), 3, True, "vtkMRMLMarkupsCurveNode")
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 3 + expectedEmptyHierarchyItemCount)
             filteredObject.addNodeAttributeFilter("ParentAttribute", "", True, "vtkMRMLMarkupsAngleNode")
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 5)
@@ -625,7 +625,7 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
             filteredObject.includeNodeAttributeNamesFilter = []
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
             # Check with empty attribute value
-            filteredObject.addNodeAttributeFilter("Markups.MovingMarkupIndex", "", True, "vtkMRMLMarkupsCurveNode")
+            filteredObject.addNodeAttributeFilter(slicer.vtkMRMLMarkupsNode.GetMovingMarkupIndexAttributeName(), "", True, "vtkMRMLMarkupsCurveNode")
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 4 + expectedEmptyHierarchyItemCount)
             filteredObject.includeNodeAttributeNamesFilter = []
             self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -376,7 +376,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.setPlaybackEnabled(False)
 
     def onInputCurveControlPointModified(self, *_unused):
-        if self.inputCurve.GetAttribute("Markups.MovingMarkupIndex"):
+        if self.inputCurve.GetAttribute(slicer.vtkMRMLMarkupsDisplayNode.GetMovingMarkupIndexAttributeName()):
             return
         self.logic.setControlPointsByResamplingAndInterpolationFromInputCurve(self.inputCurve)
 


### PR DESCRIPTION
# Brief Description

Streamline reuse of attributes `"Markups.MovingInSliceView"` and `"Markups.MovingMarkupIndex"` by declaring `static GetMoving(InSliceView|MarkupIndex)AttributeName()` functions in the `vtkMRMLMarkupsDisplayNode` class as public members. This will allow for consistent use of the attribute strings across C++ and Python scripts.

```cpp
  static const char* GetMovingInSliceViewAttributeName() { return "Markups.MovingInSliceView"; }
  static const char* GetMovingMarkupIndexAttributeName() { return "Markups.MovingMarkupIndex"; }

```

> [!NOTE]
> The function naming convention of `GetxxxxxxxxAttributeName()` is chosen so that we understand from the function name that it is returning a name of an attribute and not the attribute value itself. 