### PR TITLE
[5.8] ENH: Update BRAINSTools from 2024-05-31 to 2024-11-09 and include macOS build fix

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -304,7 +304,7 @@ set(BRAINSTools_slicer_options
 
 Slicer_Remote_Add(BRAINSTools
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/BRAINSia/BRAINSTools.git
-  GIT_TAG "7c37d9e8c238f66f8a83f997d9c9bb659c494c90"  # 2024-11-09
+  GIT_TAG "3b3cfd0d45a35e924569ee930a29c4f6292a8d1f" # 2025-01-29
   LICENSE_FILES "https://www.apache.org/licenses/LICENSE-2.0.txt"
   OPTION_NAME Slicer_BUILD_BRAINSTOOLS
   OPTION_DEPENDS "Slicer_BUILD_CLI_SUPPORT;Slicer_BUILD_CLI"

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -304,7 +304,7 @@ set(BRAINSTools_slicer_options
 
 Slicer_Remote_Add(BRAINSTools
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/BRAINSia/BRAINSTools.git
-  GIT_TAG "d88a4f43e7d6c7447876d20676b538185f5edea1"  # 2024-05-31
+  GIT_TAG "7c37d9e8c238f66f8a83f997d9c9bb659c494c90"  # 2024-11-09
   LICENSE_FILES "https://www.apache.org/licenses/LICENSE-2.0.txt"
   OPTION_NAME Slicer_BUILD_BRAINSTOOLS
   OPTION_DEPENDS "Slicer_BUILD_CLI_SUPPORT;Slicer_BUILD_CLI"


### PR DESCRIPTION
Backport from #8191 and #8197

--------

ENH: Update BRAINSTools from 2024-05-31 to 2024-11-09 

List of BRAINSTools changes:

```
$ git shortlog d88a4f43..7c37d9e8 --no-merges
Hans J. Johnson (22):
      ENH: Update to VTK 9.3 to support builds on newer m3 mac.
      COMP: ITKv5.4.0 requires C++17 features.
      ENH: Update to newer versions of python packages
      ENH: Checks for toml xml yaml
      ENH: Add shabang for executable files, remove execute permissions
      ENH: Fixed end-of-file inconsistencies.
      ENH: Enforce rigors end of line symantics
      ENH: Adding python tests naming consistency.
      ENH: forbid new submodules
      ENH: Initial ruff code fixes for safe code updates.
      ENH: Code cleanups for comparison to bool values
      ENH: Modernize codebase with pyupgrade to 3.10 syntax recommendations.
      ENH: Prepratory shell check comments that will need more work before using.
      ENH: Need slightly larger tolerance for m3 native builds
      COMP: Set apple build environment flags consistently in packages.
      COMP: Update pre-commit settings inspired by Slicer.
      ENH: Ignore python local env.
      BUG: xml parser removed getiterator member function
      ENH: Python3.9 module pathing fixes.
      ENH: Update requirements.txt for BAW
      ENH: Replace deprecated function uses.
      ENH: SimpleITK 2.4.0 migration changes for ObjectMorphology

dependabot[bot] (1):
      Bump black from 19.3b0 to 24.3.0 in /AutoWorkup
```

(cherry picked from commit 244a6c3)


---

COMP: Update BRAINSTools to fix macOS build 

The commit fixes the following configuration error introduced following
the BRAINSTools update in (244a6c3, "ENH: Update BRAINSTools from 2024-05-31 to 2024-11-09", 2025-01-24)

```
CMake Error at /path/to/Slicer-build/BRAINSTools/CMakeLists.txt:34 (message):
  FAILURE 13.0 != 11.0
```

List of changes:

```
$ git shortlog 7c37d9e8c..3b3cfd0d4 --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Support specifying macOS deployment target ≥ 11.0
```

(cherry picked from commit 8e2780d)

