### PR TITLE
ENH: Generalize CompositeNode "opacity" API introducing "Nth Layer" functions

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
@@ -281,6 +281,64 @@ SetNthLayerVolumeID(int layerIndex, const char* volumeNodeID)
   }
 }
 
+//----------------------------------------------------------------------------
+double vtkMRMLSliceCompositeNode::GetNthLayerOpacity(int layerIndex)
+{
+  if (layerIndex < 0)
+  {
+    vtkErrorMacro(<< "GetNthLayerOpacity: Non-negative layer index is expected.");
+    return 1.0;
+  }
+  if (layerIndex < static_cast<int>(this->LayerOpacities.size()))
+    {
+    return this->LayerOpacities.at(layerIndex);
+    }
+  return 1.0;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceCompositeNode::SetNthLayerOpacity(int layerIndex, double value)
+{
+  if (layerIndex < 0)
+  {
+    vtkErrorMacro(<< "SetNthLayerOpacity: Non-negative layer index is expected.");
+    return;
+  }
+  if (layerIndex >= static_cast<int>(this->LayerOpacities.size()))
+    {
+    this->LayerOpacities.resize(layerIndex + 1);
+    }
+  if (this->LayerOpacities.at(layerIndex) != value)
+    {
+    this->LayerOpacities.at(layerIndex) = value;
+    this->Modified();
+    }
+}
+
+//----------------------------------------------------------------------------
+double vtkMRMLSliceCompositeNode::GetForegroundOpacity()
+{
+  return this->GetNthLayerOpacity(vtkMRMLSliceCompositeNode::LayerForeground);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceCompositeNode::SetForegroundOpacity(double value)
+{
+  this->SetNthLayerOpacity(vtkMRMLSliceCompositeNode::LayerForeground, value);
+}
+
+//----------------------------------------------------------------------------
+double vtkMRMLSliceCompositeNode::GetLabelOpacity()
+{
+  return this->GetNthLayerOpacity(vtkMRMLSliceCompositeNode::LayerLabel);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceCompositeNode::SetLabelOpacity(double value)
+{
+  this->SetNthLayerOpacity(vtkMRMLSliceCompositeNode::LayerLabel, value);
+}
+
 //-----------------------------------------------------------
 int vtkMRMLSliceCompositeNode::GetSliceIntersectionVisibility()
 {

--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
@@ -106,19 +106,28 @@ public:
   vtkSetMacro (ClipToBackgroundVolume, bool);
   /// @}
 
-  ///
-  /// opacity of the Foreground for rendering over background
-  /// TODO: make this an arbitrary list of layers
-  /// TODO: make different composite types (checkerboard, etc)
-  vtkGetMacro (ForegroundOpacity, double);
-  vtkSetMacro (ForegroundOpacity, double);
+  /// @{
+  /// Opacity of layer N over layer N-1
+  /// \note Only Foreground and Label opacity are saved into the MRML Scene
+  double GetNthLayerOpacity(int layerIndex);
+  void SetNthLayerOpacity(int layerIndex, double value);
+  /// @}
 
-  ///
-  /// opacity of the Label for rendering over background
-  /// TODO: make this an arbitrary list of layers
+  /// @{
+  /// opacity of the Foreground for rendering over background
   /// TODO: make different composite types (checkerboard, etc)
-  vtkGetMacro (LabelOpacity, double);
-  vtkSetMacro (LabelOpacity, double);
+  /// \sa GetNthLayerOpacity, SetNthLayerOpacity
+  double GetForegroundOpacity();
+  void SetForegroundOpacity(double value);
+  /// @}
+
+  /// @{
+  /// opacity of the Label for rendering over background
+  /// TODO: make different composite types (checkerboard, etc)
+  /// \sa GetNthLayerOpacity, SetNthLayerOpacity
+  double GetLabelOpacity();
+  void SetLabelOpacity(double value);
+  /// @}
 
   /// @{
   /// toggle that gangs control of slice viewers
@@ -252,15 +261,16 @@ protected:
   // Cached value of last found displayable node (it is expensive to determine it)
   vtkWeakPointer<vtkMRMLSliceDisplayNode> LastFoundSliceDisplayNode;
 
-  // start by showing only the background volume
-  double ForegroundOpacity{ 0.0 };
+  std::vector<double> LayerOpacities = {
+    1.0, // Layer N (Background)
+    0.0, // Layer N (Foreground) over layer N-1 (Background): Start by showing only the background volume
+    1.0, // Layer N (Label) over layer N-1 (Foreground): Show the label if there is one
+  };
 
   int Compositing{ Alpha };
 
   bool ClipToBackgroundVolume{ true };
 
-  // Show the label if there is one
-  double LabelOpacity{ 1.0 };
   int LinkedControl{ 0 };
   int HotLinkedControl{ 0 };
 

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -1139,9 +1139,9 @@ void vtkMRMLSliceLogic::UpdatePipeline()
           this->SliceCompositeNode->GetClipToBackgroundVolume(),
           this->GetNthLayerImageDataConnection(vtkMRMLSliceLogic::LayerBackground),
           this->GetNthLayerImageDataConnection(vtkMRMLSliceLogic::LayerForeground),
-          this->SliceCompositeNode->GetForegroundOpacity(),
+          this->SliceCompositeNode->GetNthLayerOpacity(vtkMRMLSliceLogic::LayerForeground),
           this->GetNthLayerImageDataConnection(vtkMRMLSliceLogic::LayerLabel),
-          this->SliceCompositeNode->GetLabelOpacity()
+          this->SliceCompositeNode->GetNthLayerOpacity(vtkMRMLSliceLogic::LayerLabel)
           );
 
     std::deque<SliceLayerInfo> layersUVW;
@@ -1151,9 +1151,9 @@ void vtkMRMLSliceLogic::UpdatePipeline()
           this->SliceCompositeNode->GetClipToBackgroundVolume(),
           this->GetNthLayerImageDataConnectionUVW(vtkMRMLSliceLogic::LayerBackground),
           this->GetNthLayerImageDataConnectionUVW(vtkMRMLSliceLogic::LayerForeground),
-          this->SliceCompositeNode->GetForegroundOpacity(),
+          this->SliceCompositeNode->GetNthLayerOpacity(vtkMRMLSliceLogic::LayerForeground),
           this->GetNthLayerImageDataConnectionUVW(vtkMRMLSliceLogic::LayerLabel),
-          this->SliceCompositeNode->GetLabelOpacity()
+          this->SliceCompositeNode->GetNthLayerOpacity(vtkMRMLSliceLogic::LayerLabel)
           );
 
     if (this->SliceCompositeNode->GetCompositing() == vtkMRMLSliceCompositeNode::Add


### PR DESCRIPTION
This PR refactors `vtkMRMLSliceCompositeNode` to generalize opacity management using the **Nth Layer API**, replacing hardcoded foreground and label opacity values.

### 1. Introduce `Nth Layer` opacity functions

- Add `GetNthLayerOpacity(int layerIndex)` and `SetNthLayerOpacity(int layerIndex, double value)`, replacing individual opacity variables.
- Modify `ForegroundOpacity` and `LabelOpacity` to internally use `Nth Layer` methods.
- Update `vtkMRMLSliceCompositeNode` to store opacity values in a dynamically resizable vector (`LayerOpacities`).

### 2. Refactor `vtkMRMLSliceLogic::UpdatePipeline()`

- Replace explicit calls to `GetForegroundOpacity()` and `GetLabelOpacity()` with `GetNthLayerOpacity(layerIndex)`.

> [!NOTE]
> This PR is part of a broader effort to generalize and expand Slicer's multi-layer rendering capabilities.
> Future work includes:
>
> - Modifying UI components to allow dynamic adjustment of multiple layer opacities.
> - Enhancing `vtkMRMLSliceLogic::UpdatePipeline()` to handle more than three layers dynamically.
> More details:
> * https://github.com/Slicer/Slicer/pull/8210