### PR TITLE
ENH: Consolidate SliceLogic calls to SetInterpolateTexture

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -617,19 +617,6 @@ void vtkMRMLSliceLogic::ProcessMRMLLogicsEvents()
     /// \tbd Ideally it should not be fired if the output polydata is not
     /// modified.
     plane->Modified();
-
-    vtkMRMLModelDisplayNode *modelDisplayNode = this->SliceModelNode->GetModelDisplayNode();
-    if ( modelDisplayNode )
-    {
-      if (this->LabelLayer && this->LabelLayer->GetImageDataConnectionUVW())
-      {
-        modelDisplayNode->SetInterpolateTexture(0);
-      }
-      else
-      {
-        modelDisplayNode->SetInterpolateTexture(1);
-      }
-    }
   }
 
   // This is called when a slice layer is modified, so pass it on
@@ -1155,7 +1142,7 @@ void vtkMRMLSliceLogic::UpdatePipeline()
       {
         displayNode->SetTextureImageDataConnection(this->ExtractModelTexture->GetOutputPort());
       }
-        if ( this->LabelLayer && this->LabelLayer->GetImageDataConnection())
+        if (this->LabelLayer && (this->LabelLayer->GetImageDataConnection() || this->LabelLayer->GetImageDataConnectionUVW()))
         {
           displayNode->SetInterpolateTexture(0);
         }


### PR DESCRIPTION
This pull request removes redundant `vtkMRMLModelDisplayNode::SetInterpolateTexture` call in
`vtkMRMLSliceLogic::ProcessMRMLLogicsEvents()`, by handled the remaining call in `vtkMRMLSliceLogic::UpdatePipeline()` with a more comprehensive check.

### Rationale

After reviewing the logic, checking only for `GetImageDataConnectionUVW()` would be sufficient because:

- The model slice node (`vtkMRMLModelDisplayNode`) is only associated with 3D views (see use of `SetViewNodeIDs` depicted below).
- `vtkMRMLModelDisplayableManager`, responsible for displaying the slice model node, derives from `vtkMRMLAbstractThreeDViewDisplayableManager`.
- `vtkMRMLModelSliceDisplayableManager` is responsible for displaying model intersections on slice planes and does not handle the model associated with the slice viewer.

### Future Optimization

This PR focuses on removing redundancy. Further optimizations should be handled separately.

### Reference: ModelSliceNode Association with 3D Views

https://github.com/Slicer/Slicer/blob/9195b3f94ab121acb9250c21068dea012d33d7e1/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx#L483-L489