### PR TITLE
COMP: Fix -Winconsistent-missing-override in `vtkMRMLMarkupsROINode`

### DIFF
--- a/Libs/MRML/Core/vtkMRMLMarkupsROINode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsROINode.h
@@ -233,7 +233,7 @@ public:
   /// Get the implicit function that represents the ROI in node coordinates.
   vtkGetObjectMacro(ImplicitFunction, vtkImplicitFunction);
   /// Get the implicit function that represents the ROI in world coordinates.
-  vtkGetObjectMacro(ImplicitFunctionWorld, vtkImplicitFunction);
+  vtkImplicitFunction* GetImplicitFunctionWorld() override { return this->ImplicitFunctionWorld; }
 
   /// Create ROI box as surface mesh in the world coordinate system as a new vtkPolyData object.
   /// Only in C++: The caller must take ownership of the returned object.


### PR DESCRIPTION
Follow-up of d6f6b7dbc2 ("ENH: Add clipping options to models, segmentation, and volume rendering", 2024-11-13) fixing the following warning:

```
/path/to/Slicer/Libs/MRML/Core/vtkMRMLMarkupsROINode.h:236:3:
warning: 'GetImplicitFunctionWorld' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  236 |   vtkGetObjectMacro(ImplicitFunctionWorld, vtkImplicitFunction);
      |   ^
[...]
/path/to/Slicer/Libs/MRML/Core/vtkMRMLTransformableNode.h:123:32: note: overridden virtual function is here
  123 |   virtual vtkImplicitFunction* GetImplicitFunctionWorld() { return nullptr; };
      |                                ^
```