### PR TITLE
ENH: Generalize CompositeNode API introducing "Nth Layer" functions

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
@@ -16,6 +16,7 @@ Version:   $Revision: 1.2 $
 #include "vtkMRMLSliceCompositeNode.h"
 #include "vtkMRMLSliceDisplayNode.h"
 #include "vtkMRMLModelNode.h"
+#include "vtkMRMLVolumeNode.h"
 #include "vtkMRMLScene.h"
 
 // VTK includes
@@ -173,37 +174,111 @@ void vtkMRMLSliceCompositeNode::PrintSelf(ostream& os, vtkIndent indent)
 //-----------------------------------------------------------
 void vtkMRMLSliceCompositeNode::SetBackgroundVolumeID(const char* id)
 {
-  this->SetNodeReferenceID(BackgroundVolumeNodeReferenceRole, id);
+  this->SetNthLayerVolumeID(vtkMRMLSliceCompositeNode::LayerBackground, id);
 }
 
 //-----------------------------------------------------------
 const char* vtkMRMLSliceCompositeNode::GetBackgroundVolumeID()
 {
-  return this->GetNodeReferenceID(BackgroundVolumeNodeReferenceRole);
+  return this->GetNthLayerVolumeID(vtkMRMLSliceCompositeNode::LayerBackground);
 }
 
 //-----------------------------------------------------------
 void vtkMRMLSliceCompositeNode::SetForegroundVolumeID(const char* id)
 {
-  this->SetNodeReferenceID(ForegroundVolumeNodeReferenceRole, id);
+  this->SetNthLayerVolumeID(vtkMRMLSliceCompositeNode::LayerForeground, id);
 }
 
 //-----------------------------------------------------------
 const char* vtkMRMLSliceCompositeNode::GetForegroundVolumeID()
 {
-  return this->GetNodeReferenceID(ForegroundVolumeNodeReferenceRole);
+  return this->GetNthLayerVolumeID(vtkMRMLSliceCompositeNode::LayerForeground);
 }
 
 //-----------------------------------------------------------
 void vtkMRMLSliceCompositeNode::SetLabelVolumeID(const char* id)
 {
-  this->SetNodeReferenceID(LabelVolumeNodeReferenceRole, id);
+  this->SetNthLayerVolumeID(vtkMRMLSliceCompositeNode::LayerLabel, id);
 }
 
 //-----------------------------------------------------------
 const char* vtkMRMLSliceCompositeNode::GetLabelVolumeID()
 {
-  return this->GetNodeReferenceID(LabelVolumeNodeReferenceRole);
+  return this->GetNthLayerVolumeID(vtkMRMLSliceCompositeNode::LayerLabel);
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLVolumeNode* vtkMRMLSliceCompositeNode::GetNthLayerVolume(int layerIndex)
+{
+  if (layerIndex < 0)
+  {
+    vtkErrorMacro(<< "GetNthLayerVolume: Non-negative layer index is expected.");
+    return nullptr;
+  }
+  if (layerIndex == vtkMRMLSliceCompositeNode::LayerBackground)
+  {
+    return vtkMRMLVolumeNode::SafeDownCast(this->GetNodeReference(BackgroundVolumeNodeReferenceRole));
+  }
+  else if (layerIndex == vtkMRMLSliceCompositeNode::LayerForeground)
+  {
+    return vtkMRMLVolumeNode::SafeDownCast(this->GetNodeReference(ForegroundVolumeNodeReferenceRole));
+  }
+  else if (layerIndex == vtkMRMLSliceCompositeNode::LayerLabel)
+  {
+    return vtkMRMLVolumeNode::SafeDownCast(this->GetNodeReference(LabelVolumeNodeReferenceRole));
+  }
+  return nullptr;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceCompositeNode::SetNthLayerVolume(int layerIndex, vtkMRMLVolumeNode* volumeNode)
+{
+  if (layerIndex < 0)
+  {
+    vtkErrorMacro(<< "SetNthLayerVolume: Non-negative layer index is expected.");
+    return;
+  }
+  char* volumeNodeID = volumeNode != nullptr ? volumeNode->GetID() : nullptr;
+  this->SetNthLayerVolumeID(layerIndex, volumeNodeID);
+}
+
+//----------------------------------------------------------------------------
+const char* vtkMRMLSliceCompositeNode::GetNthLayerVolumeID(int layerIndex)
+{
+  if (layerIndex < 0)
+  {
+    vtkErrorMacro(<< "GetNthLayerVolumeID: Non-negative layer index is expected.");
+    return nullptr;
+  }
+  vtkMRMLVolumeNode* volumeNode = this->GetNthLayerVolume(layerIndex);
+  if (volumeNode)
+    {
+    return volumeNode->GetID();
+    }
+  return nullptr;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceCompositeNode::
+SetNthLayerVolumeID(int layerIndex, const char* volumeNodeID)
+{
+  if (layerIndex < 0)
+  {
+    vtkErrorMacro(<< "SetNthLayerVolumeID: Non-negative layer index is expected.");
+    return;
+  }
+  if (layerIndex == vtkMRMLSliceCompositeNode::LayerBackground)
+  {
+    this->SetNodeReferenceID(BackgroundVolumeNodeReferenceRole, volumeNodeID);
+  }
+  else if (layerIndex == vtkMRMLSliceCompositeNode::LayerForeground)
+  {
+    this->SetNodeReferenceID(ForegroundVolumeNodeReferenceRole, volumeNodeID);
+  }
+  else if (layerIndex == vtkMRMLSliceCompositeNode::LayerLabel)
+  {
+    this->SetNodeReferenceID(LabelVolumeNodeReferenceRole, volumeNodeID);
+  }
 }
 
 //-----------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
@@ -19,6 +19,7 @@
 
 class vtkMRMLModelNode;
 class vtkMRMLSliceDisplayNode;
+class vtkMRMLVolumeNode;
 
 /// \brief MRML node for storing a slice through RAS space.
 ///
@@ -48,6 +49,7 @@ public:
 
   /// @{
   /// the ID of a MRMLVolumeNode
+  /// \sa GetNthLayerVolumeID
   const char* GetBackgroundVolumeID();
   void SetBackgroundVolumeID(const char* id);
   void SetReferenceBackgroundVolumeID(const char *id) { this->SetBackgroundVolumeID(id); }
@@ -55,6 +57,7 @@ public:
 
   /// @{
   /// the ID of a MRMLVolumeNode
+  /// \sa GetNthLayerVolumeID
   const char* GetForegroundVolumeID();
   void SetForegroundVolumeID(const char* id);
   void SetReferenceForegroundVolumeID(const char *id) { this->SetForegroundVolumeID(id); }
@@ -62,9 +65,31 @@ public:
 
   /// @{
   /// the ID of a MRMLVolumeNode
+  /// \sa GetNthLayerVolumeID
   const char* GetLabelVolumeID();
   void SetLabelVolumeID(const char* id);
   void SetReferenceLabelVolumeID(const char *id) { this->SetLabelVolumeID(id); }
+  /// @}
+
+  enum
+  {
+    LayerNone = -1,
+    LayerBackground = 0,
+    LayerForeground = 1,
+    LayerLabel = 2,
+    Layer_Last // must be last
+  };
+
+  /// @{
+  /// \sa GetNthLayerVolumeID, SetNthLayerVolumeID
+  vtkMRMLVolumeNode* GetNthLayerVolume(int layerIndex);
+  void SetNthLayerVolume(int layerIndex, vtkMRMLVolumeNode* volumeNode);
+  /// @}
+
+  /// @{
+  /// \sa GetNthLayerVolume, SetNthLayerVolume
+  const char* GetNthLayerVolumeID(int layerIndex);
+  void SetNthLayerVolumeID(int layerIndex, const char* volumeNodeID);
   /// @}
 
   /// @{

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -27,7 +27,6 @@
 #include <vtkMRMLProceduralColorNode.h>
 #include <vtkMRMLScalarVolumeDisplayNode.h>
 #include <vtkMRMLScene.h>
-#include <vtkMRMLSliceCompositeNode.h>
 #include <vtkMRMLSliceDisplayNode.h>
 
 // VTK includes
@@ -1102,16 +1101,8 @@ void vtkMRMLSliceLogic::UpdatePipeline()
     // get the background and foreground image data from the layers
     // so we can use them as input to the image blend
 
-    const char *id;
-
     // Background
-    id = this->SliceCompositeNode->GetBackgroundVolumeID();
-    vtkMRMLVolumeNode *bgnode = nullptr;
-    if (id)
-    {
-      bgnode = vtkMRMLVolumeNode::SafeDownCast (this->GetMRMLScene()->GetNodeByID(id));
-    }
-
+    vtkMRMLVolumeNode *bgnode = this->SliceCompositeNode->GetNthLayerVolume(vtkMRMLSliceLogic::LayerBackground);
     if (this->GetBackgroundLayer())
     {
       if ( this->GetBackgroundLayer()->GetVolumeNode() != bgnode )
@@ -1122,13 +1113,7 @@ void vtkMRMLSliceLogic::UpdatePipeline()
     }
 
     // Foreground
-    id = this->SliceCompositeNode->GetForegroundVolumeID();
-    vtkMRMLVolumeNode *fgnode = nullptr;
-    if (id)
-    {
-      fgnode = vtkMRMLVolumeNode::SafeDownCast (this->GetMRMLScene()->GetNodeByID(id));
-    }
-
+    vtkMRMLVolumeNode *fgnode = this->SliceCompositeNode->GetNthLayerVolume(vtkMRMLSliceLogic::LayerForeground);
     if (this->GetForegroundLayer())
     {
       if ( this->GetForegroundLayer()->GetVolumeNode() != fgnode )
@@ -1139,13 +1124,7 @@ void vtkMRMLSliceLogic::UpdatePipeline()
     }
 
     // Label
-    id = this->SliceCompositeNode->GetLabelVolumeID();
-    vtkMRMLVolumeNode *lbnode = nullptr;
-    if (id)
-    {
-      lbnode = vtkMRMLVolumeNode::SafeDownCast (this->GetMRMLScene()->GetNodeByID(id));
-    }
-
+    vtkMRMLVolumeNode *lbnode = this->SliceCompositeNode->GetNthLayerVolume(vtkMRMLSliceLogic::LayerLabel);
     if (this->GetLabelLayer())
     {
       if ( this->GetLabelLayer()->GetVolumeNode() != lbnode )
@@ -1549,25 +1528,7 @@ vtkMRMLVolumeNode *vtkMRMLSliceLogic::GetNthLayerVolumeNode(int layer)
   {
     return nullptr;
   }
-  const char *id = nullptr;
-  switch (layer)
-  {
-    case LayerBackground:
-    {
-      id = this->SliceCompositeNode->GetBackgroundVolumeID();
-      break;
-    }
-    case LayerForeground:
-    {
-      id = this->SliceCompositeNode->GetForegroundVolumeID();
-      break;
-    }
-    case LayerLabel:
-    {
-      id = this->SliceCompositeNode->GetLabelVolumeID();
-      break;
-    }
-  }
+  const char *id = this->SliceCompositeNode->GetNthLayerVolumeID(layer);
   vtkMRMLScene* scene = this->GetMRMLScene();
   return scene ? vtkMRMLVolumeNode::SafeDownCast(
     scene->GetNodeByID( id )) : nullptr;

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -23,11 +23,11 @@
 #include <vector>
 
 // MRML includes
+#include <vtkMRMLSliceCompositeNode.h>
 class vtkMRMLDisplayNode;
 class vtkMRMLLinearTransformNode;
 class vtkMRMLModelDisplayNode;
 class vtkMRMLModelNode;
-class vtkMRMLSliceCompositeNode;
 class vtkMRMLSliceDisplayNode;
 class vtkMRMLSliceLayerLogic;
 class vtkMRMLSliceNode;
@@ -71,10 +71,10 @@ public:
 
   enum
   {
-    LayerNone = -1,
-    LayerBackground = 0,
-    LayerForeground = 1,
-    LayerLabel = 2,
+    LayerNone = vtkMRMLSliceCompositeNode::LayerNone,
+    LayerBackground = vtkMRMLSliceCompositeNode::LayerBackground,
+    LayerForeground = vtkMRMLSliceCompositeNode::LayerForeground,
+    LayerLabel = vtkMRMLSliceCompositeNode::LayerLabel,
     Layer_Last // must be last
   };
 


### PR DESCRIPTION
This PR extends the previous Nth Layer generalization by updating `vtkMRMLSliceCompositeNode` to support multiple layers dynamically, aligning with the recent refactor of `vtkMRMLSliceLogic` introduced in https://github.com/Slicer/Slicer/pull/8277.


### 1. Generalize `vtkMRMLSliceCompositeNode` API

- Replace explicit `BackgroundVolumeID`, `ForegroundVolumeID`, and `LabelVolumeID` with a flexible, indexed `Nth Layer` system.
- Introduce new methods:
  - `GetNthLayerVolume(int layerIndex)`
  - `SetNthLayerVolume(int layerIndex, vtkMRMLVolumeNode* volumeNode)`
  - `GetNthLayerVolumeID(int layerIndex)`
  - `SetNthLayerVolumeID(int layerIndex, const char* volumeNodeID)`
- Update existing getter/setter methods (`GetBackgroundVolumeID()`, etc.) to internally call `Nth Layer` functions.

### 2. Refactor `vtkMRMLSliceLogic` to use the new API

- Replace hardcoded `GetBackgroundVolumeID()`, `GetForegroundVolumeID()`, and `GetLabelVolumeID()` calls with `GetNthLayerVolumeID(layerIndex)`.
- Update `vtkMRMLSliceLogic::UpdatePipeline()` to fetch layer volumes using the new composite node API.


> [!NOTE]
> This PR further prepares the system for upcoming enhancements, including:
> - Expanding pipeline blending logic to support dynamic multi-layer rendering.
> - Updating layer management (`AddLayers()`, `UpdateFractions()`, `UpdateStages()`) and adjusting computations for additional layers.
> - Enhancing `vtkMRMLSliceLogic::UpdatePipeline()` to dynamically create missing layer logics and improve scalability.
>
> More details:
> * https://github.com/Slicer/Slicer/pull/8210
