### PR TITLE
BUG: Adjust the FieldOfView to match the aspect ratio of the slice dimensions.

### DIFF
--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -59,6 +59,8 @@ vtkMRMLAbstractViewNode::vtkMRMLAbstractViewNode()
   {
     this->AxisLabels->InsertNextValue(DEFAULT_AXIS_LABELS[i]);
   }
+
+  this->MappedInLayout = false;
 }
 
 //----------------------------------------------------------------------------
@@ -100,6 +102,9 @@ void vtkMRMLAbstractViewNode::WriteXML(ostream& of, int nIndent)
   // Do not write screenScaleFactor attribute, as we should not use the
   // value that is in the scene but what the user has set in application settings.
   // vtkMRMLWriteXMLFloatMacro(screenScaleFactor, ScreenScaleFactor);
+
+  // Do not write MappedInLayout attribute, as it is set dynamically by the layout manager.
+  // It should not be copied between objects or saved to file.
 
   vtkMRMLWriteXMLEndMacro();
 
@@ -151,6 +156,9 @@ void vtkMRMLAbstractViewNode::ReadXMLAttributes(const char** atts)
   // Do not read screenScaleFactor attribute, as we should not use the
   // value that is in the scene but what the user has set in application settings.
   // vtkMRMLReadXMLFloatMacro(screenScaleFactor, ScreenScaleFactor);
+
+  // Do not read MappedInLayout attribute, as it is set dynamically by the layout manager.
+  // It should not be copied between objects or saved to file.
 
   vtkMRMLReadXMLEndMacro();
 
@@ -205,11 +213,6 @@ void vtkMRMLAbstractViewNode::ReadXMLAttributes(const char** atts)
   }
 #endif
 
-  // Do not restore MappedInLayout state, because the view may not be mapped into the layout just yet.
-  // (the attribute tells that it was mapped into the layout when the scene was saved but the current
-  // layout may be different, see issue #6284).
-  this->SetAttribute("MappedInLayout", nullptr);
-
   this->EndModify(disabledModify);
 }
 
@@ -238,6 +241,10 @@ void vtkMRMLAbstractViewNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=tr
   }
   vtkMRMLCopyEnumMacro(RulerColor);
   vtkMRMLCopyFloatMacro(ScreenScaleFactor);
+
+  // Do not copy MappedInLayout attribute, as it is set dynamically by the layout manager.
+  // It should not be copied between objects or saved to file.
+
   vtkMRMLCopyEndMacro();
 
   vtkMRMLAbstractViewNode *node = vtkMRMLAbstractViewNode::SafeDownCast(anode);
@@ -333,23 +340,10 @@ bool vtkMRMLAbstractViewNode::SetInteractionNode(vtkMRMLNode* node)
   return this->SetInteractionNodeID(node ? node->GetID() : nullptr);
 }
 
-int vtkMRMLAbstractViewNode::IsMappedInLayout()
-{
-  if (!this->GetAttribute("MappedInLayout"))
-  {
-    return 0;
-  }
-  return strcmp(this->GetAttribute("MappedInLayout"), "1") == 0;
-}
-
 //------------------------------------------------------------------------------
-void vtkMRMLAbstractViewNode::SetMappedInLayout(int value)
+bool vtkMRMLAbstractViewNode::IsMappedInLayout()
 {
-  if (this->IsMappedInLayout() == value)
-  {
-    return;
-  }
-  this->SetAttribute("MappedInLayout", value ? "1" : "0");
+  return this->MappedInLayout;
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
@@ -132,8 +132,8 @@ public:
   /// \sa GetVisibility()
   /// \sa IsViewVisibleInLayout()
   /// \sa vtkMRMLLayoutNode::SetViewArrangement()
-  virtual int IsMappedInLayout();
-  virtual void SetMappedInLayout(int value);
+  vtkSetMacro(MappedInLayout, bool);
+  virtual bool IsMappedInLayout();
 
   /// Get parent layout node.
   /// Default is no reference, meaning that the view is managed by the main layout.
@@ -357,6 +357,10 @@ protected:
   ///
   /// Labels of coordinate system axes
   vtkSmartPointer<vtkStringArray> AxisLabels;
+
+  ///
+  /// Define if the view is displayed in the current layout.
+  bool MappedInLayout;
 
   static const char* ParentLayoutNodeReferenceRole;
   static const char* InteractionNodeReferenceRole;

--- a/Libs/MRML/Core/vtkMRMLSliceNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.cxx
@@ -951,7 +951,17 @@ void vtkMRMLSliceNode::ReadXMLAttributes(const char** atts)
     // Layout color is set in Superclass
     layoutColorFound = true;
   }
+
   vtkMRMLReadXMLVectorMacro(fieldOfView, FieldOfView, double, 3);
