### PR TITLE
[5.8] ENH: Update vtkAddon

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -203,7 +203,7 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG 8c43b66edcdf54c89d5b0ddce053fd078ea05518
+  GIT_TAG b5aa0615a6486b6bdceeb13bd59c2fb9f89cce42
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_vtkAddon Slicer_REMOTE_DEPENDENCIES vtkAddon)

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -203,7 +203,7 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG 3f317421da77b9f6fd48aaf40608545db4fec3e0
+  GIT_TAG 8c43b66edcdf54c89d5b0ddce053fd078ea05518
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_vtkAddon Slicer_REMOTE_DEPENDENCIES vtkAddon)


### PR DESCRIPTION
Backport from #8227 and #8239

---

ENH: Update vtkAddon 

List of changes:

```
$ git shortlog 3f317421d..8c43b66ed --no-merges
AlexyPellegrini (1):
      ENH: Replace WIN32 with _WIN32 to fix build with Ninja (#51)

Ebrahim Ebrahim (1):
      BUG: Fix matrix comparisons for exact equality (#54)
```

(cherry picked from commit 0776014)

---

ENH: Update vtkAddon anticipating update to VTK >= 9.4 

List of vtkAddon changes:

```
$ git shortlog 8c43b66ed..b5aa0615a --no-merges
Alexy Pellegrini (2):
      ENH: Remove use of vtk_glew.h from vtkOpenGLTextureImage.h
      ENH: Includes vtk_glad.h instead of vtk_glew.h when using VTK 9.4 or newer
```

(cherry picked from commit ae95058)
