### PR TITLE
STYLE: Prefer declaring CMake min max required versions as variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_minimum_required(VERSION 3.16.3...3.19.7 FATAL_ERROR)
+set(MIN_REQUIRED_VERSION "3.16.3")
+set(MAX_REQUIRED_VERSION "3.19.7")
+
+cmake_minimum_required(VERSION ${MIN_REQUIRED_VERSION}...${MAX_REQUIRED_VERSION} FATAL_ERROR)
 
 if("${CMAKE_VERSION}" VERSION_EQUAL "3.21.0")
   message(FATAL_ERROR "CMake version is ${CMAKE_VERSION} and using CMake==3.21.0 is not supported.\nSee https://gitlab.kitware.com/cmake/cmake/-/issues/22476")


### PR DESCRIPTION
Prefer declaring CMake min max required versions as variables:
- When one of the min/max versions needs to be updated, this would enable keeping the part that is not affected unmodified.
- If these values need to be available elsewhere, the proposed solution would enable so.