### PR TITLE
DOC: Remove link to wiki from list of modules

### DIFF
--- a/Docs/user_guide/modules/index.md
+++ b/Docs/user_guide/modules/index.md
@@ -1,11 +1,5 @@
 # Modules
 
-:::{note}
-
-This documentation is still a work in progress. Additional module documentation is available on the [Slicer wiki](https://www.slicer.org/wiki/Documentation/Nightly).
-
-:::
-
 **Main modules**
 
 ```{toctree}


### PR DESCRIPTION
The wiki is out of date and documentation has been moved to slicer.readthedocs.io