### PR TITLE
BUG: Update CTK to fix `ctkDICOMDatabase::fileValue` for non-cached files

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "82cae5781621845486bad2697aed095f04cfbe76"
+    "7f8e1a67dcd179d9c1ff89d5edc21c064e19664b"
     QUIET
     )
 


### PR DESCRIPTION
Commit commontk/CTK@88ff72b (introduced through f0138cd0b) changed `ctkDICOMDatabase::fileValue` behavior so that it no longer returns DICOM tag value for files that are not already in the database.

This is an issue because this method has been used universally for any DICOM files (it returned result faster for files that are cached in the DICOM database but it worked for files not in the database, too).

This commit restores the previous, preferred behavior.

List of CTK changes:

```
$ git shortlog 82cae578..7f8e1a67 --no-merges
Andras Lasso (1):
      BUG: Fix ctkDICOMDatabase::fileValue for non-cached files
```