### PR TITLE
ENH: Add support for additional NumPy types in `slicer.util.updateTableFromArray`

### DIFF
--- a/Applications/SlicerApp/Testing/Python/UtilTest.py
+++ b/Applications/SlicerApp/Testing/Python/UtilTest.py
@@ -284,6 +284,17 @@ class UtilTestTest(ScriptedLoadableModuleTest):
         self.assertEqual(tableNode3.GetColumnName(1), "height")
         self.assertEqual(tableNode3.GetColumnType("height"), vtk.VTK_LONG_LONG)
 
+        self.delayDisplay("Test boolean array update")
+        tableNode4 = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode")
+        narray = np.array([True, False, True])
+        slicer.util.updateTableFromArray(tableNode4, narray)
+        self.assertEqual(tableNode4.GetNumberOfColumns(), 1)
+        self.assertEqual(tableNode4.GetNumberOfRows(), 3)
+        self.assertEqual(tableNode4.GetColumnType(tableNode4.GetColumnName(0)), vtk.VTK_BIT)
+        self.assertEqual(tableNode4.GetTable().GetValue(0, 0), 1)
+        self.assertEqual(tableNode4.GetTable().GetValue(1, 0), 0)
+        self.assertEqual(tableNode4.GetTable().GetValue(2, 0), 1)
+
         self.delayDisplay("Testing slicer.util.test_updateTableFromArray passed")
 
     def test_arrayFromModelPoints(self):

--- a/Applications/SlicerApp/Testing/Python/UtilTest.py
+++ b/Applications/SlicerApp/Testing/Python/UtilTest.py
@@ -268,6 +268,22 @@ class UtilTestTest(ScriptedLoadableModuleTest):
         self.assertEqual(tableNode2.GetNumberOfColumns(), 2)
         self.assertEqual(tableNode2.GetNumberOfRows(), 11)
 
+        self.delayDisplay("Test structured array update")
+        tableNode3 = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode")
+        data_type = np.dtype([("mountain_rank", np.uint16), ("height", int)])
+        structured_array = np.array([
+            (1, 8859), # Mount Everest
+            (2, 8611), # K2
+            (3, 8586), # Kangchenjunga
+        ], dtype=data_type)
+        slicer.util.updateTableFromArray(tableNode3, structured_array)
+        self.assertEqual(tableNode3.GetNumberOfColumns(), 2)
+        self.assertEqual(tableNode3.GetNumberOfRows(), 3)
+        self.assertEqual(tableNode3.GetColumnName(0), "mountain_rank")
+        self.assertEqual(tableNode3.GetColumnType("mountain_rank"), vtk.VTK_UNSIGNED_SHORT)
+        self.assertEqual(tableNode3.GetColumnName(1), "height")
+        self.assertEqual(tableNode3.GetColumnType("height"), vtk.VTK_LONG_LONG)
+
         self.delayDisplay("Testing slicer.util.test_updateTableFromArray passed")
 
     def test_arrayFromModelPoints(self):

--- a/Applications/SlicerApp/Testing/Python/UtilTest.py
+++ b/Applications/SlicerApp/Testing/Python/UtilTest.py
@@ -295,6 +295,17 @@ class UtilTestTest(ScriptedLoadableModuleTest):
         self.assertEqual(tableNode4.GetTable().GetValue(1, 0), 0)
         self.assertEqual(tableNode4.GetTable().GetValue(2, 0), 1)
 
+        self.delayDisplay("Test boolean array update with setBoolAsUchar=True")
+        tableNode5 = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode")
+        narray = np.array([True, False, True])
+        slicer.util.updateTableFromArray(tableNode5, narray, setBoolAsUchar=True)
+        self.assertEqual(tableNode5.GetNumberOfColumns(), 1)
+        self.assertEqual(tableNode5.GetNumberOfRows(), 3)
+        self.assertEqual(tableNode5.GetColumnType(tableNode4.GetColumnName(0)), vtk.VTK_UNSIGNED_CHAR)
+        self.assertEqual(tableNode5.GetTable().GetValue(0, 0), 1)
+        self.assertEqual(tableNode5.GetTable().GetValue(1, 0), 0)
+        self.assertEqual(tableNode5.GetTable().GetValue(2, 0), 1)
+
         self.delayDisplay("Testing slicer.util.test_updateTableFromArray passed")
 
     def test_arrayFromModelPoints(self):

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2515,7 +2515,11 @@ def updateTableFromArray(tableNode, narrays, columnNames=None):
     :return: Updated ``vtkMRMLTableNode``.
     :raises ValueError: If the input ``narrays`` is not a recognized format.
 
