### PR TITLE
ENH: Add invert colors option to Volumes module

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
@@ -30,6 +30,7 @@ class vtkImageStencil;
 class vtkImageThreshold;
 class vtkImageExtractComponents;
 class vtkImageMathematics;
+class vtkScalarsToColors;
 
 // STD includes
 #include <vector>
@@ -141,6 +142,13 @@ class VTK_MRML_EXPORT vtkMRMLScalarVolumeDisplayNode : public vtkMRMLVolumeDispl
   vtkSetMacro(Interpolate, int);
   vtkBooleanMacro(Interpolate, int);
 
+  ///
+  /// Set/Get invert order of colors
+  /// If non-zero then colors at the end of the color table are assigned to low values.
+  vtkGetMacro(InvertDisplayScalarRange, int);
+  virtual void SetInvertDisplayScalarRange(int invert);
+  vtkBooleanMacro(InvertDisplayScalarRange, int);
+
   void SetDefaultColorMap() override;
 
   ///
@@ -194,6 +202,11 @@ class VTK_MRML_EXPORT vtkMRMLScalarVolumeDisplayNode : public vtkMRMLVolumeDispl
   /// Volume node and returns its image data scalar range.
   virtual void GetDisplayScalarRange(double range[2]);
 
+  /// Get lookup table that is used for assigning colors to scalar values.
+  /// The returned lookup table is managed by the display node object
+  /// and its content should not be modified externally.
+  virtual vtkScalarsToColors* GetLookupTable();
+
 protected:
   vtkMRMLScalarVolumeDisplayNode();
   ~vtkMRMLScalarVolumeDisplayNode() override;
@@ -233,6 +246,7 @@ protected:
   int AutoWindowLevel;
   int ApplyThreshold;
   int AutoThreshold;
+  int InvertDisplayScalarRange;
 
   vtkImageLogic *AlphaLogic;
   vtkImageMapToColors *MapToColors;

--- a/Modules/Loadable/Colors/MRMLDM/vtkMRMLColorLegendDisplayableManager.cxx
+++ b/Modules/Loadable/Colors/MRMLDM/vtkMRMLColorLegendDisplayableManager.cxx
@@ -488,6 +488,24 @@ bool vtkMRMLColorLegendDisplayableManager::vtkInternal::UpdateActor(vtkMRMLColor
   {
     return false;
   }
+
+  // Handle invert flag for scalar volume display nodes
+  if (scalarVolumeDisplayNode && scalarVolumeDisplayNode->GetInvertDisplayScalarRange())
+  {
+    // Invert the lookup table colors
+    vtkNew<vtkLookupTable> invertedLut;
+    invertedLut->DeepCopy(lut);
+    // Reverse the order of colors in the table
+    int numColors = invertedLut->GetNumberOfTableValues();
+    for (int i = 0; i < numColors; i++)
+    {
+      double rgba[4] = { 0.0, 0.0, 0.0, 0.0 };
+      lut->GetTableValue(i, rgba);
+      invertedLut->SetTableValue(numColors - 1 - i, rgba);
+    }
+    lut = invertedLut;
+  }
+
   lut->SetTableRange(range);
 
   // Color name == label with valid number of colors (size of validColorMask vector in non zero)

--- a/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerScalarVolumeDisplayWidget.ui
+++ b/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerScalarVolumeDisplayWidget.ui
@@ -90,7 +90,24 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
+   <item row="3" column="0">
+    <widget class="QLabel" name="InvertDisplayScalarRangeLabel">
+     <property name="text">
+      <string>Invert:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QCheckBox" name="InvertDisplayScalarRangeCheckbox">
+     <property name="toolTip">
+      <string>Reverse the order of colors in the lookup table to display this volume.</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string/>
@@ -108,7 +125,7 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string/>
@@ -126,7 +143,7 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <widget class="ctkCollapsibleGroupBox" name="HistogramGroupBox">
      <property name="toolTip">
       <string>Shows the number of pixels (y axis) vs the image intensity (x axis) over a background of the current window/level and threshold mapping.</string>

--- a/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
@@ -132,6 +132,8 @@ void qSlicerScalarVolumeDisplayWidgetPrivate::init()
 
   QObject::connect(this->InterpolateCheckbox, SIGNAL(toggled(bool)),
                    q, SLOT(setInterpolate(bool)));
+  QObject::connect(this->InvertDisplayScalarRangeCheckbox, SIGNAL(toggled(bool)),
+                   q, SLOT(setInvert(bool)));
   QObject::connect(this->ColorTableComboBox, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
                    q, SLOT(setColorNode(vtkMRMLNode*)));
   QObject::connect(this->HistogramGroupBox, SIGNAL(toggled(bool)),
@@ -232,6 +234,7 @@ void qSlicerScalarVolumeDisplayWidget::updateWidgetFromMRML()
   {
     d->ColorTableComboBox->setCurrentNode(displayNode->GetColorNode());
     d->InterpolateCheckbox->setChecked(displayNode->GetInterpolate());
+    d->InvertDisplayScalarRangeCheckbox->setChecked(displayNode->GetInvertDisplayScalarRange());
   }
   this->updateHistogram();
 }
@@ -379,6 +382,18 @@ void qSlicerScalarVolumeDisplayWidget::setInterpolate(bool interpolate)
     return;
   }
   displayNode->SetInterpolate(interpolate);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerScalarVolumeDisplayWidget::setInvert(bool invert)
+{
+  vtkMRMLScalarVolumeDisplayNode* displayNode =
+    this->volumeDisplayNode();
+  if (!displayNode)
+  {
+    return;
+  }
+  displayNode->SetInvertDisplayScalarRange(invert);
 }
 
 // --------------------------------------------------------------------------

--- a/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.h
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.h
@@ -43,11 +43,12 @@ public slots:
 
   ///
   /// Set the MRML node of interest
-  void setMRMLVolumeNode(vtkMRMLScalarVolumeNode* volumeNode);
   void setMRMLVolumeNode(vtkMRMLNode* node);
+  void setMRMLVolumeNode(vtkMRMLScalarVolumeNode* node);
 
   void setInterpolate(bool interpolate);
-  void setColorNode(vtkMRMLNode* colorNode);
+  void setInvert(bool invert);
+  void setColorNode(vtkMRMLNode* node);
   void setPreset(const QString& presetName);
 
 protected slots:


### PR DESCRIPTION
If enabled, the order of colors in the lookup table is reversed. This makes it possible to use the same color tables for images regardless of the objects of interest have higher or lower voxel values than the background.

The reversed colors are also applied to volume rendering, if the user chose to synchronize volume rendering transfer functions with scalar volume display.

![image](https://github.com/user-attachments/assets/e7682cd7-3631-45bf-babf-05c279009638)

![image](https://github.com/user-attachments/assets/8de3ccd4-a246-4934-bb42-d73c4329f5f4)

@muratmaga 