### PR TITLE
ENH: Add segment visibility toggle option

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
@@ -1181,13 +1181,13 @@ void qMRMLSegmentsTableView::contextMenuEvent(QContextMenuEvent* event)
 
   if (selectedSegmentIDs.size() > 0)
   {
+    QAction* toggleSelectedAction = new QAction(tr("Toggle selected segments visibility"), this);
+    QObject::connect(toggleSelectedAction, SIGNAL(triggered()), this, SLOT(toggleSelectedSegmentsVisibility()));
+    contextMenu->addAction(toggleSelectedAction);
+
     QAction* showOnlySelectedAction = new QAction(tr("Show only selected segments"), this);
     QObject::connect(showOnlySelectedAction, SIGNAL(triggered()), this, SLOT(showOnlySelectedSegments()));
     contextMenu->addAction(showOnlySelectedAction);
-
-    QAction* toggleSelectedAction = new QAction(tr("Toggle selected segments"), this);
-    QObject::connect(toggleSelectedAction, SIGNAL(triggered()), this, SLOT(toggleSelectedSegments()));
-    contextMenu->addAction(toggleSelectedAction);
 
     contextMenu->addSeparator();
 
@@ -1426,7 +1426,7 @@ void qMRMLSegmentsTableView::showOnlySelectedSegments()
 }
 
 //------------------------------------------------------------------------------
-void qMRMLSegmentsTableView::toggleSelectedSegments()
+void qMRMLSegmentsTableView::toggleSelectedSegmentsVisibility()
 {
   QStringList selectedSegmentIDs = this->selectedSegmentIDs();
   if (selectedSegmentIDs.size() == 0)

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
@@ -166,6 +166,9 @@ public slots:
   /// Show only selected segments
   void showOnlySelectedSegments();
 
+  /// Toggle visibility for the selected segments
+  void toggleSelectedSegments();
+
   /// Jump position of all slice views to show the segment's center.
   /// Segment's center is determined as the center of bounding box.
   void jumpSlices();

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
@@ -167,7 +167,7 @@ public slots:
   void showOnlySelectedSegments();
 
   /// Toggle visibility for the selected segments
-  void toggleSelectedSegments();
+  void toggleSelectedSegmentsVisibility();
 
   /// Jump position of all slice views to show the segment's center.
   /// Segment's center is determined as the center of bounding box.


### PR DESCRIPTION
This PR proposes addition of a context menu item for the segmentations widget to toggle visibility of the selected segments. This feature is very convenient while reviewing segmentations with the large number of segments, when a subset of segments need to be shown/hidden without affecting visibility of other segments.

![2025-02-20_18-07-18](https://github.com/user-attachments/assets/e02378a8-879f-4a2a-b6c4-444fdbbddafd)
