### PR TITLE
BUG: Fix DICOM scene export

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMExportScene.py
+++ b/Modules/Scripted/DICOMLib/DICOMExportScene.py
@@ -148,9 +148,7 @@ class DICOMExportScene:
         # cmd = "img2dcm -k 'SeriesDescription=Slicer Data Bundle' -df %s/template.dcm %s %s" % (saveDirectoryPath, imageFile, self.sdbFile)
         seriesDescription = "Slicer Data Bundle" if self.seriesDescription is None else str(self.seriesDescription)
 
-        args = [
-            "-k", f"SeriesDescription={seriesDescription}",
-            "--no-latin1"]  # With this option the UTF8 encoding of the reference file is preserved, otherwise the character set would be forced to Latin1
+        args = ["-k", f"SeriesDescription={seriesDescription}"]
 
         # TODO: It could be safer to pass these fields through the reference file instead of using command-line arguments (from character set point of view)
         for key, value in self.optionalTags.items():


### PR DESCRIPTION
It seems that in the new DCMTK version the img2dcm (and probably others) do not have the --no-latin1 flag anymore. This commit removes the use of that flag, which caused an error on MRB DICOM export. I tested it with special characters (Japanese and Hungarian) and export succeeded.