### PR TITLE
BUG: Fix excessive qMRMLSceneViewMenu::resetMenu calls

### DIFF
--- a/Modules/Loadable/SceneViews/GUI/qMRMLSceneViewMenu.cxx
+++ b/Modules/Loadable/SceneViews/GUI/qMRMLSceneViewMenu.cxx
@@ -95,7 +95,6 @@ void qMRMLSceneViewMenuPrivate::onMRMLNodeAdded(vtkObject* mrmlScene, vtkObject 
   // Add observer to the sequence browser node
   qvtkConnect(sequenceBrowserNode, vtkCommand::ModifiedEvent, this, SLOT(resetMenu()));
   qvtkConnect(sequenceBrowserNode, vtkMRMLSequenceBrowserNode::SequenceNodeModifiedEvent, this, SLOT(resetMenu()));
-  qvtkConnect(sequenceBrowserNode, vtkMRMLSequenceBrowserNode::ProxyNodeModifiedEvent, this, SLOT(resetMenu()));
   resetMenu();
 }
 
@@ -143,7 +142,6 @@ void qMRMLSceneViewMenuPrivate::onMRMLNodeRemoved(vtkObject* mrmlScene, vtkObjec
   // Remove observer from the sequence browser node
   qvtkDisconnect(sequenceBrowserNode, vtkCommand::ModifiedEvent, this, SLOT(resetMenu()));
   qvtkDisconnect(sequenceBrowserNode, vtkMRMLSequenceBrowserNode::SequenceNodeModifiedEvent, this, SLOT(resetMenu()));
-  qvtkDisconnect(sequenceBrowserNode, vtkMRMLSequenceBrowserNode::ProxyNodeModifiedEvent, this, SLOT(resetMenu()));
   resetMenu();
 }
 


### PR DESCRIPTION
`qMRMLSceneViewMenu::resetMenu` was previously called every time a sequence proxy node was modified. The menu shouldn't need to update if the proxy node is modified, so it makes sense to remove this call to improve performance.