### PR TITLE
BUG: Add cleanup to SegmentEditorEffect

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/AbstractScriptedSegmentEditorAutoCompleteEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/AbstractScriptedSegmentEditorAutoCompleteEffect.py
@@ -66,6 +66,15 @@ class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEdi
         self.delayedAutoUpdateTimer.stop()
         self.observeSegmentation(False)
 
+    def cleanup(self):
+        # Disconnect the timer signal to allow proper garbage collection.
+        #
+        # This prevents lingering signal/slot connections from keeping
+        # the object alive. For more details, see the parent class
+        # cleanup() docstring or the following issue:
+        # https://github.com/Slicer/Slicer/issues/7392
+        self.delayedAutoUpdateTimer.disconnect("timeout()", self.onPreview)
+
     @staticmethod
     def isBackgroundLabelmap(labelmapOrientedImageData, label=None):
         if labelmapOrientedImageData is None:

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/AbstractScriptedSegmentEditorEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/AbstractScriptedSegmentEditorEffect.py
@@ -53,6 +53,22 @@ class AbstractScriptedSegmentEditorEffect:
         effectFactorySingleton = slicer.qSlicerSegmentEditorEffectFactory.instance()
         effectFactorySingleton.registerEffect(self.scriptedEffect)
 
+    def cleanup(self):
+        """
+        Clean up resources, event observers, and Qt signal/slot connections
+        to ensure proper object deletion.
+
+        Subclasses should override this method to disconnect any subclass-specific
+        signals and slots. This method should be called before the object is
+        garbage collected or explicitly deleted on the C++ side.
+
+        Failing to disconnect signals/slots may prevent the object from being
+        garbage collected, leading to memory leaks.
+
+        For more details, see: https://github.com/Slicer/Slicer/issues/7392
+        """
+        pass
+
     #
     # Utility functions for convenient coordinate transformations
     #

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorThresholdEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorThresholdEffect.py
@@ -67,6 +67,15 @@ class SegmentEditorThresholdEffect(AbstractScriptedSegmentEditorEffect):
         # In such cases, enableViewInteractions can be set to False.
         self.enableViewInteractions = True
 
+    def cleanup(self):
+        # Disconnect the timer signal to allow proper garbage collection.
+        #
+        # This prevents lingering signal/slot connections from keeping
+        # the object alive. For more details, see the parent class
+        # cleanup() docstring or the following issue:
+        # https://github.com/Slicer/Slicer/issues/7392
+        self.timer.disconnect("timeout()", self.preview)
+
     def clone(self):
         import qSlicerSegmentationsEditorEffectsPythonQt as effects
 

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorThresholdEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorThresholdEffect.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import weakref
 
 import ctk
 import vtk
@@ -992,10 +993,17 @@ class PreviewPipeline:
 # Histogram threshold
 #
 class HistogramEventFilter(qt.QObject):
-    thresholdEffect = None
+
+    def __init__(self, *args, **kwargs):
+        qt.QObject.__init__(self, *args, **kwargs)
+        self.thresholdEffectWeakRef = None
+
+    @property
+    def thresholdEffect(self):
+        return self.thresholdEffectWeakRef() if self.thresholdEffectWeakRef else None
 
     def setThresholdEffect(self, thresholdEffect):
-        self.thresholdEffect = thresholdEffect
+        self.thresholdEffectWeakRef = weakref.ref(thresholdEffect)
 
     def eventFilter(self, object, event):
         if self.thresholdEffect is None:

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.h
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.h
@@ -192,6 +192,14 @@ public:
   /// Let the effect know that the interaction node is modified.
   /// Default behavior is to deactivate the effect if not in view mode.
   virtual void interactionNodeModified(vtkMRMLInteractionNode* interactionNode);
+  /// Clean up resources, event observers, and Qt signal/slot connections before deletion.
+  ///
+  /// This ensures proper object destruction, as active signal/slot connections
+  /// can prevent the object from being deleted. Subclasses should override this
+  /// method to handle additional cleanup as needed.
+  ///
+  /// For more details, see: https://github.com/Slicer/Slicer/issues/7392
+  Q_INVOKABLE virtual void cleanup() { };
 
 public slots:
   /// Update user interface from parameter set node

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedEffect.cxx
@@ -69,6 +69,7 @@ public:
     InteractionNodeModifiedMethod,
     UpdateGUIFromMRMLMethod,
     UpdateMRMLFromGUIMethod,
+    CleanupMethod,
   };
 
   mutable qSlicerPythonCppAPI PythonCppAPI;
