### PR TITLE
BUG: Fix volume rendering clipping for volumes with negative scalar

### DIFF
--- a/Libs/MRML/Core/vtkImageMathematicsAddon.cxx
+++ b/Libs/MRML/Core/vtkImageMathematicsAddon.cxx
@@ -196,7 +196,10 @@ void vtkImageMathematicsAddonExecute2(vtkImageMathematicsAddon* self, vtkImageDa
       }
       for (idxR = 0; idxR < rowLength; idxR++)
       {
-        *outPtr = *inPtr * static_cast<float>((*outPtr - normalizeScalarRange[0]) / normalizeMagnitude);
+        // The formula interpolates between the input value (*inPtr) and the lower bound of the scalar range
+        // (normalizeScalarRange[0]), weighted by the normalized value.
+        float normalizedValue = static_cast<float>((*outPtr - normalizeScalarRange[0]) / normalizeMagnitude);
+        *outPtr = normalizedValue * (*inPtr) + (1.0 - normalizedValue) * normalizeScalarRange[0];
         outPtr++;
         inPtr++;
       }

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.cxx
@@ -93,6 +93,8 @@ void vtkMRMLVolumeRenderingDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLIntMacro(ignoreVolumeDisplayNodeThreshold, IgnoreVolumeDisplayNodeThreshold);
   vtkMRMLReadXMLIntMacro(useSingleVolumeProperty, UseSingleVolumeProperty);
   vtkMRMLReadXMLFloatMacro(clippingSoftEdgeVoxels, ClippingSoftEdgeVoxels);
+  vtkMRMLReadXMLFloatMacro(clippingBlankVoxelValue, ClippingBlankVoxelValue);
+  vtkMRMLReadXMLBooleanMacro(autoClippingBlankVoxelValue, AutoClippingBlankVoxelValue);
   vtkMRMLReadXMLEndMacro();
 }
 
@@ -109,6 +111,8 @@ void vtkMRMLVolumeRenderingDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLIntMacro(ignoreVolumeDisplayNodeThreshold, IgnoreVolumeDisplayNodeThreshold);
   vtkMRMLWriteXMLIntMacro(useSingleVolumeProperty, UseSingleVolumeProperty);
   vtkMRMLWriteXMLFloatMacro(clippingSoftEdgeVoxels, ClippingSoftEdgeVoxels);
+  vtkMRMLWriteXMLFloatMacro(clippingBlankVoxelValue, ClippingBlankVoxelValue);
+  vtkMRMLWriteXMLBooleanMacro(autoClippingBlankVoxelValue, AutoClippingBlankVoxelValue);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -128,6 +132,8 @@ void vtkMRMLVolumeRenderingDisplayNode::Copy(vtkMRMLNode *anode)
   vtkMRMLCopyIntMacro(IgnoreVolumeDisplayNodeThreshold);
   vtkMRMLCopyIntMacro(UseSingleVolumeProperty);
   vtkMRMLCopyFloatMacro(ClippingSoftEdgeVoxels);
+  vtkMRMLCopyFloatMacro(ClippingBlankVoxelValue);
+  vtkMRMLCopyBooleanMacro(AutoClippingBlankVoxelValue);
   vtkMRMLCopyEndMacro();
 
   this->EndModify(wasModifying);
@@ -146,6 +152,8 @@ void vtkMRMLVolumeRenderingDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintIntMacro(IgnoreVolumeDisplayNodeThreshold);
   vtkMRMLPrintIntMacro(UseSingleVolumeProperty);
   vtkMRMLPrintFloatMacro(ClippingSoftEdgeVoxels);
+  vtkMRMLPrintFloatMacro(ClippingBlankVoxelValue);
+  vtkMRMLPrintBooleanMacro(AutoClippingBlankVoxelValue);
   vtkMRMLPrintEndMacro();
 }
 

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.h
@@ -96,6 +96,24 @@ public:
   vtkGetMacro(ClippingSoftEdgeVoxels, double);
   //@}
 
+  //@{
+  /// Get/Set the blank voxel value for the volume rendering.
+  /// This value is used for the fill value when clipping for volume rendering.
+  /// It is only used when AutoClippingBlankVoxelValue is false.
+  /// The default value is 0.0.
+  vtkSetMacro(ClippingBlankVoxelValue, double);
+  vtkGetMacro(ClippingBlankVoxelValue, double);
+  //@}
+
+  //@{
+  /// Get/Set whether the blank voxel value is automatically set to the background value of the volume node.
+  /// If disabled, then ClippingBlankVoxelValue is used.
+  /// The default value is true.
+  vtkSetMacro(AutoClippingBlankVoxelValue, bool);
+  vtkGetMacro(AutoClippingBlankVoxelValue, bool);
+  vtkBooleanMacro(AutoClippingBlankVoxelValue, bool);
+  //@}
+
 protected:
   vtkMRMLVolumeRenderingDisplayNode();
   ~vtkMRMLVolumeRenderingDisplayNode() override;
