### PR TITLE
ENH: Generalize SliceLogic API introducing "Nth Layer" functions

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -898,6 +898,38 @@ vtkAlgorithmOutput * vtkMRMLSliceLogic::GetImageDataConnection()
 }
 
 //----------------------------------------------------------------------------
+bool vtkMRMLSliceLogic::HasInputs()
+{
+  for (LayerListIterator iterator = this->Layers.begin();
+       iterator != this->Layers.end();
+       ++iterator)
+  {
+    vtkMRMLSliceLayerLogic* layer = *iterator;
+    if (layer != nullptr && layer->GetImageDataConnection() != nullptr)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLSliceLogic::HasUVWInputs()
+{
+  for (LayerListIterator iterator = this->Layers.begin();
+       iterator != this->Layers.end();
+       ++iterator)
+  {
+    vtkMRMLSliceLayerLogic* layer = *iterator;
+    if (layer != nullptr && layer->GetImageDataConnectionUVW() != nullptr)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLSliceLogic::UpdateImageData ()
 {
   if (this->SliceNode->GetSliceResolutionMode() == vtkMRMLSliceNode::SliceResolutionMatch2DView)
@@ -912,9 +944,7 @@ void vtkMRMLSliceLogic::UpdateImageData ()
   // It seems very strange that the imagedata can be null.
   // It should probably be always a valid imagedata with invalid bounds if needed
 
-  if ( (this->GetBackgroundLayer() != nullptr && this->GetBackgroundLayer()->GetImageDataConnection() != nullptr) ||
-       (this->GetForegroundLayer() != nullptr && this->GetForegroundLayer()->GetImageDataConnection() != nullptr) ||
-       (this->GetLabelLayer() != nullptr && this->GetLabelLayer()->GetImageDataConnection() != nullptr) )
+  if (this->HasInputs())
   {
     if (this->ImageDataConnection == nullptr || this->Pipeline->Blend->GetOutputPort()->GetMTime() > this->ImageDataConnection->GetMTime())
     {
@@ -1201,9 +1231,9 @@ void vtkMRMLSliceLogic::UpdatePipeline()
 
       // Manage texture interpolation based on input availability
       if ( (this->SliceNode->GetSliceResolutionMode() != vtkMRMLSliceNode::SliceResolutionMatch2DView &&
-          !((backgroundImagePortUVW != nullptr) || (foregroundImagePortUVW != nullptr) || (labelImagePortUVW != nullptr) ) ) ||
+            !this->HasUVWInputs()) ||
           (this->SliceNode->GetSliceResolutionMode() == vtkMRMLSliceNode::SliceResolutionMatch2DView &&
-          !((backgroundImagePort != nullptr) || (foregroundImagePort != nullptr) || (labelImagePort != nullptr) ) ))
+           !this->HasInputs()) )
       {
         displayNode->SetTextureImageDataConnection(nullptr);
       }

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -169,6 +169,14 @@ public:
   /// -- returns nullptr if none of the inputs exist
   vtkAlgorithmOutput *GetImageDataConnection();
 
+  /// Return True if at least one layer has an image data
+  /// \sa vtkMRMLSliceLayerLogic::GetImageDataConnection()
+  bool HasInputs();
+
+  /// Return True if at least one layer has an UVW image data
+  /// \sa vtkMRMLSliceLayerLogic::GetImageDataConnectionUVW()
+  bool HasUVWInputs();
+
   /// update the pipeline to reflect the current state of the nodes
   void UpdatePipeline();
 

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -93,24 +93,31 @@ public:
 
   /// @{
   /// The background slice layer
-  /// TODO: this will eventually be generalized to a list of layers
-  vtkGetObjectMacro (BackgroundLayer, vtkMRMLSliceLayerLogic);
+  vtkMRMLSliceLayerLogic* GetBackgroundLayer();
   void SetBackgroundLayer (vtkMRMLSliceLayerLogic *BackgroundLayer);
   /// @}
 
   /// @{
   /// The foreground slice layer
-  /// TODO: this will eventually be generalized to a list of layers
-  vtkGetObjectMacro (ForegroundLayer, vtkMRMLSliceLayerLogic);
+  vtkMRMLSliceLayerLogic* GetForegroundLayer();
   void SetForegroundLayer (vtkMRMLSliceLayerLogic *ForegroundLayer);
   /// @}
 
   /// @{
   /// The Label slice layer
-  /// TODO: this will eventually be generalized to a list of layers
-  vtkGetObjectMacro (LabelLayer, vtkMRMLSliceLayerLogic);
+  vtkMRMLSliceLayerLogic* GetLabelLayer();
   void SetLabelLayer (vtkMRMLSliceLayerLogic *LabelLayer);
   /// @}
+
+  vtkMRMLSliceLayerLogic* GetNthLayer(int layerIndex);
+  void SetNthLayer(int layerIndex, vtkMRMLSliceLayerLogic *layer);
+
+  vtkAlgorithmOutput* GetNthLayerImageDataConnection(int layerIndex);
+  vtkAlgorithmOutput* GetNthLayerImageDataConnectionUVW(int layerIndex);
+
+  /// Get the volume node corresponding to layer
+  /// (0=background, 1=foreground, 2=label)
+  vtkMRMLVolumeNode* GetNthLayerVolumeNode(int layerIndex);
 
   /// Helper to set the background layer Window/Level
   void SetBackgroundWindowLevel(double window, double level);
@@ -181,8 +188,10 @@ public:
   /// Manage and synchronize the SliceCompositeNode
   void UpdateSliceCompositeNode();
 
+  /// \deprecated
   /// Get the volume node corresponding to layer
   /// (0=background, 1=foreground, 2=label)
+  /// \sa GetNthLayerVolumeNode
   vtkMRMLVolumeNode *GetLayerVolumeNode(int layer);
 
   /// Get the size of the volume, transformed to RAS space
@@ -395,6 +404,9 @@ protected:
   static vtkMRMLSliceNode* GetSliceNode(vtkMRMLScene* scene,
     const char* layoutName);
 
+  /// Set volume associated with a layer
+  void SetNthLayerVolumeNode(int layerIndex, vtkMRMLVolumeNode* volumeNode);
+
   /// @{
   /// Helper to get/set Window/Level in any layer
   void SetWindowLevel(int layer, double window, double level);
@@ -434,13 +446,17 @@ protected:
     return true;
   };
 
+  typedef vtkSmartPointer<vtkMRMLSliceLayerLogic> LayerListItem;
+  typedef std::vector<LayerListItem> LayerList;
+  typedef std::vector<LayerListItem>::iterator LayerListIterator;
+  typedef std::vector<LayerListItem>::const_iterator LayerListConstIterator;
+
+  LayerList Layers;
+
   bool                          AddingSliceModelNodes;
 
   vtkMRMLSliceNode*             SliceNode;
   vtkMRMLSliceCompositeNode*    SliceCompositeNode;
-  vtkMRMLSliceLayerLogic*       BackgroundLayer;
-  vtkMRMLSliceLayerLogic*       ForegroundLayer;
-  vtkMRMLSliceLayerLogic*       LabelLayer;
 
   BlendPipeline*                Pipeline;
   BlendPipeline*                PipelineUVW;

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
@@ -331,7 +331,7 @@ void qSlicerSubjectHierarchyVolumesPlugin::showViewContextMenuActionsForItem(vtk
   int volumeLayer = sliceLogic->GetEditableLayerAtWorldPosition(worldPos);
 
   // Cache nodes to have them available for the menu action execution.
-  d->SelectedVolumeNode = sliceLogic->GetLayerVolumeNode(volumeLayer);
+  d->SelectedVolumeNode = sliceLogic->GetNthLayerVolumeNode(volumeLayer);
 
   bool hasPrimaryDisplayNode = false;
   bool colorLegendIsVisible = false;


### PR DESCRIPTION
This PR refactors `vtkMRMLSliceLogic` to introduce support for multiple slice layers using a generalized "Nth Layer" API. Additionally, it provides new methods for checking whether any layers have inputs.

## 1. Generalize `vtkMRMLSliceLogic` with "Nth Layer" functions

- Replace explicit `BackgroundLayer`, `ForegroundLayer`, and `LabelLayer` members with a dynamic `Layers` list.
- Introduce new methods:
  - `GetNthLayer(int layerIndex)`
  - `SetNthLayer(int layerIndex, vtkMRMLSliceLayerLogic *layer)`
  - `GetNthLayerImageDataConnection(int layerIndex)`
  - `GetNthLayerImageDataConnectionUVW(int layerIndex)`
  - `GetNthLayerVolumeNode(int layerIndex)`
  - `SetNthLayerVolumeNode(int layerIndex, vtkMRMLVolumeNode* volumeNode)`
- Update references to the old layer variables (`BackgroundLayer`, etc.) with their `NthLayer` equivalents.
- Deprecate `GetLayerVolumeNode(int layer)` in favor of `GetNthLayerVolumeNode(int layerIndex)`.  

## 2. Introduce `HasInputs()` and `HasUVWInputs()`

- Add `HasInputs()`, which returns `true` if at least one layer has a valid image data connection.
- Add `HasUVWInputs()`, which checks if any layer contains UVW image data.
- Refactor `UpdateImageData()` and `UpdatePipeline()` to use these methods, improving readability and maintainability.

> [!NOTE]
> This PR lays the groundwork for future improvements, including:  
> - Expanding `vtkMRMLSliceCompositeNode` and pipeline blending logic to support dynamic multi-layer rendering.
> - Updating layer management (`AddLayers()`, `UpdateFractions()`, `UpdateStages()`) and adjusting slice offset calculations, volume retrieval, and print functions for additional layers.
> - Enhancing `vtkMRMLSliceLogic::UpdatePipeline()` to dynamically create missing layer logics and improve overall scalability.
> 
> More details:
> * https://github.com/Slicer/Slicer/pull/8210
