### PR TITLE
DOC: Remove obsolete comment from vtkMRMLSliceLogic::UpdatePipeline

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -1030,8 +1030,6 @@ void vtkMRMLSliceLogic::UpdatePipeline()
   {
     // get the background and foreground image data from the layers
     // so we can use them as input to the image blend
-    // TODO: change logic to use a volume node superclass rather than
-    // a scalar volume node once the superclass is sorted out for vector/tensor Volumes
 
     const char *id;
 


### PR DESCRIPTION
The comment was originally introduced in 2c46933490 ("ENH: fixed pipeline from mrml scene to composited image data", 2006-03-30) and become obsolete following these commits:
* 95ac4f1fb4 ("ENH: DownCast Foreground and Background layer to MRMLVolumeNode so it can hold different type of volumes like Diffusion Tensor, Diffusion Weighted Volumes and Vector Volumes", 2007-01-03)
* 4189ee6eef ("ENH: Adding layer infrastructure to handle different types of MRMLVolumeNodes. We currently support: Scalars, Vectors, Diffusion Tensors, Diffusion Weighted Volumes", 2007-01-03)