### PR TITLE
[5.8] BUG: Fix saving into .mrb with long node names

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -4594,6 +4594,7 @@ bool vtkMRMLScene::SaveStorableNodeToSlicerDataBundleDirectory(vtkMRMLStorableNo
       // for saving to MRB all nodes will be written in their default format
       storageFileName = storageNode->GetFileNameWithoutExtension(storageFileName.c_str()) + defaultWriteExtension;
     }
+    storageFileName = storageNode->ClampFileName(storageFileName);
     vtkDebugMacro("updated file name = " << storageFileName.c_str());
     storageNode->SetFileName(storageFileName.c_str());
   }

--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -1599,9 +1599,8 @@ void vtkMRMLStorageNode::SetWriteFileFormat(const char* writeFileFormat)
 //-----------------------------------------------------------------------------
 std::string vtkMRMLStorageNode::ClampFileName(const std::string& filename, int maxFileNameLength/*=-1*/, int hashLength/*=4*/)
 {
-  std::string baseName = this->GetFileNameWithoutExtension(filename.c_str());
   std::string extension = this->GetSupportedFileExtension(filename.c_str());
-  return vtkMRMLStorageNode::ClampFileNameExtension(baseName, maxFileNameLength, hashLength, extension.length());
+  return vtkMRMLStorageNode::ClampFileNameExtension(filename, maxFileNameLength, hashLength, extension.length());
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Backport from #8214

---

When saving scene into .mrb file, long filenames were generated automatically from long node names, which prevented scene saving on Windows. Added the missing ClampFileName call and fixed a bug in vtkMRMLStorageNode::ClampFileName to resolve the problem. Now long filenames are automatically shortened.

(cherry picked from commit 74eb12951a382b71be7030acc5d7c56704d37e3a)