### PR TITLE
ENH: Add CopyContent methods to vtkMRMLLayoutNode and vtkMRMLSequenceBrowserNode

### DIFF
--- a/Libs/MRML/Core/vtkMRMLLayoutNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLayoutNode.cxx
@@ -287,13 +287,6 @@ void vtkMRMLLayoutNode::UpdateCurrentLayoutDescription()
     return;
   }
   int viewArrangement = this->ViewArrangement;
-  if (!this->IsLayoutDescription(viewArrangement))
-  {
-    vtkWarningMacro(<< "View arrangement " << this->ViewArrangement
-      << " is not recognized, register it with "
-      << "AddLayoutDescription()");
-    viewArrangement = vtkMRMLLayoutNode::SlicerLayoutDefaultView;
-  }
   std::string description = this->GetLayoutDescription(viewArrangement);
   if (this->GetCurrentLayoutDescription() &&
       description == this->GetCurrentLayoutDescription())
@@ -351,11 +344,11 @@ vtkXMLDataElement* vtkMRMLLayoutNode::ParseLayout(const char* description)
 //----------------------------------------------------------------------------
 // Copy the node's attributes to this object.
 // Does NOT copy: ID, FilePrefix, LabelText, ID
-void vtkMRMLLayoutNode::Copy(vtkMRMLNode *anode)
+void vtkMRMLLayoutNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
 {
-  int disabledModify = this->StartModify();
+  MRMLNodeModifyBlocker blocker(this);
+  Superclass::CopyContent(anode, deepCopy);
 
-//  vtkObject::Copy(anode);
   vtkMRMLLayoutNode *node = (vtkMRMLLayoutNode *) anode;
   // Try to copy the registered layout descriptions. However, if the node
   // currently has layout descriptions (more than the default None description)
@@ -363,22 +356,23 @@ void vtkMRMLLayoutNode::Copy(vtkMRMLNode *anode)
   if (node->Layouts.size() > 1 && this->Layouts.size() == 1)
   {
     this->Layouts = node->Layouts;
+    this->Modified();
   }
-  this->SetViewArrangement (node->GetViewArrangement() );
-  this->SetGUIPanelVisibility(node->GetGUIPanelVisibility()) ;
-  this->SetBottomPanelVisibility (node->GetBottomPanelVisibility());
-  this->SetGUIPanelLR ( node->GetGUIPanelLR());
-  this->SetCollapseSliceControllers( node->GetCollapseSliceControllers() );
-  this->SetNumberOfCompareViewRows ( node->GetNumberOfCompareViewRows() );
-  this->SetNumberOfCompareViewColumns ( node->GetNumberOfCompareViewColumns() );
-  this->SetNumberOfCompareViewLightboxRows ( node->GetNumberOfCompareViewLightboxRows() );
-  this->SetNumberOfCompareViewLightboxColumns ( node->GetNumberOfCompareViewLightboxColumns() );
 
-  this->SetMainPanelSize( node->GetMainPanelSize() );
-  this->SetSecondaryPanelSize( node->GetSecondaryPanelSize() );
-  this->SetSelectedModule( node->GetSelectedModule() );
-
-  this->EndModify(disabledModify);
+  vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyIntMacro(ViewArrangement);
+  vtkMRMLCopyIntMacro(GUIPanelVisibility);
+  vtkMRMLCopyIntMacro(BottomPanelVisibility);
+  vtkMRMLCopyIntMacro(GUIPanelLR);
+  vtkMRMLCopyIntMacro(CollapseSliceControllers);
+  vtkMRMLCopyIntMacro(NumberOfCompareViewRows);
+  vtkMRMLCopyIntMacro(NumberOfCompareViewColumns);
+  vtkMRMLCopyIntMacro(NumberOfCompareViewLightboxRows);
+  vtkMRMLCopyIntMacro(NumberOfCompareViewLightboxColumns);
+  vtkMRMLCopyIntMacro(MainPanelSize);
+  vtkMRMLCopyIntMacro(SecondaryPanelSize);
+  vtkMRMLCopyStringMacro(SelectedModule);
+  vtkMRMLCopyEndMacro();
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLLayoutNode.h
+++ b/Libs/MRML/Core/vtkMRMLLayoutNode.h
@@ -30,7 +30,7 @@ public:
   void WriteXML(ostream& of, int indent) override;
 
   /// Copy the node's attributes to this object
-  void Copy(vtkMRMLNode *node) override;
+  void CopyContent(vtkMRMLNode* node, bool deepCopy = true) override;
 
   /// \brief Reimplemented to reset maximized view node.
   void Reset(vtkMRMLNode* defaultNode) override;
@@ -72,7 +72,8 @@ public:
   vtkGetMacro(SecondaryPanelSize, int);
   vtkSetMacro(SecondaryPanelSize, int);
 
-  /// Set/Get the size of the last selected module
+  /// Set/Get the name of the last selected module
+  /// Note: this is property is no longer used and may be removed in the future.
   vtkGetStringMacro(SelectedModule);
   vtkSetStringMacro(SelectedModule);
 

--- a/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.cxx
+++ b/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.cxx
@@ -354,11 +354,8 @@ void vtkMRMLSequenceBrowserNode::ReadXMLAttributes(const char** atts)
 }
 
 //----------------------------------------------------------------------------