@@ -99,6 +100,7 @@ qSlicerSegmentEditorScriptedEffectPrivate::qSlicerSegmentEditorScriptedEffectPri
   this->PythonCppAPI.declareMethod(Self::InteractionNodeModifiedMethod, "interactionNodeModified");
   this->PythonCppAPI.declareMethod(Self::UpdateGUIFromMRMLMethod, "updateGUIFromMRML");
   this->PythonCppAPI.declareMethod(Self::UpdateMRMLFromGUIMethod, "updateMRMLFromGUI");
+  this->PythonCppAPI.declareMethod(Self::CleanupMethod, "cleanup");
 }
 
 //-----------------------------------------------------------------------------
@@ -493,4 +495,17 @@ void qSlicerSegmentEditorScriptedEffect::updateMRMLFromGUI()
 
   Q_D(const qSlicerSegmentEditorScriptedEffect);
   d->PythonCppAPI.callMethod(d->UpdateMRMLFromGUIMethod);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSegmentEditorScriptedEffect::cleanup()
+{
+  // Base class implementation needs to be called before the effect-specific one
+  // Note: Left here as comment in case this class is used as template for adaptor
+  //  classes of effect base classes that have default implementation of this method
+  //  (such as LabelEffect, etc.)
+  //this->Superclass::cleanup();
+
+  Q_D(const qSlicerSegmentEditorScriptedEffect);
+  d->PythonCppAPI.callMethod(d->CleanupMethod);
 }

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedEffect.h
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedEffect.h
@@ -120,6 +120,9 @@ public:
   /// Let the effect know that the interaction node is modified
   void interactionNodeModified(vtkMRMLInteractionNode* interactionNode) override;
 
+  /// Clean up resources, event observers, and Qt signal/slot connections before deletion.
+  void cleanup() override;
+
 public slots:
   /// Update user interface from parameter set node
   void updateGUIFromMRML() override;

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -358,6 +358,7 @@ qMRMLSegmentEditorWidgetPrivate::~qMRMLSegmentEditorWidgetPrivate()
 
   foreach(qSlicerSegmentEditorAbstractEffect* effect, this->RegisteredEffects)
   {
+    effect->cleanup();
     delete effect;
   }
   this->RegisteredEffects.clear();


### PR DESCRIPTION
Closes #7392 

Adds a `cleanup` method to the various editor effects classes that disconnects any signals / slots. This is necessary before calling `delete`, as the connection may keep the object alive otherwise

Here's the output of the patch / code linked in the original issue after applying this fix:

```
Deleting AbstractScriptedSegmentEditorAutoCompleteEffect: <class 'SegmentEditorEffects.SegmentEditorFillBetweenSlicesEffect.SegmentEditorFillBetweenSlicesEffect'>
Deleting AbstractScriptedSegmentEditorEffect: <class 'SegmentEditorEffects.SegmentEditorFillBetweenSlicesEffect.SegmentEditorFillBetweenSlicesEffect'>
Deleting AbstractScriptedSegmentEditorAutoCompleteEffect: <class 'SegmentEditorEffects.SegmentEditorGrowFromSeedsEffect.SegmentEditorGrowFromSeedsEffect'>
Deleting AbstractScriptedSegmentEditorEffect: <class 'SegmentEditorEffects.SegmentEditorGrowFromSeedsEffect.SegmentEditorGrowFromSeedsEffect'>
Deleting AbstractScriptedSegmentEditorEffect: <class 'SegmentEditorEffects.SegmentEditorHollowEffect.SegmentEditorHollowEffect'>
Deleting AbstractScriptedSegmentEditorEffect: <class 'SegmentEditorEffects.SegmentEditorIslandsEffect.SegmentEditorIslandsEffect'>
Deleting AbstractScriptedSegmentEditorEffect: <class 'SegmentEditorEffects.SegmentEditorLogicalEffect.SegmentEditorLogicalEffect'>
Deleting AbstractScriptedSegmentEditorEffect: <class 'SegmentEditorEffects.SegmentEditorMarginEffect.SegmentEditorMarginEffect'>
Deleting AbstractScriptedSegmentEditorEffect: <class 'SegmentEditorEffects.SegmentEditorMaskVolumeEffect.SegmentEditorMaskVolumeEffect'>
Switch to module:  ""
Deleting AbstractScriptedSegmentEditorEffect: <class 'SegmentEditorDrawEffect.SegmentEditorDrawEffect'>
Deleting AbstractScriptedSegmentEditorEffect: <class 'SegmentEditorLevelTracingEffect.SegmentEditorLevelTracingEffect'>
Deleting AbstractScriptedSegmentEditorEffect: <class 'SegmentEditorSmoothingEffect.SegmentEditorSmoothingEffect'>

```

Unlike before, the `FillBetweenSlices` and `GrowFromSeeds` effects are deleted. All of the non-abstract effects are deleted (The C++ ones aren't printed out because the patch only applied to the python) 