### PR TITLE
BUG: Call Modified if segment display properties changed during copy

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
@@ -224,7 +224,11 @@ void vtkMRMLSegmentationDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCo
   vtkMRMLCopyBooleanMacro(ClippingCapSurface);
   vtkMRMLCopyFloatMacro(ClippingCapOpacity);
   vtkMRMLCopyBooleanMacro(ClippingOutline);
-  this->SegmentationDisplayProperties = node->SegmentationDisplayProperties;
+  if (this->SegmentationDisplayProperties != node->SegmentationDisplayProperties)
+  {
+    this->SegmentationDisplayProperties = node->SegmentationDisplayProperties;
+    this->Modified();
+  }
   // Reset segment list source to allow writing display properties to XML,
   // even if referenced segmentation node cannot be found (for example,
   // if SegmentListUpdateSource was not set to nullptr then segment display properties

--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.h
@@ -70,6 +70,27 @@ public:
 
     // Automatically generated operator= and copy constructor work
     // correctly for these members, so there is no need to define them.
+
+    bool operator==(const SegmentDisplayProperties& rhs) const
+    {
+      // color comparison
+      for (int i = 0; i < 3; ++i)
+      {
+        if (fabs(OverrideColor[i] - rhs.OverrideColor[i]) > VTK_DBL_EPSILON)
+        {
+          return false;
+        }
+      }
+      return
+        Visible == rhs.Visible &&
+        Visible3D == rhs.Visible3D &&
+        Visible2DFill == rhs.Visible2DFill &&
+        Visible2DOutline == rhs.Visible2DOutline &&
+        Opacity3D == rhs.Opacity3D &&
+        Opacity2DFill == rhs.Opacity2DFill &&
+        Opacity2DOutline == rhs.Opacity2DOutline &&
+        Pickable == rhs.Pickable;
+    }
   };
 
   typedef std::map<std::string, SegmentDisplayProperties> SegmentDisplayPropertiesMap;


### PR DESCRIPTION
This commit adds to vtkMRMLSegmentationDisplayNode:
  - Test for equality for segment display parameters
  - Call Modified() if they are not equal