### PR TITLE
BUG: Show the currently selected volume rendering preset name

### DIFF
--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingPresetComboBox.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingPresetComboBox.cxx
@@ -323,6 +323,10 @@ void qSlicerVolumeRenderingPresetComboBox::applyPreset(vtkMRMLNode* node)
 
   d->VolumePropertyNode->CopyContent(presetNode);
 
+  // Associate the volume property node by the preset by copying its name.
+  // Note: it would be more robust to save the preset ID into the volume property node.
+  d->VolumePropertyNode->SetName(presetNode->GetName());
+
   this->resetOffset();
 }
 


### PR DESCRIPTION
When selecting a volume rendering preset, the preset name was not reflected in the preset selector. The problem was that the volume rendering preset selector looked up what preset should be the selected one by the name of the vtkMRMLVolumePropertyNode and recently copying of the volume property node was changed so that the name was no longer copied.

A quick fix was to copy the preset name to the vtkMRMLVolumePropertyNode.

In the long term, it would be more robust to store the preset node ID in the vtkMRMLVolumePropertyNode when a preset is applied to it.

Fixes the issue reported at https://discourse.slicer.org/t/no-selection-in-the-preset-of-volume-rendering/42038