### PR TITLE
ENH: Set color picker to use basic colors tab by default

### DIFF
--- a/Modules/Loadable/Colors/qSlicerColorsModule.cxx
+++ b/Modules/Loadable/Colors/qSlicerColorsModule.cxx
@@ -132,7 +132,6 @@ void qSlicerColorsModule::setup()
   ctkColorDialog::addDefaultTab(d->ColorDialogPickerWidget.data(),
                                 "Labels", SIGNAL(colorSelected(QColor)),
                                 SIGNAL(colorNameSelected(QString)));
-  ctkColorDialog::setDefaultTab(1);
 
   // Register Subject Hierarchy core plugins
   qSlicerSubjectHierarchyColorLegendPlugin* colorLegendPlugin = new qSlicerSubjectHierarchyColorLegendPlugin();


### PR DESCRIPTION
With application setting "Subject Hierarchy->Use standard terminology" set to Off, then double-clicking on color in the Markups table produces the following result:

| `main` | This PR |
|--------|----------|
|![image](https://github.com/user-attachments/assets/72744b8e-460e-41d9-8e8f-5991fb7471f3)|![image](https://github.com/user-attachments/assets/08ba3b11-4966-46cc-979c-ae598de7c6b5)|

I have set the tab to remain the first tab which is the basic colors. This is because when not using standard terminology there is not a need for the "Labels" tab to be used where "GenericAnatomyColors" is essentially picking terminologies again. The "Labels" color picker functionality is a little weird in this dialog as do users really care to pick a specific color from a color table node? I would assume they would likely just be picking a basic color or pick from one of their saved custom colors. 