### PR TITLE
COMP: Fix Windows build error by explicitly including Windows.h

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -35,6 +35,10 @@
 #include <QStandardPaths>
 #include <QTemporaryFile>
 
+#ifdef Q_OS_WIN32
+#include <Windows.h> // For ExitProcess
+#endif
+
 // For:
 //  - Slicer_BIN_DIR
 //  - Slicer_BUILD_APPLICATIONUPDATE_SUPPORT


### PR DESCRIPTION
This is a follow-up to https://github.com/Slicer/Slicer/commit/582437a93c7f7a174f6894137001109f686831a9 to fix another location of missing `Windows.h` found when building a Slicer custom application with `Slicer_BUILD_DICOM_SUPPORT` turned `OFF`. It was observed in another Slicer custom application with near identical configuration, but with `Slicer_BUILD_DICOM_SUPPORT` turned `ON` did not run into this build error.

-----------------------

Explicitly include `Windows.h` in `Base/QTCore/qSlicerCoreApplication.cxx` to ensure the availability of Windows-specific function `ExitProcess()`.

This fixes a regression introduced in commit https://github.com/Slicer/Slicer/commit/975fa530e490d60ce5c0164af81872ead78d617c ("COMP: Remove direct dependency on ITK from vtkSlicerApplicationLogic", 2025-01-28), which removed the `itkThreadSupport.h` include from `vtkSlicerApplicationLogic.h`. Since `itkThreadSupport.h` indirectly included `Windows.h`, its removal caused missing Windows 
definitions in `qSlicerCoreApplication.cxx`, leading to the following errors:

- `Base/QTCore/qSlicerCoreApplication.cxx(624,3): error C3861: 'ExitProcess': identifier not found`

Including `Windows.h` ensures all required dependencies are correctly included.

> [!NOTE]
> Although `ExitProcess()` is defined in `processthreadsapi.h`, including only `processthreadsapi.h` results in the following error:
>
> ```
> C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\um\winnt.h(169,1):
> error C1189: #error: "No Target Architecture"
> ```