### PR TITLE
COMP: Fix Windows build errors by explicitly including `Windows.h`

### DIFF
--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
@@ -56,6 +56,7 @@
 #include <set>
 
 #ifdef _WIN32
+#include <Windows.h> // For GetCurrentProcessId
 #else
 #include <sys/types.h>
 #include <unistd.h>

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -1225,15 +1225,6 @@ void qSlicerApplication::logApplicationInformation() const
   // total page file size is a better indication of actually available memory for the process.
   // The issue has been fixed in kwSys release at the end of 2014, therefore when VTK is upgraded then
   // this workaround may not be needed anymore.
-#if defined(_MSC_VER) && _MSC_VER < 1300
-  MEMORYSTATUS ms;
-  ms.dwLength = sizeof(ms);
-  GlobalMemoryStatus(&ms);
-  unsigned long totalPhysicalBytes = ms.dwTotalPhys;
-  totalPhysicalMemoryMb = totalPhysicalBytes>>10>>10;
-  unsigned long totalVirtualBytes = ms.dwTotalPageFile;
-  totalVirtualMemoryMb = totalVirtualBytes>>10>>10;
-#else
   MEMORYSTATUSEX ms;
   ms.dwLength = sizeof(ms);
   if (GlobalMemoryStatusEx(&ms))
@@ -1243,7 +1234,6 @@ void qSlicerApplication::logApplicationInformation() const
     DWORDLONG totalVirtualBytes = ms.ullTotalPageFile;
     totalVirtualMemoryMb = totalVirtualBytes>>10>>10;
   }
-#endif
 #endif
   qDebug() << qPrintable(QString("%0: %1 MB physical, %2 MB virtual")
                          .arg(titles.at(titleIndex++).leftJustified(titleWidth, '.'))

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -35,6 +35,7 @@
 
 #if defined(Q_OS_WIN32)
   #include <QtPlatformHeaders\QWindowsWindowFunctions> // for setHasBorderInFullScreen
+  #include <Windows.h> // For MEMORYSTATUSEX and GlobalMemoryStatusEx
 #endif
 
 #include "vtkSlicerConfigure.h" // For Slicer_USE_*, Slicer_BUILD_*_SUPPORT


### PR DESCRIPTION
Explicitly include `Windows.h` in `Base/QTCLI/vtkSlicerCLIModuleLogic.cxx` and 
`Base/QTGUI/qSlicerApplication.cxx` to ensure the availability of Windows-specific 
symbols `MEMORYSTATUSEX` and functions `GetCurrentProcessId()` and `GlobalMemoryStatusEx()`.

----

This fixes a regression introduced in commit 975fa530e49 ("COMP: Remove direct dependency 
on ITK from vtkSlicerApplicationLogic", 2025-01-28), which removed the `itkThreadSupport.h` 
include from `vtkSlicerApplicationLogic.h`. Since `itkThreadSupport.h` indirectly included 
`Windows.h`, its removal caused missing Windows definitions in `qSlicerApplication.cxx` and 
`vtkSlicerCLIModuleLogic.cxx`, leading to the following errors:

- `Base/QTGUI/qSlicerApplication.cxx(1237,3): error C2065: 'MEMORYSTATUSEX': undeclared identifier`
- `Base/QTCLI/vtkSlicerCLIModuleLogic.cxx(469,16): error C3861: 'GetCurrentProcessId': identifier not found`

Including `Windows.h` ensures all required dependencies are correctly included.

> [!NOTE]
> Although `MEMORYSTATUSEX` and `GlobalMemoryStatusEx()` are defined in `sysinfoapi.h`, including only `sysinfoapi.h` results in the following error:
>
> ```
> C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\um\winnt.h(169,1): 
> error C1189: #error: "No Target Architecture"
> ```
