### PR TITLE
DOC: Moved 2 modules to match application module selector

### DIFF
--- a/Docs/user_guide/modules/index.md
+++ b/Docs/user_guide/modules/index.md
@@ -83,6 +83,8 @@ multivolumeexplorer.md
 :maxdepth: 1
 dwiconvert.md
 brainsdwicleanup.md
+resampledtivolume.md
+resamplescalarvectordwivolume.md
 ```
 
 ## Filtering
@@ -141,8 +143,6 @@ createdicomseries.md
 cropvolume.md
 orientscalarvolume.md
 vectortoscalarvolume.md
-resampledtivolume.md
-resamplescalarvectordwivolume.md
 ```
 
 ## Developer Tools


### PR DESCRIPTION
The modules Resample DTI Volume and Resample Scalar/Vector/DWI Volume are under Diffusion > Utilities in the Slicer 5.9.0 GUI, but are under Converters at https://slicer.readthedocs.io/en/latest/user_guide/modules/index.html. I have moved them.

fixed #8320