### PR TITLE
ENH: Select first preferred terminology if no entry is found

### DIFF
--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
@@ -1746,7 +1746,7 @@ bool qSlicerTerminologyNavigatorWidgetPrivate::findTerminology(
   else
   {
     // Not found, select the first terminology item by default
-    terminologyNameToSelect = (!preferredTerminologyNames.empty() ? preferredTerminologyNames[0].c_str() : this->ComboBox_Terminology->itemText(0));
+    terminologyNameToSelect = (!preferredTerminologyNames.empty() ? QString::fromStdString(preferredTerminologyNames[0]) : this->ComboBox_Terminology->itemText(0));
     colorNodeIDToSelect = this->ComboBox_Terminology->itemData(0).toString();
     colorIndexInColorTable = -1;
   }

--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
@@ -1746,7 +1746,7 @@ bool qSlicerTerminologyNavigatorWidgetPrivate::findTerminology(
   else
   {
     // Not found, select the first terminology item by default
-    terminologyNameToSelect = this->ComboBox_Terminology->itemText(0);
+    terminologyNameToSelect = (!preferredTerminologyNames.empty() ? preferredTerminologyNames[0].c_str() : this->ComboBox_Terminology->itemText(0));
     colorNodeIDToSelect = this->ComboBox_Terminology->itemData(0).toString();
     colorIndexInColorTable = -1;
   }


### PR DESCRIPTION
If select by terminology is used in Colors module, there is no entry found when trying to find the last used terminology, so the first item in the combobox is selected. If instead, we select the first of the preferred terminologies in this case, the user will will get the convenience of being able to use the last context, thus speeding up the workflow.

Re #8394