### PR TITLE
COMP: Remove deprecated Jacobian methods for ITK_LEGACY_REMOVE compliance

### DIFF
--- a/Libs/MRML/Core/vtkITKTransformInverse.h
+++ b/Libs/MRML/Core/vtkITKTransformInverse.h
@@ -194,13 +194,6 @@ namespace itk
     {
       itkExceptionMacro( "Only storage methods are implemented for InverseDisplacementFieldTransform" );
     }
-    // Deprecated in ITKv5. It should be removed when ITK_LEGACY_REMOVE is set to ON.
-    void ComputeJacobianWithRespectToPosition(
-        const typename Superclass::InputPointType  &,
-        typename Superclass::JacobianType &) const override
-    {
-      itkExceptionMacro( "Only storage methods are implemented for InverseDisplacementFieldTransform" );
-    }
     void ComputeJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
         typename Superclass::JacobianPositionType &) const override
@@ -210,12 +203,6 @@ namespace itk
     void ComputeJacobianWithRespectToPosition(
         const typename Superclass::IndexType  &,
         typename Superclass::JacobianPositionType &) const override
-    {
-      itkExceptionMacro( "Only storage methods are implemented for InverseDisplacementFieldTransform" );
-    }
-    void ComputeInverseJacobianWithRespectToPosition(
-        const typename Superclass::InputPointType  &,
-        typename Superclass::JacobianType &) const override
     {
       itkExceptionMacro( "Only storage methods are implemented for InverseDisplacementFieldTransform" );
     }

--- a/Modules/CLI/ResampleDTIVolume/itkWarpTransform3D.h
+++ b/Modules/CLI/ResampleDTIVolume/itkWarpTransform3D.h
@@ -50,15 +50,8 @@ public:
 
   OutputPointType TransformPoint( const InputPointType & inputPoint ) const override;
 
-  void ComputeJacobianWithRespectToParameters(const InputPointType  & p,
+  void ComputeJacobianWithRespectToParameters(const InputPointType & p,
       JacobianType & jacobian ) const override;
-
-  void ComputeJacobianWithRespectToPosition(
-    const InputPointType & itkNotUsed(x),
-    JacobianType & itkNotUsed(j) ) const override
-  {
-    itkExceptionMacro("ComputeJacobianWithRespectToPosition is not implemented for WarpTransform3D");
-  }
 
   void ComputeJacobianWithRespectToPosition(
     const InputPointType & itkNotUsed(x),

--- a/Modules/CLI/ResampleDTIVolume/itkWarpTransform3D.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkWarpTransform3D.txx
@@ -64,8 +64,7 @@ WarpTransform3D<FieldData>
   OutputPointType      transformedPoint;
   DeformationPixelType displacement;
 
-  itk::Index<3> index;
-  m_DeformationField->TransformPhysicalPointToIndex( inputPoint, index );
+  itk::Index<3> index = m_DeformationField->TransformPhysicalPointToIndex( inputPoint );
   if( !m_DeformationField->GetLargestPossibleRegion().IsInside( index ) )
   {
     return inputPoint;
@@ -85,8 +84,7 @@ WarpTransform3D<FieldData>
   ConstNeighborhoodIteratorType bit;
 
   itk::ImageRegion<3> region;
-  itk::Index<3>       start;
-  m_DeformationField->TransformPhysicalPointToIndex( inputPoint, start );
+  itk::Index<3>       start = m_DeformationField->TransformPhysicalPointToIndex( inputPoint );
   jacobian.SetSize( 3, 3 );
   if( !m_DeformationField->GetLargestPossibleRegion().IsInside( start ) )
   {


### PR DESCRIPTION
Removed deprecated Jacobian-related methods to ensure compatibility with ITK configured with ITK_LEGACY_REMOVE set to ON.

Key Changes:
- Removed legacy methods `ComputeJacobianWithRespectToPosition` and `ComputeInverseJacobianWithRespectToPosition` in `vtkITKTransformInverse.h` and `itkWarpTransform3D.h`.
- Simplified code by eliminating outdated API usage.
- Updated `TransformPhysicalPointToIndex` calls for improved clarity and adherence to ITK's current conventions.

This will make it easier to turn on ITK_LEGACY_REMOVE, and eventually move to a newer version of ITK (e.g. 6.0).