### PR TITLE
BUG: Fix core IO manager initialization

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -652,6 +652,20 @@ void qSlicerCoreApplicationPrivate::initDataIO()
   this->DataIOManagerLogic->SetMRMLApplicationLogic(this->AppLogic);
   this->DataIOManagerLogic->SetAndObserveDataIOManager(
     this->MRMLRemoteIOLogic->GetDataIOManager());
+
+  if (!this->CoreIOManager.isNull())
+  {
+    QSettings* userSettings = q->userSettings();
+    if (userSettings)
+    {
+      int maximumFileNameLength = userSettings->value("ioManager/MaximumFileNameLength", this->CoreIOManager->defaultMaximumFileNameLength()).toInt();
+      this->CoreIOManager->setDefaultMaximumFileNameLength(maximumFileNameLength);
+    }
+    else
+    {
+      qWarning() << Q_FUNC_INFO << ": failed to access application settings, using default defaultMaximumFileNameLength value";
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerCoreIOManager.cxx
+++ b/Base/QTCore/qSlicerCoreIOManager.cxx
@@ -222,19 +222,6 @@ qSlicerCoreIOManager::qSlicerCoreIOManager(QObject* _parent)
   // constructor.
   qRegisterMetaType<qSlicerIO::IOFileType>("qSlicerIO::IOFileType");
   qRegisterMetaType<qSlicerIO::IOProperties>("qSlicerIO::IOProperties");
-
-  qSlicerCoreApplication* app = qSlicerCoreApplication::application();
-  QSettings* userSettings = app ? app->userSettings() : nullptr;
-  if (userSettings)
-  {
-    int maximumFileNameLength = userSettings->value("ioManager/MaximumFileNameLength", this->defaultMaximumFileNameLength()).toInt();
-    this->setDefaultMaximumFileNameLength(maximumFileNameLength);
-  }
-  else
-  {
-  qWarning() << Q_FUNC_INFO << ": failed to access application settings, using default defaultMaximumFileNameLength value";
-  }
-
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -527,6 +527,16 @@ qSlicerApplication::qSlicerApplication(int &_argc, char **_argv)
   //       qSlicerIOManager is not added to the constructor initialization list.
   //       Indeed, internally qSlicerIOManager registers qSlicerDataDialog, ...
   d->CoreIOManager = QSharedPointer<qSlicerIOManager>(new qSlicerIOManager);
+  QSettings* userSettings = this->userSettings();
+  if (userSettings)
+  {
+    int maximumFileNameLength = userSettings->value("ioManager/MaximumFileNameLength", d->CoreIOManager->defaultMaximumFileNameLength()).toInt();
+    d->CoreIOManager->setDefaultMaximumFileNameLength(maximumFileNameLength);
+  }
+  else
+  {
+    qWarning() << Q_FUNC_INFO << ": failed to access application settings, using default defaultMaximumFileNameLength value";
+  }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Addresses a regression introduced in a984ec47b50 ("ENH: Make maximum file length configurable", 2025-02-20) through https://github.com/Slicer/Slicer/pull/8245.

- Move the retrieval of `MaximumFileNameLength` from `qSlicerCoreIOManager`'s constructor to `qSlicerCoreApplicationPrivate::initDataIO()`, ensuring proper initialization after the application object is fully set up.

- Remove redundant settings initialization from `qSlicerCoreIOManager`'s constructor.

- Ensure `qSlicerApplication` correctly applies the `MaximumFileNameLength` setting from user preferences when creating the IO Manager.

- Add fallback warning when application settings are inaccessible.

This change ensures consistent settings initialization and avoids potential issues due to premature access in `qSlicerCoreIOManager`.

It fixes the following tests:
- `qSlicerApplicationUpdateManagerTest`
- `qSlicerCamerasModuleWidgetTest1`
- `qSlicerCoreApplicationTest1`
- `qSlicerCoreIOManagerTest1`
- `qSlicerExtensionsManagerModelTest`
- `qSlicerModuleFactoryManagerTest1`

### Related issues and pull requests

* https://github.com/Slicer/Slicer/issues/8284
* https://github.com/Slicer/Slicer/pull/8245