### PR TITLE
Reduce warnings during legacy scene load

### DIFF
--- a/Libs/MRML/Core/vtkMRMLCameraNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLCameraNode.cxx
@@ -409,13 +409,18 @@ const char* vtkMRMLCameraNode::GetActiveTag()
 //---------------------------------------------------------------------------
 void vtkMRMLCameraNode::SetActiveTag(const char* newActiveTag)
 {
-  vtkWarningMacro("vtkMRMLCameraNode::SetActiveTag() is deprecated. Use vtkMRMLCameraNode::SetLayoutName() instead.");
+  // When reading legacy scenes, "activeTag" attribute is still used, so don't warn in that case
+  if (this->GetScene() && !this->GetScene()->IsImporting())
+  {
+    vtkWarningMacro("vtkMRMLCameraNode::SetActiveTag() is deprecated. Use vtkMRMLCameraNode::SetLayoutName() instead.");
+  }
+
   std::string newActiveTagStr = newActiveTag ? newActiveTag : "";
   if (vtksys::SystemTools::StringStartsWith(newActiveTagStr, "vtkMRMLViewNode"))
   {
     // remove "vtkMRMLViewNode" from the beginning of the view node ID to get its singleton tag,
     // which is the layout name
-    std::string layoutName = newActiveTag;
+    std::string layoutName = newActiveTagStr;
     layoutName.erase(0, 15); // 15 = length of "vtkMRMLViewNode"
     this->SetLayoutName(layoutName.c_str());
   }

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -908,6 +908,18 @@ int vtkMRMLScene::Import(vtkMRMLMessageCollection* userMessagesInput/*=nullptr*/
     this->UpdateNodeReferences(addedNodes);
     this->RemoveReservedIDs();
 
+    // This must run after node references are updated, but before nodes are loaded
+    for (addedNodes->InitTraversal(it);
+      (node = (vtkMRMLNode*)addedNodes->GetNextItemAsObject(it));)
+    {
+      vtkMRMLStorageNode* storageNode = vtkMRMLStorageNode::SafeDownCast(node);
+      if (!storageNode || storageNode->GetAddToScene())
+      {
+        continue;
+      }
+      storageNode->FixFileName();
+    }
+
     this->InvokeEvent(vtkMRMLScene::NewSceneEvent, nullptr);
 
     // Notify the imported nodes about that all nodes are created

--- a/Libs/MRML/Core/vtkMRMLSequenceNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSequenceNode.cxx
@@ -831,6 +831,12 @@ vtkMRMLNode* vtkMRMLSequenceNode::DeepCopyNodeToScene(vtkMRMLNode* source, vtkMR
   // Since the singleton tags are not copied with CopyContent, it is safe to disable them here.
   target->SetSingletonOff();
 
+  // Switch do batch process state to prevent unnecessary updates and warning messages
+  // (for example in vtkMRMLLabelMapVolumeDisplayNode::UpdateImageDataPipeline())
+  scene->StartState(vtkMRMLScene::BatchProcessState);
+
   vtkMRMLNode* addedTargetNode = scene->AddNode(target);
+
+  scene->EndState(vtkMRMLScene::BatchProcessState);
   return addedTargetNode;
 }

--- a/Libs/MRML/Core/vtkMRMLStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.h
@@ -393,6 +393,21 @@ public:
   static std::string ClampFileName(const std::string& filename, int extensionLength, int maxFileNameLength, int hashLength = 4);
   //@}
 
+  /// Attempts to correct legacy file paths stored in the node's FileName property.
+  /// This is primarily used during scene loading to handle outdated or invalid file references.
+  ///
+  /// If the file specified by FileName does not exist, the method attempts to resolve it
+  /// relative to the file's original directory (archetype path). If a valid path is found,
+  /// FileName is updated accordingly.
+  ///
+  /// To avoid unnecessary warnings, a message is only logged if the storage node is
+  /// referenced by at least one other node in the scene. Orphan storage nodes (those not
+  /// referenced by any other node) are silently ignored.
+  ///
+  /// This method is automatically invoked during scene loading and usually does not need
+  /// to be called explicitly.
+  void FixFileName();
+
 protected:
   vtkMRMLStorageNode();
   ~vtkMRMLStorageNode() override;

--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
@@ -219,7 +219,9 @@ vtkMRMLSequenceBrowserNode* vtkSlicerSceneViewsModuleLogic::ConvertSceneViewNode
     {
       continue;
     }
+    dataNode->GetScene()->StartState(vtkMRMLScene::BatchProcessState);
     dataNode->CopyContent(snapshotNode);
+    dataNode->GetScene()->EndState(vtkMRMLScene::BatchProcessState);
   }
 
   // Restore the disabled modified event state

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyFoldersTest1.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyFoldersTest1.py
@@ -81,14 +81,12 @@ class SubjectHierarchyFoldersTest1(unittest.TestCase):
 
         import SampleData
 
-        sceneFile = SampleData.downloadFromURL(
+        SampleData.downloadFromURL(
             fileNames="NACBrainAtlas2015.mrb",
             # Note: this data set is from SlicerDataStore (not from SlicerTestingData) repository
             uris=DATA_STORE_URL + "SHA256/d69d0331d4fd2574be1459b7734921f64f5872d3cb9589ec01b2f53dadc7112f",
-            checksums="SHA256:d69d0331d4fd2574be1459b7734921f64f5872d3cb9589ec01b2f53dadc7112f")[0]
-
-        ioManager = slicer.app.ioManager()
-        ioManager.loadFile(sceneFile)
+            checksums="SHA256:d69d0331d4fd2574be1459b7734921f64f5872d3cb9589ec01b2f53dadc7112f",
+            loadFiles=True)
 
         # Check number of models to see if atlas was fully loaded
         self.assertEqual(298, slicer.mrmlScene.GetNumberOfNodesByClass("vtkMRMLModelNode"))  # 301 with main window due to the slice views


### PR DESCRIPTION
These commits removes logging of false alarm error/warning messages during loading scenes.
This makes it easier to see actual problems during scene loading.
