### PR TITLE
ENH: Update CTK to add components to ctkVTKVolumePropertyWidget

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "c68d1c9fa4f3aa611d1f95f4d19f35ba9f79e08b"
+    "9c9c1495dd5f1a83236fe0e43636558d66f192b4"
     QUIET
     )
 


### PR DESCRIPTION
The current component in ctkVTKVolumePropertyWidget can now be changed, allowing transfer functions for components besides the first one to be visualized/changed.

$ git shortlog c68d1c9fa..9c9c1495d --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Fix CI removing use of deprecated "ubuntu-20-04" runner

Kyle Sunderland (1):
      ENH: Add option to set current component in ctkVTKVolumePropertyWidget