### PR TITLE
ENH: Move singleton declaration from vtkMRMLLayoutNode constructor

### DIFF
--- a/Libs/MRML/Core/vtkMRMLLayoutNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLayoutNode.cxx
@@ -16,7 +16,6 @@ vtkMRMLNodeNewMacro(vtkMRMLLayoutNode);
 //----------------------------------------------------------------------------
 vtkMRMLLayoutNode::vtkMRMLLayoutNode()
 {
-  this->SetSingletonTag("vtkMRMLLayoutNode");
   this->GUIPanelVisibility = 1;
   this->BottomPanelVisibility = 1;
   this->GUIPanelLR = 0;

--- a/Libs/MRML/Logic/vtkMRMLLayoutLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLLayoutLogic.cxx
@@ -1248,6 +1248,7 @@ void vtkMRMLLayoutLogic::UpdateLayoutNode()
   else
   {
     sceneLayoutNode = vtkMRMLLayoutNode::New();
+    sceneLayoutNode->SetSingletonTag("vtkMRMLLayoutNode");
 
     // we want to set the node to the logic before adding it into the scene, in
     // case an object listens to the scene node added event and query the logic


### PR DESCRIPTION
Defining the singleton tag in the constructor causes issues when trying to record sequences with layout nodes. This commit moves the layout node singleton tag initialization to vtkMRMLLayoutLogic.