### PR TITLE
ENH: Add `ctkColorPickerButton` support with `QColor` in `parameterNodeWrapper`

### DIFF
--- a/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
@@ -706,6 +706,39 @@ class qMRMLNodeComboBoxToNodeConnector(GuiConnector):
         self._widget.setCurrentNode(value)
 
 
+@parameterNodeGuiConnector
+class ctkColorPickerButtonToQColorConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return type(widget) == ctk.ctkColorPickerButton and unannotatedType(datatype) == qt.QColor
+
+    @staticmethod
+    def create(widget, datatype):
+        if ctkColorPickerButtonToQColorConnector.canRepresent(widget, datatype):
+            return ctkColorPickerButtonToQColorConnector(widget, datatype)
+        return None
+
+    def __init__(self, widget: ctk.ctkColorPickerButton, datatype):
+        super().__init__()
+        self._widget: ctk.ctkColorPickerButton = widget
+        self._type = unannotatedType(datatype)
+
+    def _connect(self):
+        self._widget.colorChanged.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.colorChanged.disconnect(self.changed)
+
+    def widget(self) -> ctk.ctkColorPickerButton:
+        return self._widget
+
+    def read(self) -> qt.QColor:
+        return self._widget.color
+
+    def write(self, value : qt.QColor) -> None:
+        self._widget.color = value
+
+
 SlicerPackParameterNamePropertyName = "SlicerPackParameterName"
 
 

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
@@ -267,6 +267,44 @@ class ParameterNodeWrapperGuiTest(unittest.TestCase):
         self.assertEqual(param.charlie, 0.1)
         self.assertEqual(widgetCharlie.value, 0.1)
 
+    def test_ctkColorPickerButtonToQColor(self):
+
+        @parameterNodeWrapper
+        class ParameterNodeWrapper:
+            alpha: qt.QColor
+            bravo: Annotated[qt.QColor, Default(qt.QColor("red"))]
+
+        colorPickerAlpha = ctk.ctkColorPickerButton()
+        colorPickerAlpha.deleteLater()
+        colorPickerBravo = ctk.ctkColorPickerButton()
+        colorPickerBravo.deleteLater()
+        param = ParameterNodeWrapper(newParameterNode())
+
+        # Phase 0 - connect parameterNode to GUI
+        mapping = {
+            "alpha": colorPickerAlpha,
+            "bravo": colorPickerBravo,
+        }
+        param.connectParametersToGui(mapping)
+        self.assertEqual(param.alpha, qt.QColor("#000000"))
+        self.assertEqual(colorPickerAlpha.color, qt.QColor("#000000"))
+        self.assertEqual(param.bravo, qt.QColor("red"))
+        self.assertEqual(colorPickerBravo.color, qt.QColor("red"))
+
+        # Phase 1 - write to GUI
+        colorPickerAlpha.color = qt.QColor("green")
+        self.assertEqual(param.alpha, qt.QColor("green"))
+        self.assertEqual(colorPickerAlpha.color, qt.QColor("green"))
+        self.assertEqual(param.bravo, qt.QColor("red"))
+        self.assertEqual(colorPickerBravo.color, qt.QColor("red"))
+
+        # Phase 2 - write to parameterNode
+        param.bravo = qt.QColor("blue")
+        self.assertEqual(param.alpha, qt.QColor("green"))
+        self.assertEqual(colorPickerAlpha.color, qt.QColor("green"))
+        self.assertEqual(param.bravo, qt.QColor("blue"))
+        self.assertEqual(colorPickerBravo.color, qt.QColor("blue"))
+
     def test_QDoubleSpinBoxToFloat(self):
         self.impl_CheckFloatWidgetToUnboundedFloatParam(qt.QDoubleSpinBox)
         self.impl_CheckFloatWidgetToBoundedFloatParam(qt.QDoubleSpinBox)


### PR DESCRIPTION
This commit introduces:
- A new GuiConnector (`ctkColorPickerButtonToQColorConnector`) that binds `ctkColorPickerButton` to a `QColor` property in the parameter node.
- A new serializer (`QColorSerializer`) enabling QColor to be saved and restored from the parameter node.
- An `ObservedQColor` subclass that automatically updates the parameter node whenever a “set*” method modifies the color value.


part of #7308 