### PR TITLE
[5.8] BUG: Do not load DWMRI volumes as sequences

### DIFF
--- a/Modules/Loadable/Volumes/qSlicerVolumesReader.h
+++ b/Modules/Loadable/Volumes/qSlicerVolumesReader.h
@@ -45,6 +45,11 @@ public:
   QStringList extensions()const override;
   qSlicerIOOptions* options()const override;
 
+  /// Returns a positive number (>0) if the reader can load this file.
+  /// In case the file uses a generic file extension (such as .nrrd) then the confidence value is adjusted based on
+  /// the file content: if the file contains a dwmri nrrd file then confidence is increased to 0.7
+  double canLoadFileConfidence(const QString& file)const override;
+
   bool load(const IOProperties& properties) override;
 
   /// Implements the file list examination for the corresponding method in the core


### PR DESCRIPTION
Backport from #8242

---

Improve qSlicerSequencesReader heuristics to know that dwmri modality is not typically loaded as a sequence by lowering the confidence for files of this type.

Also fixes code to now read the entire nrrd header so that other keys won't be missed in files with large headers (dwmri files typically have over 1000 characters before the modality tag).

Fixes #8240

(cherry picked from commit ef756a160661be3152831b6744d0dd51e5785fe6)