### PR TITLE
ENH: Define a window icon for all windows 

### DIFF
--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -360,6 +360,12 @@ void qSlicerApplicationPrivate::init()
 
   this->initStyle();
 
+  QIcon icon;
+  icon.addFile(":/Icons/Medium/DesktopIcon.png");
+  icon.addFile(":/Icons/Large/DesktopIcon.png");
+  icon.addFile(":/Icons/XLarge/DesktopIcon.png");
+  q->setWindowIcon(icon);
+
   this->ToolTipTrapper = new ctkToolTipTrapper(q);
   this->ToolTipTrapper->setToolTipsTrapped(false);
   this->ToolTipTrapper->setToolTipsWordWrapped(true);


### PR DESCRIPTION
https://doc.qt.io/qt-5/qapplication.html#windowIcon-prop

Defining the QApplication window icon sets the default window icon. Slicer currently sets the QMainWindow window icon which is primarily used for windows that are children of the main window. Before this commit the QApplication window icon was undefined so no icon was used for a widget with no parent.

| `main`  | This PR |
|---------|---------|
|![{9738F05D-BFF0-4C2C-A512-300FEE842AE3}](https://github.com/user-attachments/assets/52e20125-2dd3-4fea-a796-645d7f0403f4)|![{68C46A8D-C1AC-43EF-B2EF-A7DBA0E95F39}](https://github.com/user-attachments/assets/0a2a748c-e65c-40f4-b5b3-887504ef3409)|