### PR TITLE
BUG: Fix editing color list in picker widget

### DIFF
--- a/Modules/Loadable/Colors/Widgets/qMRMLColorPickerWidget.cxx
+++ b/Modules/Loadable/Colors/Widgets/qMRMLColorPickerWidget.cxx
@@ -77,6 +77,7 @@ void qMRMLColorPickerWidgetPrivate::init()
                    q, SIGNAL(colorSelected(QColor)));
   QObject::connect(this->MRMLColorListView, SIGNAL(colorSelected(QString)),
                    q, SIGNAL(colorNameSelected(QString)));
+  this->MRMLColorListView->setDragDropMode(QAbstractItemView::NoDragDrop);
 
   // SearchBox
   this->SearchBox->setPlaceholderText("Search color...");


### PR DESCRIPTION
A color could be drag-and-drop to insert a new copy of the color in the color list view which wouldn't actually update the color table node. See video below:

https://github.com/user-attachments/assets/be74e3b6-50af-46b6-bf08-5a0e33c6f0e5


```python
picker_widget = slicer.qMRMLColorPickerWidget()
picker_widget.setMRMLScene(slicer.mrmlScene)
picker_widget.show()
```

This PR sets the qMRMLColorPickerWidget to set its Color List View to have no DragDrop so that the color table is not attempted to be updated in the color picker widget.