### PR TITLE
ENH: Remove additional code handling VTK support <= 9.1

### DIFF
--- a/Libs/MRML/Core/vtkArchive.cxx
+++ b/Libs/MRML/Core/vtkArchive.cxx
@@ -549,11 +549,7 @@ bool vtkArchive::UnZip(const char* zipFileName, const char* destinationDirectory
 
   std::string cwd = vtksys::SystemTools::GetCurrentWorkingDirectory();
 
-#if (VTK_MAJOR_VERSION >= 9 && VTK_MINOR_VERSION >= 0 && VTK_BUILD_VERSION >= 20210806)
   if ( !vtksys::SystemTools::ChangeDirectory(destinationDirectory) )
-#else
-  if ( vtksys::SystemTools::ChangeDirectory(destinationDirectory) )
-#endif
   {
     vtkArchiveTools::Error("Unzip:", "could not change to destination directory");
     return false;
@@ -662,11 +658,7 @@ bool vtkArchive::UnZip(const char* zipFileName, const char* destinationDirectory
     return false;
   }
 
-#if (VTK_MAJOR_VERSION >= 9 && VTK_MINOR_VERSION >= 0 && VTK_BUILD_VERSION >= 20210806)
   if ( !vtksys::SystemTools::ChangeDirectory(cwd.c_str()) )
-#else
-  if ( vtksys::SystemTools::ChangeDirectory(cwd.c_str()) )
-#endif
   {
     vtkArchiveTools::Error("Unzip:", "could not change back to working directory");
     return false;


### PR DESCRIPTION
This is a follow-up to https://github.com/Slicer/Slicer/commit/dfde1cfc68f2d8d6da6678fb0a22fa4dd184288c where this code change should have been included. The VTK minimum supported version is 9.2, so there is no need to handle logic for earlier versions.