### PR TITLE
ENH: Make all colors defined by default when setting a LUT 

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLColorTableNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLColorTableNodeTest1.cxx
@@ -98,10 +98,6 @@ int vtkMRMLColorTableNodeTest1(int argc, char * argv[])
           lut->SetTableValue(2, 0.0, 1.0, 0.0, 1.0);
           lut->Build();
           colorNode->SetAndObserveLookupTable(lut);
-          colorNode->SetNumberOfColors(3);
-          colorNode->SetColorDefined(0, true);
-          colorNode->SetColorDefined(1, true);
-          colorNode->SetColorDefined(2, true);
         }
 
         // add node to the scene

--- a/Libs/MRML/Core/vtkMRMLColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorNode.cxx
@@ -746,3 +746,29 @@ void vtkMRMLColorNode::SetContainsTerminology(bool containsTerminology)
     this->RemoveAttribute(this->GetContainsTerminologyAttributeName());
   }
 }
+
+//----------------------------------------------------------------------------
+void vtkMRMLColorNode::SetAllColorsDefined()
+{
+  int numberOfColors = this->GetNumberOfColors();
+  bool modified = false;
+  if (this->Properties.size() < numberOfColors)
+  {
+    this->Properties.resize(numberOfColors);
+    modified = true;
+  }
+  for (int index = 0; index < numberOfColors; index++)
+  {
+    if (this->Properties[index].Defined == true)
+    {
+      // no change
+      continue;
+    }
+    this->Properties[index].Defined = true;
+    modified = true;
+  }
+  if (modified)
+  {
+    this->Modified();
+  }
+}

--- a/Libs/MRML/Core/vtkMRMLColorNode.h
+++ b/Libs/MRML/Core/vtkMRMLColorNode.h
@@ -103,6 +103,9 @@ public:
   /// Set the color defined flag for the given entry
   void SetColorDefined(int ind, bool defined);
 
+  /// Convenience method to set all colors as defined.
+  void SetAllColorsDefined();
+
   /// Get name of a color from its index (index is 0-based)
   /// Return empty string if undefined or if index is out of range.
   /// \sa GetColorIndexByName()

--- a/Libs/MRML/Core/vtkMRMLColorTableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableNode.cxx
@@ -168,7 +168,10 @@ void vtkMRMLColorTableNode::Copy(vtkMRMLNode *anode)
     if (this->LookupTable == nullptr)
     {
       vtkNew<vtkLookupTable> lut;
-      this->SetAndObserveLookupTable(lut.GetPointer());
+      // Only copy the RGBA values and not modify the defined state of colors
+      // (all the color properties are copied in Superclass::Copy).
+      const bool setAllColorsToDefined = false;
+      this->SetAndObserveLookupTable(lut, setAllColorsToDefined);
     }
     if (this->LookupTable != node->GetLookupTable())
     {
@@ -1506,12 +1509,17 @@ vtkLookupTable* vtkMRMLColorTableNode::GetLookupTable()
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLColorTableNode::SetAndObserveLookupTable(vtkLookupTable *lut)
+void vtkMRMLColorTableNode::SetAndObserveLookupTable(vtkLookupTable *lut, bool markAllColorsAsDefined/*=true*/)
 {
   if (lut == this->LookupTable)
   {
     return;
   }
+  MRMLNodeModifyBlocker blocker(this);
   vtkSetAndObserveMRMLObjectMacro(this->LookupTable, lut);
+  if (markAllColorsAsDefined && this->LookupTable)
+  {
+    this->SetAllColorsDefined();
+  }
   this->Modified();
 }

--- a/Libs/MRML/Core/vtkMRMLColorTableNode.h
+++ b/Libs/MRML/Core/vtkMRMLColorTableNode.h
@@ -57,15 +57,17 @@ public:
   vtkLookupTable* GetLookupTable() override;
 
   /// Set lookup table object that this object will use.
+  /// By default, all colors in the lookup table are set to "defined" for backward compatibility.
+  /// To avoid this, set markAllColorsAsDefined to false.
   /// \sa GetLookupTable()
-  virtual void SetAndObserveLookupTable(vtkLookupTable *newLookupTable);
+  virtual void SetAndObserveLookupTable(vtkLookupTable *newLookupTable, bool markAllColorsAsDefined=true);
 
   /// \deprecated Kept only for backward compatibility.
   /// Use SetAndObserveLookupTable method instead.
   /// \sa SetAndObserveLookupTable()
   virtual void SetLookupTable(vtkLookupTable* newLookupTable)
   {
-    SetAndObserveLookupTable(newLookupTable);
+    SetAndObserveLookupTable(newLookupTable, true);
   }
 
   ///

--- a/Libs/MRML/Core/vtkMRMLColorTableNode.h
+++ b/Libs/MRML/Core/vtkMRMLColorTableNode.h
@@ -67,7 +67,7 @@ public:
   /// \sa SetAndObserveLookupTable()
   virtual void SetLookupTable(vtkLookupTable* newLookupTable)
   {
-    SetAndObserveLookupTable(newLookupTable, true);
+    this->SetAndObserveLookupTable(newLookupTable, /*markAllColorsAsDefined=*/true);
   }
 
   ///
@@ -252,6 +252,9 @@ protected:
   ~vtkMRMLColorTableNode() override;
   vtkMRMLColorTableNode(const vtkMRMLColorTableNode&);
   void operator=(const vtkMRMLColorTableNode&);
+
+  /// Log error message and return false if not a valid color index.
+  bool IsValidColorIndex(int entry, const std::string& callerMethod, bool isCallerMethodSet=false);
 
   ///
   /// The look up table, constructed according to the Type.


### PR DESCRIPTION
When a color is set in a color node then its color is automatically set to defined.
However, when colors were set in bulk using SetAndObserveLookupTable, the colors were not set to "defined".

This commit changes the default behavior of SetAndObserveLookupTable so that it sets all the colors in the lookup table to "defined".
This way, the code does that most developers expect it to do.

The pull request also cleans up the ColorTable node a bit to more consistently set number of colors and report errors.

It includes commit from https://github.com/Slicer/Slicer/pull/8348, so it should be merged after that PR is merged.

Related pull requests:
* https://github.com/Slicer/Slicer/pull/8348