### PR TITLE
BUG: Fix crash in SystemTools::RemoveADirectory

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -3903,9 +3903,9 @@ std::string vtkMRMLScene::GetTemporaryBundleDirectory()
 {
   std::stringstream ss;
   ss << vtksys::SystemTools::GetCurrentDateTime("_tmp%Y%m%d");
-  const char validCharacters[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-  int numberOfCharacters = sizeof(validCharacters) - 1;
-  std::uniform_int_distribution<int> distribution(0, numberOfCharacters);
+  const char validCharacters[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  int numberOfCharacters = sizeof(validCharacters) - 1; // -1 because the null terminator is included in sizeof()
+  std::uniform_int_distribution<int> distribution(0, numberOfCharacters - 1); // -1 because the upper bound is inclusive
   for (int i = 0; i < 5; i++)
   {
     ss << validCharacters[distribution(this->RandomGenerator)];


### PR DESCRIPTION
`vtkMRMLScene::GetTemporaryBundleDirectory` could return a string that contained a "\0" character. C string manipulation functions mostly ignore what is after the "\0" character.

Since this string was used as a directory name, it was passed to `kwSys::SystemTools::RemoveADirectory` method, which got into an infinite recursion and crashed with stack overflow, because the appended "/" + filename effectively has not been appended.

This caused several tests to randomly fail, such as `vtkMRMLSequenceStorageNodeTest1`.

The regression was introduced in commit 47c791c77fe4091a18fb894f9f2d19f5c50ad903 (BUG: Fix loading and saving `.mrb` files with trailing space in filename) on 2025-01-11.

@jcfr The fix has to be added to a Slicer-5.8 patch release, preferably soon, as it can cause crash during scene saving.
