### PR TITLE
BUG: Fix crash when entering into Transforms module

### DIFF
--- a/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.cxx
+++ b/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.cxx
@@ -331,6 +331,17 @@ void qSlicerTransformsModuleWidget::onNodeSelected(vtkMRMLNode* node)
 
   vtkMRMLTransformNode* transformNode = vtkMRMLTransformNode::SafeDownCast(node);
 
+  this->qvtkReconnect(d->MRMLTransformNode, transformNode,
+    vtkMRMLTransformableNode::TransformModifiedEvent,
+    this, SLOT(onMRMLTransformNodeModified(vtkObject*)));
+
+  if (d->MRMLTransformNode == nullptr && transformNode != nullptr)
+  {
+    d->TransformedCollapsibleButton->setCollapsed(false);
+  }
+
+  d->MRMLTransformNode = transformNode;
+
   bool isTransform = (transformNode != nullptr);
   bool isLinearTransform = (transformNode!=nullptr && transformNode->IsLinear());
   bool isCompositeTransform = (transformNode!=nullptr && transformNode->IsComposite());
@@ -390,17 +401,6 @@ void qSlicerTransformsModuleWidget::onNodeSelected(vtkMRMLNode* node)
   }
   d->TransformableTreeView->sortFilterProxyModel()
     ->setHiddenNodeIDs(hiddenNodeIDs);
-
-  this->qvtkReconnect(d->MRMLTransformNode, transformNode,
-                      vtkMRMLTransformableNode::TransformModifiedEvent,
-                      this, SLOT(onMRMLTransformNodeModified(vtkObject*)));
-
-  if (d->MRMLTransformNode == nullptr && transformNode != nullptr)
-  {
-    d->TransformedCollapsibleButton->setCollapsed(false);
-  }
-
-  d->MRMLTransformNode = transformNode;
 
   // If there is no display node then collapse the display section.
   // This allows creation of transform display nodes on request:


### PR DESCRIPTION
Slicer crashed when Transforms module was opened when a transform was automatically selected when entering the module and that transform already had a display node. The problem was that in qSlicerTransformsModuleWidget::onNodeSelected() the d->MRMLTransformNode member was updated too late. Some method calls in that method had the side effect of calling qSlicerTransformsModuleWidget::onSubjectHierarchyItemModified, which reset the transform node from d->MRMLTransformNode, which was still nullptr. Fixed the issue by updating d->MRMLTransformNode early, before calling any other methods.

fixes #8386