### PR TITLE
BUG: Fix crash in multivolume rendering

### DIFF
--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
@@ -1409,8 +1409,12 @@ void vtkMRMLVolumeRenderingDisplayableManager::vtkInternal::UpdateMultiVolumeMap
   {
     vtkMRMLMultiVolumeRenderingDisplayNode* multiDisplayNode =
       vtkMRMLMultiVolumeRenderingDisplayNode::SafeDownCast(pipeline->DisplayNode);
+    if (!multiDisplayNode)
+    {
+      continue;
+    }
     vtkMRMLVolumeNode* volumeNode = multiDisplayNode->GetVolumeNode();
-    if (!multiDisplayNode || !volumeNode)
+    if (!volumeNode)
     {
       continue;
     }


### PR DESCRIPTION
EchoVolumeRenderer module in SlicerHeart extension crashed the application when multivolume rendering technique was chosen. Fixed it by correcting a null-pointer check.