### PR TITLE
BUG: Fix duplicated registration of Markups node in tests

### DIFF
--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest2.cxx
@@ -306,18 +306,7 @@ int vtkMRMLMarkupsStorageNodeTest2(int argc, char* argv[])
   // Application logic - Handle creation of vtkMRMLSelectionNode and vtkMRMLInteractionNode
   vtkNew<vtkMRMLApplicationLogic> applicationLogic;
   applicationLogic->SetMRMLScene(scene);
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsFiducialNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsLineNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsAngleNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsCurveNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsClosedCurveNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsDisplayNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsPlaneDisplayNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsPlaneNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsPlaneJsonStorageNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsFiducialDisplayNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsROIDisplayNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsROINode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsROIJsonStorageNode>::New());
 
   scene->AddNode(storageNodeJson);

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumeRenderingDisplayableManagerTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumeRenderingDisplayableManagerTest1.cxx
@@ -88,12 +88,10 @@ int vtkMRMLVolumeRenderingDisplayableManagerTest1(int argc, char* argv[])
   //renderer->GetActiveCamera()->SetPosition(0,0,-500.);
 
   vtkNew<vtkMRMLAnnotationROINode> annotationROINode;
-  vtkNew<vtkMRMLMarkupsROINode> markupsROINode;
 
   // MRML scene
   vtkMRMLScene* scene = vtkMRMLScene::New();
   scene->RegisterNodeClass(annotationROINode);
-  scene->RegisterNodeClass(markupsROINode);
 
   // Application logic - Handle creation of vtkMRMLSelectionNode and vtkMRMLInteractionNode
   vtkMRMLApplicationLogic* applicationLogic = vtkMRMLApplicationLogic::New();


### PR DESCRIPTION
This commit resolves issues in the following tests caused by a regression introduced in commit d919d2fd693 ("COMP: Move classes from Modules/Loadable/Markups/MRML to Libs/MRML/Core", 2025-01-21):
- `vtkMRMLVolumeRenderingDisplayableManagerTest1`
- `vtkMRMLMarkupsStorageNodeTest2`

The regression resulted from redundant calls to `RegisterNodeClass`. Since these nodes are now part of the core, they are automatically registered in `vtkMRMLScene`. The explicit registrations are no longer necessary and have been removed.

This resolves errors like the following:

```
426: 2025-01-26 18:58:38.183 (   0.260s) [        A9A39980]       vtkMRMLScene.cxx:574   WARN| vtkMRMLScene (0x563228bb7d20): Tag MarkupsROI has already been registered, unregistering previous node class vtkMRMLMarkupsROINode to register vtkMRMLMarkupsROINode
[,,,]
426: Assertion failed in /home/jcfr/Projects/Slicer-Release/Slicer-build/Modules/Loadable/VolumeRendering/Testing/Cxx/qSlicerVolumeRenderingModuleCxxTests.cxx:229 - expected 0 error or warning messages, got 1
```