@@ -127,6 +145,9 @@ protected:
   double WindowLevel[2];
 
   double ClippingSoftEdgeVoxels{ 0.0 };
+
+  double ClippingBlankVoxelValue{ 0.0 };
+  bool AutoClippingBlankVoxelValue{ true };
 };
 
 #endif

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
@@ -78,7 +78,7 @@
         <property name="transformColumnVisible">
          <bool>false</bool>
         </property>
-        <property name="pluginAllowList">
+        <property name="pluginAllowList" stdset="0">
          <stringlist notr="true">
           <string>Volumes</string>
           <string>Folder</string>
@@ -311,8 +311,15 @@
          <bool>true</bool>
         </property>
         <layout class="QGridLayout" name="gridLayout">
-         <item row="3" column="0" colspan="3">
-          <widget class="qMRMLClipNodeWidget" name="MRMLClipNodeWidget"/>
+         <item row="2" column="0">
+          <widget class="QLabel" name="ClippingSoftEdgeLabel">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Soft edge:</string>
+           </property>
+          </widget>
          </item>
          <item row="1" column="0">
           <widget class="QLabel" name="ClippingLabel">
@@ -331,7 +338,27 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="2">
+         <item row="3" column="1">
+          <widget class="QCheckBox" name="ClippingBlankVoxelValueAutoCheckBox">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Auto</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="ClippingBlankVoxelValueLabel">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Blank value:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1" colspan="2">
           <widget class="QCheckBox" name="ClippingCheckBox">
            <property name="enabled">
             <bool>false</bool>
@@ -341,7 +368,7 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="2">
+         <item row="0" column="1" colspan="2">
           <widget class="qMRMLNodeComboBox" name="ClipNodeSelector">
            <property name="nodeTypes">
             <stringlist notr="true">
@@ -365,17 +392,10 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="ClippingSoftEdgeLabel">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="text">
-            <string>Soft edge:</string>
-           </property>
-          </widget>
+         <item row="5" column="0" colspan="3">
+          <widget class="qMRMLClipNodeWidget" name="MRMLClipNodeWidget"/>
          </item>
-         <item row="2" column="2">
+         <item row="2" column="1" colspan="2">
           <widget class="qMRMLSliderWidget" name="ClippingSoftEdgeSlider">
            <property name="enabled">
             <bool>false</bool>
@@ -388,6 +408,22 @@
            </property>
            <property name="maximum">
             <double>10.000000000000000</double>
+           </property>
+           <property name="quantity">
+            <string notr="true"/>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="qMRMLSliderWidget" name="ClippingBlankVoxelValueSlider">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="minimum">
+            <double>-1000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>1000.000000000000000</double>
            </property>
            <property name="quantity">
             <string notr="true"/>
@@ -651,71 +687,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>qMRMLCheckableNodeComboBox</class>
-   <extends>qMRMLNodeComboBox</extends>
-   <header>qMRMLCheckableNodeComboBox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLClipNodeWidget</class>
-   <extends>qMRMLWidget</extends>
-   <header>qMRMLClipNodeWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLDisplayNodeViewComboBox</class>
-   <extends>qMRMLCheckableNodeComboBox</extends>
-   <header>qMRMLDisplayNodeViewComboBox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLNodeComboBox</class>
-   <extends>QWidget</extends>
-   <header>qMRMLNodeComboBox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLSliderWidget</class>
-   <extends>ctkSliderWidget</extends>
-   <header>qMRMLSliderWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLWidget</class>
-   <extends>QWidget</extends>
-   <header>qMRMLWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>qSlicerWidget</class>
-   <extends>QWidget</extends>
-   <header>qSlicerWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLMarkupsROIWidget</class>
-   <extends>QWidget</extends>
-   <header>qMRMLMarkupsROIWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLSubjectHierarchyTreeView</class>
-   <extends>QTreeView</extends>
-   <header>qMRMLSubjectHierarchyTreeView.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLVolumePropertyNodeWidget</class>
-   <extends>QWidget</extends>
-   <header>qMRMLVolumePropertyNodeWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qSlicerVolumeRenderingPresetComboBox</class>
-   <extends>qSlicerWidget</extends>
-   <header>qSlicerVolumeRenderingPresetComboBox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>qSlicerGPUMemoryComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qSlicerGPUMemoryComboBox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>ctkCheckablePushButton</class>
    <extends>ctkPushButton</extends>
    <header>ctkCheckablePushButton.h</header>
@@ -757,6 +728,65 @@
    <class>ctkSliderWidget</class>
    <extends>QWidget</extends>
    <header>ctkSliderWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLCheckableNodeComboBox</class>
