### PR TITLE
BUG: Restore fallback DICOM SEG upload with alternative storescu config

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -580,9 +580,12 @@ class DICOMSender:
         :param file: Path to the local DICOM file to transmit.
         """
 
-        if self._dicomSendSCU(file):
-            # success
-            return True
+        try:
+            if self._dicomSendSCU(file):
+                # success
+                return True
+        except UserWarning as uw:
+            logging.info(f'Initial DICOM storescu attempt raised: "{uw}". Possible cause: unsupported SOP class.')
 
         # Retry transfer with alternative configuration with presentation contexts which support SEG/SR.
         # A common cause of failure is an incomplete set of dcmtk/DCMSCU presentation context UIDS.


### PR DESCRIPTION
Sending SEG files to a DICOM server using DIMSE currently fails because the first storescu attempt will raise a UserWarning, so the second attempt with the modified storescu configuration doesn't go through.

This is the easiest and least intrusive solution I could come up with, although switching to dcmsend might be a good idea.

---

Catch `UserWarning` raised on failure of the initial `storescu` send attempt, allowing fallback to a custom configuration to proceed.

This restores functionality originally introduced in 21f8ba46beb ("ENH: Add custom DICOM send configuration", 2021-06-14), which was most likely broken by adb997269ba ("COMP: Refactor DICOMProcess and DICOMCommand", 2023-10-02).
