### PR TITLE
BUG: Fix crash in vtkSlicerApplicationLogic destructor

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogic.cxx
+++ b/Base/Logic/vtkSlicerApplicationLogic.cxx
@@ -84,19 +84,8 @@ vtkSlicerApplicationLogic::vtkSlicerApplicationLogic()
 //----------------------------------------------------------------------------
 vtkSlicerApplicationLogic::~vtkSlicerApplicationLogic()
 {
-  // Note that we can not kill a thread safely. So we wait
-  // for the thread to finish.  We need to signal the thread that we
-  // want to terminate
-  if (this->ProcessingThread.joinable())
-  {
-    // Signal the processingThread that we are terminating.
-    this->ProcessingThreadActiveLock.lock();
-    this->ProcessingThreadActive = false;
-    this->ProcessingThreadActiveLock.unlock();
-
-    // Wait for the thread to finish
-    this->ProcessingThread.join();
-  }
+  // All processing must stop before the queue objects are deleted
+  this->TerminateProcessingThread();
 
   delete this->InternalTaskQueue;
 


### PR DESCRIPTION
Fix application logic destruction and two other minor (almost just style) fixes.

---

After threading rework in https://github.com/Slicer/Slicer/commit/47da17d4c90f4b2a0dff3034b5305cc1d864c31f, `vtkSlicerApplicationLogicTest1` test started to fail due to crash in the destructor.
The problem was that the networking threads were deleted before waiting for them to finish.

Fixed by calling `TerminateProcessingThread()` method that joins all created threads (instead of just joining the ProcessingThread as it was implemented in the destructor before).
