### PR TITLE
ENH: Add option to hide missing display nodes in sequences

### DIFF
--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
@@ -436,7 +436,7 @@ void vtkSlicerSceneViewsModuleLogic::CreateSceneView(std::vector<vtkMRMLNode*> s
       sequenceNode->SetIndexType(vtkMRMLSequenceNode::TextIndex);
       sequenceNode->SetAttribute(vtkSlicerSceneViewsModuleLogic::GetSceneViewNodeAttributeName(),
         vtkSlicerSceneViewsModuleLogic::GetSceneViewNodeAttributeValue());
-      sequenceBrowser->SetMissingItemMode(sequenceNode, vtkMRMLSequenceBrowserNode::MissingItemIgnore);
+      sequenceBrowser->SetMissingItemMode(sequenceNode, vtkMRMLSequenceBrowserNode::MissingItemDisplayHidden);
     }
     sequenceBrowser->SetRecording(sequenceNode, true);
   }

--- a/Modules/Loadable/Sequences/Logic/vtkSlicerSequencesLogic.cxx
+++ b/Modules/Loadable/Sequences/Logic/vtkSlicerSequencesLogic.cxx
@@ -435,11 +435,14 @@ void vtkSlicerSequencesLogic::UpdateProxyNodesFromSequences(vtkMRMLSequenceBrows
       }
       if (missingItemMode == vtkMRMLSequenceBrowserNode::MissingItemCreateFromDefault
         || missingItemMode == vtkMRMLSequenceBrowserNode::MissingItemSetToDefault
-        || missingItemMode == vtkMRMLSequenceBrowserNode::MissingItemIgnore)
+        || missingItemMode == vtkMRMLSequenceBrowserNode::MissingItemIgnore
+        || missingItemMode == vtkMRMLSequenceBrowserNode::MissingItemDisplayHidden)
       {
         // We are not saving changes, but we may need to reset the proxy node to the default
         sourceDataNode = synchronizedSequenceNode->GetDataNodeAtValue(indexValue, /* exactMatchRequired= */ true);
-        if (!sourceDataNode && missingItemMode != vtkMRMLSequenceBrowserNode::MissingItemIgnore)
+        if (!sourceDataNode
+          && missingItemMode != vtkMRMLSequenceBrowserNode::MissingItemIgnore
+          && missingItemMode != vtkMRMLSequenceBrowserNode::MissingItemDisplayHidden)
         {
           // item is missing, use an empty node as source node for the proxy node
           sourceDataNode = synchronizedSequenceNode->GetNthDataNode(0);
@@ -451,8 +454,20 @@ void vtkSlicerSequencesLogic::UpdateProxyNodesFromSequences(vtkMRMLSequenceBrows
         }
       }
     }
+
     if (sourceDataNode==nullptr)
     {
+      if (missingItemMode == vtkMRMLSequenceBrowserNode::MissingItemDisplayHidden)
+      {
+        vtkMRMLNode* targetProxyNode = browserNode->GetProxyNode(synchronizedSequenceNode);
+        vtkMRMLDisplayNode* proxyDisplayNode = vtkMRMLDisplayNode::SafeDownCast(targetProxyNode);
+        if (proxyDisplayNode)
+        {
+          // Hide the proxy node if the source node is not available
+          proxyDisplayNode->VisibilityOff();
+        }
+      }
+
       // no source node is available
       continue;
     }

--- a/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.cxx
+++ b/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.cxx
@@ -1559,6 +1559,7 @@ std::string vtkMRMLSequenceBrowserNode::GetMissingItemModeAsString(int missingIt
     case vtkMRMLSequenceBrowserNode::MissingItemCreateFromDefault: return "createFromDefault";
     case vtkMRMLSequenceBrowserNode::MissingItemSetToDefault: return "setToDefault";
     case vtkMRMLSequenceBrowserNode::MissingItemIgnore: return "ignore";
+    case vtkMRMLSequenceBrowserNode::MissingItemDisplayHidden: return "displayHidden";
     default:
       return "";
   }

--- a/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.h
+++ b/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.h
@@ -71,6 +71,7 @@ public:
     MissingItemCreateFromDefault, ///< the new item is created from the default node (typically an empty node)
     MissingItemSetToDefault, ///< the proxy node is set to the default (empty) node; new item is not created
     MissingItemIgnore, ///< the proxy node is not modified
+    MissingItemDisplayHidden, ///< if it is a vtkMRMLDisplayNode the proxy node is hidden, otherwise behaves as MissingItemIgnore
     NumberOfMissingItemModes // this line must be the last one
   };
 


### PR DESCRIPTION
This commit adds an additional missing item mode to vtkMRMLSequenceBrowserNode to hide proxy display nodes that are not present in a sequence. This option is used by SceneViews to hide display nodes for scene views that were captured before the display node was present.