### PR TITLE
BUG: Fixing writing empty color names into ctbl format

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLColorTableNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLColorTableNodeTest1.cxx
@@ -20,6 +20,7 @@
 // VTK includes
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
+#include <vtkLookupTable.h>
 
 using namespace vtkMRMLCoreTestingUtilities;
 
@@ -45,65 +46,141 @@ int vtkMRMLColorTableNodeTest1(int argc, char * argv[])
   const char* tempDir = argv[1];
 
   std::string sceneFileName = std::string(tempDir) + "/vtkMRMLColorTableNodeTest1.mrml";
-  std::string colorTableFileName = std::string(tempDir) + "/vtkMRMLColorTableNodeTest1.ctbl";
 
-  // check that extra single quotes don't appear in color names via round trip
-  // to xml
-
-  std::string expectedColorNodeId;
-
+  for (int fileFormat = 0; fileFormat < 2; fileFormat++)
   {
-    vtkNew<vtkMRMLColorTableNode> colorNode;
-    colorNode->SetTypeToUser();
-    colorNode->SetNumberOfColors(3);
-    colorNode->SetColor(0, "zero", 0.0, 0.0, 0.0, 1.0);
-    colorNode->SetColor(1, "one", 1.0, 0.0, 0.0, 1.0);
-    colorNode->SetColor(2, "two", 0.0, 1.0, 0.0, 1.0);
+    // Test ctbl and csv file format
+    std::string colorTableFileName = std::string(tempDir) + "/";
+    if (fileFormat == 0)
+    {
+      colorTableFileName += "vtkMRMLColorTableNodeTest1.ctbl";
+    }
+    else
+    {
+      colorTableFileName += "vtkMRMLColorTableNodeTest1.csv";
+    }
+    std::cout << "Output file: " << colorTableFileName << std::endl;
 
-    // add node to the scene
-    vtkNew<vtkMRMLScene> scene;
-    scene->SetRootDirectory(tempDir);
-    CHECK_NOT_NULL(scene->AddNode(colorNode.GetPointer()));
+    for (int colorSettingMethod = 0; colorSettingMethod < 2; colorSettingMethod++)
+    {
+      // Test one-by-one and bulk color setting
+      if (colorSettingMethod == 0)
+      {
+        std::cout << "Setting colors one by one." << std::endl;
+      }
+      else
+      {
+        std::cout << "Setting colors in bulk using a lookup table." << std::endl;
+      }
 
-    // add storage node to the scene
-    vtkSmartPointer<vtkMRMLStorageNode> colorStorageNode =
-        vtkSmartPointer<vtkMRMLStorageNode>::Take(colorNode->CreateDefaultStorageNode());
+      std::string expectedColorNodeId;
 
-    scene->AddNode(colorStorageNode);
-    colorNode->SetAndObserveStorageNodeID(colorStorageNode->GetID());
+      // Write color table to file
+      {
+        vtkNew<vtkMRMLColorTableNode> colorNode;
+        colorNode->SetTypeToUser();
 
-    // keep track of the id
-    expectedColorNodeId = std::string(colorNode->GetID());
+        if (colorSettingMethod == 0)
+        {
+          // Set colors and names one by one
+          colorNode->SetNumberOfColors(3);
+          colorNode->SetColor(0, "zero", 0.0, 0.0, 0.0, 1.0);
+          colorNode->SetColor(1, "one", 1.0, 0.0, 0.0, 0.5);
+          colorNode->SetColor(2, "two", 0.0, 1.0, 0.0, 1.0);
+        }
+        else
+        {
+          // Set colors in bulk using a lookup table
+          vtkNew<vtkLookupTable> lut;
+          lut->SetNumberOfTableValues(3);
+          lut->SetTableValue(0, 0.0, 0.0, 0.0, 1.0);
+          lut->SetTableValue(1, 1.0, 0.0, 0.0, 0.5);
+          lut->SetTableValue(2, 0.0, 1.0, 0.0, 1.0);
+          lut->Build();
+          colorNode->SetAndObserveLookupTable(lut);
+          colorNode->SetNumberOfColors(3);
+          colorNode->SetColorDefined(0, true);
+          colorNode->SetColorDefined(1, true);
+          colorNode->SetColorDefined(2, true);
+        }
 
-    // write color table file
-    colorStorageNode->SetFileName(colorTableFileName.c_str());
-    colorStorageNode->WriteData(colorNode.GetPointer());
-    colorNode->SetName("CustomColorTable");
+        // add node to the scene
+        vtkNew<vtkMRMLScene> scene;
+        scene->SetRootDirectory(tempDir);
+        CHECK_NOT_NULL(scene->AddNode(colorNode.GetPointer()));
 
-    // write MRML file
-    scene->SetURL(sceneFileName.c_str());
-    CHECK_INT(scene->Commit(), 1);
+        // add storage node to the scene
+        vtkSmartPointer<vtkMRMLStorageNode> colorStorageNode =
+          vtkSmartPointer<vtkMRMLStorageNode>::Take(colorNode->CreateDefaultStorageNode());
+
+        scene->AddNode(colorStorageNode);
+
+        colorNode->SetAndObserveStorageNodeID(colorStorageNode->GetID());
+
+        // keep track of the id
+        expectedColorNodeId = std::string(colorNode->GetID());
+
+        // write color table file
+        colorStorageNode->SetFileName(colorTableFileName.c_str());
+        colorStorageNode->WriteData(colorNode.GetPointer());
+        colorNode->SetName("CustomColorTable");
+
+        // write MRML file
+        scene->SetURL(sceneFileName.c_str());
+        CHECK_INT(scene->Commit(), 1);
+      }
+
+      // Read color table from file and test content
+      {
+        vtkNew<vtkMRMLScene> scene;
+        scene->SetRootDirectory(tempDir);
+        vtkNew<vtkMRMLParser> parser;
+        parser->SetMRMLScene(scene.GetPointer());
+        parser->SetFileName(sceneFileName.c_str());
+        CHECK_INT(parser->Parse(), 1);
+
+        // test the color node
+        vtkMRMLColorTableNode* colorNode =
+          vtkMRMLColorTableNode::SafeDownCast(scene->GetNodeByID(expectedColorNodeId.c_str()));
+        CHECK_NOT_NULL(colorNode);
+
+        CHECK_INT(colorNode->GetStorageNode()->ReadData(colorNode), 1);
+
+        if (colorSettingMethod == 0)
+        {
+          CHECK_STRING(colorNode->GetColorName(0), "zero");
+          CHECK_STRING(colorNode->GetColorName(1), "one");
+          CHECK_STRING(colorNode->GetColorName(2), "two");
+        }
+        else
+        {
+          CHECK_STRING(colorNode->GetColorName(0), "");
+          CHECK_STRING(colorNode->GetColorName(1), "");
+          CHECK_STRING(colorNode->GetColorName(2), "");
+        }
+
+        // Check colors
+        double tolerance = 1.0 / 255.0; // color is saved as uint8_t, so 1/255 is the precision
+        double color[4];
+        colorNode->GetColor(0, color);
+        CHECK_DOUBLE_TOLERANCE(color[0], 0.0, tolerance);
+        CHECK_DOUBLE_TOLERANCE(color[1], 0.0, tolerance);
+        CHECK_DOUBLE_TOLERANCE(color[2], 0.0, tolerance);
+        CHECK_DOUBLE_TOLERANCE(color[3], 1.0, tolerance);
+
+        colorNode->GetColor(1, color);
+        CHECK_DOUBLE_TOLERANCE(color[0], 1.0, tolerance);
+        CHECK_DOUBLE_TOLERANCE(color[1], 0.0, tolerance);
+        CHECK_DOUBLE_TOLERANCE(color[2], 0.0, tolerance);
+        CHECK_DOUBLE_TOLERANCE(color[3], 0.5, tolerance);
+
+        colorNode->GetColor(2, color);
+        CHECK_DOUBLE_TOLERANCE(color[0], 0.0, tolerance);
+        CHECK_DOUBLE_TOLERANCE(color[1], 1.0, tolerance);
+        CHECK_DOUBLE_TOLERANCE(color[2], 0.0, tolerance);
+        CHECK_DOUBLE_TOLERANCE(color[3], 1.0, tolerance);
+      }
+    }
   }
