### PR TITLE
BUG: Update CTK to ensure robust Python auto-completion anticipating VTK 9.4

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "7f8e1a67dcd179d9c1ff89d5edc21c064e19664b"
+    "c68d1c9fa4f3aa611d1f95f4d19f35ba9f79e08b"
     QUIET
     )
 


### PR DESCRIPTION
These changes address failures in the Python completion model caused by unhandled errors when retrieving attributes from VTK classes. VTK 9.4 introduces additional wrapping of property-like accessors requiring to fix improve CTK’s auto-completion infrastructure. See https://www.kitware.com/vtk-9-4-a-step-closer-to-the-ways-of-python/ for more details.

List of CTK changes:

```
$ git shortlog 7f8e1a67d..c68d1c9fa --no-merges
Jean-Christophe Fillion-Robin (5):
      STYLE: Remove unneeded line continuation from ctkAbstractPythonManager
      COMP: Simplify pythonAttributes by removing unused dict variable
      ENH: Make ctkAbstractPythonManager::pythonAttributes available from Python
      BUG: Fix python manager error handling in `pythonAttributes` and `dir_object`
      BUG: Ensure new reference associated with classToInstantiate is cleared
```

Related pull requests:
* https://github.com/Slicer/Slicer/pull/8238