### PR TITLE
COMP: Report CMake4 incompatibility in Slicer-5.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ if("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.25.0" AND "${CMAKE_VERSION}" VERS
   message(FATAL_ERROR "CMake version is ${CMAKE_VERSION} and using CMake >=3.25.0,<=3.25.2 is not supported.\nSee https://gitlab.kitware.com/cmake/cmake/-/issues/24567")
 endif()
 
+if("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "4.0")
+  message(FATAL_ERROR "CMake version is ${CMAKE_VERSION} and using CMake >=4.0 is not supported.")
+endif()
+
 #-----------------------------------------------------------------------------
 # Setting C++ Standard
 #-----------------------------------------------------------------------------

--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -47,7 +47,8 @@ sudo apt update && sudo apt install git build-essential cmake cmake-curses-gui c
 
 :::{note}
 The CMake version currently included in Debian 12 Bookworm (Stable) is not compatible with the current development version of Slicer.
-For more details, see the Slicer [CMakeLists.txt](https://github.com/Slicer/Slicer/blob/98c092edb8f5a274277d2e486a4f7e584f58605e/CMakeLists.txt#L3-L5) file. On Debian 12 Bookworm (Stable), you will need to upgrade CMake manually by downloading CMake 3.25.3 or higher from the [CMake website](https://cmake.org/download/) and following the CMake installation instructions.
+For more details, see the Slicer [CMakeLists.txt](https://github.com/Slicer/Slicer/blob/98c092edb8f5a274277d2e486a4f7e584f58605e/CMakeLists.txt#L3-L5) file. On Debian 12 Bookworm (Stable), you will need to upgrade CMake manually by downloading CMake version >= 3.25.3 and < 4 from the [CMake website](https://cmake.org/download/) and following the CMake installation instructions. **Slicer build scripts are not yet compatible with CMake 4.x**
+
 :::
 
 ### Ubuntu 23.04 (Lunar Lobster)
@@ -60,8 +61,8 @@ sudo apt update && sudo apt install git git-lfs build-essential \
   libxt-dev
 ```
 
-Install CMake manually by downloading CMake 3.25.3 or higher from the [CMake website](https://cmake.org/download/)
-and by following the CMake installation instructions.
+Install CMake manually by downloading CMake >=3.25.3 and < 4 from the [CMake website](https://cmake.org/download/)
+and by following the CMake installation instructions. **Slicer build scripts are not yet compatible with CMake 4.x**
 
 :::{note}
 The CMake version currently included in Ubuntu 23.04 is CMake 3.25.1 (see [here](https://packages.ubuntu.com/lunar/cmake))

--- a/Docs/developer_guide/build_instructions/macos.md
+++ b/Docs/developer_guide/build_instructions/macos.md
@@ -10,7 +10,7 @@ The prerequisites listed below are required to be able to configure/build/packag
 xcode-select --install
 ```
 
-- A CMake version that meets at least the minimum required CMake version [here](https://github.com/Slicer/Slicer/blob/main/CMakeLists.txt#L1)
+- A CMake version that meets at least the minimum required CMake version [here](https://github.com/Slicer/Slicer/blob/main/CMakeLists.txt#L1). **Slicer build scripts are not yet compatible with CMake 4.x**
 - Qt 5: **tested and recommended**.
   - For building Slicer: download and execute [qt-unified-mac-x64-online.dmg](https://download.qt.io/official_releases/online_installers/qt-unified-mac-x64-online.dmg), install Qt 5.15.2, make sure to select the `qtwebengine` component.
   - For packaging and redistributing Slicer: build Qt using [qt-easy-build](https://github.com/jcfr/qt-easy-build#readme)

--- a/Docs/developer_guide/build_instructions/windows.md
+++ b/Docs/developer_guide/build_instructions/windows.md
@@ -8,8 +8,9 @@ Slicer relies on a number of large third-party libraries (such VTK, ITK, DCMTK),
 
 ## Install prerequisites
 
-- [CMake](https://www.cmake.org/cmake/resources/software.html) version >= 3.16.3.
+- [CMake](https://www.cmake.org/cmake/resources/software.html) version >= 3.16.3 and < 4.
   - Avoid versions with known Slicer build issues:
+    - **4.x (Slicer build scripts are not yet compatible with CMake 4.x)**
     - 3.21.0 (CMake issue [22476](https://gitlab.kitware.com/cmake/cmake/-/issues/22476))
     - 3.25.0 to 3.25.2 (CMake issues [24180](https://gitlab.kitware.com/cmake/cmake/-/issues/24180), [24567](https://gitlab.kitware.com/cmake/cmake/-/issues/24567))
 - [Git](https://git-scm.com/download/win) >= 1.7.10


### PR DESCRIPTION
Update documentation and report error if attempting to build Slicer-5.8 with CMake4.