+  // Adjust the FieldOfView to match the aspect ratio of the slice dimensions.
+  // This adjustment ensures that the FieldOfView remains consistent with the current
+  // render window's aspect ratio. It is particularly important when loading or restoring
+  // slice configurations that were saved with a different render window aspect ratio,
+  // as mismatched aspect ratios could lead to distorted or improperly scaled slice views.
+  double windowAspect = (this->Dimensions[0] != 0 ? double(this->Dimensions[1]) / double(this->Dimensions[0]) : 1.);
+  this->FieldOfView[0] = fabs(windowAspect) > 1.e-6 ? this->FieldOfView[1] / windowAspect : this->FieldOfView[0];
+  // Dimensions is not copied since it is set using the geometry of the qwidget.
+
   vtkMRMLReadXMLVectorMacro(xyzOrigin, XYZOrigin, double, 3);
   vtkMRMLReadXMLVectorMacro(uvwOrigin, UVWOrigin, double, 3);
   vtkMRMLReadXMLVectorMacro(uvwExtents, UVWExtents, double, 3);
@@ -970,7 +980,6 @@ void vtkMRMLSliceNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLStringMacro(defaultOrientation, DefaultOrientation);
   vtkMRMLReadXMLStringMacro(orientationReference, OrientationReference);
   vtkMRMLReadXMLStringMacro(layoutName, LayoutName);
-  vtkMRMLReadXMLVectorMacro(dimensions, Dimensions, int, 3);
 
   // resliceDimensions: Setting of UVWDimensions based of the "resliceDimensions" attribute
   // was originally introduced in 2012 through commit Slicer@01ffcb5326 (ENH 9124. Added
@@ -1127,7 +1136,15 @@ void vtkMRMLSliceNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
   vtkMRMLCopyIntMacro(SliceResolutionMode);
 
   vtkMRMLCopyVectorMacro(FieldOfView, double, 3);
-  vtkMRMLCopyVectorMacro(Dimensions, int, 3);
+  // Adjust the FieldOfView to match the aspect ratio of the slice dimensions.
+  // This adjustment ensures that the FieldOfView remains consistent with the current
+  // render window's aspect ratio. It is particularly important when loading or restoring
+  // slice configurations that were saved with a different render window aspect ratio,
+  // as mismatched aspect ratios could lead to distorted or improperly scaled slice views.
+  double windowAspect = (this->Dimensions[0] != 0 ? double(this->Dimensions[1]) / double(this->Dimensions[0]) : 1.);
+  this->FieldOfView[0] = fabs(windowAspect) > 1.e-6 ? this->FieldOfView[1] / windowAspect : this->FieldOfView[0];
+  // Dimensions is not copied since it is set using the geometry of the qwidget.
+
   vtkMRMLCopyVectorMacro(XYZOrigin, double, 3);
   vtkMRMLCopyVectorMacro(UVWDimensions, int, 3);
   vtkMRMLCopyVectorMacro(UVWExtents, double, 3);

--- a/Libs/MRML/Widgets/qMRMLLayoutViewFactory.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutViewFactory.cxx
@@ -343,7 +343,7 @@ void qMRMLLayoutViewFactory::beginSetupLayout()
   this->Superclass::beginSetupLayout();
   foreach(vtkMRMLAbstractViewNode* viewNode, d->Views.keys())
   {
-    viewNode->SetMappedInLayout(0);
+    viewNode->SetMappedInLayout(false);
   }
 }
 
@@ -614,7 +614,7 @@ void qMRMLLayoutViewFactory::setupView(QDomElement viewElement, QWidget* view)
   this->Superclass::setupView(viewElement, view);
   vtkMRMLAbstractViewNode* viewNode = this->viewNode(view);
   Q_ASSERT(viewNode);
-  viewNode->SetMappedInLayout(1);
+  viewNode->SetMappedInLayout(true);
   view->setVisible(viewNode->GetVisibility());
   view->setWindowTitle(viewNode->GetName());
 }


### PR DESCRIPTION
This is a small fix introduced in https://github.com/Slicer/Slicer/pull/8141

Kyle asked if it can be integrated in a separate PR:
https://github.com/Slicer/Slicer/pull/8141#discussion_r2038099444

to reproduce:
1) enter in dual monitor layout
2) load example nrrd file
3) Copy and paste in the python console
```
a = slicer.mrmlScene.GetNodeByID("vtkMRMLSliceNodeRed")
b = slicer.mrmlScene.GetNodeByID("vtkMRMLSliceNodeRed+")
a.Copy(b)
```
4) you get
![image](https://github.com/user-attachments/assets/7b9d552e-ebda-4373-86ee-3d9e4fa2361a)

With this fix:
![image](https://github.com/user-attachments/assets/0a11b45e-1cff-40a2-a281-dcb8889eff8c)

@Sunderlandkyl @lassoan 
