### PR TITLE
ENH: Remove support for building against VTK <= 9.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,8 @@ if(NOT "${Slicer_VTK_VERSION_MAJOR}" MATCHES "^(9)$")
 endif()
 mark_as_superbuild(Slicer_VTK_VERSION_MAJOR)
 
+set(Slicer_VTK_MINIMUM_SUPPORTED_VERSION "9.1")
+
 #
 # SimpleITK has large internal libraries, which take an extremely long
 # time to link on windows when they are static. Creating shared
@@ -596,6 +598,7 @@ message(STATUS "Configuring VTK")
 message(STATUS "  Slicer_VTK_RENDERING_BACKEND is ${Slicer_VTK_RENDERING_BACKEND}")
 message(STATUS "  Slicer_VTK_SMP_IMPLEMENTATION_TYPE is ${Slicer_VTK_SMP_IMPLEMENTATION_TYPE}")
 message(STATUS "  Slicer_VTK_VERSION_MAJOR is ${Slicer_VTK_VERSION_MAJOR}")
+message(STATUS "  Slicer_VTK_MINIMUM_SUPPORTED_VERSION is ${Slicer_VTK_MINIMUM_SUPPORTED_VERSION}")
 
 #-----------------------------------------------------------------------------
 # Slicer_VTK_COMPONENTS
@@ -897,7 +900,7 @@ endif()
 #-----------------------------------------------------------------------------
 find_package(VTK REQUIRED)
 set(VTK_LIBRARIES "")
-find_package(VTK ${Slicer_VTK_VERSION_MAJOR} COMPONENTS ${Slicer_VTK_COMPONENTS} REQUIRED)
+find_package(VTK ${Slicer_VTK_MINIMUM_SUPPORTED_VERSION} COMPONENTS ${Slicer_VTK_COMPONENTS} REQUIRED)
 set(VTK_GUI_SUPPORT_QT_TARGET_NAME "VTK::GUISupportQt")
 
 if(NOT TARGET ${VTK_GUI_SUPPORT_QT_TARGET_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,7 +430,7 @@ if(NOT "${Slicer_VTK_VERSION_MAJOR}" MATCHES "^(9)$")
 endif()
 mark_as_superbuild(Slicer_VTK_VERSION_MAJOR)
 
-set(Slicer_VTK_MINIMUM_SUPPORTED_VERSION "9.1")
+set(Slicer_VTK_MINIMUM_SUPPORTED_VERSION "9.2")
 
 #
 # SimpleITK has large internal libraries, which take an extremely long

--- a/Libs/MRML/Core/vtkCacheManager.cxx
+++ b/Libs/MRML/Core/vtkCacheManager.cxx
@@ -642,11 +642,7 @@ int vtkCacheManager::ClearCache()
     this->MarkNodesBeforeDeletingDataFromCache ( this->RemoteCacheDirectory.c_str() );
     vtksys::SystemTools::RemoveADirectory ( this->RemoteCacheDirectory.c_str() );
   }
-#if (VTK_MAJOR_VERSION >= 9 && VTK_MINOR_VERSION >= 0 && VTK_BUILD_VERSION >= 20210806)
   if ( !vtksys::SystemTools::MakeDirectory ( this->RemoteCacheDirectory.c_str() ) )
-#else
-  if ( vtksys::SystemTools::MakeDirectory ( this->RemoteCacheDirectory.c_str() ) == false )
-#endif
   {
     vtkWarningMacro ( "Cache cleared: Error: unable to recreate cache directory after deleting its contents." );
     return 0;

--- a/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
@@ -656,11 +656,7 @@ int vtkMRMLVolumeArchetypeStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
       }
     }
     // delete the temporary dir and all remaining contents
-#if (VTK_MAJOR_VERSION >= 9 && VTK_MINOR_VERSION >= 0 && VTK_BUILD_VERSION >= 20210806)
     bool dirRemoved = vtksys::SystemTools::RemoveADirectory(moveFromDir.c_str()).IsSuccess();
-#else
-    bool dirRemoved = vtksys::SystemTools::RemoveADirectory(moveFromDir.c_str());
-#endif
     if (!dirRemoved)
     {
       vtkWarningMacro("Failed to remove temporary write directory " << moveFromDir);
@@ -939,11 +935,7 @@ std::string vtkMRMLVolumeArchetypeStorageNode::UpdateFileList(vtkMRMLNode *refNo
 
   // look through the new dir and populate the file list
   vtksys::Directory dir;
-#if (VTK_MAJOR_VERSION >= 9 && VTK_MINOR_VERSION >= 0 && VTK_BUILD_VERSION >= 20210806)
   success = dir.Load(tempDir.c_str()).IsSuccess();
-#else
-  success = dir.Load(tempDir.c_str());
-#endif
   vtkDebugMacro("UpdateFileList: tempdir " << tempDir.c_str() << " has " << dir.GetNumberOfFiles() << " in it");
   if (!success)
   {

--- a/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
+++ b/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
@@ -29,7 +29,6 @@
 #include <vtkCompositeDataIterator.h>
 #include <vtkDecimatePro.h>
 #include <vtkDiscreteFlyingEdges3D.h>
-#include <vtkExtractSelectedThresholds.h>
 #include <vtkGeometryFilter.h>
 #include <vtkImageAccumulate.h>
 #include <vtkImageChangeInformation.h>
@@ -58,7 +57,6 @@
 #include <vtkSelection.h>
 #include <vtkSelectionNode.h>
 #include <vtkFloatArray.h>
-#include <vtkExtractSelectedIds.h>
 #include <vtkInformation.h>
 #include <vtkExtractSelection.h>
 #include <vtkSelectionSource.h>

--- a/Libs/vtkSegmentationCore/vtkPolyDataToFractionalLabelmapFilter.cxx
+++ b/Libs/vtkSegmentationCore/vtkPolyDataToFractionalLabelmapFilter.cxx
@@ -41,6 +41,7 @@
 #include <vtkStripper.h>
 #include <vtkImageStencil.h>
 #include <vtkImageCast.h>
+#include <vtkVersion.h> // For VTK_VERSION_*
 
 // std includes
 #include <map>


### PR DESCRIPTION
Introduce `Slicer_VTK_MINIMUM_SUPPORTED_VERSION` CMake variable to describe the minimum supported version of VTK.

Anticipate support for building against VTK 9.4 by removing use of APIs originally deprecated in VTK 9.1 or earlier and removed from VTK 9.3.

Update `vtkBinaryLabelmapToClosedSurfaceConversionRule` removing unused `vtkExtractSelectedIds.h` and `vtkExtractSelectedThresholds.h` includes
originally introduced in https://github.com/Slicer/Slicer/commit/fcb40b0738c65ab418731a1a34292f3c85b2133a ("ENH: Add support for shared binary labelmap segmentations", 2019-10-08). These classes have been removed in VTK 9.4 in favor of `vtkExtractSelection`.