### PR TITLE
DOC: Dynamically generate links to slicer doxygen based on ReadTheDocs version

### DIFF
--- a/Docs/developer_guide/advanced_topics.md
+++ b/Docs/developer_guide/advanced_topics.md
@@ -129,7 +129,7 @@ this should be used:
 n = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLLinearTransformNode')
 ```
 
-Note: MRML scene's `CreateNodeByClass` creates a node with the default settings set in the scene for that node type (using [vtkMRMLScene::AddDefaultNode](https://apidocs.slicer.org/main/classvtkMRMLScene.html#ae302c5ed4aabb2910bc35dcc9aa2513f)).
+Note: MRML scene's `CreateNodeByClass` creates a node with the default settings set in the scene for that node type (using [vtkMRMLScene::AddDefaultNode](slicerapidocs:classvtkMRMLScene.html#ae302c5ed4aabb2910bc35dcc9aa2513f)).
 
 ## Working directory
 

--- a/Docs/developer_guide/modules/transforms.md
+++ b/Docs/developer_guide/modules/transforms.md
@@ -1,11 +1,11 @@
 # Transforms
 
 ## Related MRML nodes
-- [vtkMRMLTransformableNode](https://apidocs.slicer.org/main/classvtkMRMLTransformableNode.html): any node that can be transformed
-- [vtkMRMLTransformNode](https://apidocs.slicer.org/main/classvtkMRMLTransformNode.html): it can store any linear or deformable transform or composite of multiple transforms
-  - [vtkMRMLLinearTransformNode](https://apidocs.slicer.org/main/classvtkMRMLLinearTransformNode.html): Deprecated. The transform does exactly the same as vtkMRMLTransformNode but has a different class name, which are still used for showing only certain transform types in node selectors. In the future this class will be removed. A vtkMRMLLinearTransformNode may contain non-linear components after a non-linear transform is hardened on it. Therefore, to check linearity of a transform the vtkMRMLTransformNode::IsLinear() and vtkMRMLTransformNode::IsTransformToWorldLinear() and vtkMRMLTransformNode::IsTransformToNodeLinear() methods must be used instead of using vtkMRMLLinearTransformNode::SafeDownCast(transform)!=NULL.
-  - [vtkMRMLBSplineTransformNode](https://apidocs.slicer.org/main/classvtkMRMLBSplineTransformNode.html): Deprecated. The transform does exactly the same as vtkMRMLTransformNode but has a different class name, which are still used for showing only certain transform types in node selectors. In the future this class will be removed.
-  - [vtkMRMLGridTransformNode](https://apidocs.slicer.org/main/classvtkMRMLGridTransformNode.html): Deprecated. The transform does exactly the same as vtkMRMLTransformNode but has a different class name, which are still used for showing only certain transform types in node selectors. In the future this class will be removed.
+- [vtkMRMLTransformableNode](slicerapidocs:classvtkMRMLTransformableNode.html): any node that can be transformed
+- [vtkMRMLTransformNode](slicerapidocs:classvtkMRMLTransformNode.html#): it can store any linear or deformable transform or composite of multiple transforms
+  - [vtkMRMLLinearTransformNode](slicerapidocs:classvtkMRMLLinearTransformNode.html): Deprecated. The transform does exactly the same as vtkMRMLTransformNode but has a different class name, which are still used for showing only certain transform types in node selectors. In the future this class will be removed. A vtkMRMLLinearTransformNode may contain non-linear components after a non-linear transform is hardened on it. Therefore, to check linearity of a transform the vtkMRMLTransformNode::IsLinear() and vtkMRMLTransformNode::IsTransformToWorldLinear() and vtkMRMLTransformNode::IsTransformToNodeLinear() methods must be used instead of using vtkMRMLLinearTransformNode::SafeDownCast(transform)!=NULL.
+  - [vtkMRMLBSplineTransformNode](slicerapidocs:classvtkMRMLBSplineTransformNode.html): Deprecated. The transform does exactly the same as vtkMRMLTransformNode but has a different class name, which are still used for showing only certain transform types in node selectors. In the future this class will be removed.
+  - [vtkMRMLGridTransformNode](slicerapidocs:classvtkMRMLGridTransformNode.html): Deprecated. The transform does exactly the same as vtkMRMLTransformNode but has a different class name, which are still used for showing only certain transform types in node selectors. In the future this class will be removed.
 
 ## Transform files
 
@@ -19,7 +19,7 @@
 
 ## Events
 
-When a transform node is observed by a transformable node, [vtkMRMLTransformableNode::TransformModifiedEvent](https://apidocs.slicer.org/main/classvtkMRMLTransformableNode.html#a2614fa4d0c7c096d4782ceae75af0c82a4993bf6e23a6dfc138cb2efc1b9ce43b) is fired on the transformable node at observation time. Anytime a transform is modified, vtkCommand::ModifiedEvent is fired on the transform node and [vtkMRMLTransformableNode::TransformModifiedEvent](https://apidocs.slicer.org/main/classvtkMRMLTransformableNode.html#a2614fa4d0c7c096d4782ceae75af0c82a4993bf6e23a6dfc138cb2efc1b9ce43b) is fired on the transformable node.
+When a transform node is observed by a transformable node, [vtkMRMLTransformableNode::TransformModifiedEvent](slicerapidocs:classvtkMRMLTransformableNode.html) is fired on the transformable node at observation time. Anytime a transform is modified, vtkCommand::ModifiedEvent is fired on the transform node and [vtkMRMLTransformableNode::TransformModifiedEvent](slicerapidocs:classvtkMRMLTransformableNode.html) is fired on the transformable node.
 
 ## Examples
 

--- a/Docs/developer_guide/modules/transforms.md
+++ b/Docs/developer_guide/modules/transforms.md
@@ -19,7 +19,7 @@
 
 ## Events
 
-When a transform node is observed by a transformable node, [vtkMRMLTransformableNode::TransformModifiedEvent](slicerapidocs:classvtkMRMLTransformableNode.html) is fired on the transformable node at observation time. Anytime a transform is modified, vtkCommand::ModifiedEvent is fired on the transform node and [vtkMRMLTransformableNode::TransformModifiedEvent](slicerapidocs:classvtkMRMLTransformableNode.html) is fired on the transformable node.
+When a transform node is observed by a transformable node, [vtkMRMLTransformableNode::TransformModifiedEvent](slicerapidocs:classvtkMRMLTransformableNode.html#a2614fa4d0c7c096d4782ceae75af0c82a4993bf6e23a6dfc138cb2efc1b9ce43b) is fired on the transformable node at observation time. Anytime a transform is modified, vtkCommand::ModifiedEvent is fired on the transform node and [vtkMRMLTransformableNode::TransformModifiedEvent](slicerapidocs:classvtkMRMLTransformableNode.html#a2614fa4d0c7c096d4782ceae75af0c82a4993bf6e23a6dfc138cb2efc1b9ce43b) is fired on the transformable node.
 
 ## Examples
 

--- a/Docs/developer_guide/python_faq.md
+++ b/Docs/developer_guide/python_faq.md
@@ -158,7 +158,7 @@ cliNode = slicer.cli.runSync(slicer.modules.simpleregiongrowingsegmentation, Non
 
 ### Running CLI in the background
 
-If the CLI module is executed using `slicer.cli.run` method then the CLI module runs in a background thread, so the call to `startProcessing` will return right away and the user interface will not be blocked. The `slicer.cli.run` call returns a cliNode (an instance of [vtkMRMLCommandLineModuleNode](https://apidocs.slicer.org/main/classvtkMRMLCommandLineModuleNode.html)) which can be used to monitor the progress of the module.
+If the CLI module is executed using `slicer.cli.run` method then the CLI module runs in a background thread, so the call to `startProcessing` will return right away and the user interface will not be blocked. The `slicer.cli.run` call returns a cliNode (an instance of [vtkMRMLCommandLineModuleNode](slicerapidocs:classvtkMRMLCommandLineModuleNode.html)) which can be used to monitor the progress of the module.
 
 In this example we create a simple callback `onProcessingStatusUpdate` that will be called whenever the cliNode is modified.  The status will tell you if the nodes is Pending, Running, or Completed.
 

--- a/Docs/developer_guide/script_repository/volumes.md
+++ b/Docs/developer_guide/script_repository/volumes.md
@@ -920,7 +920,7 @@ propertyNode->SetScalarOpacity(opacities);
 // optionally set the gradients opacities with SetGradientOpacity
 ```
 
