### PR TITLE
[5.8] ENH: Make maximum file length configurable

### DIFF
--- a/Base/QTCore/Testing/Cxx/qSlicerCoreIOManagerTest1.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerCoreIOManagerTest1.cxx
@@ -51,7 +51,10 @@ int TestLongNodeNameSaving(const char* temporaryDirectory)
   std::string extension = ".txt";
   std::string longFileName = longNodeName + extension;
   std::string safeFileName = qSlicerCoreIOManager::forceFileNameValidCharacters(QString::fromStdString(longFileName)).toStdString();
-  safeFileName = qSlicerCoreIOManager::forceFileNameMaxLengthExtension(QString::fromStdString(longFileName), extension.length()).toStdString();
+
+  qSlicerCoreIOManager ioManager;
+  ioManager.setDefaultMaximumFileNameLength(25);
+  safeFileName = ioManager.forceFileNameMaxLength(QString::fromStdString(longFileName), extension.length()).toStdString();
 
   vtkSmartPointer<vtkMRMLTextNode> textNode = vtkMRMLTextNode::SafeDownCast(
     scene->AddNewNodeByClass("vtkMRMLTextNode", longNodeName));

--- a/Base/QTCore/qSlicerCoreIOManager.cxx
+++ b/Base/QTCore/qSlicerCoreIOManager.cxx
@@ -23,6 +23,7 @@
 #include <QDir>
 #include <QElapsedTimer>
 #include <QFileInfo>
+#include <QSettings>
 
 // CTK includes
 #include <ctkUtils.h>
@@ -69,13 +70,18 @@ public:
     vtkMRMLScene* scene = nullptr
   ) const;
 
-  QSettings*        ExtensionFileType;
   QList<qSlicerFileReader*> Readers;
   QList<qSlicerFileWriter*> Writers;
   QMap<qSlicerIO::IOFileType, QStringList> FileTypes;
 
   QString DefaultSceneFileType;
+
+  // This is the default maximum length of a file name.
+  int DefaultMaximumFileNameLength{ 1000 };
 };
+
+CTK_GET_CPP(qSlicerCoreIOManager, int, defaultMaximumFileNameLength, DefaultMaximumFileNameLength);
+CTK_SET_CPP(qSlicerCoreIOManager, int, setDefaultMaximumFileNameLength, DefaultMaximumFileNameLength);
 
 //-----------------------------------------------------------------------------
 qSlicerCoreIOManagerPrivate::qSlicerCoreIOManagerPrivate() = default;
@@ -216,6 +222,19 @@ qSlicerCoreIOManager::qSlicerCoreIOManager(QObject* _parent)
   // constructor.
   qRegisterMetaType<qSlicerIO::IOFileType>("qSlicerIO::IOFileType");
   qRegisterMetaType<qSlicerIO::IOProperties>("qSlicerIO::IOProperties");
+
+  qSlicerCoreApplication* app = qSlicerCoreApplication::application();
+  QSettings* userSettings = app ? app->userSettings() : nullptr;
+  if (userSettings)
+  {
+    int maximumFileNameLength = userSettings->value("ioManager/MaximumFileNameLength", this->defaultMaximumFileNameLength()).toInt();
+    this->setDefaultMaximumFileNameLength(maximumFileNameLength);
+  }
+  else
+  {
+  qWarning() << Q_FUNC_INFO << ": failed to access application settings, using default defaultMaximumFileNameLength value";
+  }
+
 }
 
 //-----------------------------------------------------------------------------
@@ -486,16 +505,13 @@ QString qSlicerCoreIOManager::forceFileNameValidCharacters(const QString& filena
 }
 
 //-----------------------------------------------------------------------------