+   <extends>qMRMLNodeComboBox</extends>
+   <header>qMRMLCheckableNodeComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLClipNodeWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLClipNodeWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLDisplayNodeViewComboBox</class>
+   <extends>qMRMLCheckableNodeComboBox</extends>
+   <header>qMRMLDisplayNodeViewComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLSliderWidget</class>
+   <extends>ctkSliderWidget</extends>
+   <header>qMRMLSliderWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerWidget</class>
+   <extends>QWidget</extends>
+   <header>qSlicerWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLMarkupsROIWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLMarkupsROIWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLSubjectHierarchyTreeView</class>
+   <extends>QTreeView</extends>
+   <header>qMRMLSubjectHierarchyTreeView.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLVolumePropertyNodeWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLVolumePropertyNodeWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerVolumeRenderingPresetComboBox</class>
+   <extends>qSlicerWidget</extends>
+   <header>qSlicerVolumeRenderingPresetComboBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerGPUMemoryComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qSlicerGPUMemoryComboBox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.cxx
@@ -183,6 +183,11 @@ void qSlicerVolumeRenderingModuleWidgetPrivate::setupUi(qSlicerVolumeRenderingMo
   QObject::connect(this->ClippingSoftEdgeSlider, SIGNAL(valueChanged(double)),
                    q, SLOT(setSoftEdgeVoxels(double)));
 
+  QObject::connect(this->ClippingBlankVoxelValueAutoCheckBox, SIGNAL(toggled(bool)),
+                   q, SLOT(setClippingBlankVoxelValueAuto(bool)));
+  QObject::connect(this->ClippingBlankVoxelValueSlider, SIGNAL(valueChanged(double)),
+                   q, SLOT(setClippingBlankVoxelValue(double)));
+
   // Disable markups ROI widget by default
   this->MarkupsROIWidget->setVisible(false);
 
@@ -500,6 +505,18 @@ void qSlicerVolumeRenderingModuleWidget::updateWidgetFromMRML()
   d->ClippingSoftEdgeSlider->setEnabled(clipNode != nullptr);
   d->ClippingSoftEdgeSlider->setValue(displayNode ? displayNode->GetClippingSoftEdgeVoxels() : 0.0);
   d->ClippingSoftEdgeSlider->blockSignals(wasBlocking);
+
+  wasBlocking = d->ClippingBlankVoxelValueAutoCheckBox->blockSignals(true);
+  d->ClippingBlankVoxelValueAutoCheckBox->setEnabled(clipNode != nullptr);
+  d->ClippingBlankVoxelValueAutoCheckBox->setChecked(displayNode ? displayNode->GetAutoClippingBlankVoxelValue() : false);
+  d->ClippingBlankVoxelValueAutoCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->ClippingBlankVoxelValueSlider->blockSignals(true);
+  d->ClippingBlankVoxelValueLabel->setEnabled(clipNode != nullptr);
+  d->ClippingBlankVoxelValueSlider->setEnabled(displayNode != nullptr && !displayNode->GetAutoClippingBlankVoxelValue());
+  d->ClippingBlankVoxelValueSlider->setValue(displayNode ? displayNode->GetClippingBlankVoxelValue() : 0.0);
+  d->ClippingBlankVoxelValueSlider->blockSignals(wasBlocking);
+
 }
 
 // --------------------------------------------------------------------------
@@ -1077,6 +1094,28 @@ void qSlicerVolumeRenderingModuleWidget::setSoftEdgeVoxels(double softEdgeVoxels
     return;
   }
   displayNode->SetClippingSoftEdgeVoxels(softEdgeVoxels);
+}
+
+//-----------------------------------------------------------
+void qSlicerVolumeRenderingModuleWidget::setClippingBlankVoxelValueAuto(bool autoValue)
+{
+  vtkMRMLVolumeRenderingDisplayNode* displayNode = this->mrmlDisplayNode();
+  if (!displayNode)
+  {
+    return;
+  }
+  displayNode->SetAutoClippingBlankVoxelValue(autoValue);
+}
+
+//-----------------------------------------------------------
+void qSlicerVolumeRenderingModuleWidget::setClippingBlankVoxelValue(double blankValue)
+{
+  vtkMRMLVolumeRenderingDisplayNode* displayNode = this->mrmlDisplayNode();
+  if (!displayNode)
+  {
+    return;
+  }
+  displayNode->SetClippingBlankVoxelValue(blankValue);
 }
 
 //-----------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.h
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.h
@@ -98,6 +98,10 @@ protected slots:
 
   void setClippingEnabled(bool state);
   void setSoftEdgeVoxels(double SoftEdgeVoxels);
+
+  void setClippingBlankVoxelValueAuto(bool state);
+  void setClippingBlankVoxelValue(double value);
+
   void setMRMLClipNode(vtkMRMLNode* clipNode);
 
 protected:


### PR DESCRIPTION
When applying clipping to the volume, the clipped regions would be filled with "0", which could result in the region not being clipped if the transfer function had visible voxel values at "0". Fixed by adding adding ClippingBlankVoxelValue and AutoClippingBlankVoxelValue attributes. By default the clipped voxel value will be automatically set from vtkMRMLVolumeNode::GetImageBackgroundScalarComponentAsDouble(). The clipped scalar value can be set to any scalar by setting ClippingBlankVoxelValue when AutoClippingBlankVoxelValue is disabled.

![image](https://github.com/user-attachments/assets/ba1db0d0-c214-46fe-9889-d77b981f5373)
