### PR TITLE
Add multi-slice layer support

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
@@ -16,6 +16,7 @@ Version:   $Revision: 1.2 $
 #include "vtkMRMLSliceCompositeNode.h"
 #include "vtkMRMLSliceDisplayNode.h"
 #include "vtkMRMLModelNode.h"
+#include "vtkMRMLVolumeNode.h"
 #include "vtkMRMLScene.h"
 
 // VTK includes
@@ -32,6 +33,8 @@ static const char* ForegroundVolumeNodeReferenceRole = "foregroundVolume";
 static const char* ForegroundVolumeNodeReferenceMRMLAttributeName = "foregroundVolumeID";
 static const char* LabelVolumeNodeReferenceRole = "labelVolume";
 static const char* LabelVolumeNodeReferenceMRMLAttributeName = "labelVolumeID";
+
+static const char* LayerVolumeNodeReferenceRole = "layerVolume";
 
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLSliceCompositeNode);
@@ -173,37 +176,100 @@ void vtkMRMLSliceCompositeNode::PrintSelf(ostream& os, vtkIndent indent)
 //-----------------------------------------------------------
 void vtkMRMLSliceCompositeNode::SetBackgroundVolumeID(const char* id)
 {
-  this->SetNodeReferenceID(BackgroundVolumeNodeReferenceRole, id);
+  this->SetLayerVolumeID(vtkMRMLSliceCompositeNode::LayerBackground, id);
 }
 
 //-----------------------------------------------------------
 const char* vtkMRMLSliceCompositeNode::GetBackgroundVolumeID()
 {
-  return this->GetNodeReferenceID(BackgroundVolumeNodeReferenceRole);
+  return this->GetLayerVolumeID(vtkMRMLSliceCompositeNode::LayerBackground);
 }
 
 //-----------------------------------------------------------
 void vtkMRMLSliceCompositeNode::SetForegroundVolumeID(const char* id)
 {
-  this->SetNodeReferenceID(ForegroundVolumeNodeReferenceRole, id);
+  this->SetLayerVolumeID(vtkMRMLSliceCompositeNode::LayerForeground, id);
 }
 
 //-----------------------------------------------------------
 const char* vtkMRMLSliceCompositeNode::GetForegroundVolumeID()
 {
-  return this->GetNodeReferenceID(ForegroundVolumeNodeReferenceRole);
+  return this->GetLayerVolumeID(vtkMRMLSliceCompositeNode::LayerForeground);
 }
 
 //-----------------------------------------------------------
 void vtkMRMLSliceCompositeNode::SetLabelVolumeID(const char* id)
 {
-  this->SetNodeReferenceID(LabelVolumeNodeReferenceRole, id);
+  this->SetLayerVolumeID(vtkMRMLSliceCompositeNode::LayerLabel, id);
 }
 
 //-----------------------------------------------------------
 const char* vtkMRMLSliceCompositeNode::GetLabelVolumeID()
 {
-  return this->GetNodeReferenceID(LabelVolumeNodeReferenceRole);
+  return this->GetLayerVolumeID(vtkMRMLSliceCompositeNode::LayerLabel);
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLVolumeNode* vtkMRMLSliceCompositeNode::GetLayerVolume(unsigned int layerIndex)
+{
+  if (layerIndex == vtkMRMLSliceCompositeNode::LayerBackground)
+  {
+    return vtkMRMLVolumeNode::SafeDownCast(this->GetNodeReference(BackgroundVolumeNodeReferenceRole));
+  }
+  else if (layerIndex == vtkMRMLSliceCompositeNode::LayerForeground)
+  {
+    return vtkMRMLVolumeNode::SafeDownCast(this->GetNodeReference(ForegroundVolumeNodeReferenceRole));
+  }
+  else if (layerIndex == vtkMRMLSliceCompositeNode::LayerLabel)
+  {
+    return vtkMRMLVolumeNode::SafeDownCast(this->GetNodeReference(LabelVolumeNodeReferenceRole));
+  }
+  else if (layerIndex >= vtkMRMLSliceCompositeNode::Layer_Last)
+  {
+    return vtkMRMLVolumeNode::SafeDownCast(
+          this->GetNthNodeReference(LayerVolumeNodeReferenceRole, layerIndex));
+  }
+  return nullptr;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceCompositeNode::SetLayerVolume(unsigned int layerIndex, vtkMRMLVolumeNode* volumeNode)
+{
+  char * volumeNodeID = volumeNode != nullptr ? volumeNode->GetID() : nullptr;
+  this->SetLayerVolumeID(layerIndex, volumeNodeID);
+}
+
+//----------------------------------------------------------------------------
+const char* vtkMRMLSliceCompositeNode::GetLayerVolumeID(unsigned int layerIndex)
+{
+  vtkMRMLVolumeNode* volumeNode = this->GetLayerVolume(layerIndex);
+  if (volumeNode)
+    {
+    return volumeNode->GetID();
+    }
+  return 0;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceCompositeNode::
+SetLayerVolumeID(unsigned int layerIndex, const char* volumeNodeID)
+{
+  if (layerIndex == vtkMRMLSliceCompositeNode::LayerBackground)
+  {
+    this->SetNodeReferenceID(BackgroundVolumeNodeReferenceRole, volumeNodeID);
+  }
+  else if (layerIndex == vtkMRMLSliceCompositeNode::LayerForeground)
+  {
+    this->SetNodeReferenceID(ForegroundVolumeNodeReferenceRole, volumeNodeID);
+  }
+  else if (layerIndex == vtkMRMLSliceCompositeNode::LayerLabel)
+  {
+    this->SetNodeReferenceID(LabelVolumeNodeReferenceRole, volumeNodeID);
+  }
+  else if (layerIndex >= vtkMRMLSliceCompositeNode::Layer_Last)
+  {
+    this->SetNthNodeReferenceID(LayerVolumeNodeReferenceRole, layerIndex, volumeNodeID);
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
@@ -137,6 +137,12 @@ void vtkMRMLSliceCompositeNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=
   vtkMRMLCopyBooleanMacro(ClipToBackgroundVolume);
   vtkMRMLCopyFloatMacro(ForegroundOpacity);
   vtkMRMLCopyFloatMacro(LabelOpacity);
+  for(unsigned int layerIndex = vtkMRMLSliceCompositeNode::LayerForeground;
+      layerIndex < vtkMRMLSliceCompositeNode::Layer_Last + static_cast<unsigned int>(node->GetNumberOfNodeReferences(LayerVolumeNodeReferenceRole));
+      ++layerIndex)
+  {
+    this->SetLayerOpacity(layerIndex, node->GetLayerOpacity(layerIndex));
+  }
   vtkMRMLCopyIntMacro(LinkedControl);
   vtkMRMLCopyIntMacro(HotLinkedControl);
   vtkMRMLCopyIntMacro(FiducialVisibility);
@@ -270,6 +276,54 @@ SetLayerVolumeID(unsigned int layerIndex, const char* volumeNodeID)
   {
     this->SetNthNodeReferenceID(LayerVolumeNodeReferenceRole, layerIndex, volumeNodeID);
   }
+}
+
+//----------------------------------------------------------------------------
+double vtkMRMLSliceCompositeNode::GetLayerOpacity(unsigned int layerIndex)
+{
+  if (layerIndex < this->LayerOpacities.size())
+    {
+    return this->LayerOpacities.at(layerIndex);
+    }
+  return 1.0;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceCompositeNode::SetLayerOpacity(unsigned int layerIndex, double value)
+{
+  if (layerIndex >= this->LayerOpacities.size())
+    {
+    this->LayerOpacities.resize(layerIndex + 1);
+    }
+  if (this->LayerOpacities.at(layerIndex) != value)
+    {
+    this->LayerOpacities.at(layerIndex) = value;
+    this->Modified();
+    }
+}
+
+//----------------------------------------------------------------------------
+double vtkMRMLSliceCompositeNode::GetForegroundOpacity()
+{
+  return this->GetLayerOpacity(vtkMRMLSliceCompositeNode::LayerForeground);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceCompositeNode::SetForegroundOpacity(double value)
+{
+  this->SetLayerOpacity(vtkMRMLSliceCompositeNode::LayerForeground, value);
+}
+
+//----------------------------------------------------------------------------
+double vtkMRMLSliceCompositeNode::GetLabelOpacity()
+{
+  return this->GetLayerOpacity(vtkMRMLSliceCompositeNode::LayerLabel);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceCompositeNode::SetLabelOpacity(double value)
+{
+  this->SetLayerOpacity(vtkMRMLSliceCompositeNode::LayerLabel, value);
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
@@ -206,6 +206,22 @@ const char* vtkMRMLSliceCompositeNode::GetLabelVolumeID()
   return this->GetNodeReferenceID(LabelVolumeNodeReferenceRole);
 }
 
+//----------------------------------------------------------------------------
+int vtkMRMLSliceCompositeNode::GetCompositing()
+{
+  return this->Compositing;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceCompositeNode::SetCompositing(int value)
+{
+  if (this->Compositing != value)
+  {
+    this->Compositing = value;
+    this->Modified();
+  }
+}
+
 //-----------------------------------------------------------
 int vtkMRMLSliceCompositeNode::GetSliceIntersectionVisibility()
 {

--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
@@ -95,19 +95,28 @@ public:
   vtkGetMacro (ClipToBackgroundVolume, bool);
   vtkSetMacro (ClipToBackgroundVolume, bool);
 
-  ///
-  /// opacity of the Foreground for rendering over background
-  /// TODO: make this an arbitrary list of layers
-  /// TODO: make different composite types (checkerboard, etc)
-  vtkGetMacro (ForegroundOpacity, double);
-  vtkSetMacro (ForegroundOpacity, double);
+  /// @{
+  /// Opacity of layer N over layer N-1
+  /// \note Only Foreground and Label opacity are saved into the MRML Scene
+  double GetLayerOpacity(unsigned int layerIndex);
+  void SetLayerOpacity(unsigned int layerIndex, double value);
+  /// }@
 
-  ///
-  /// opacity of the Label for rendering over background
-  /// TODO: make this an arbitrary list of layers
+  /// @{
+  /// opacity of the Foreground for rendering over background
   /// TODO: make different composite types (checkerboard, etc)
-  vtkGetMacro (LabelOpacity, double);
-  vtkSetMacro (LabelOpacity, double);
+  /// \sa GetLayerOpacity, SetLayerOpacity
+  double GetForegroundOpacity();
+  void SetForegroundOpacity(double value);
+  /// }@
+
+  /// @{
+  /// opacity of the Label for rendering over background
+  /// TODO: make different composite types (checkerboard, etc)
+  /// \sa GetLayerOpacity, SetLayerOpacity
+  double GetLabelOpacity();
+  void SetLabelOpacity(double value);
+  /// }@
 
   ///
   /// toggle that gangs control of slice viewers
@@ -229,15 +238,15 @@ protected:
   // Cached value of last found displayable node (it is expensive to determine it)
   vtkWeakPointer<vtkMRMLSliceDisplayNode> LastFoundSliceDisplayNode;
 
-  // start by showing only the background volume
-  double ForegroundOpacity{ 0.0 };
+  std::vector<double> LayerOpacities = {
+    0.0, // Layer N (Foreground) over layer N-1 (Background): Start by showing only the background volume
+    1.0, // Layer N (Label) over layer N-1 (Foreground): Show the label if there is one
+  };
 
   int Compositing{ Alpha };
 
   bool ClipToBackgroundVolume{ true };
 
-  // Show the label if there is one
-  double LabelOpacity{ 1.0 };
   int LinkedControl{ 0 };
   int HotLinkedControl{ 0 };
 

--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
@@ -70,8 +70,8 @@ public:
   ///
   /// Compositing mode for foreground and background can be alpha
   /// blending, reverse alpha blending, addition, or subtraction
-  vtkGetMacro (Compositing, int);
-  vtkSetMacro (Compositing, int);
+  int GetCompositing();
+  void SetCompositing(int value);
 
   ///
   /// Configures the behavior for blending layers.

--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
@@ -19,10 +19,11 @@
 
 class vtkMRMLModelNode;
 class vtkMRMLSliceDisplayNode;
+class vtkMRMLVolumeNode;
 
 /// \brief MRML node for storing a slice through RAS space.
 ///
-/// This node stores the information about how to composite two
+/// This node stores the information about how to composite N
 /// vtkMRMLVolumes into a single display image.
 class VTK_MRML_EXPORT vtkMRMLSliceCompositeNode : public vtkMRMLNode
 {
@@ -66,6 +67,21 @@ public:
   const char* GetLabelVolumeID();
   void SetLabelVolumeID(const char* id);
   void SetReferenceLabelVolumeID(const char *id) { this->SetLabelVolumeID(id); }
+
+  enum
+  {
+    LayerNone = -1,
+    LayerBackground = 0,
+    LayerForeground = 1,
+    LayerLabel = 2,
+    Layer_Last // must be last
+  };
+
+  vtkMRMLVolumeNode* GetLayerVolume(unsigned int layerIndex);
+  void SetLayerVolume(unsigned int layerIndex, vtkMRMLVolumeNode* volumeNode);
+
+  const char* GetLayerVolumeID(unsigned int layerIndex);
+  void SetLayerVolumeID(unsigned int layerIndex, const char* volumeNodeID);
 
   ///
   /// Compositing mode for foreground and background can be alpha

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -225,9 +225,6 @@ vtkStandardNewMacro(vtkMRMLSliceLogic);
 //----------------------------------------------------------------------------
 vtkMRMLSliceLogic::vtkMRMLSliceLogic()
 {
-  this->BackgroundLayer = nullptr;
-  this->ForegroundLayer = nullptr;
-  this->LabelLayer = nullptr;
   this->SliceNode = nullptr;
   this->SliceCompositeNode = nullptr;
 
@@ -265,9 +262,10 @@ vtkMRMLSliceLogic::~vtkMRMLSliceLogic()
     this->ExtractModelTexture = nullptr;
   }
 
-  this->SetBackgroundLayer (nullptr);
-  this->SetForegroundLayer (nullptr);
-  this->SetLabelLayer (nullptr);
+  for (unsigned int layerIndex = 0; layerIndex < this->Layers.size(); ++layerIndex)
+  {
+    this->SetLayer(layerIndex, nullptr);
+  }
 
   if (this->SliceCompositeNode)
   {
@@ -293,9 +291,9 @@ void vtkMRMLSliceLogic::SetMRMLSceneInternal(vtkMRMLScene * newScene)
 
   this->ProcessMRMLLogicsEvents();
 
-  this->BackgroundLayer->SetMRMLScene(newScene);
-  this->ForegroundLayer->SetMRMLScene(newScene);
-  this->LabelLayer->SetMRMLScene(newScene);
+  this->GetBackgroundLayer()->SetMRMLScene(newScene);
+  this->GetForegroundLayer()->SetMRMLScene(newScene);
+  this->GetLabelLayer()->SetMRMLScene(newScene);
 
   this->ProcessMRMLSceneEvents(newScene, vtkMRMLScene::EndBatchProcessEvent, nullptr);
 }
@@ -331,7 +329,8 @@ void vtkMRMLSliceLogic::UpdateSliceCompositeNode()
 
   // find SliceCompositeNode in the scene
   std::string layoutName = (this->SliceNode->GetLayoutName() ? this->SliceNode->GetLayoutName() : "");
-  vtkMRMLSliceCompositeNode* updatedSliceCompositeNode = vtkMRMLSliceLogic::GetSliceCompositeNode(this->GetMRMLScene(), layoutName.c_str());
+  vtkSmartPointer<vtkMRMLSliceCompositeNode> updatedSliceCompositeNode =
+      vtkMRMLSliceLogic::GetSliceCompositeNode(this->GetMRMLScene(), layoutName.c_str());
 
   if (this->SliceCompositeNode && updatedSliceCompositeNode &&
        (!this->SliceCompositeNode->GetID() || strcmp(this->SliceCompositeNode->GetID(), updatedSliceCompositeNode->GetID()) != 0) )
@@ -345,11 +344,10 @@ void vtkMRMLSliceLogic::UpdateSliceCompositeNode()
     if (!updatedSliceCompositeNode && !layoutName.empty())
     {
       // Use CreateNodeByClass instead of New to use default node specified in the scene
-      updatedSliceCompositeNode = vtkMRMLSliceCompositeNode::SafeDownCast(this->GetMRMLScene()->CreateNodeByClass("vtkMRMLSliceCompositeNode"));
+      updatedSliceCompositeNode = vtkSmartPointer<vtkMRMLSliceCompositeNode>::Take(vtkMRMLSliceCompositeNode::SafeDownCast(this->GetMRMLScene()->CreateNodeByClass("vtkMRMLSliceCompositeNode")));
       updatedSliceCompositeNode->SetLayoutName(layoutName.c_str());
       this->GetMRMLScene()->AddNode(updatedSliceCompositeNode);
       this->SetSliceCompositeNode(updatedSliceCompositeNode);
-      updatedSliceCompositeNode->Delete();
     }
     else
     {
@@ -521,17 +519,17 @@ void vtkMRMLSliceLogic::ProcessMRMLLogicsEvents()
   //
   // if we don't have layers yet, create them
   //
-  if ( this->BackgroundLayer == nullptr )
+  if ( this->GetBackgroundLayer() == nullptr )
   {
     vtkNew<vtkMRMLSliceLayerLogic> layer;
     this->SetBackgroundLayer(layer.GetPointer());
   }
-  if ( this->ForegroundLayer == nullptr )
+  if ( this->GetForegroundLayer() == nullptr )
   {
     vtkNew<vtkMRMLSliceLayerLogic> layer;
     this->SetForegroundLayer(layer.GetPointer());
   }
-  if ( this->LabelLayer == nullptr )
+  if ( this->GetLabelLayer() == nullptr )
   {
     vtkNew<vtkMRMLSliceLayerLogic> layer;
     // turn on using the label outline only in this layer
@@ -621,7 +619,7 @@ void vtkMRMLSliceLogic::ProcessMRMLLogicsEvents()
     vtkMRMLModelDisplayNode *modelDisplayNode = this->SliceModelNode->GetModelDisplayNode();
     if ( modelDisplayNode )
     {
-      if (this->LabelLayer && this->LabelLayer->GetImageDataConnectionUVW())
+      if (this->GetLayerImageDataConnectionUVW(vtkMRMLSliceLogic::LayerLabel))
       {
         modelDisplayNode->SetInterpolateTexture(0);
       }
@@ -678,21 +676,18 @@ void vtkMRMLSliceLogic::SetSliceNode(vtkMRMLSliceNode * newSliceNode)
 
   this->UpdateSliceCompositeNode();
 
-  if (this->BackgroundLayer)
+  for (LayerListIterator iterator = this->Layers.begin();
+       iterator != this->Layers.end();
+       ++iterator)
   {
-    this->BackgroundLayer->SetSliceNode(newSliceNode);
-  }
-  if (this->ForegroundLayer)
-  {
-    this->ForegroundLayer->SetSliceNode(newSliceNode);
-  }
-  if (this->LabelLayer)
-  {
-    this->LabelLayer->SetSliceNode(newSliceNode);
+    vtkMRMLSliceLayerLogic* layer = *iterator;
+    if (layer != nullptr)
+    {
+      layer->SetSliceNode(newSliceNode);
+    }
   }
 
   this->Modified();
-
 }
 
 //----------------------------------------------------------------------------
@@ -709,80 +704,96 @@ void vtkMRMLSliceLogic::SetSliceCompositeNode(vtkMRMLSliceCompositeNode *sliceCo
 }
 
 //----------------------------------------------------------------------------
+vtkMRMLSliceLayerLogic* vtkMRMLSliceLogic::GetBackgroundLayer()
+{
+  return this->GetLayer(vtkMRMLSliceLogic::LayerBackground);
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLSliceLogic::SetBackgroundLayer(vtkMRMLSliceLayerLogic *backgroundLayer)
 {
-  // TODO: Simplify the whole set using a macro similar to vtkMRMLSetAndObserve
-  if (this->BackgroundLayer)
-  {
-    this->BackgroundLayer->SetMRMLScene( nullptr );
-    this->BackgroundLayer->Delete();
-  }
-  this->BackgroundLayer = backgroundLayer;
+  this->SetLayer(vtkMRMLSliceLogic::LayerBackground, backgroundLayer);
+}
 
-  if (this->BackgroundLayer)
-  {
-    this->BackgroundLayer->Register(this);
-
-    this->BackgroundLayer->SetMRMLScene(this->GetMRMLScene());
-
-    this->BackgroundLayer->SetSliceNode(SliceNode);
-    vtkEventBroker::GetInstance()->AddObservation(
-      this->BackgroundLayer, vtkCommand::ModifiedEvent,
-      this, this->GetMRMLLogicsCallbackCommand());
-  }
-
-  this->Modified();
+//----------------------------------------------------------------------------
+vtkMRMLSliceLayerLogic* vtkMRMLSliceLogic::GetForegroundLayer()
+{
+  return this->GetLayer(vtkMRMLSliceLogic::LayerForeground);
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLSliceLogic::SetForegroundLayer(vtkMRMLSliceLayerLogic *foregroundLayer)
 {
-  // TODO: Simplify the whole set using a macro similar to vtkMRMLSetAndObserve
-  if (this->ForegroundLayer)
-  {
-    this->ForegroundLayer->SetMRMLScene( nullptr );
-    this->ForegroundLayer->Delete();
-  }
-  this->ForegroundLayer = foregroundLayer;
+  this->SetLayer(vtkMRMLSliceLogic::LayerForeground, foregroundLayer);
+}
 
-  if (this->ForegroundLayer)
-  {
-    this->ForegroundLayer->Register(this);
-    this->ForegroundLayer->SetMRMLScene( this->GetMRMLScene());
-
-    this->ForegroundLayer->SetSliceNode(SliceNode);
-    vtkEventBroker::GetInstance()->AddObservation(
-      this->ForegroundLayer, vtkCommand::ModifiedEvent,
-      this, this->GetMRMLLogicsCallbackCommand());
-  }
-
-  this->Modified();
+//----------------------------------------------------------------------------
+vtkMRMLSliceLayerLogic* vtkMRMLSliceLogic::GetLabelLayer()
+{
+  return this->GetLayer(vtkMRMLSliceLogic::LayerLabel);
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLSliceLogic::SetLabelLayer(vtkMRMLSliceLayerLogic *labelLayer)
 {
+  this->SetLayer(vtkMRMLSliceLogic::LayerLabel, labelLayer);
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLSliceLayerLogic* vtkMRMLSliceLogic::GetLayer(unsigned int layerIndex)
+{
+  if (layerIndex < this->Layers.size())
+    {
+    return this->Layers.at(layerIndex);
+    }
+  return nullptr;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceLogic::SetLayer(unsigned int layerIndex, vtkMRMLSliceLayerLogic *layer)
+{
   // TODO: Simplify the whole set using a macro similar to vtkMRMLSetAndObserve
-  if (this->LabelLayer)
-  {
-    this->LabelLayer->SetMRMLScene( nullptr );
-    this->LabelLayer->Delete();
-  }
-  this->LabelLayer = labelLayer;
+  vtkMRMLSliceLayerLogic * currentLayer = this->GetLayer(layerIndex);
+  if (currentLayer)
+    {
+    currentLayer->SetMRMLScene(0);
+    }
+  if (layerIndex >= this->Layers.size())
+    {
+    this->Layers.resize(layerIndex + 1);
+    }
+  this->Layers.at(layerIndex) = layer;
+  if (layer)
+    {
+    layer->SetMRMLScene(this->GetMRMLScene());
 
-  if (this->LabelLayer)
-  {
-    this->LabelLayer->Register(this);
-
-    this->LabelLayer->SetMRMLScene(this->GetMRMLScene());
-
-    this->LabelLayer->SetSliceNode(SliceNode);
+    layer->SetSliceNode(this->SliceNode);
     vtkEventBroker::GetInstance()->AddObservation(
-      this->LabelLayer, vtkCommand::ModifiedEvent,
+      layer, vtkCommand::ModifiedEvent,
       this, this->GetMRMLLogicsCallbackCommand());
-  }
-
+    }
   this->Modified();
+}
+
+//----------------------------------------------------------------------------
+vtkAlgorithmOutput* vtkMRMLSliceLogic::GetLayerImageDataConnection(unsigned int layerIndex)
+{
+  return this->GetLayer(layerIndex) ? this->GetLayer(layerIndex)->GetImageDataConnection() : nullptr;
+}
+
+//----------------------------------------------------------------------------
+vtkAlgorithmOutput* vtkMRMLSliceLogic::GetLayerImageDataConnectionUVW(unsigned int layerIndex)
+{
+  return this->GetLayer(layerIndex) ? this->GetLayer(layerIndex)->GetImageDataConnectionUVW() : nullptr;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceLogic::SetLayerVolumeNode(int layerIndex, vtkMRMLVolumeNode* volumeNode)
+{
+  if (this->GetLayer(layerIndex))
+    {
+    this->GetLayer(layerIndex)->SetVolumeNode(volumeNode);
+    }
 }
 
 //----------------------------------------------------------------------------
@@ -881,6 +892,22 @@ vtkAlgorithmOutput * vtkMRMLSliceLogic::GetImageDataConnection()
 }
 
 //----------------------------------------------------------------------------
+bool vtkMRMLSliceLogic::HasInputs()
+{
+  for (LayerListIterator iterator = this->Layers.begin();
+       iterator != this->Layers.end();
+       ++iterator)
+  {
+    vtkMRMLSliceLayerLogic* layer = *iterator;
+    if (layer != nullptr && layer->GetImageDataConnection() != nullptr)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLSliceLogic::UpdateImageData ()
 {
   if (this->SliceNode->GetSliceResolutionMode() == vtkMRMLSliceNode::SliceResolutionMatch2DView)
@@ -895,9 +922,7 @@ void vtkMRMLSliceLogic::UpdateImageData ()
   // It seems very strange that the imagedata can be null.
   // It should probably be always a valid imagedata with invalid bounds if needed
 
-  if ( (this->GetBackgroundLayer() != nullptr && this->GetBackgroundLayer()->GetImageDataConnection() != nullptr) ||
-       (this->GetForegroundLayer() != nullptr && this->GetForegroundLayer()->GetImageDataConnection() != nullptr) ||
-       (this->GetLabelLayer() != nullptr && this->GetLabelLayer()->GetImageDataConnection() != nullptr) )
+  if (this->HasInputs())
   {
     if (this->ImageDataConnection == nullptr || this->Pipeline->Blend->GetOutputPort()->GetMTime() > this->ImageDataConnection->GetMTime())
     {
@@ -1043,11 +1068,11 @@ void vtkMRMLSliceLogic::UpdatePipeline()
       bgnode = vtkMRMLVolumeNode::SafeDownCast (this->GetMRMLScene()->GetNodeByID(id));
     }
 
-    if (this->BackgroundLayer)
+    if (this->GetBackgroundLayer())
     {
-      if ( this->BackgroundLayer->GetVolumeNode() != bgnode )
+      if ( this->GetBackgroundLayer()->GetVolumeNode() != bgnode )
       {
-        this->BackgroundLayer->SetVolumeNode (bgnode);
+        this->SetLayerVolumeNode(vtkMRMLSliceLogic::LayerBackground, bgnode);
         modified = 1;
       }
     }
@@ -1060,11 +1085,11 @@ void vtkMRMLSliceLogic::UpdatePipeline()
       fgnode = vtkMRMLVolumeNode::SafeDownCast (this->GetMRMLScene()->GetNodeByID(id));
     }
 
-    if (this->ForegroundLayer)
+    if (this->GetForegroundLayer())
     {
-      if ( this->ForegroundLayer->GetVolumeNode() != fgnode )
+      if ( this->GetForegroundLayer()->GetVolumeNode() != fgnode )
       {
-        this->ForegroundLayer->SetVolumeNode (fgnode);
+        this->SetLayerVolumeNode(vtkMRMLSliceLogic::LayerForeground, fgnode);
         modified = 1;
       }
     }
@@ -1077,11 +1102,11 @@ void vtkMRMLSliceLogic::UpdatePipeline()
       lbnode = vtkMRMLVolumeNode::SafeDownCast (this->GetMRMLScene()->GetNodeByID(id));
     }
 
-    if (this->LabelLayer)
+    if (this->GetLabelLayer())
     {
-      if ( this->LabelLayer->GetVolumeNode() != lbnode )
+      if ( this->GetLabelLayer()->GetVolumeNode() != lbnode )
       {
-        this->LabelLayer->SetVolumeNode (lbnode);
+        this->SetLayerVolumeNode(vtkMRMLSliceLogic::LayerLabel, lbnode);
         modified = 1;
       }
     }
@@ -1099,14 +1124,14 @@ void vtkMRMLSliceLogic::UpdatePipeline()
     //    label opacity
     //
 
-    vtkAlgorithmOutput* backgroundImagePort = this->BackgroundLayer ? this->BackgroundLayer->GetImageDataConnection() : nullptr;
-    vtkAlgorithmOutput* foregroundImagePort = this->ForegroundLayer ? this->ForegroundLayer->GetImageDataConnection() : nullptr;
+    vtkAlgorithmOutput* backgroundImagePort = this->GetLayerImageDataConnection(vtkMRMLSliceLogic::LayerBackground);
+    vtkAlgorithmOutput* foregroundImagePort = this->GetLayerImageDataConnection(vtkMRMLSliceLogic::LayerForeground);
 
-    vtkAlgorithmOutput* backgroundImagePortUVW = this->BackgroundLayer ? this->BackgroundLayer->GetImageDataConnectionUVW() : nullptr;
-    vtkAlgorithmOutput* foregroundImagePortUVW = this->ForegroundLayer ? this->ForegroundLayer->GetImageDataConnectionUVW() : nullptr;
+    vtkAlgorithmOutput* backgroundImagePortUVW = this->GetLayerImageDataConnectionUVW(vtkMRMLSliceLogic::LayerBackground);
+    vtkAlgorithmOutput* foregroundImagePortUVW = this->GetLayerImageDataConnectionUVW(vtkMRMLSliceLogic::LayerForeground);
 
-    vtkAlgorithmOutput* labelImagePort = this->LabelLayer ? this->LabelLayer->GetImageDataConnection() : nullptr;
-    vtkAlgorithmOutput* labelImagePortUVW = this->LabelLayer ? this->LabelLayer->GetImageDataConnectionUVW() : nullptr;
+    vtkAlgorithmOutput* labelImagePort = this->GetLayerImageDataConnection(vtkMRMLSliceLogic::LayerLabel);
+    vtkAlgorithmOutput* labelImagePortUVW = this->GetLayerImageDataConnectionUVW(vtkMRMLSliceLogic::LayerLabel);
 
     std::deque<SliceLayerInfo> layers;
     std::deque<SliceLayerInfo> layersUVW;
@@ -1155,7 +1180,7 @@ void vtkMRMLSliceLogic::UpdatePipeline()
       {
         displayNode->SetTextureImageDataConnection(this->ExtractModelTexture->GetOutputPort());
       }
-        if ( this->LabelLayer && this->LabelLayer->GetImageDataConnection())
+        if (this->GetLayerImageDataConnectionUVW(vtkMRMLSliceLogic::LayerLabel))
         {
           displayNode->SetInterpolateTexture(0);
         }
@@ -1206,30 +1231,30 @@ void vtkMRMLSliceLogic::PrintSelf(ostream& os, vtkIndent indent)
     os << indent << "SliceCompositeNode: (none)\n";
   }
 
-  if (this->BackgroundLayer)
+  if (this->GetBackgroundLayer())
   {
     os << indent << "BackgroundLayer: ";
-    this->BackgroundLayer->PrintSelf(os, nextIndent);
+    this->GetBackgroundLayer()->PrintSelf(os, nextIndent);
   }
   else
   {
     os << indent << "BackgroundLayer: (none)\n";
   }
 
-  if (this->ForegroundLayer)
+  if (this->GetForegroundLayer())
   {
     os << indent << "ForegroundLayer: ";
-    this->ForegroundLayer->PrintSelf(os, nextIndent);
+    this->GetForegroundLayer()->PrintSelf(os, nextIndent);
   }
   else
   {
     os << indent << "ForegroundLayer: (none)\n";
   }
 
-  if (this->LabelLayer)
+  if (this->GetLabelLayer())
   {
     os << indent << "LabelLayer: ";
-    this->LabelLayer->PrintSelf(os, nextIndent);
+    this->GetLabelLayer()->PrintSelf(os, nextIndent);
   }
   else
   {
@@ -2609,11 +2634,22 @@ bool vtkMRMLSliceLogic::IsEventInsideVolume(bool background, double worldPos[3])
 }
 
 //----------------------------------------------------------------------------
+vtkMRMLModelDisplayNode* vtkMRMLSliceLogic::GetSliceModelDisplayNode()
+{
+  return this->SliceModelDisplayNode;
+}
+
+//----------------------------------------------------------------------------
 vtkMRMLSliceDisplayNode* vtkMRMLSliceLogic::GetSliceDisplayNode()
 {
   return vtkMRMLSliceDisplayNode::SafeDownCast(this->GetSliceModelDisplayNode());
 }
 
+//----------------------------------------------------------------------------
+vtkMRMLLinearTransformNode* vtkMRMLSliceLogic::GetSliceModelTransformNode()
+{
+  return this->SliceModelTransformNode;
+}
 
 //----------------------------------------------------------------------------
 bool vtkMRMLSliceLogic::GetSliceOffsetRangeResolution(double range[2], double& resolution)

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -90,19 +90,34 @@ public:
   void SetSliceCompositeNode (vtkMRMLSliceCompositeNode *SliceCompositeNode);
 
   /// The background slice layer
-  /// TODO: this will eventually be generalized to a list of layers
-  vtkGetObjectMacro (BackgroundLayer, vtkMRMLSliceLayerLogic);
+  vtkMRMLSliceLayerLogic* GetBackgroundLayer();
   void SetBackgroundLayer (vtkMRMLSliceLayerLogic *BackgroundLayer);
 
   /// The foreground slice layer
-  /// TODO: this will eventually be generalized to a list of layers
-  vtkGetObjectMacro (ForegroundLayer, vtkMRMLSliceLayerLogic);
+  vtkMRMLSliceLayerLogic* GetForegroundLayer();
   void SetForegroundLayer (vtkMRMLSliceLayerLogic *ForegroundLayer);
 
   /// The Label slice layer
-  /// TODO: this will eventually be generalized to a list of layers
-  vtkGetObjectMacro (LabelLayer, vtkMRMLSliceLayerLogic);
+  vtkMRMLSliceLayerLogic* GetLabelLayer();
   void SetLabelLayer (vtkMRMLSliceLayerLogic *LabelLayer);
+
+  typedef vtkSmartPointer<vtkMRMLSliceLayerLogic> LayerListItem;
+  typedef std::vector<LayerListItem> LayerList;
+  typedef std::vector<LayerListItem>::iterator LayerListIterator;
+  typedef std::vector<LayerListItem>::const_iterator LayerListConstIterator;
+
+  vtkMRMLSliceLayerLogic* GetLayer(unsigned int layerIndex);
+  void SetLayer(unsigned int layerIndex, vtkMRMLSliceLayerLogic *layer);
+
+  vtkAlgorithmOutput* GetLayerImageDataConnection(unsigned int layerIndex);
+  vtkAlgorithmOutput* GetLayerImageDataConnectionUVW(unsigned int layerIndex);
+
+  /// Set volume associated with a layer
+  void SetLayerVolumeNode(int layerIndex, vtkMRMLVolumeNode* volumeNode);
+
+  /// Get the volume node corresponding to layer
+  /// (0=background, 1=foreground, 2=label)
+  vtkMRMLVolumeNode* GetLayerVolumeNode(int layerIndex);
 
   /// Helper to set the background layer Window/Level
   void SetBackgroundWindowLevel(double window, double level);
@@ -133,13 +148,13 @@ public:
 
   /// Model slice plane display properties.
   /// The method is deprecated, use SliceDisplayNode instead.
-  vtkGetObjectMacro(SliceModelDisplayNode, vtkMRMLModelDisplayNode);
+  vtkMRMLModelDisplayNode* GetSliceModelDisplayNode();
 
   /// Slice plane display properties
   vtkMRMLSliceDisplayNode* GetSliceDisplayNode();
 
   /// Model slice plane transform from xy to RAS
-  vtkGetObjectMacro(SliceModelTransformNode, vtkMRMLLinearTransformNode);
+  vtkMRMLLinearTransformNode* GetSliceModelTransformNode();
 
   /// The compositing filter
   /// TODO: this will eventually be generalized to a per-layer compositing function
@@ -153,6 +168,10 @@ public:
   /// the tail of the pipeline
   /// -- returns nullptr if none of the inputs exist
   vtkAlgorithmOutput *GetImageDataConnection();
+
+  /// Return True if at least one layer has an image data
+  /// \sa vtkMRMLSliceLayerLogic::GetImageDataConnection()
+  bool HasInputs();
 
   /// update the pipeline to reflect the current state of the nodes
   void UpdatePipeline();
@@ -173,10 +192,6 @@ public:
   /// Manage and synchronize the SliceCompositeNode
   void UpdateSliceCompositeNode();
 
-  /// Get the volume node corresponding to layer
-  /// (0=background, 1=foreground, 2=label)
-  vtkMRMLVolumeNode *GetLayerVolumeNode(int layer);
-
   /// Get the size of the volume, transformed to RAS space
   static void GetVolumeRASBox(vtkMRMLVolumeNode *volumeNode, double rasDimensions[3], double rasCenter[3]);
 
@@ -188,6 +203,7 @@ public:
   ///   voxel relative to the current slice view
   double* GetVolumeSliceSpacing(vtkMRMLVolumeNode *volumeNode) VTK_SIZEHINT(3);
 
+  ///
   /// Get the min/max bounds of the volume
   /// - note these are not translated by the current slice offset so they can
   ///   be used to calculate the range (e.g. of a slider) that operates in slice space
@@ -423,13 +439,12 @@ protected:
     return true;
   };
 
+  LayerList Layers;
+
   bool                          AddingSliceModelNodes;
 
   vtkMRMLSliceNode*             SliceNode;
   vtkMRMLSliceCompositeNode*    SliceCompositeNode;
-  vtkMRMLSliceLayerLogic*       BackgroundLayer;
-  vtkMRMLSliceLayerLogic*       ForegroundLayer;
-  vtkMRMLSliceLayerLogic*       LabelLayer;
 
   BlendPipeline*                Pipeline;
   BlendPipeline*                PipelineUVW;

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -78,7 +78,6 @@ public:
     Layer_Last // must be last
   };
 
-  ///
   /// The MRML slice node for this slice logic
   vtkGetObjectMacro (SliceNode, vtkMRMLSliceNode);
   void SetSliceNode (vtkMRMLSliceNode * newSliceNode);
@@ -86,92 +85,75 @@ public:
   /// Convenience function for adding a slice node and setting it in this logic
   vtkMRMLSliceNode* AddSliceNode(const char* layoutName);
 
-  ///
   /// The MRML slice node for this slice logic
   vtkGetObjectMacro (SliceCompositeNode, vtkMRMLSliceCompositeNode);
   void SetSliceCompositeNode (vtkMRMLSliceCompositeNode *SliceCompositeNode);
 
-  ///
   /// The background slice layer
   /// TODO: this will eventually be generalized to a list of layers
   vtkGetObjectMacro (BackgroundLayer, vtkMRMLSliceLayerLogic);
   void SetBackgroundLayer (vtkMRMLSliceLayerLogic *BackgroundLayer);
 
-  ///
   /// The foreground slice layer
   /// TODO: this will eventually be generalized to a list of layers
   vtkGetObjectMacro (ForegroundLayer, vtkMRMLSliceLayerLogic);
   void SetForegroundLayer (vtkMRMLSliceLayerLogic *ForegroundLayer);
 
-  ///
   /// The Label slice layer
   /// TODO: this will eventually be generalized to a list of layers
   vtkGetObjectMacro (LabelLayer, vtkMRMLSliceLayerLogic);
   void SetLabelLayer (vtkMRMLSliceLayerLogic *LabelLayer);
 
-  ///
   /// Helper to set the background layer Window/Level
   void SetBackgroundWindowLevel(double window, double level);
 
-  ///
   /// Helper to get the background layer Window/Level, intensity range and
   /// status of automatic Window/Level setting
   void GetBackgroundWindowLevelAndRange(double& window, double& level,
                                         double& rangeLow, double& rangeHigh, bool& autoWindowLevel);
 
-  ///
   /// Helper to get the background layer Window/Level and intensity range
   void GetBackgroundWindowLevelAndRange(double& window, double& level,
                                         double& rangeLow, double& rangeHigh);
 
-  ///
   /// Helper to set the foreground layer Window/Level
   void SetForegroundWindowLevel(double window, double level);
 
-  ///
   /// Helper to get the foreground layer Window/Level, intensity range and
   /// status of automatic Window/Level setting
   void GetForegroundWindowLevelAndRange(double& window, double& level,
                                         double& rangeLow, double& rangeHigh, bool& autoWindowLevel);
 
-  ///
   /// Helper to get the foreground layer Window/Level and intensity range
   void GetForegroundWindowLevelAndRange(double& window, double& level,
                                         double& rangeLow, double& rangeHigh);
-  ///
+
   /// Model slice plane
   vtkGetObjectMacro(SliceModelNode, vtkMRMLModelNode);
 
-  ///
   /// Model slice plane display properties.
   /// The method is deprecated, use SliceDisplayNode instead.
   vtkGetObjectMacro(SliceModelDisplayNode, vtkMRMLModelDisplayNode);
 
-  ///
   /// Slice plane display properties
   vtkMRMLSliceDisplayNode* GetSliceDisplayNode();
 
-  ///
   /// Model slice plane transform from xy to RAS
   vtkGetObjectMacro(SliceModelTransformNode, vtkMRMLLinearTransformNode);
 
-  ///
   /// The compositing filter
   /// TODO: this will eventually be generalized to a per-layer compositing function
   vtkImageBlend* GetBlend();
   vtkImageBlend* GetBlendUVW();
 
-  ///
   /// An image reslice instance to pull a single slice from the volume that
   /// represents the filmsheet display output
   vtkGetObjectMacro(ExtractModelTexture, vtkImageReslice);
 
-  ///
   /// the tail of the pipeline
   /// -- returns nullptr if none of the inputs exist
   vtkAlgorithmOutput *GetImageDataConnection();
 
-  ///
   /// update the pipeline to reflect the current state of the nodes
   void UpdatePipeline();
 
@@ -182,38 +164,30 @@ public:
   /// MRMLModelNode into the scene
   virtual bool EnterMRMLCallback() const;
 
-  ///
   /// Manage and synchronize the SliceNode
   void UpdateSliceNode();
 
-  ///
   /// Update slicer node given a layout name
   void UpdateSliceNodeFromLayout();
 
-  ///
   /// Manage and synchronize the SliceCompositeNode
   void UpdateSliceCompositeNode();
 
-  ///
   /// Get the volume node corresponding to layer
   /// (0=background, 1=foreground, 2=label)
   vtkMRMLVolumeNode *GetLayerVolumeNode(int layer);
 
-  ///
   /// Get the size of the volume, transformed to RAS space
   static void GetVolumeRASBox(vtkMRMLVolumeNode *volumeNode, double rasDimensions[3], double rasCenter[3]);
 
-  ///
   /// Get the size of the volume, transformed to slice space
   void GetVolumeSliceDimensions(vtkMRMLVolumeNode *volumeNode, double sliceDimensions[3], double sliceCenter[3]);
 
-  ///
   /// Get the spacing of the volume, transformed to slice space
   /// - to be used, for example, to set the slice increment for stepping a single
   ///   voxel relative to the current slice view
   double* GetVolumeSliceSpacing(vtkMRMLVolumeNode *volumeNode) VTK_SIZEHINT(3);
 
-  ///
   /// Get the min/max bounds of the volume
   /// - note these are not translated by the current slice offset so they can
   ///   be used to calculate the range (e.g. of a slider) that operates in slice space
@@ -221,29 +195,23 @@ public:
   /// (otherwise then bounds of voxels centers are returned).
   void GetVolumeSliceBounds(vtkMRMLVolumeNode *volumeNode, double sliceBounds[6], bool useVoxelCenter=false);
 
-  ///
   /// adjust the node's field of view to match the extent of the volume
   void FitSliceToVolume(vtkMRMLVolumeNode *volumeNode, int width, int height);
 
-  ///
   /// adjust the node's field of view to match the extent of the volume
   void FitSliceToVolumes(vtkCollection *volumeNodes, int width, int height);
 
-  ///
   /// Get the size of the volume, transformed to RAS space
   void GetBackgroundRASBox(double rasDimensions[3], double rasCenter[3]);
 
-  ///
   /// Get the size of the volume, transformed to slice space
   void GetBackgroundSliceDimensions(double sliceDimensions[3], double sliceCenter[3]);
 
-  ///
   /// Get the spacing of the volume, transformed to slice space
   /// - to be used, for example, to set the slice increment for stepping a single
   ///   voxel relative to the current slice view
   double* GetBackgroundSliceSpacing() VTK_SIZEHINT(3);
 
-  ///
   /// Get the min/max bounds of the volume
   /// - note these are not translated by the current slice offset so they can
   ///   be used to calculate the range (e.g. of a slider) that operates in slice space
@@ -255,18 +223,15 @@ public:
   /// of the volume has more than one slice then the slice view will be rotated to the closest orthogonal axis.
   void RotateSliceToLowestVolumeAxes(bool forceSlicePlaneToSingleSlice = true);
 
-  ///
   /// adjust the node's field of view to match the extent of the first selected volume (background, foregorund, labelmap)
   void FitSliceToFirst(int width = -1, int height = -1);
 
-  ///
   /// Adjust the node's field of view to match the extent of the volume visible in the slice's background.
   /// This is a more advanced version of FitSliceToAll, which takes into account that in case of
   /// ClipToBackgroundVolume is enabled then all layers above the background volume
   /// will be clipped to the background volume's extents.
   void FitSliceToBackground(int width = -1, int height = -1);
 
-  ///
   /// adjust the node's field of view to match the extent of all volume layers
   void FitSliceToAll(int width = -1, int height = -1);
 
@@ -281,7 +246,6 @@ public:
   /// time the lightbox configuration is changed.
   void ResizeSliceNode(double newWidth, double newHeight);
 
-  ///
   /// Get the spacing of the lowest volume layer (background, foreground, label),
   /// transformed to slice space
   /// - to be used, for example, to set the slice increment for stepping a single
@@ -289,7 +253,6 @@ public:
   /// - returns first non-null layer
   double* GetLowestVolumeSliceSpacing() VTK_SIZEHINT(3);
 
-  ///
   /// Get the min/max bounds of the lowest volume layer (background, foreground, label)
   /// - note these are not translated by the current slice offset so they can
   ///   be used to calculate the range (e.g. of a slider) that operates in slice space
@@ -298,16 +261,15 @@ public:
   /// (otherwise then bounds of voxels centers are returned).
   void GetLowestVolumeSliceBounds(double sliceBounds[6], bool useVoxelCenter=false);
 
-  ///
+  /// @{
   /// Get/Set the current distance from the origin to the slice plane
   double GetSliceOffset();
   void SetSliceOffset(double offset);
+  /// @}
 
-  ///
   /// Get the largest slice bounding box for all volumes in layers
   void GetSliceBounds(double sliceBounds[6]);
 
-  ///
   /// Set slice extents to all layers
   void SetSliceExtentsToSliceNode();
 
@@ -333,7 +295,6 @@ public:
   /// Indicate the slice offset value has completed its change
   void EndSliceOffsetInteraction();
 
-  ///
   /// Set the current distance so that it corresponds to the closest center of
   /// a voxel in IJK space (integer value)
   void SnapSliceOffsetToIJK();
@@ -359,12 +320,12 @@ public:
   /// SLICE_INDEX_NO_VOLUME=no volume is available
   int GetSliceIndexFromOffset(double sliceOffset);
 
-  ///
+  /// @{
   /// Make a slice model with the current configuration
   void CreateSliceModel();
   void DeleteSliceModel();
+  /// @}
 
-  ///
   /// Get  all slice displaynodes creating PolyData models like glyphs etc.
   std::vector< vtkMRMLDisplayNode*> GetPolyDataDisplayNodes();
   /// Return the associated slicerlayer nodes
@@ -404,7 +365,6 @@ protected:
 
   void SetMRMLSceneInternal(vtkMRMLScene * newScene) override;
 
-  ///
   /// process logic events
   void ProcessMRMLLogicsEvents(vtkObject * caller,
                                unsigned long event,
@@ -427,12 +387,12 @@ protected:
   static vtkMRMLSliceNode* GetSliceNode(vtkMRMLScene* scene,
     const char* layoutName);
 
-  // @{
+  /// @{
   /// Helper to get/set Window/Level in any layer
   void SetWindowLevel(int layer, double window, double level);
   void GetWindowLevelAndRange(int layer, double& window, double& level,
                                       double& rangeLow, double& rangeHigh, bool& autoWindowLevel);
-  // @}
+  /// @}
 
   /// Helper to update input of blend filter from a set of layers.
   /// It minimizes changes to the imaging pipeline (does not remove and


### PR DESCRIPTION
_This pull request is adapted from work originally done at [jcfr/SlicerGitSVNArchive#add-multi-slice-layer-support](https://github.com/jcfr/SlicerGitSVNArchive/tree/add-multi-slice-layer-support)_

It refactors the `vtkMRMLSliceLogic` and `vtkMRMLSliceCompositeNode` classes to provide an API allowing to manage and blend multiple layers.