-QString qSlicerCoreIOManager::forceFileNameMaxLength(const QString& filename, int maxLength/*=-1*/)
+QString qSlicerCoreIOManager::forceFileNameMaxLength(const QString& filename, int extensionLength, int maxLength/*=-1*/)
 {
-  QString extension = this->extractKnownExtension(filename, nullptr);
-  return qSlicerCoreIOManager::forceFileNameMaxLengthExtension(filename, maxLength, extension.length());
-}
-
-//-----------------------------------------------------------------------------
-QString qSlicerCoreIOManager::forceFileNameMaxLengthExtension(const QString& filename, int extensionLength, int maxLength/*=-1*/)
-{
-  return QString::fromStdString(vtkMRMLStorageNode::ClampFileNameExtension(filename.toStdString(), maxLength, 4, extensionLength));
+  if (maxLength < 0)
+  {
+    maxLength = this->defaultMaximumFileNameLength();
+  }
+  return QString::fromStdString(vtkMRMLStorageNode::ClampFileName(filename.toStdString(), extensionLength, maxLength));
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerCoreIOManager.h
+++ b/Base/QTCore/qSlicerCoreIOManager.h
@@ -50,6 +50,7 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerCoreIOManager:public QObject
 {
   Q_OBJECT;
   Q_PROPERTY(QString defaultSceneFileType READ defaultSceneFileType WRITE setDefaultSceneFileType)
+  Q_PROPERTY(int defaultMaximumFileNameLength READ defaultMaximumFileNameLength WRITE setDefaultMaximumFileNameLength)
 
 public:
   qSlicerCoreIOManager(QObject* parent = nullptr);
@@ -110,13 +111,16 @@ public:
   Q_INVOKABLE static QString forceFileNameValidCharacters(const QString& filename);
 
   /// Clamp the length of a filename to a maximum number of characters.
-  /// The file extension will be detected and excluded from the specified maximum length.
-  /// \sa qSlicerCoreIOManager::stripKnownExtension()
-  Q_INVOKABLE QString forceFileNameMaxLength(const QString& filename, int maxLength=-1);
-
-  /// Clamp the length of a filename to a maximum number of characters.
   /// The length of the filename extension must also be specified so that it is not included in the shortened section.
-  Q_INVOKABLE static QString forceFileNameMaxLengthExtension(const QString& filename, int extensionLength, int maxLength=-1);
+  /// If the extension is not known then extractKnownExtension() method can be used to get the extension.
+  /// If maxLength is not specified, the default maximum length (defaultMaximumFileNameLength) is used.
+  /// \sa extractKnownExtension(), defaultMaximumFileNameLength()
+  Q_INVOKABLE QString forceFileNameMaxLength(const QString& filename, int extensionLength, int maxLength=-1);
+
+  /// Default maximum length for a filename. It is used when maximum filename length is enforced by calling
+  /// forceFileNameMaxLength() without providing a specific maximum length value.
+  /// \sa forceFileNameMaxLength(), setDefaultMaximumFileNameLength()
+  int defaultMaximumFileNameLength()const;
 
   /// If \a fileName ends with an extension that is associated with \a object,
   /// then return that extension. Otherwise return an empty string.
@@ -282,6 +286,10 @@ public slots:
   /// Valid options are defined in qSlicerSceneWriter (for example, "MRML Scene (.mrml)"
   /// or "Medical Reality Bundle (.mrb)").
   void setDefaultSceneFileType(QString);
+
+  /// Default maximum length for a filename.
+  /// \sa forceFileNameMaxLength()
+  void setDefaultMaximumFileNameLength(int);
 
 signals:
 

--- a/Base/QTGUI/Resources/UI/qSlicerSettingsGeneralPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsGeneralPanel.ui
@@ -225,6 +225,29 @@ Default: {documentationbaseurl}/user_guide/modules/{lowercasemodulename}.html</s
      </property>
     </widget>
    </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="MaxFileNameLengthLabel">
+     <property name="text">
+      <string>Maximum filename length:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="1">
+    <widget class="QSpinBox" name="MaximumFileNameLengthSpinBox">
+     <property name="toolTip">
+      <string>Limit the maximum length of filenames. For compatibility with Windows systems, a low value such as 50 is recommended. Set a higher value to allow using longer filenames that match long node names.</string>
+     </property>
+     <property name="minimum">
+      <number>8</number>
+     </property>
+     <property name="maximum">
+      <number>4000</number>
+     </property>
+     <property name="value">
+      <number>1000</number>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/Base/QTGUI/qSlicerExportNodeDialog.cxx
+++ b/Base/QTGUI/qSlicerExportNodeDialog.cxx
@@ -359,7 +359,7 @@ QString qSlicerExportNodeDialogPrivate::defaultFilename(vtkMRMLNode* node, QStri
   }
 
   QString safeNodeName = qSlicerCoreIOManager::forceFileNameValidCharacters(unsafeNodeName);
-  safeNodeName = qSlicerCoreIOManager::forceFileNameMaxLengthExtension(safeNodeName, 0);
+  safeNodeName = coreIOManager->forceFileNameMaxLength(safeNodeName, 0);
   return qSlicerExportNodeDialogPrivate::forceFileNameExtension(safeNodeName, extension, node);
 }
 
@@ -1089,6 +1089,13 @@ void qSlicerExportNodeDialogPrivate::formatChangedSlot()
 //-----------------------------------------------------------------------------
 QString qSlicerExportNodeDialogPrivate::recommendedFilename(vtkMRMLStorableNode* node) const
 {
+  qSlicerCoreIOManager* coreIOManager = qSlicerCoreApplication::application()->coreIOManager();
+  if (!coreIOManager)
+  {
+    qCritical() << Q_FUNC_INFO << "failed: Core IO manager not found.";
+    return QString();
+  }
+
   if (!this->FilenameLineEdit->isEnabled())
   {
     qWarning() << Q_FUNC_INFO << "should not be used when the filename text box is disabled.";
@@ -1104,7 +1111,7 @@ QString qSlicerExportNodeDialogPrivate::recommendedFilename(vtkMRMLStorableNode*
   }
 
   // If the filename is too long, suggest a shorter one.
-  QString shortenedFilename = qSlicerCoreIOManager::forceFileNameMaxLengthExtension(this->FilenameLineEdit->text(), extension.length());
+  QString shortenedFilename = coreIOManager->forceFileNameMaxLength(this->FilenameLineEdit->text(), extension.length());
   return qSlicerExportNodeDialogPrivate::forceFileNameExtension(shortenedFilename, extension, node);
 }
 

--- a/Base/QTGUI/qSlicerSettingsGeneralPanel.h
+++ b/Base/QTGUI/qSlicerSettingsGeneralPanel.h
@@ -50,6 +50,7 @@ public:
 public slots:
   void setDefaultScenePath(const QString& path);
   void openSlicerRCFile();
+  void setMaximumFileNameLength(int length);
 
 protected slots:
   void updateAutoUpdateApplicationFromManager();

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -4571,33 +4571,30 @@ bool vtkMRMLScene::SaveStorableNodeToSlicerDataBundleDirectory(vtkMRMLStorableNo
   // (if more files are needed then storage node must generate appropriate additional file names based on the primary file name).
   storageNode->ResetFileNameList();
 
-  // Update primary file name (set name from node name if empty, encode special characters, use default file extension)
+  // Filenames are generated from node names. Very long node names could generate very long file names that are not supported by all file systems
+  // (on Windows, maximum path length is 260). To prevent saving errors on Windows (and prevent loading of scenes on Windows that were saved on other
+  // operating systems), we limit the file name length.
+  const int maxFileNameLength = 50;
+
+  // Update file name: use current base name by default (set name from node name if empty), encode special characters, use default file extension
+  std::string fileBaseName;
   if (fileName.empty())
   {
     // Default storage node usually has empty file name (if Save dialog is not opened yet)
-    // file name is encoded to handle : or / characters in the node names
-    std::string fileBaseName = this->PercentEncode(std::string(storableNode->GetName()));
-    fileBaseName = storageNode->ClampFileName(fileBaseName);
-    std::string extension = storageNode->GetDefaultWriteFileExtension();
-    std::string storageFileName = fileBaseName + std::string(".") + extension;
-    vtkDebugMacro("new file name = " << storageFileName.c_str());
-    storageNode->SetFileName(storageFileName.c_str());
+    fileBaseName = storableNode->GetName() ? storableNode->GetName() : "unnamed";
   }
   else
   {
-    // new file name is encoded to handle : or / characters in the node names
-    std::string storageFileName = this->PercentEncode(vtksys::SystemTools::GetFilenameName(fileName));
-    std::string defaultWriteExtension = std::string(".") + vtksys::SystemTools::LowerCase(storageNode->GetDefaultWriteFileExtension());
-    std::string currentExtension = storageNode->GetSupportedFileExtension(storageFileName.c_str());
-    if (defaultWriteExtension != currentExtension)
-    {
-      // for saving to MRB all nodes will be written in their default format
-      storageFileName = storageNode->GetFileNameWithoutExtension(storageFileName.c_str()) + defaultWriteExtension;
-    }
-    storageFileName = storageNode->ClampFileName(storageFileName);
-    vtkDebugMacro("updated file name = " << storageFileName.c_str());
-    storageNode->SetFileName(storageFileName.c_str());
+    // Get the filename base from the current filename.
+    // For saving to MRB, all nodes will be written in their default format, so we ignore the current file extension.
+    fileBaseName = storageNode->GetFileNameWithoutExtension(vtksys::SystemTools::GetFilenameName(fileName).c_str());
   }
+  std::string defaultWriteExtension = std::string(".") + vtksys::SystemTools::LowerCase(storageNode->GetDefaultWriteFileExtension());
+  // file name is encoded to handle : or / characters in the node names
+  std::string storageFileName = this->PercentEncode(fileBaseName) + defaultWriteExtension;
+  storageFileName = vtkMRMLStorageNode::ClampFileName(storageFileName, defaultWriteExtension.size(), maxFileNameLength);
+  vtkDebugMacro("updated file name = " << storageFileName.c_str());
+  storageNode->SetFileName(storageFileName.c_str());
 
   storageNode->SetDataDirectory(dataDir.c_str());
   vtkDebugMacro("Set data directory to " << dataDir.c_str() << ". Storable node " << storableNode->GetID()

--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -1597,19 +1597,13 @@ void vtkMRMLStorageNode::SetWriteFileFormat(const char* writeFileFormat)
 }
 
 //-----------------------------------------------------------------------------
-std::string vtkMRMLStorageNode::ClampFileName(const std::string& filename, int maxFileNameLength/*=-1*/, int hashLength/*=4*/)
+std::string vtkMRMLStorageNode::ClampFileName(const std::string& filename, int extensionLength, int maxFileNameLength, int hashLength/*=4*/)
 {
-  std::string extension = this->GetSupportedFileExtension(filename.c_str());
-  return vtkMRMLStorageNode::ClampFileNameExtension(filename, maxFileNameLength, hashLength, extension.length());
-}
-
-//-----------------------------------------------------------------------------
-std::string vtkMRMLStorageNode::ClampFileNameExtension(const std::string& filename, int maxFileNameLength/*=-1*/, int hashLength/*=4*/, int extensionLength/*=0*/)
-{
-  if (maxFileNameLength < 0)
+  if (maxFileNameLength < 8)
   {
     // Use default limit
-    maxFileNameLength = vtkMRMLStorageNode::GetRecommendedFileNameLength();
+    vtkGenericWarningMacro("ClampFileName: maxFileNameLength is too small, using default value of 8");
+    maxFileNameLength = 8;
   }
 
   // Remove extension

--- a/Libs/MRML/Core/vtkMRMLStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.h
@@ -86,7 +86,7 @@ public:
   /// Return complete file extension for the specified filename.
   /// Longest matched extension will be returned (.seg.nrrd will be returned
   /// if both .nrrd and .seg.nrrd are matched), including dot.
-  /// If filename is not specified then the current FileName will be used
+  /// If filename is not specified then the current FileName will be used.
   /// If there is no match then empty is returned.
   virtual std::string GetSupportedFileExtension(const char* fileName = nullptr, bool includeReadable = true, bool includeWriteable = true);
 
@@ -254,6 +254,7 @@ public:
 
   ///
   /// Return default file extension for writing.
+  /// Does not include the leading dot (e.g., it returns "txt" and not ".txt").
   virtual const char* GetDefaultWriteFileExtension();
 
   ///
@@ -385,17 +386,12 @@ public:
   /// Ensures that the file name (excluding the extension) is shorter than the maximum allowed length.
   /// If the filename is shorter than the maximum allowed length then it is returned unchanged.
   /// If the filename is longer than the maximum allowed length then the filename is shortened by using the following format:
-  /// [first 20 characters of the base name]_[4 character hash code].[extension]
-  /// The length of the prefix is the maximum allowed length minus the length of the hash code plus one for the added underscore.
-  /// The full base name of the file will be exactly maxFileNameLength characters long.
-  /// If maxFileNameLength is negative then the recommended file name length is used.
-  /// \sa GetRecommendedFileNameLength
-  std::string ClampFileName(const std::string& filename, int maxFileNameLength=-1, int hashLength = 4);
-  static std::string ClampFileNameExtension(const std::string& filename, int maxFileNameLength=-1, int hashLength = 4, int extensionLength=0);
+  /// [first maxFileNameLength-hashLength-1 characters of the base name]_[hashLength long hash code].[extension]
+  /// The full base name of the file will be exactly maxFileNameLength characters long. maxFileNameLength must be 8 or higher.
+  /// If extensionLength is not known then GetSupportedFileExtension() method can be used to get it from the filename.
+  /// \sa GetSupportedFileExtension()
+  static std::string ClampFileName(const std::string& filename, int extensionLength, int maxFileNameLength, int hashLength = 4);
   //@}
-
-  /// Get the recommended maximum length of the file name.
-  static int GetRecommendedFileNameLength() { return 25; };
 
 protected:
   vtkMRMLStorageNode();


### PR DESCRIPTION
Backport from #8245 

---

Make maximum file length configurable, with default set to 50 on Windows and 1000 on other operating systems. Users who do not need compatibility with Windows systems (or use short folder names) can choose to allow longer filenames to keep filenames matching node names.

fixes #8241

(cherry picked from commit a984ec47b50aacbf2f6c732bc87eeec7245714a4)