### PR TITLE
[5.8] Update GitHub CI workflow to be release specific

### DIFF
--- a/.github/actions/slicer-build/Dockerfile
+++ b/.github/actions/slicer-build/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM slicer/slicer-base
+FROM slicer/slicer-base:5.8
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   # Triggers the workflow on push or pull request events
   push:
     branches:
-      - "main"
+      - "5.8"
   pull_request:
     branches:
       - "*"
@@ -46,7 +46,7 @@ jobs:
         with:
           files: |
             SuperBuild/External_*
-          base_sha: nightly-main
+          base_sha: "5.8"
 
       # List any SuperBuild files that were changed
       - name: "List Changed SuperBuild Files"


### PR DESCRIPTION
### Summary
* Update slicer-build GitHub action to use `5.8` docker image
* Update CI GitHub workflow to test `5.8` branch instead of `main`

### Notes

The `slicer-base` image was manually tagged and published on the `metroplex` factory using the following commands:

```
docker tag slicer/slicer-base:latest slicer/slicer-base:5.8
docker push slicer/slicer-base:5.8
```

Since it is based on the `latest` version, it includes external project specific changes associated with this pull-request:
* https://github.com/Slicer/Slicer/pull/8183
* https://github.com/Slicer/Slicer/pull/8191
* https://github.com/Slicer/Slicer/pull/8197
* https://github.com/Slicer/Slicer/pull/8227
* https://github.com/Slicer/Slicer/pull/8239
* https://github.com/Slicer/Slicer/pull/8165