### PR TITLE
COMP: Exclude dependabot and pre-commit pull requests from changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,13 @@
+changelog:
+  exclude:
+    authors:
+      # Excludes automated dependency updates for GitHub workflows, as these are not Slicer dependencies and are not relevant for the changelog.
+      - dependabot
+
+      # Manages Slicer.crt certificate updates (see update-slicer-certificate-bundle.yml).
+      # PRs from slicerbot are intentionally *not* excluded, as they update the Slicer.crt certificate, and documenting these changes is useful.
+      # - slicerbot
+
+      # Excludes automated pre-commit updates (see pre-commit-autoupdate.yml) used for linting.
+      # These updates involve only formatting changes, which would add unnecessary noise to the changelog.
+      - slicer-app


### PR DESCRIPTION
Update release settings to exclude pull requests from `dependabot` and `slicer-app` (associated with pre-commit updates) when generating the changelog.

See https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes


> [!NOTE]
> PRs from `slicerbot` are not excluded, as they update the `Slicer.crt` certificate, and documenting these changes remains relevant.


---

_Adapted from https://github.com/scikit-build/scikit-build-core/commit/7dcbe5bbc4607b00c165f0fc50e978e2be6db3e2 contributed by @henryiii :pray:_