### PR TITLE
STYLE: Remove obsolete Qt4 code

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication_p.h
+++ b/Base/QTCore/qSlicerCoreApplication_p.h
@@ -90,10 +90,6 @@ public:
   void setPythonOsEnviron(const QString& key, const QString& value);
 #endif
 
-#ifdef Q_WS_WIN
-  void updatePythonOsEnviron();
-#endif
-
   /// Prepend or append value to environment variable using \a separator
   void updateEnvironmentVariable(
     const QString& key, const QString& value, QChar separator, bool prepend = false);


### PR DESCRIPTION
Per https://doc.qt.io/qt-5/portingguide.html, the Q_WS_WIN preprocessor macros was replaced with Q_OS_WIN.

This commit is a follow-up to https://github.com/Slicer/Slicer/commit/ec58ea1cdf9ed15ffd7ddc19b7a27ffe1a4c589c when `updatePythonOsEnviron` was actually removed.