### PR TITLE
COMP: Workaround VTK 9.4 wrapping issue for SetNthControlPointPositionMissing

### DIFF
--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -415,6 +415,43 @@ if(VTK_WRAP_PYTHON)
       set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()
   endif()
+
+  # --------------------------------------------------------------------------
+  # Workaround issue https://gitlab.kitware.com/vtk/vtk/-/issues/19627
+  # --------------------------------------------------------------------------
+  set(_generated_wrapper_cxx "vtkMRMLMarkupsNodePython.cxx")
+  set(_patched_wrapper_cxx "${_generated_wrapper_cxx}.patched")
+  set(_patched_done "${CMAKE_CURRENT_BINARY_DIR}/${_generated_wrapper_cxx}.patched.done")
+
+  # Ensure patching happens when the wrapper is regenerated
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_patched_wrapper_cxx}
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${_generated_wrapper_cxx}
+    COMMAND ${PYTHON_EXECUTABLE} -c
+      "import sys; in_file, out_file, search_text, replace_text = sys.argv[1:]; content = open(in_file).read().replace(search_text, replace_text); open(out_file, 'w').write(content)"
+      ${CMAKE_CURRENT_BINARY_DIR}/${_generated_wrapper_cxx}
+      ${CMAKE_CURRENT_BINARY_DIR}/${_patched_wrapper_cxx}
+      "WrappedSetNthControlPointPositionMissing" "SetNthControlPointPositionMissing"
+    COMMENT "Patching generated Python wrapper source ${_generated_wrapper_cxx}"
+    VERBATIM
+    )
+
+  # Copy the patched file back to the original location, ensuring CMake tracks completion
+  add_custom_command(
+    OUTPUT ${_patched_done}
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${_patched_wrapper_cxx}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      ${CMAKE_CURRENT_BINARY_DIR}/${_patched_wrapper_cxx}
+      ${CMAKE_CURRENT_BINARY_DIR}/${_generated_wrapper_cxx}
+    COMMAND ${CMAKE_COMMAND} -E touch ${_patched_done}
+    COMMENT "Replacing original ${_generated_wrapper_cxx} with patched version"
+    VERBATIM
+  )
+
+  # Ensure the MRMLCorePython target depends on the patched wrapper
+  add_custom_target(PatchMRMLCorePythonWrappers DEPENDS ${_patched_done})
+
+  add_dependencies(MRMLCorePython PatchMRMLCorePythonWrappers)
 endif()
 
 # --------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.cxx
@@ -2333,6 +2333,12 @@ void vtkMRMLMarkupsNode::SetNthControlPointPositionMissing(int n)
 }
 
 //---------------------------------------------------------------------------
+void vtkMRMLMarkupsNode::WrappedSetNthControlPointPositionMissing(int pointIndex)
+{
+  this->SetNthControlPointPositionMissing(pointIndex);
+}
+
+//---------------------------------------------------------------------------
 void vtkMRMLMarkupsNode::ResetNthControlPointPosition(int n)
 {
   ControlPoint* controlPoint = this->GetNthControlPointCustomLog(n, "ResetNthControlPointPosition");

--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.h
@@ -468,7 +468,33 @@ public:
   void UnsetNthControlPointPosition(int pointIndex);
 
   /// Set control point status to ignored.
+  /// Excluded from wrapping to prevent unintended `SET_NTH` recognition.
+  /// This behavior was introduced in VTK 9.4 (kitware/VTK@5672af1f) and requires
+  /// specific function signatures. Until the VTK wrapping infrastructure is improved,
+  /// this method should remain excluded. See https://gitlab.kitware.com/vtk/vtk/-/issues/19627.
+  VTK_WRAPEXCLUDE
   void SetNthControlPointPositionMissing(int pointIndex);
+
+  /// \internal
+  /// Workaround for a VTK 9.4 wrapping limitation that prevents
+  /// `SetNthControlPointPositionMissing` from being correctly recognized.
+  ///
+  /// This method is intentionally introduced as an alias for
+  /// `SetNthControlPointPositionMissing` to be patched in the generated
+  /// Python wrapper (`vtkMRMLMarkupsNodePython.cxx`).
+  ///
+  /// The custom target `PatchMRMLCorePythonWrappers` (defined in `CMakeLists.txt`)
+  /// ensures that occurrences of `WrappedSetNthControlPointPositionMissing`
+  /// in the generated wrapper are replaced with `SetNthControlPointPositionMissing`,
+  /// maintaining Python compatibility.
+  ///
+  /// This function should NOT be called directly in C++ code and will be removed
+  /// once the VTK wrapping infrastructure is improved.
+  ///
+  /// See https://gitlab.kitware.com/vtk/vtk/-/issues/19627 for more details.
+  ///
+  /// \sa SetNthControlPointPositionMissing()
+  void WrappedSetNthControlPointPositionMissing(int pointIndex);
 
   /// Set control point status to preview
   void ResetNthControlPointPosition(int n);


### PR DESCRIPTION
This commit addresses an issue introduced in VTK 9.4 (kitware/VTK@5672af1f), where `SetNthControlPointPositionMissing` is incorrectly recognized as a `SET_NTH` function by the VTK wrapping system, leading to build failures due to signature mismatches.

### Changes and Workarounds

1. Exclude `SetNthControlPointPositionMissing` from wrapping:
   - Marked with `VTK_WRAPEXCLUDE` to prevent automatic recognition as a `SET_NTH` function.
   - Ensures compatibility until the VTK wrapping infrastructure is improved.
   - Related issue: [VTK Issue #19627](https://gitlab.kitware.com/vtk/vtk/-/issues/19627).

2. Introduce `WrappedSetNthControlPointPositionMissing` as a wrapper method:
   - Serves as an intermediate function that can be replaced in generated Python bindings.
   - Ensures that `SetNthControlPointPositionMissing` remains callable from Python.

3. Patch the generated Python wrapper (`vtkMRMLMarkupsNodePython.cxx`) at build time:
   - Added a CMake custom command to modify the generated wrapper **after VTK wrapping**.
   - Uses a **Python script** to replace occurrences of `WrappedSetNthControlPointPositionMissing`
     with `SetNthControlPointPositionMissing` in `vtkMRMLMarkupsNodePython.cxx`.
   - Ensures that Python bindings remain functional without modifying VTK itself.

4. Ensure the patching process is reliably triggered:
   - `PatchMRMLCorePythonWrappers` is added as a dependency of `MRMLCorePython`.
   - Uses `copy_if_different` to avoid unnecessary rebuilds.

This workaround allows the build to succeed without modifying upstream VTK while ensuring the method remains accessible in Python.