### PR TITLE
BUG: Fix vtkMRMLMarkupsLineNode::GetLineStartPosition crash for empty node

### DIFF
--- a/Libs/MRML/Core/vtkMRMLMarkupsLineNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsLineNode.cxx
@@ -147,15 +147,18 @@ bool vtkMRMLMarkupsLineNode::GetLineEndPosition(double position[3])
 //---------------------------------------------------------------------------
 vtkVector3d vtkMRMLMarkupsLineNode::GetLineStartPosition()
 {
-  return vtkVector3d(this->GetNthControlPointPosition(0));
+  double position[3] = { 0.0, 0.0, 0.0 };
+  this->GetNthControlPointPosition(0, position);
+  return vtkVector3d(position);
 }
 
 //---------------------------------------------------------------------------
 vtkVector3d vtkMRMLMarkupsLineNode::GetLineEndPosition()
 {
-  return vtkVector3d(this->GetNthControlPointPosition(1));
+  double position[3] = { 0.0, 0.0, 0.0 };
+  this->GetNthControlPointPosition(1, position);
+  return vtkVector3d(position);
 }
-
 
 //---------------------------------------------------------------------------
 vtkVector3d vtkMRMLMarkupsLineNode::GetLineStartPositionWorld()

--- a/Libs/MRML/Core/vtkMRMLMarkupsLineNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsLineNode.cxx
@@ -80,8 +80,8 @@ void vtkMRMLMarkupsLineNode::PrintSelf(ostream& os, vtkIndent indent)
 //----------------------------------------------------------------------------
 double vtkMRMLMarkupsLineNode::GetLineLengthWorld()
 {
-  double p1[3] = { 0.0 };
-  double p2[3] = { 0.0 };
+  double p1[3] = { 0.0, 0.0, 0.0 };
+  double p2[3] = { 0.0, 0.0, 0.0 };
   this->GetNthControlPointPositionWorld(0, p1);
   this->GetNthControlPointPositionWorld(1, p2);
   double length = sqrt(vtkMath::Distance2BetweenPoints(p1, p2));
@@ -105,7 +105,7 @@ void vtkMRMLMarkupsLineNode::UpdateInteractionHandleToWorldMatrix()
   double point1_World[3];
   this->GetNthControlPointPositionWorld(1, point1_World);
 
-  double vectorPoint0ToPoint1_World[4] = { 0.0 };
+  double vectorPoint0ToPoint1_World[4] = { 0.0, 0.0, 0.0, 1.0 };
   vtkMath::Subtract(point1_World, point0_World, vectorPoint0ToPoint1_World);
 
   double angle = vtkMath::DegreesFromRadians(vtkMath::AngleBetweenVectors(vectorPoint0ToPoint1_World, handleX_World));
@@ -115,7 +115,7 @@ void vtkMRMLMarkupsLineNode::UpdateInteractionHandleToWorldMatrix()
     return;
   }
 
-  double rotationVector_Local[3] = { 0.0 };
+  double rotationVector_Local[3] = { 1.0, 0.0, 0.0 };
   vtkMath::Cross(handleX_World, vectorPoint0ToPoint1_World, rotationVector_Local);
 
   double origin_World[4] = { 0.0, 0.0, 0.0, 1.0 };

--- a/Libs/MRML/Core/vtkMRMLMarkupsLineNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsLineNode.h
@@ -81,6 +81,7 @@ public:
   //@{
   /// Convenience method to get the line start or end position
   /// (control point indices 0 and 1).
+  /// Returns (0, 0, 0) vector if the point position is not defined.
   vtkVector3d GetLineStartPosition();
   vtkVector3d GetLineEndPosition();
   vtkVector3d GetLineStartPositionWorld();


### PR DESCRIPTION
When start or end point of a markups line was not specified then calling `vtkMRMLMarkupsLineNode::GetLineStartPosition` and `vtkMRMLMarkupsLineNode::GetLineEndPosition` crashed.

fixes #8407
