### PR TITLE
BUG: Fix crash in vtkSlicerTerminologiesModuleLogic

### DIFF
--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.cxx
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.cxx
@@ -2552,7 +2552,7 @@ bool vtkSlicerTerminologiesModuleLogic::FindFirstColorNodeOrTerminology(
   std::string categoryScheme;
   std::string categoryValue;
   vtkSlicerTerminologyCategory* categoryObject = entry->GetCategoryObject();
-  if (categoryObject)
+  if (categoryObject && categoryObject->GetCodingSchemeDesignator() && categoryObject->GetCodeValue())
   {
     categoryScheme = categoryObject->GetCodingSchemeDesignator();
     categoryValue = categoryObject->GetCodeValue();
@@ -2560,7 +2560,7 @@ bool vtkSlicerTerminologiesModuleLogic::FindFirstColorNodeOrTerminology(
   std::string typeScheme;
   std::string typeValue;
   vtkSlicerTerminologyType* typeObject = entry->GetTypeObject();
-  if (typeObject)
+  if (typeObject && typeObject->GetCodingSchemeDesignator() && typeObject->GetCodeValue())
   {
     typeScheme = typeObject->GetCodingSchemeDesignator();
     typeValue = typeObject->GetCodeValue();


### PR DESCRIPTION
Added missing null-pointer check to avoid crash in case of incomplete terminology.

fixes #8360