### PR TITLE
[5.8] BUG: Avoid additional error message in DICOMReaders.py

### DIFF
--- a/Applications/SlicerApp/Testing/Python/DICOMReaders.py
+++ b/Applications/SlicerApp/Testing/Python/DICOMReaders.py
@@ -103,6 +103,7 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
         # first, get the data - a zip file of dicom data
         #
         self.delayDisplay("Downloading")
+        originalDatabaseDirectory = None
         for dataset in referenceData:
             try:
                 import SampleData
@@ -196,7 +197,8 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
                 testPass = False
 
         self.delayDisplay("Restoring original database directory")
-        DICOMUtils.closeTemporaryDatabase(originalDatabaseDirectory)
+        if originalDatabaseDirectory:
+            DICOMUtils.closeTemporaryDatabase(originalDatabaseDirectory)
         slicer.util.selectModule("DICOMReaders")
 
         logging.info(loadingResult)


### PR DESCRIPTION
Backport from #8215

---

When SampleData.downloadFromURL failed then there was an extra error logged about failing to clean up the database directory, because the directory has not even been created. Added a check so that we only remove the directory if it has been created.

(cherry picked from commit d94ad217a6375e5ed551edf124ad959f5b6becb8)