### PR TITLE
[5.8] DOC: Fix various broken documentation links in developer guide

### DIFF
--- a/Docs/developer_guide/extensions.md
+++ b/Docs/developer_guide/extensions.md
@@ -716,7 +716,7 @@ Extensions integrating third party libraries should follow the [SuperBuild exten
 
 Each third party libraries will be configured and built using a dedicated `External_MyLib.cmake` file, the install location of binaries and libraries should be set to `Slicer_INSTALL_BIN_DIR` and `Slicer_INSTALL_LIB_DIR`.
 
-Also, starting with [Slicer r25959](http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=25959), extension can package python modules and packages using `PYTHON_SITE_PACKAGES_SUBDIR` CMake variable to specify the install destination.
+Also, starting with [Slicer v4.8.0](https://github.com/Slicer/Slicer/releases/tag/v4.8.0) (introduced in [this commit](https://github.com/Slicer/Slicer/commit/b16753775e49bca14c456a4b45803e8fb9e97eab)), extension can package python modules and packages using `PYTHON_SITE_PACKAGES_SUBDIR` CMake variable to specify the install destination.
 
 These relative paths are the one that the extensions manager will consider when generating the launcher and application settings for a given extension.
 

--- a/Docs/developer_guide/module_overview.md
+++ b/Docs/developer_guide/module_overview.md
@@ -73,7 +73,7 @@ Recommended for fast prototyping and custom workflow development.
 Specifications:
 * Written in Python.
 * Full [Slicer API](api.md#python) is accessible.
-* Full access to the API of [MRML](mrml.md), [VTK](http://www.vtk.org), [Qt](https://doc.qt.io/), [ITK](https://itkpythonpackage.readthedocs.io) and [SimpleITK](http://www.itk.org/SimpleITKDoxygen/html/classes.html) since are Python wrapped.
+* Full access to the API of [MRML](mrml.md), [VTK](https://docs.vtk.org), [Qt](https://doc.qt.io/), [ITK](https://docs.itk.org/) and [SimpleITK](https://simpleitk.readthedocs.io/) since those are Python wrapped.
 
 :::{admonition} Getting started
 Download Slicer and create an initial skeleton using the [Extension Wizard](/user_guide/modules/extensionwizard.md#extension-wizard) adding a module of type `scripted`.

--- a/Docs/developer_guide/style_guide.md
+++ b/Docs/developer_guide/style_guide.md
@@ -88,7 +88,7 @@ Useful information about some coding style decisions: <https://google.github.io/
   - `vtkSlicer` not `vTKSlicer`
 - Words should be spelled out and not abbreviated
   - `GetWindow` not `GetWin`
-- File names must follow the [https://en.wikipedia.org/wiki/CamelCase Camel case] convention
+- File names must follow the [Camel case](https://en.wikipedia.org/wiki/CamelCase) convention
   - `TestMyFeature.cxx` not `Test-My_Feature.cxx`
 - Use US English words and spelling
   - "Millimeter" not "Millimetre"
@@ -110,7 +110,7 @@ Examples:
 When dealing with files names and path, use:
 - [kwsys::SystemTools](https://github.com/Kitware/VTK/blob/master/Utilities/KWSys/vtksys/SystemTools.hxx.in) in VTK classes
 - [QFileInfo](https://doc.qt.io/qt-5/qfileinfo.html)/[QDir](https://doc.qt.io/qt-5/qdir.html) in Qt classes
-- [https://docs.python.org/library/os.path.html os.path] in Python.
+- [os.path](https://docs.python.org/library/os.path.html) in Python.
 
 Instead of doing string manipulation manually:
 
@@ -232,7 +232,7 @@ The ITK, VTK, Qt, std::cout, std::cerr .. all appear in the error log and can ea
 
 ### In Qt-based classes
 
-For error messages, use [qCritical()](https://qt-project.org/doc/qt-4.8/qtglobal.html#qCritical):
+For error messages, use [qCritical()](https://doc.qt.io/qt-5/qtglobal.html#qCritical):
 
 ```
 if (somethingWrongHappened)
@@ -242,13 +242,13 @@ if (somethingWrongHappened)
   }
 ```
 
-For warnings, use [qWarning()](https://qt-project.org/doc/qt-4.8/qtglobal.html#qWarning):
+For warnings, use [qWarning()](https://doc.qt.io/qt-5/qtglobal.html#qWarning):
 
 ```
 qWarning() << "Be careful here, this is dangerous";
 ```
 
-For debug, use [qDebug()](https://qt-project.org/doc/qt-4.8/qtglobal.html#qDebug):
+For debug, use [qDebug()](https://doc.qt.io/qt-5/qtglobal.html#qDebug):
 
 ```
 qDebug() << "This variable has the value: "<< value;
@@ -364,8 +364,8 @@ See [r23377](https://github.com/Slicer/Slicer/commit/3e04040d2e960ec4cd294cb8404
 
 ### Resources
 
-- Read more on [https://chris.beams.io/posts/git-commit/ How to Write a Git Commit Message]
-- Discussion section of [https://git-scm.com/docs/git-commit git-commit(1)]
+- Read more on [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/)
+- Discussion section of [git-commit(1)](https://git-scm.com/docs/git-commit)
 
 ## UI Design Guidelines
 


### PR DESCRIPTION
Backport from #7179

---

* Fix various broken documentation links
* Update developer guide to link to Qt 5 API docs instead of Qt 4.8
* Use more specific website for links to API docs of dependencies
* Fix formatting of links in Style guide

(cherry picked from commit 0dff9bdbd3567d2cfdc0f7bf270a5e174740786d)