### PR TITLE
Add reset ambient shading options

### DIFF
--- a/Base/QTGUI/Resources/UI/qSlicerSettingsViewsPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsViewsPanel.ui
@@ -570,5 +570,37 @@ p, li { white-space: pre-wrap; }
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>ThreeDShadowsVisibilityCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>ThreeDAmbientShadowsIntensityScaleSlider</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>305</x>
+     <y>292</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>314</x>
+     <y>360</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ThreeDShadowsVisibilityCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>ThreeDAmbientShadowsIntensityShiftSlider</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>305</x>
+     <y>292</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>314</x>
+     <y>384</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
 </ui>

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -24,6 +24,7 @@
 #include <QInputDialog>
 #include <QLabel>
 #include <QMenu>
+#include <QSettings>
 #include <QWidgetAction>
 
 // CTK includes
@@ -359,6 +360,13 @@ void qMRMLThreeDViewControllerWidgetPrivate::setupShadowsMenu()
   ambientShadowsIntensityShiftAction->setDefaultWidget(this->AmbientShadowsIntensityShiftSlider);
   ambientShadowsIntensityShiftMenu->addAction(ambientShadowsIntensityShiftAction);
   this->ShadowsMenu->addMenu(ambientShadowsIntensityShiftMenu);
+
+  // Reset settings button
+  this->ShadowsMenu->addSeparator();
+  QAction* resetAction = new QAction(qMRMLThreeDViewControllerWidget::tr("Reset settings to default"), this->ShadowsMenu);
+  QObject::connect(resetAction, SIGNAL(triggered()),
+    q, SLOT(resetAmbientShadows()));
+  this->ShadowsMenu->addAction(resetAction);
 
   this->ShadowsButton->setMenu(this->ShadowsMenu);
 }
@@ -1097,4 +1105,28 @@ void qMRMLThreeDViewControllerWidget::setAmbientShadowsIntensityShift(double val
   d->ViewLogic->StartViewNodeInteraction(vtkMRMLViewNode::AmbientShadowsIntensityShiftFlag);
   this->mrmlThreeDViewNode()->SetAmbientShadowsIntensityShift(value);
   d->ViewLogic->EndViewNodeInteraction();
+}
+
+// --------------------------------------------------------------------------
+void qMRMLThreeDViewControllerWidget::resetAmbientShadows()
+{
+  Q_D(qMRMLThreeDViewControllerWidget);
+  if (!this->mrmlThreeDViewNode())
+    {
+    return;
+    }
+
+  // Read default values from application settings
+  QSettings settings;
+  settings.beginGroup("Default3DView");
+  double sizeScale = settings.value("AmbientShadowsSizeScale", 0.0).toDouble();
+  double opacityThreshold = settings.value("AmbientShadowsVolumeOpacityThreshold", 0.0).toDouble();
+  double intensityScale = settings.value("AmbientShadowsIntensityScale", 1.0).toDouble();
+  double intensityShift = settings.value("AmbientShadowsIntensityShift", 0.0).toDouble();
+  settings.endGroup();
+
+  d->AmbientShadowsSizeScaleSlider->setValue(sizeScale);
+  d->AmbientShadowsVolumeOpacityThresholdPercentSlider->setValue(opacityThreshold * 100.0);
+  d->AmbientShadowsIntensityScaleSlider->setValue(intensityScale);
+  d->AmbientShadowsIntensityShiftSlider->setValue(intensityShift);
 }

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.h
@@ -129,6 +129,9 @@ public slots:
   void setAmbientShadowsIntensityScale(double value);
   void setAmbientShadowsIntensityShift(double value);
 
+  /// Reset ambient shadows settings to default values
+  void resetAmbientShadows();
+
 protected slots:
   void updateWidgetFromMRMLViewLogic();
   void updateWidgetFromMRMLView() override;


### PR DESCRIPTION
Added a menu item to revert ambient shadows options to the default to make it easier to get ambient shadows back to a working state after modifying several parameters.

![image](https://github.com/user-attachments/assets/3e2abeda-dc93-4b0c-a0e1-e90002c47704)

@muratmaga 