### PR TITLE
[5.8] BUG: Fix typo in Grow From Seeds help text

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorGrowFromSeedsEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorGrowFromSeedsEffect.py
@@ -45,7 +45,7 @@ class SegmentEditorGrowFromSeedsEffect(AbstractScriptedSegmentEditorAutoComplete
         Location, size, and shape of initial segments and content of source volume are taken into account.
         Final segment boundaries will be placed where source volume brightness changes abruptly. Instructions:<p>
         <ul style="margin: 0">
-        <li>Use Paint or other offects to draw seeds in each region that should belong to a separate segment.
+        <li>Use Paint or other effects to draw seeds in each region that should belong to a separate segment.
         Paint each seed with a different segment. Minimum two segments are required.
         <li>Click <dfn>Initialize</dfn> to compute preview of full segmentation.
         <li>Browse through image slices. If previewed segmentation result is not correct then switch to


### PR DESCRIPTION
Backport from #8166

---

(cherry picked from commit d09caa4bda46ac5c6231f816bc0a35d974a44765)