### PR TITLE
ENH: Support specifying extension contributors as CMake list

### DIFF
--- a/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake
+++ b/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake
@@ -133,6 +133,27 @@ endfunction()
 # Testing
 ################################################################################
 
+function(_check_generated_description_file)
+  set(options
+    )
+  set(oneValueArgs
+    BASELINE
+    GENERATED
+    )
+  set(multiValueArgs
+    )
+  cmake_parse_arguments(MY "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol
+      ${MY_GENERATED}
+      ${MY_BASELINE}
+    RESULT_VARIABLE result
+    )
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR "The generated and baseline files are different but are expected to match. Generated [${MY_GENERATED}]. Baseline [${MY_BASELINE}]")
+  endif()
+endfunction()
+
 #
 # cmake -DTEST_<testfunction>:BOOL=ON -P <this_script>.cmake
 #
@@ -143,8 +164,9 @@ function(slicer_generate_extension_description_test)
     set(Slicer_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)
   endif()
 
+  set(destination_dir ${CMAKE_CURRENT_BINARY_DIR})
   set(common_args
-    DESTINATION_DIR ${CMAKE_CURRENT_BINARY_DIR}
+    DESTINATION_DIR ${destination_dir}
     EXTENSION_DESCRIPTION "The SlicerToKiwiExporter module provides Slicer user with any easy way to export models into a KiwiViewer scene file.
 This is a line of text.<br>And another one."
     EXTENSION_CATEGORY "Exporter"
@@ -172,17 +194,10 @@ This is a line of text.<br>And another one."
     #EXTENSION_DEPENDS
     #EXTENSION_ENABLED
     )
-  set(generated "${CMAKE_CURRENT_BINARY_DIR}/SlicerToKiwiExporter.s4ext")
-  set(baseline "${Slicer_SOURCE_DIR}/Extensions/CMake/Testing/extension_description_without_depends.s4ext")
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol
-      ${generated}
-      ${baseline}
-    RESULT_VARIABLE result
+  _check_generated_description_file(
+    GENERATED "${destination_dir}/SlicerToKiwiExporter.s4ext"
+    BASELINE "${Slicer_SOURCE_DIR}/Extensions/CMake/Testing/extension_description_without_depends.s4ext"
     )
-  if(NOT result EQUAL 0)
-    message(FATAL_ERROR "The generated and baseline files are different but are expected to match. Generated [${generated}]. Baseline [${baseline}]")
-  endif()
 
   # Generate description file of an extension *with* dependencies
   # where EXTENSION_DEPENDS is a space separated string
@@ -192,17 +207,10 @@ This is a line of text.<br>And another one."
     EXTENSION_DEPENDS "Foo Bar"
     EXTENSION_ENABLED 0
     )
-  set(generated "${CMAKE_CURRENT_BINARY_DIR}/SlicerToKiwiExporter.s4ext")
-  set(baseline "${Slicer_SOURCE_DIR}/Extensions/CMake/Testing/extension_description_with_depends.s4ext")
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol
-      ${generated}
-      ${baseline}
-    RESULT_VARIABLE result
+  _check_generated_description_file(
+    GENERATED "${destination_dir}/SlicerToKiwiExporter.s4ext"
+    BASELINE "${Slicer_SOURCE_DIR}/Extensions/CMake/Testing/extension_description_with_depends.s4ext"
     )
-  if(NOT result EQUAL 0)
-    message(FATAL_ERROR "The generated and baseline files are different but are expected to match. Generated [${generated}]. Baseline [${baseline}]")
-  endif()
 
   # Generate description file of an extension *with* dependencies
   # where EXTENSION_DEPENDS is a list
@@ -213,17 +221,10 @@ This is a line of text.<br>And another one."
     EXTENSION_ENABLED 0
     EXTENSION_STATUS ""
     )
-  set(generated "${CMAKE_CURRENT_BINARY_DIR}/SlicerToKiwiExporter.s4ext")
-  set(baseline "${Slicer_SOURCE_DIR}/Extensions/CMake/Testing/extension_description_with_depends.s4ext")
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol
-      ${generated}
-      ${baseline}
-    RESULT_VARIABLE result
+  _check_generated_description_file(
+    GENERATED "${destination_dir}/SlicerToKiwiExporter.s4ext"
+    BASELINE "${Slicer_SOURCE_DIR}/Extensions/CMake/Testing/extension_description_with_depends.s4ext"
     )
-  if(NOT result EQUAL 0)
-    message(FATAL_ERROR "The generated and baseline files are different but are expected to match. Generated [${generated}]. Baseline [${baseline}]")
-  endif()
 
   message("SUCCESS")
 endfunction()

--- a/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake
+++ b/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake
@@ -71,6 +71,19 @@ function(slicerFunctionGenerateExtensionDescription)
     endif()
   endforeach()
 
+  function(_convert_items_to_s4ext _items _separator _output_var)
+    # Remove newlines
+    string(REPLACE "\n" "" _items "${_items}")
+    # Strip contiguous spaces
+    string(REGEX REPLACE " +" " " _items "${_items}")
+    # Strip leading and trailing spaces
+    string(STRIP "${_items}" _items)
+    # Convert to space separated list
+    list_to_string("${_separator}" "${_items}" _items)
+
+    set(${_output_var} "${_items}" PARENT_SCOPE)
+  endfunction()
+
   # contributors: Remove newlines
   string(REPLACE "\n" "" MY_EXTENSION_CONTRIBUTORS "${MY_EXTENSION_CONTRIBUTORS}")
   # contributors: Strip contiguous spaces
@@ -79,14 +92,8 @@ function(slicerFunctionGenerateExtensionDescription)
   # description: Replace newlines with "<br>"
   string(REPLACE "\n" "<br>" MY_EXTENSION_DESCRIPTION "${MY_EXTENSION_DESCRIPTION}")
 
-  # screenshoturls: Remove newlines
-  string(REPLACE "\n" "" MY_EXTENSION_SCREENSHOTURLS "${MY_EXTENSION_SCREENSHOTURLS}")
-  # screenshoturls: Strip contiguous spaces
-  string(REGEX REPLACE " +" " " MY_EXTENSION_SCREENSHOTURLS "${MY_EXTENSION_SCREENSHOTURLS}")
-  # screenshoturls: Strip leading and trailing spaces
-  string(STRIP "${MY_EXTENSION_SCREENSHOTURLS}" MY_EXTENSION_SCREENSHOTURLS)
   # screenshoturls: Convert to space separated list
-  list_to_string(" " "${MY_EXTENSION_SCREENSHOTURLS}" MY_EXTENSION_SCREENSHOTURLS)
+  _convert_items_to_s4ext("${MY_EXTENSION_SCREENSHOTURLS}" " " MY_EXTENSION_SCREENSHOTURLS)
 
   # depends: Convert to space separated list
   list_to_string(" " "${MY_EXTENSION_DEPENDS}" MY_EXTENSION_DEPENDS)


### PR DESCRIPTION
Resolves https://github.com/Slicer/Slicer/issues/7721.
The `EXTENSION_CONTRIBUTORS` argument to the function [`slicerFunctionGenerateExtensionDescription()`](https://github.com/Slicer/Slicer/blob/80c243f06764d81b0dbb7d40ef4832baf7296f8f/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake#L32-L130) now supports both a string input with the contributors names (to be joined by `, `), as well as a CMake list of the contributors, still applying suitable whitespace stripping. The test for this function has been updated to verify both cases.