### PR TITLE
BUG: Add missing newlines and fix  indentation in `PrintSelf`

### DIFF
--- a/Base/Logic/vtkImageFillROI.cxx
+++ b/Base/Logic/vtkImageFillROI.cxx
@@ -46,9 +46,9 @@ void vtkImageFillROI::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os,indent);
 
-  os << indent << "Value: "  << this->Value;
-  os << indent << "Radius: " << this->Radius;
-  os << indent << "Shape: "  << this->Shape;
+  os << indent << "Value: "  << this->Value << "\n";
+  os << indent << "Radius: " << this->Radius << "\n";
+  os << indent << "Shape: "  << this->Shape << "\n";
 
   // vtkSetObjectMacro
   os << indent << "Points: ";

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -289,7 +289,7 @@ void vtkMRMLAbstractViewNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintFloatMacro(ScreenScaleFactor);
   vtkMRMLPrintEndMacro();
 
-  os << indent << " AxisLabels: ";
+  os << indent << "AxisLabels: ";
   for (int i=0; i<vtkMRMLAbstractViewNode::AxisLabelsCount; i++)
   {
     os << (i>0?";":"") << this->GetAxisLabel(i);

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -1208,7 +1208,7 @@ void vtkMRMLSliceLogic::PrintSelf(ostream& os, vtkIndent indent)
 
   if (this->BackgroundLayer)
   {
-    os << indent << "BackgroundLayer: ";
+    os << indent << "BackgroundLayer:\n";
     this->BackgroundLayer->PrintSelf(os, nextIndent);
   }
   else
@@ -1218,7 +1218,7 @@ void vtkMRMLSliceLogic::PrintSelf(ostream& os, vtkIndent indent)
 
   if (this->ForegroundLayer)
   {
-    os << indent << "ForegroundLayer: ";
+    os << indent << "ForegroundLayer:\n";
     this->ForegroundLayer->PrintSelf(os, nextIndent);
   }
   else
@@ -1228,7 +1228,7 @@ void vtkMRMLSliceLogic::PrintSelf(ostream& os, vtkIndent indent)
 
   if (this->LabelLayer)
   {
-    os << indent << "LabelLayer: ";
+    os << indent << "LabelLayer:\n";
     this->LabelLayer->PrintSelf(os, nextIndent);
   }
   else
@@ -1238,7 +1238,7 @@ void vtkMRMLSliceLogic::PrintSelf(ostream& os, vtkIndent indent)
 
   if (this->Pipeline->Blend.GetPointer())
   {
-    os << indent << "Blend: ";
+    os << indent << "Blend:\n";
     this->Pipeline->Blend->PrintSelf(os, nextIndent);
   }
   else
@@ -1248,7 +1248,7 @@ void vtkMRMLSliceLogic::PrintSelf(ostream& os, vtkIndent indent)
 
   if (this->PipelineUVW->Blend.GetPointer())
   {
-    os << indent << "BlendUVW: ";
+    os << indent << "BlendUVW:\n";
     this->PipelineUVW->Blend->PrintSelf(os, nextIndent);
   }
   else

--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyEntry.cxx
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyEntry.cxx
@@ -83,7 +83,7 @@ void vtkSlicerTerminologyEntry::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "CategoryObject: ";
   if (this->CategoryObject)
   {
-    this->CategoryObject->PrintSelf(os, indent.GetNextIndent());
+    this->CategoryObject->PrintSelf(os << "\n", indent.GetNextIndent());
   }
   else
   {
@@ -92,7 +92,7 @@ void vtkSlicerTerminologyEntry::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "TypeObject: ";
   if (this->TypeObject)
   {
-    this->TypeObject->PrintSelf(os, indent.GetNextIndent());
+    this->TypeObject->PrintSelf(os << "\n", indent.GetNextIndent());
   }
   else
   {
@@ -101,7 +101,7 @@ void vtkSlicerTerminologyEntry::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "TypeModifierObject: ";
   if (this->TypeModifierObject)
   {
-    this->TypeModifierObject->PrintSelf(os, indent.GetNextIndent());
+    this->TypeModifierObject->PrintSelf(os << "\n", indent.GetNextIndent());
   }
   else
   {
@@ -112,7 +112,7 @@ void vtkSlicerTerminologyEntry::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "AnatomicRegionObject: ";
   if (this->AnatomicRegionObject)
   {
-    this->AnatomicRegionObject->PrintSelf(os, indent.GetNextIndent());
+    this->AnatomicRegionObject->PrintSelf(os << "\n", indent.GetNextIndent());
   }
   else
   {
@@ -121,7 +121,7 @@ void vtkSlicerTerminologyEntry::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "AnatomicRegionModifierObject: ";
   if (this->AnatomicRegionModifierObject)
   {
-    this->AnatomicRegionModifierObject->PrintSelf(os, indent.GetNextIndent());
+    this->AnatomicRegionModifierObject->PrintSelf(os << "\n", indent.GetNextIndent());
   }
   else
   {

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.cxx
@@ -123,7 +123,7 @@ void vtkMRMLShaderPropertyNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os,indent);
 
-  os << indent << "ShaderProperty: ";
+  os << indent << "ShaderProperty:\n";
   this->ShaderProperty->PrintSelf(os,indent.GetNextIndent());
 }
 

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.cxx
@@ -198,7 +198,7 @@ void vtkMRMLVolumePropertyNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintVectorMacro(EffectiveRange, double, 2);
   vtkMRMLPrintEndMacro();
 
-  os << indent << "VolumeProperty: ";
+  os << indent << "VolumeProperty:\n";
   this->VolumeProperty->PrintSelf(os,indent.GetNextIndent());
 }
 


### PR DESCRIPTION




Fix indentation in `vtkMRMLAbstractViewNode::PrintSelf` and add missing newlines in `PrintSelf` .

Follow-up these commits were the newlines were omitted:
* `vtkMRMLSliceLogic`: de98785 ("BUG: fix print methods so tests will pass", 2010-01-15)
* `vtkMRMLShaderPropertyNode`: ea47570 ("ENH: Add new node types to support custom shader code for volume rendering", 2019-06-04)
* `vtkMRMLVolumePropertyNode`: b13f089 ("ENH: fixed visibility in modelHierarchy widget", 2009-01-14)
* `vtkSlicerTerminologyEntry`: fe0e596 ("ENH: Added Terminologies module for handling standard terminologies", 2016-10-14)
* `vtkImageFillROI`: e934e58 ("ENH: poly draw class brought over from slicer2 for use in the editor", 2006-11-15)

Before:

```
  [...]
  VolumeProperty:     Debug: Off
    Modified Time: 533642
    Reference Count: 2
    Registered Events:
  [...]
```

After:

```
  [...]
  VolumeProperty:
    Debug: Off
    Modified Time: 533642
    Reference Count: 2
    Registered Events:
  [...]
```