### PR TITLE
[5.8] COMP: Update VTK backporting fix to support building on Linux with clang

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -138,7 +138,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "57bacae7e9d8613c1a5fc955028211c455f3787a") # slicer-v9.2.20230607-1ff325c54-2
+    set(_git_tag "492821449a5f2a9a1f5c73c3c6dd4389f1059d66") # slicer-v9.2.20230607-1ff325c54-2
     set(vtk_egg_info_version "9.2.20230607")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
Backport from #8183

---

List of VTK changes:

```
$ git shortlog 57bacae7e9..492821449a --no-merges
Jaswant Panchumarti (1):
      [Backport] Fix undefined variable name in octree_node
```

VTK References:
- Issue: https://gitlab.kitware.com/vtk/vtk/-/issues/19358
- Merge Request: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/11178 mentioned this came up due to a newer clang.

(cherry picked from commit 1fb3d94fc447299b6ebab30804de8ebab943b665)