-    All existing columns in the target table node are removed before adding new columns.
+    This function automatically detects the data type of each input array using
+    ``vtk.util.numpy_support.get_vtk_array_type`` and maps it to the corresponding VTK array type. As a
+    result, a broader range of numeric and complex data (e.g., int, float, and complex) is supported
+    without requiring manual conversions. All existing columns in the target table node are removed
+    before adding new columns.
 
     .. warning:: Data in the table node is stored by value (deep copy). Modifying the NumPy array after calling
         this function does not update the table node's data.
@@ -2548,7 +2552,8 @@ def updateTableFromArray(tableNode, narrays, columnNames=None):
     if isinstance(columnNames, str):
         columnNames = [columnNames]
     for columnIndex, ncolumn in enumerate(ncolumns):
-        vcolumn = vtk.util.numpy_support.numpy_to_vtk(num_array=ncolumn.ravel(), deep=True, array_type=vtk.VTK_FLOAT)
+        vtype = vtk.util.numpy_support.get_vtk_array_type(ncolumn.dtype)
+        vcolumn = vtk.util.numpy_support.numpy_to_vtk(num_array=ncolumn.ravel(), deep=True, array_type=vtype)
         if (columnNames is not None) and (columnIndex < len(columnNames)):
             vcolumn.SetName(columnNames[columnIndex])
         tableNode.AddColumn(vcolumn)

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2498,16 +2498,29 @@ def arrayFromTableColumnModified(tableNode, columnName):
 
 
 def updateTableFromArray(tableNode, narrays, columnNames=None):
-    """Set values in a table node from a numpy array.
+    """Set values in a table node from a NumPy array or an array-like object (list/tuple of NumPy arrays).
 
-    :param columnNames: may contain a string or list of strings that will be used as column name(s).
-    :raises ValueError: in case of failure
+    :param tableNode: The table node to be updated. If ``None``, a new ``vtkMRMLTableNode`` is
+      created and added to the scene.
+    :type tableNode: vtkMRMLTableNode or None
+    :param narrays: One of:
+        - A 1D NumPy array
+        - A 2D NumPy array (values will be transposed so each column becomes a table column)
+        - A list/tuple of 1D NumPy arrays
+    :type narrays: np.ndarray, tuple, or list
+    :param columnNames: Optional string or list of strings specifying names for the columns. If fewer
+      names are provided than columns, only the specified columns are named;
+      otherwise columns get default names. If ``None`` is passed, no column names are set.
+    :type columnNames: str, list of str, or None
+    :return: Updated ``vtkMRMLTableNode``.
+    :raises ValueError: If the input ``narrays`` is not a recognized format.
 
-    Values are copied, therefore if the numpy array  is modified after calling this method,
-    values in the table node will not change.
-    All previous content of the table is deleted.
+    All existing columns in the target table node are removed before adding new columns.
 
-    Example::
+    .. warning:: Data in the table node is stored by value (deep copy). Modifying the NumPy array after calling
+        this function does not update the table node's data.
+
+    .. code-block:: python
 
       import numpy as np
       histogram = np.histogram(arrayFromVolume(getNode('MRHead')))


### PR DESCRIPTION
See updated description below: https://github.com/Slicer/Slicer/pull/8180#issuecomment-2649364818

<details><summary>Previous description</summary>
<p>

Allow additional `dtypes` to be handled when converting to `vtk` array. All types supported by `vtk.util.numpy_support.get_vtk_array_type` can be converted.

However, I don't think this still supports `boolean` or `string` arrays.
We need to figure out a way to generate and possibly use the following VTK array types:
`bool` numpy array --> `vtkBitArray`
`string` numpy array --> `vtkStringArray`

</p>
</details> 

Partially addresses:
 - https://github.com/Slicer/Slicer/issues/5827
