### PR TITLE
BUG: Fix scene loading warning message

### DIFF
--- a/Modules/Loadable/Data/qSlicerSceneReader.cxx
+++ b/Modules/Loadable/Data/qSlicerSceneReader.cxx
@@ -145,7 +145,7 @@ bool qSlicerSceneReader::load(const qSlicerIO::IOProperties& properties)
     }
     if (!sceneVersionWarningMessages.isEmpty())
     {
-      sceneVersionWarningMessages.push_back(tr("The scene may not load correctly."));
+      sceneVersionWarningMessages << tr("The scene may not load correctly.");
       this->userMessages()->AddMessage(vtkCommand::WarningEvent, sceneVersionWarningMessages.join(" ").toStdString());
     }
   }

--- a/Modules/Loadable/Data/qSlicerSceneReader.cxx
+++ b/Modules/Loadable/Data/qSlicerSceneReader.cxx
@@ -145,7 +145,7 @@ bool qSlicerSceneReader::load(const qSlicerIO::IOProperties& properties)
     }
     if (!sceneVersionWarningMessages.isEmpty())
     {
-      sceneVersionWarningMessages.push_front(tr("The scene may not load correctly.").arg(file));
+      sceneVersionWarningMessages.push_back(tr("The scene may not load correctly."));
       this->userMessages()->AddMessage(vtkCommand::WarningEvent, sceneVersionWarningMessages.join(" ").toStdString());
     }
   }


### PR DESCRIPTION
When the user was warned about potential scene loading issues, the message was formatted incorrectly: the scene file name was specified as argument but the argument was not used.

Since the scene file name is added to the message at higher level, we can simply remove the unneeded argument.