-
-  {
-    vtkNew<vtkMRMLScene> scene;
-    scene->SetRootDirectory(tempDir);
-    vtkNew<vtkMRMLParser> parser;
-    parser->SetMRMLScene(scene.GetPointer());
-    parser->SetFileName(sceneFileName.c_str());
-    CHECK_INT(parser->Parse(), 1);
-
-    // test the color node
-    vtkMRMLColorTableNode *colorNode =
-        vtkMRMLColorTableNode::SafeDownCast(scene->GetNodeByID(expectedColorNodeId.c_str()));
-    CHECK_NOT_NULL(colorNode);
-
-    CHECK_INT(colorNode->GetStorageNode()->ReadData(colorNode),1);
-
-    CHECK_STRING(colorNode->GetColorName(0), "zero")
-    CHECK_STRING(colorNode->GetColorName(1), "one")
-    CHECK_STRING(colorNode->GetColorName(2), "two")
-  }
-
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
@@ -555,6 +555,13 @@ int vtkMRMLColorTableStorageNode::ReadCtblFile(std::string fullFileName, vtkMRML
     g = g / 255.0;
     b = b / 255.0;
     a = a / 255.0;
+    if (name == "_")
+    {
+      // Special case, empty name is stored as "_"
+      name = "";
+    }
+    // Space in name is replaced by underscores for storage, we restore the original name now
+    std::replace(name.begin(), name.end(), '_', ' ');
     // if the name has ticks around it, from copying from a mrml file, trim
     // them off the string
     if (name.find("'") != std::string::npos)
@@ -576,9 +583,6 @@ int vtkMRMLColorTableStorageNode::ReadCtblFile(std::string fullFileName, vtkMRML
         << ", breaking the loop over " << lines.size() << " lines in the file " << this->FileName);
       return 0;
     }
-    // Space in name is replaced by underscores for storage, we restore the original name now
-    std::replace(name.begin(), name.end(), '_', ' ');
-    colorNode->SetColorName(id, name.c_str());
   }
   if (lines.size() > 0 && !biggerThanOne)
   {
@@ -755,6 +759,11 @@ int vtkMRMLColorTableStorageNode::WriteCtblFile(std::string fullFileName, vtkMRM
       // If the name has spaces in it, we need to replace them with underscores due to limitation of the file format.
       std::string name = std::string(colorNode->GetColorName(i));
       std::replace(name.begin(), name.end(), ' ', '_');
+      if (name.empty())
+      {
+        // name cannot be completely empty, because then the parser would then mix up the columns
+        name = "_";
+      }
       of << name << " ";
       // the color look up table uses 0-1, file values are 0-255,
       double* rgba = colorNode->GetLookupTable()->GetTableValue(i);


### PR DESCRIPTION
Recently color table infrastructure was refactored (65409219f724bf03bd0307e9c2062c06030f3951) and now it is possible to have empty color names. When writing to .ctbl format the empty name confused the parser (it read the R color component as color name).

Fixed the issue by replacing empty color name by "_" when writing to .ctbl file format. Default file save format is .csv now and color name is normally not empty, so the error.