### PR TITLE
COMP: Update BRAINSTools to fix macOS build

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -304,7 +304,7 @@ set(BRAINSTools_slicer_options
 
 Slicer_Remote_Add(BRAINSTools
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/BRAINSia/BRAINSTools.git
-  GIT_TAG "7c37d9e8c238f66f8a83f997d9c9bb659c494c90"  # 2024-11-09
+  GIT_TAG "3b3cfd0d45a35e924569ee930a29c4f6292a8d1f"  # 2024-11-09
   LICENSE_FILES "https://www.apache.org/licenses/LICENSE-2.0.txt"
   OPTION_NAME Slicer_BUILD_BRAINSTOOLS
   OPTION_DEPENDS "Slicer_BUILD_CLI_SUPPORT;Slicer_BUILD_CLI"

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -304,7 +304,7 @@ set(BRAINSTools_slicer_options
 
 Slicer_Remote_Add(BRAINSTools
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/BRAINSia/BRAINSTools.git
-  GIT_TAG "3b3cfd0d45a35e924569ee930a29c4f6292a8d1f"  # 2024-11-09
+  GIT_TAG "3b3cfd0d45a35e924569ee930a29c4f6292a8d1f" # 2025-01-29
   LICENSE_FILES "https://www.apache.org/licenses/LICENSE-2.0.txt"
   OPTION_NAME Slicer_BUILD_BRAINSTOOLS
   OPTION_DEPENDS "Slicer_BUILD_CLI_SUPPORT;Slicer_BUILD_CLI"


### PR DESCRIPTION
The commit fixes the following configuration error introduced following the BRAINSTools update in (244a6c3a788, "ENH: Update BRAINSTools from 2024-05-31 to 2024-11-09", 2025-01-24)

```
CMake Error at /path/to/Slicer-build/BRAINSTools/CMakeLists.txt:34 (message):
  FAILURE 13.0 != 11.0
```

List of changes:

```
$ git shortlog 7c37d9e8c..3b3cfd0d4 --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Support specifying macOS deployment target ≥ 11.0
```

Related pull requests:
* https://github.com/Slicer/Slicer/pull/8191
* https://github.com/BRAINSia/BRAINSTools/pull/538