### PR TITLE
BUG: Fix DICOM SEG uploads with storescu

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -580,9 +580,12 @@ class DICOMSender:
         :param file: Path to the local DICOM file to transmit.
         """
 
-        if self._dicomSendSCU(file):
-            # success
-            return True
+        try:
+            if self._dicomSendSCU(file):
+                # success
+                return True
+        except UserWarning as uw:
+            logging.info(f"DICOM storescu raised: \"{uw}\", possibly due to a SEG file sent with a default configuration.")
 
         # Retry transfer with alternative configuration with presentation contexts which support SEG/SR.
         # A common cause of failure is an incomplete set of dcmtk/DCMSCU presentation context UIDS.


### PR DESCRIPTION
Sending SEG files to a DICOM server using DIMSE currently fails because the first storescu attempt will raise a UserWarning, so the second attempt with the modified storescu configuration doesn't go through. 

This is the easiest and least intrusive solution I could come up with, although switching to dcmsend might be a good idea.