-Volume rendering logic has utility functions to help you create those transfer functions: [SetWindowLevelToVolumeProp](https://apidocs.slicer.org/main/classvtkSlicerVolumeRenderingLogic.html#a3436ef769a321ff287d58f17118e8550), [SetThresholdToVolumeProp](https://apidocs.slicer.org/main/classvtkSlicerVolumeRenderingLogic.html#a1dcbe614493f3cbb9aa50c68a64764ca), [SetLabelMapToVolumeProp](https://apidocs.slicer.org/main/classvtkSlicerVolumeRenderingLogic.html#a359314889c2b386fd4c3ffe5414522da).
+Volume rendering logic has utility functions to help you create those transfer functions: [SetWindowLevelToVolumeProp](slicerapidocs:classvtkSlicerVolumeRenderingLogic.html#a3436ef769a321ff287d58f17118e8550), [SetThresholdToVolumeProp](slicerapidocs:classvtkSlicerVolumeRenderingLogic.html#a1dcbe614493f3cbb9aa50c68a64764ca), [SetLabelMapToVolumeProp](slicerapidocs:classvtkSlicerVolumeRenderingLogic.html#a359314889c2b386fd4c3ffe5414522da).
 
 ### Limit volume rendering to a specific region of the volume
 
@@ -940,7 +940,7 @@ displayNode->SetCroppingEnabled(1);
 
 ### Register a new Volume Rendering mapper
 
-You need to derive from [vtkMRMLVolumeRenderingDisplayNode](https://apidocs.slicer.org/main/classvtkMRMLVolumeRenderingDisplayNode.html) and register your class within [vtkSlicerVolumeRenderingLogic](https://apidocs.slicer.org/main/classvtkSlicerVolumeRenderingLogic.html).
+You need to derive from [vtkMRMLVolumeRenderingDisplayNode](slicerapidocs:classvtkMRMLVolumeRenderingDisplayNode.html) and register your class within [vtkSlicerVolumeRenderingLogic](slicerapidocs:classvtkSlicerVolumeRenderingLogic.html).
 
 C++:
 
@@ -969,7 +969,7 @@ void qSlicerMyABCVolumeRenderingModule::setup()
 }
 ```
 
-If you want to expose control widgets for your volume rendering method, then register your widget with [addRenderingMethodWidget()](https://apidocs.slicer.org/main/classqSlicerVolumeRenderingModuleWidget.html#acd9cdb60f1fd260f3ebf74428bb7c45b).
+If you want to expose control widgets for your volume rendering method, then register your widget with [addRenderingMethodWidget()](slicerapidocs:classqSlicerVolumeRenderingModuleWidget.html#acd9cdb60f1fd260f3ebf74428bb7c45b).
 
 ### Register custom volume rendering presets
 


### PR DESCRIPTION
This pull request introduces a systematic mechanism to generate Doxygen documentation links dynamically, aligning with the ReadTheDocs version of the project.

- Extracts `<major>.<minor>` version information from the top-level `CMakeLists.txt`.
- Updates `conf.py` to construct Doxygen links dynamically for either the release or main branch based on the minor version parity:
  - **Odd minor versions**: Links to the corresponding Preview documentation (`/main` sub-directory).
  - **Even minor versions**: Links to the corresponding Stable documentation sub-directory (e.g., `/X.Y`).
- Implements a custom URL scheme `slicerapidocs` to facilitate consistent and version-specific cross-referencing in Markdown files.

Closes #7119