### PR TITLE
BUG: Avoid unnecessary error message in UpdateAddSubOperation

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -963,10 +963,8 @@ bool vtkMRMLSliceLogic::UpdateAddSubOperation(vtkImageMathematics* addSubMath, i
 {
   if (compositing != vtkMRMLSliceCompositeNode::Add && compositing != vtkMRMLSliceCompositeNode::Subtract)
   {
-    vtkErrorWithObjectMacro(nullptr, << "UpdateAddSubOperation: Unexpected compositing mode (" << compositing << "). "
-                            << "Supported values are "
-                            << "Add (" << vtkMRMLSliceCompositeNode::Add << ") or "
-                            << "Subtract(" << vtkMRMLSliceCompositeNode::Subtract << ")");
+    // Silently return for unsupported compositing modes, as this function
+    // may be called with any mode.
     return false;
   }
   vtkMTimeType oldAddSubMathMTime = addSubMath->GetMTime();


### PR DESCRIPTION
Fixes an issue introduced in 26fd93d49e ("BUG: Ensure blend pipeline is updated when setting operation Add or Subtract", 2025-02-17) through https://github.com/Slicer/Slicer/pull/8233.

The function `vtkMRMLSliceLogic::UpdateAddSubOperation` may be called with any compositing mode, including unsupported ones. Instead of logging an error, silently return when encountering an unsupported mode, as it does not require special handling.