### PR TITLE
ENH: Include slice intersection mouse move info in tooltip

### DIFF
--- a/Base/QTGUI/qSlicerViewersToolBar.cxx
+++ b/Base/QTGUI/qSlicerViewersToolBar.cxx
@@ -326,7 +326,7 @@ void qSlicerViewersToolBarPrivate::init()
   this->IntersectingSlicesVisibleAction->setIcon(QIcon(":/Icons/SliceIntersections.png"));
   this->IntersectingSlicesVisibleAction->setText(qSlicerViewersToolBar::tr("Slice intersections"));
   this->IntersectingSlicesVisibleAction->setToolTip(
-    qSlicerViewersToolBar::tr("Show how the other slice planes intersect each slice plane."));
+    qSlicerViewersToolBar::tr("Toggle slice intersection visibility. Hold Shift key and move mouse in a view to set slice intersection position."));
   this->IntersectingSlicesVisibleAction->setCheckable(true);
   this->SliceIntersectionsToolButton->setDefaultAction(this->IntersectingSlicesVisibleAction);
   QObject::connect(this->IntersectingSlicesVisibleAction, SIGNAL(triggered(bool)),


### PR DESCRIPTION
To improve discoverability of the shift+mouse move functionality for slice intersections I have added it to the toggle slice intersection tooltip.

This tooltip is structured like the existing Crosshair visibility action tooltip. This helps indicate that Shift+Mouse move is available for crosshair and slice intersection positioning.

Here for example is the existing Crosshair visibility tooltip:
![{168D0BEF-DE74-4E9B-A023-9AC9855B5C57}](https://github.com/user-attachments/assets/a6ac4906-d8f6-400c-8efe-9a154d97976d)
