### PR TITLE
BUG: Fix invalid scene view indexing

### DIFF
--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
@@ -647,7 +647,7 @@ int vtkSlicerSceneViewsModuleLogic::SceneViewIndexToSequenceBrowserIndex(int sce
   for (vtkMRMLNode* node : nodes)
   {
     vtkMRMLSequenceBrowserNode* sequenceBrowserNode = vtkMRMLSequenceBrowserNode::SafeDownCast(node);
-    if (!sequenceBrowserNode)
+    if (!sequenceBrowserNode || !this->IsSceneViewNode(sequenceBrowserNode))
     {
       continue;
     }


### PR DESCRIPTION
SceneViewIndexToSequenceBrowserIndex should only look through SceneViews sequences when trying to determine the index of a specific scene view, however all sequences were being iterated through. This caused the wrong index to be returned when trying to find the index of a scene that contained other sequences.

Fixed by only looking at sequence browser nodes that belong to SceneViews.