### PR TITLE
ENH: Select the first suitable node by default in tree views

### DIFF
--- a/Modules/Loadable/Models/qSlicerModelsModuleWidget.cxx
+++ b/Modules/Loadable/Models/qSlicerModelsModuleWidget.cxx
@@ -187,6 +187,16 @@ void qSlicerModelsModuleWidget::enter()
   }
 
   this->Superclass::enter();
+
+  // If no node is selected then select the first displayed node to save the user a click
+  if (!d->SubjectHierarchyTreeView->currentNode())
+  {
+    vtkMRMLNode* node = d->SubjectHierarchyTreeView->findFirstNodeByClass("vtkMRMLModelNode");
+    if (node)
+    {
+      d->SubjectHierarchyTreeView->setCurrentNode(node);
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
@@ -185,6 +185,16 @@ void qSlicerSegmentationsModuleWidget::onEnter()
   this->qvtkConnect(this->mrmlScene(), vtkMRMLScene::EndRestoreEvent,
                     this, SLOT(onMRMLSceneEndRestoreEvent()));
 
+  // If no node is selected then select the first displayed node to save the user a click
+  if (!d->MRMLNodeSelector_Segmentation->currentNode())
+  {
+    vtkMRMLNode* node = d->MRMLNodeSelector_Segmentation->findFirstNodeByClass("vtkMRMLSegmentationNode");
+    if (node)
+    {
+      d->MRMLNodeSelector_Segmentation->setCurrentNode(node);
+    }
+  }
+
   this->onSegmentationNodeChanged(d->MRMLNodeSelector_Segmentation->currentNode());
 
   d->populateTerminologyContextComboBox();

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
@@ -253,6 +253,10 @@ public:
   /// An empty blocklist means all plugins are enabled. That is the default.
   QStringList pluginBlockList()const;
 
+  /// Finds the first node that is visible in the tree and is of the specified class
+  /// (either exactly that class or it is a class derived from that class).
+  Q_INVOKABLE vtkMRMLNode* findFirstNodeByClass(const QString& className)const;
+
 public slots:
   /// Set MRML scene
   virtual void setMRMLScene(vtkMRMLScene* scene);

--- a/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.cxx
+++ b/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.cxx
@@ -271,6 +271,16 @@ void qSlicerTransformsModuleWidget::enter()
     qCritical() << Q_FUNC_INFO << ": Invalid subject hierarchy";
   }
 
+  // If no node is selected then select the first displayed node to save the user a click
+  if (!d->TransformNodeSelector->currentNode())
+  {
+    vtkMRMLNode* node = d->TransformNodeSelector->findFirstNodeByClass("vtkMRMLTransformNode");
+    if (node)
+    {
+      d->TransformNodeSelector->setCurrentNode(node);
+    }
+  }
+
   this->Superclass::enter();
 }
 

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.cxx
@@ -1078,3 +1078,21 @@ void qSlicerVolumeRenderingModuleWidget::setSoftEdgeVoxels(double softEdgeVoxels
   }
   displayNode->SetClippingSoftEdgeVoxels(softEdgeVoxels);
 }
+
+//-----------------------------------------------------------
+void qSlicerVolumeRenderingModuleWidget::enter()
+{
+  Q_D(qSlicerVolumeRenderingModuleWidget);
+
+  this->Superclass::enter();
+
+  // If no node is selected then select the first displayed node to save the user a click
+  if (!d->VolumeNodeSelector->currentNode())
+  {
+    vtkMRMLNode* node = d->VolumeNodeSelector->findFirstNodeByClass("vtkMRMLVolumeNode");
+    if (node)
+    {
+      d->VolumeNodeSelector->setCurrentNode(node);
+    }
+  }
+}

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.h
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.h
@@ -60,6 +60,8 @@ public:
   bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString()) override;
   double nodeEditable(vtkMRMLNode* node) override;
 
+  void enter() override;
+
 public slots:
   void setMRMLVolumeNode(vtkMRMLNode* node);
   void setMRMLROINode(vtkMRMLNode* node);

--- a/Modules/Loadable/Volumes/qSlicerVolumesModuleWidget.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesModuleWidget.cxx
@@ -276,3 +276,21 @@ void qSlicerVolumesModuleWidget::colorLegendCollapsibleButtonCollapsed(bool coll
   }
   d->ColorLegendDisplayNodeWidget->setMRMLColorLegendDisplayNode(colorLegendNode);
 }
+
+//-----------------------------------------------------------
+void qSlicerVolumesModuleWidget::enter()
+{
+  Q_D(qSlicerVolumesModuleWidget);
+
+  this->Superclass::enter();
+
+  // If no node is selected then select the first displayed node to save the user a click
+  if (!d->ActiveVolumeNodeSelector->currentNode())
+  {
+    vtkMRMLNode* node = d->ActiveVolumeNodeSelector->findFirstNodeByClass("vtkMRMLVolumeNode");
+    if (node)
+    {
+      d->ActiveVolumeNodeSelector->setCurrentNode(node);
+    }
+  }
+}

--- a/Modules/Loadable/Volumes/qSlicerVolumesModuleWidget.h
+++ b/Modules/Loadable/Volumes/qSlicerVolumesModuleWidget.h
@@ -42,6 +42,8 @@ public:
 
   bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString()) override;
 
+  void enter() override;
+
 protected:
   void setup() override;
 


### PR DESCRIPTION
Small usability improvement in Segmentations, Transforms, VolumeRendering, Volumes, Models modules. Save users an unnecessary click when entering the module, by making the module selector automatically select the first suitable node.