-// Copy the node's attributes to this object.
-// Does NOT copy: ID, FilePrefix, Name, VolumeID
-void vtkMRMLSequenceBrowserNode::Copy(vtkMRMLNode *anode)
+void vtkMRMLSequenceBrowserNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
 {
-  // TODO: Convert to use MRML node macros
   vtkMRMLSequenceBrowserNode* node = vtkMRMLSequenceBrowserNode::SafeDownCast(anode);
   if (!node)
   {
@@ -367,26 +364,33 @@ void vtkMRMLSequenceBrowserNode::Copy(vtkMRMLNode *anode)
   }
 
   MRMLNodeModifyBlocker blocker(this);
-  Superclass::Copy(anode);
+  Superclass::CopyContent(anode);
 
-  // Note: node references are copied by the superclass
-  this->SynchronizationPostfixes = node->SynchronizationPostfixes;
-  this->SynchronizationPropertiesMap = node->SynchronizationPropertiesMap;
-  this->RecordingTimeOffsetSec = node->RecordingTimeOffsetSec;
-  this->LastSaveProxyNodesStateTimeSec = node->LastSaveProxyNodesStateTimeSec;
-  this->LastPostfixIndex = node->LastPostfixIndex;
-  this->SetHideFromEditors(node->GetHideFromEditors());
-  this->SetPlaybackActive(node->GetPlaybackActive());
-  this->SetPlaybackRateFps(node->GetPlaybackRateFps());
-  this->SetPlaybackItemSkippingEnabled(node->GetPlaybackItemSkippingEnabled());
-  this->SetPlaybackLooped(node->GetPlaybackLooped());
-  this->SetRecordMasterOnly(node->GetRecordMasterOnly());
-  this->SetRecordingSamplingMode(node->GetRecordingSamplingMode());
-  this->SetIndexDisplayMode(node->GetIndexDisplayMode());
-  this->SetIndexDisplayFormat(node->GetIndexDisplayFormat());
-  this->SetRecordingActive(node->GetRecordingActive());
-
-  this->SetSelectedItemNumber(node->GetSelectedItemNumber());
+  vtkMRMLCopyBeginMacro(anode);
+  if (this->SynchronizationPostfixes != node->SynchronizationPostfixes)
+  {
+    this->SynchronizationPostfixes = node->SynchronizationPostfixes;
+    this->Modified();
+  }
+  if (this->SynchronizationPropertiesMap != node->SynchronizationPropertiesMap)
+  {
+    this->SynchronizationPropertiesMap = node->SynchronizationPropertiesMap;
+    this->Modified();
+  }
+  vtkMRMLCopyFloatMacro(RecordingTimeOffsetSec);
+  vtkMRMLCopyFloatMacro(LastSaveProxyNodesStateTimeSec);
+  vtkMRMLCopyIntMacro(LastPostfixIndex);
+  vtkMRMLCopyBooleanMacro(PlaybackActive);
+  vtkMRMLCopyFloatMacro(PlaybackRateFps);
+  vtkMRMLCopyBooleanMacro(PlaybackItemSkippingEnabled);
+  vtkMRMLCopyBooleanMacro(PlaybackLooped);
+  vtkMRMLCopyBooleanMacro(RecordMasterOnly);
+  vtkMRMLCopyIntMacro(RecordingSamplingMode);
+  vtkMRMLCopyIntMacro(IndexDisplayMode);
+  vtkMRMLCopyStringMacro(IndexDisplayFormat);
+  vtkMRMLCopyBooleanMacro(RecordingActive);
+  vtkMRMLCopyIntMacro(SelectedItemNumber);
+  vtkMRMLCopyEndMacro();
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.h
+++ b/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.h
@@ -91,7 +91,7 @@ public:
   void WriteXML(ostream& of, int indent) override;
 
   /// Copy the node's attributes to this object
-  void Copy(vtkMRMLNode *node) override;
+  void CopyContent(vtkMRMLNode *node, bool deepCopy=true) override;
 
   /// Get unique node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override {return "SequenceBrowser";};
@@ -393,9 +393,16 @@ protected:
   bool PlaybackLooped{true};
   int SelectedItemNumber{-1};
 
-  bool RecordingActive{false};
   double RecordingTimeOffsetSec; // difference between universal time and index value
+  vtkSetMacro(RecordingTimeOffsetSec, double);
+  vtkGetMacro(RecordingTimeOffsetSec, double);
+
+  bool RecordingActive{false};
+
   double LastSaveProxyNodesStateTimeSec;
+  vtkSetMacro(LastSaveProxyNodesStateTimeSec, double);
+  vtkGetMacro(LastSaveProxyNodesStateTimeSec, double);
+
   bool RecordMasterOnly{false};
   int RecordingSamplingMode{vtkMRMLSequenceBrowserNode::SamplingLimitedToPlaybackFrameRate};
   int IndexDisplayMode{vtkMRMLSequenceBrowserNode::IndexDisplayAsIndexValue};
@@ -407,6 +414,8 @@ protected:
 
   // Counter that is used for generating the unique (only for this class) proxy node postfix strings
   int LastPostfixIndex{0};
+  vtkSetMacro(LastPostfixIndex, int);
+  vtkGetMacro(LastPostfixIndex, int);
 
 private:
   struct SynchronizationProperties;


### PR DESCRIPTION
This allows both vtkMRMLLayoutNode and vtkMRMLSequenceBrowserNode to be recorded in Sequences.