### PR TITLE
BUG: Avoid unnecessary error message in UpdateAddSubOperation

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -1122,14 +1122,18 @@ void vtkMRMLSliceLogic::UpdatePipeline()
       backgroundImagePortUVW, foregroundImagePortUVW, this->SliceCompositeNode->GetForegroundOpacity(),
       labelImagePortUVW, this->SliceCompositeNode->GetLabelOpacity());
 
-    // Update add/subtract operations in the pipeline
-    if (vtkMRMLSliceLogic::UpdateAddSubOperation(this->Pipeline->AddSubMath.GetPointer(), this->SliceCompositeNode->GetCompositing()))
+    if (this->SliceCompositeNode->GetCompositing() == vtkMRMLSliceCompositeNode::Add
+        || this->SliceCompositeNode->GetCompositing() == vtkMRMLSliceCompositeNode::Subtract)
     {
-      modified = 1;
-    }
-    if (vtkMRMLSliceLogic::UpdateAddSubOperation(this->PipelineUVW->AddSubMath.GetPointer(), this->SliceCompositeNode->GetCompositing()))
-    {
-      modified = 1;
+      // Update add/subtract operations in the pipeline
+      if (vtkMRMLSliceLogic::UpdateAddSubOperation(this->Pipeline->AddSubMath.GetPointer(), this->SliceCompositeNode->GetCompositing()))
+      {
+        modified = 1;
+      }
+      if (vtkMRMLSliceLogic::UpdateAddSubOperation(this->PipelineUVW->AddSubMath.GetPointer(), this->SliceCompositeNode->GetCompositing()))
+      {
+        modified = 1;
+      }
     }
 
     // Update opacity fractions for additional layers in add/subtract blending mode


### PR DESCRIPTION
Fixes an issue introduced in 26fd93d ("BUG: Ensure blend pipeline is updated when setting operation Add or Subtract", 2025-02-17).

`vtkMRMLSliceLogic::UpdateAddSubOperation` may be called with any compositing mode, including unsupported ones, leading to unnecessary error messages. This update ensures the function is only called for supported modes (`Add` or `Subtract`), preventing unintended log errors.