### PR TITLE
BUG: Fix py_UtilTest on Windows

### DIFF
--- a/Applications/SlicerApp/Testing/Python/UtilTest.py
+++ b/Applications/SlicerApp/Testing/Python/UtilTest.py
@@ -270,7 +270,7 @@ class UtilTestTest(ScriptedLoadableModuleTest):
 
         self.delayDisplay("Test structured array update")
         tableNode3 = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode")
-        data_type = np.dtype([("mountain_rank", np.uint16), ("height", int)])
+        data_type = np.dtype([("mountain_rank", np.uint16), ("height", np.int32)])
         structured_array = np.array([
             (1, 8859), # Mount Everest
             (2, 8611), # K2
@@ -282,7 +282,7 @@ class UtilTestTest(ScriptedLoadableModuleTest):
         self.assertEqual(tableNode3.GetColumnName(0), "mountain_rank")
         self.assertEqual(tableNode3.GetColumnType("mountain_rank"), vtk.VTK_UNSIGNED_SHORT)
         self.assertEqual(tableNode3.GetColumnName(1), "height")
-        self.assertEqual(tableNode3.GetColumnType("height"), vtk.VTK_LONG_LONG)
+        self.assertEqual(tableNode3.GetColumnType("height"), vtk.VTK_INT)
 
         self.delayDisplay("Test boolean array update")
         tableNode4 = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode")


### PR DESCRIPTION
py_UtilTest's test_updateTableFromArray test failed on Windows:

-----

FAIL: test_updateTableFromArray (UtilTest.UtilTestTest) 
---------------------------------------------------------------------- 
Traceback (most recent call last):
  File "C:/D/P/S-0-build/Slicer-build/lib/Slicer-5.9/qt-scripted-modules/UtilTest.py", line 285, in test_updateTableFromArray
    self.assertEqual(tableNode3.GetColumnType("height"), vtk.VTK_LONG_LONG)
AssertionError: 6 != 16

-----

The root cause is that "int" type is mapped to np.int64 on linux and macOS but on Windows it is mapped to np.int32.

Fixed the test by making the behaviour consistent on all platforms, by using np.int32 as column data type.