### PR TITLE
Improvements to default node usage across different node creation methods

### DIFF
--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -92,6 +92,8 @@ vtkMRMLNode* vtkMRMLCommandLineModuleNode::CreateNodeInstance()
 //----------------------------------------------------------------------------
 vtkMRMLCommandLineModuleNode::vtkMRMLCommandLineModuleNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLCommandLineModuleNode", "Command Line Module");
+
   this->Internal = new vtkInternal();
   this->HideFromEditors = true;
   this->Internal->Status = vtkMRMLCommandLineModuleNode::Idle;

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
@@ -45,10 +45,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "CommandLineModule"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  virtual std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLCommandLineModuleNode", "Command Line Module"); };
-
   /// List of events that can be fired on or by the node.
   enum CLINodeEvent
   {

--- a/Libs/MRML/Core/vtkMRMLBSplineTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLBSplineTransformNode.cxx
@@ -25,6 +25,8 @@ vtkMRMLNodeNewMacro(vtkMRMLBSplineTransformNode);
 //----------------------------------------------------------------------------
 vtkMRMLBSplineTransformNode::vtkMRMLBSplineTransformNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLBSplineTransformNode", "B-Spline Transform");
+
   // Set up the node with a dummy bspline grid (that contains a small set of
   // null-vectors) to make sure the node is valid and can be saved
   double gridSize[3] = { 4, 4, 4 };

--- a/Libs/MRML/Core/vtkMRMLBSplineTransformNode.h
+++ b/Libs/MRML/Core/vtkMRMLBSplineTransformNode.h
@@ -49,10 +49,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "BSplineTransform"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLBSplineTransformNode", "B-Spline Transform"); };
-
   ///
   /// Create default storage node or nullptr if does not have one
   vtkMRMLStorageNode* CreateDefaultStorageNode() override { return Superclass::CreateDefaultStorageNode(); };

--- a/Libs/MRML/Core/vtkMRMLCameraNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLCameraNode.cxx
@@ -40,6 +40,8 @@ vtkMRMLNodeNewMacro(vtkMRMLCameraNode);
 //----------------------------------------------------------------------------
 vtkMRMLCameraNode::vtkMRMLCameraNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLCameraNode", "Camera");
+
   this->HideFromEditors = 0;
 
   vtkNew<vtkCamera> camera;

--- a/Libs/MRML/Core/vtkMRMLCameraNode.h
+++ b/Libs/MRML/Core/vtkMRMLCameraNode.h
@@ -59,10 +59,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "Camera"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLCameraNode", "Camera"); };
-
   ///
   /// Deprecated. Use SetLayoutName instead.
   /// Set the camera active tag, i.e. the tag for which object (view) this

--- a/Libs/MRML/Core/vtkMRMLClipModelsNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLClipModelsNode.cxx
@@ -27,6 +27,8 @@ vtkMRMLClipModelsNode::~vtkMRMLClipModelsNode() = default;
 //----------------------------------------------------------------------------
 void vtkMRMLClipModelsNode::ReadXMLAttributes(const char** atts)
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLClipModelsNode", "Clip Models");
+
   MRMLNodeModifyBlocker blocker(this);
 
   Superclass::ReadXMLAttributes(atts);

--- a/Libs/MRML/Core/vtkMRMLClipModelsNode.h
+++ b/Libs/MRML/Core/vtkMRMLClipModelsNode.h
@@ -49,10 +49,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "ClipModels"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLClipModelsNode", "Clip Models"); };
-
 protected:
   vtkMRMLClipModelsNode();
   ~vtkMRMLClipModelsNode() override;

--- a/Libs/MRML/Core/vtkMRMLClipNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLClipNode.cxx
@@ -49,6 +49,8 @@ vtkMRMLNodeNewMacro(vtkMRMLClipNode);
 //----------------------------------------------------------------------------
 vtkMRMLClipNode::vtkMRMLClipNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLClipNode", "Clip");
+
   this->HideFromEditors = true;
   this->ClippingMethod = vtkMRMLClipNode::Straight;
 

--- a/Libs/MRML/Core/vtkMRMLClipNode.h
+++ b/Libs/MRML/Core/vtkMRMLClipNode.h
@@ -72,10 +72,6 @@ public:
     ClipNodeModifiedEvent = 53001
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLClipNode", "Clip"); };
-
   enum ClipTypeType
   {
     ClipIntersection = 0,

--- a/Libs/MRML/Core/vtkMRMLColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorNode.cxx
@@ -32,6 +32,8 @@ Version:   $Revision: 1.0 $
 //----------------------------------------------------------------------------
 vtkMRMLColorNode::vtkMRMLColorNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLColorNode", "Color");
+
   this->Type = -1;
   this->HideFromEditors = 1;
 }

--- a/Libs/MRML/Core/vtkMRMLColorNode.h
+++ b/Libs/MRML/Core/vtkMRMLColorNode.h
@@ -64,10 +64,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "Color"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLColorNode", "Color"); };
-
   /// Reset node attributes to the initial state as defined in the constructor.
   /// NOTE:   it preserves values several dynamic attributes that may be set by an application: type, name
   void Reset(vtkMRMLNode* defaultNode) override;

--- a/Libs/MRML/Core/vtkMRMLColorTableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableNode.cxx
@@ -33,6 +33,8 @@ vtkMRMLNodeNewMacro(vtkMRMLColorTableNode);
 //----------------------------------------------------------------------------
 vtkMRMLColorTableNode::vtkMRMLColorTableNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLColorTableNode", "Color Table");
+
   this->SetName("");
   this->SetDescription("Color Table");
   this->LookupTable = nullptr;

--- a/Libs/MRML/Core/vtkMRMLColorTableNode.h
+++ b/Libs/MRML/Core/vtkMRMLColorTableNode.h
@@ -181,10 +181,6 @@ public:
     CoolTint3 = 38
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLColorTableNode", "Color Table"); };
-
   ///
   /// Return the lowest and highest integers, for use in looping
   int GetFirstType() override { return this->FullRainbow; };

--- a/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
@@ -44,6 +44,8 @@ vtkMRMLNodeNewMacro(vtkMRMLColorTableStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLColorTableStorageNode::vtkMRMLColorTableStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLColorTableStorageNode", "Color Table Storage");
+
   // When a color table file contains very large numbers then most likely
   // it is not a valid file (probably it is some other text file and not
   // a color table). The highest acceptable color ID is specified in MaximumColorID.

--- a/Libs/MRML/Core/vtkMRMLColorTableStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLColorTableStorageNode.h
@@ -35,10 +35,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   const char* GetNodeTagName() override { return "ColorTableStorage"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLColorTableStorageNode", "Color Table Storage"); };
-
   /// Return true if the node can be read in
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
 

--- a/Libs/MRML/Core/vtkMRMLCrosshairNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLCrosshairNode.cxx
@@ -28,6 +28,8 @@ vtkMRMLNodeNewMacro(vtkMRMLCrosshairNode);
 //----------------------------------------------------------------------------
 vtkMRMLCrosshairNode::vtkMRMLCrosshairNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLCrosshairNode", "Crosshair");
+
   this->HideFromEditors = 1;
   this->SetSingletonTag("default");
 }

--- a/Libs/MRML/Core/vtkMRMLCrosshairNode.h
+++ b/Libs/MRML/Core/vtkMRMLCrosshairNode.h
@@ -54,10 +54,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "Crosshair"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLCrosshairNode", "Crosshair"); };
-
   ///@{
   /// Configure crosshair appearance.
   vtkGetMacro(CrosshairMode, int);

--- a/Libs/MRML/Core/vtkMRMLDiffusionImageVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionImageVolumeNode.cxx
@@ -28,6 +28,8 @@ vtkMRMLNodeNewMacro(vtkMRMLDiffusionImageVolumeNode);
 //----------------------------------------------------------------------------
 vtkMRMLDiffusionImageVolumeNode::vtkMRMLDiffusionImageVolumeNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLDiffusionImageVolumeNode", "Diffusion Image Volume");
+
   this->BaselineNodeID = nullptr;
   this->MaskNodeID = nullptr;
   this->DiffusionWeightedNodeID = nullptr;

--- a/Libs/MRML/Core/vtkMRMLDiffusionImageVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLDiffusionImageVolumeNode.h
@@ -52,10 +52,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "DiffusionImageVolume"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLDiffusionImageVolumeNode", "Diffusion Image Volume"); };
-
   /// Description:
   /// String ID of the storage MRML node
   void SetBaselineNodeID(const char* id);

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorDisplayPropertiesNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorDisplayPropertiesNode.cxx
@@ -31,6 +31,7 @@ vtkMRMLNodeNewMacro(vtkMRMLDiffusionTensorDisplayPropertiesNode);
 //----------------------------------------------------------------------------
 vtkMRMLDiffusionTensorDisplayPropertiesNode::vtkMRMLDiffusionTensorDisplayPropertiesNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLDiffusionTensorDisplayPropertiesNode", "Diffusion Tensor Display Properties");
 
   // Default display is FA (often used) and line glyphs (quickest to render)
   this->ScalarInvariant = this->FractionalAnisotropy;

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorDisplayPropertiesNode.h
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorDisplayPropertiesNode.h
@@ -95,10 +95,6 @@ public:
     ColorOrientationMinEigenvector = 25
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLDiffusionTensorDisplayPropertiesNode", "Diffusion Tensor Display Properties"); };
-
   static bool ScalarInvariantHasKnownScalarRange(int ScalarInvariant);
   static void ScalarInvariantKnownScalarRange(int ScalarInvariant, double range[2]);
 

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.cxx
@@ -45,6 +45,8 @@ vtkMRMLNodeNewMacro(vtkMRMLDiffusionTensorVolumeDisplayNode);
 //----------------------------------------------------------------------------
 vtkMRMLDiffusionTensorVolumeDisplayNode::vtkMRMLDiffusionTensorVolumeDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLDiffusionTensorVolumeDisplayNode", "Diffusion Tensor Volume Display");
+
   this->ScalarInvariant = vtkMRMLDiffusionTensorDisplayPropertiesNode::ColorOrientation;
   this->DTIMathematics = vtkDiffusionTensorMathematics::New();
   this->DTIMathematicsAlpha = vtkDiffusionTensorMathematics::New();

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.h
@@ -104,10 +104,6 @@ public:
   /// Set scalar invariant to trace (sum of eigenvalues).
   void SetScalarInvariantToTrace() { this->SetScalarInvariant(vtkMRMLDiffusionTensorDisplayPropertiesNode::Trace); };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLDiffusionTensorVolumeDisplayNode", "Diffusion Tensor Volume Display"); };
-
   // Description:
   /// Set scalar invariant to relative anisotropy
   void SetScalarInvariantToRelativeAnisotropy() { this->SetScalarInvariant(vtkMRMLDiffusionTensorDisplayPropertiesNode::RelativeAnisotropy); };

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeNode.cxx
@@ -28,6 +28,8 @@ vtkMRMLNodeNewMacro(vtkMRMLDiffusionTensorVolumeNode);
 //----------------------------------------------------------------------------
 vtkMRMLDiffusionTensorVolumeNode::vtkMRMLDiffusionTensorVolumeNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLDiffusionTensorVolumeNode", "Diffusion Tensor Volume");
+
   this->Order = 2; // Second order Tensor
 }
 

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeNode.h
@@ -40,10 +40,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "DiffusionTensorVolume"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLDiffusionTensorVolumeNode", "Diffusion Tensor Volume"); };
-
   /// Copy node content (excludes basic data, such as name and node references).
   /// \sa vtkMRMLNode::CopyContent
   vtkMRMLCopyContentDefaultMacro(vtkMRMLDiffusionTensorVolumeNode);

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeSliceDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeSliceDisplayNode.cxx
@@ -34,6 +34,7 @@ vtkMRMLNodeNewMacro(vtkMRMLDiffusionTensorVolumeSliceDisplayNode);
 vtkMRMLDiffusionTensorVolumeSliceDisplayNode::vtkMRMLDiffusionTensorVolumeSliceDisplayNode()
   : vtkMRMLGlyphableVolumeSliceDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLDiffusionTensorVolumeSliceDisplayNode", "Diffusion Tensor Volume Slice Display Node");
 
   // Enumerated
   this->DiffusionTensorDisplayPropertiesNode = nullptr;

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeSliceDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeSliceDisplayNode.h
@@ -112,10 +112,6 @@ public:
     colorModeUseCellScalars = 3
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLDiffusionTensorVolumeSliceDisplayNode", "Diffusion Tensor Volume Slice Display Node"); };
-
   //--------------------------------------------------------------------------
   /// Display Information: ColorMode for ALL nodes
   //--------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeDisplayNode.cxx
@@ -33,6 +33,8 @@ vtkMRMLNodeNewMacro(vtkMRMLDiffusionWeightedVolumeDisplayNode);
 //----------------------------------------------------------------------------
 vtkMRMLDiffusionWeightedVolumeDisplayNode::vtkMRMLDiffusionWeightedVolumeDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLDiffusionWeightedVolumeDisplayNode", "Diffusion Weighted Volume Display");
+
   this->DiffusionComponent = 0;
   this->ExtractComponent = vtkImageExtractComponents::New();
   this->Threshold->SetInputConnection(this->ExtractComponent->GetOutputPort());

--- a/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeDisplayNode.h
@@ -57,10 +57,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "DiffusionWeightedVolumeDisplay"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLDiffusionWeightedVolumeDisplayNode", "Diffusion Weighted Volume Display"); };
-
   ///
   /// Get the pipeline input
   vtkAlgorithmOutput* GetInputImageDataConnection() override;

--- a/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeNode.cxx
@@ -33,6 +33,8 @@ vtkMRMLDiffusionWeightedVolumeNode::vtkMRMLDiffusionWeightedVolumeNode()
   : DiffusionGradients(vtkDoubleArray::New())
   , BValues(vtkDoubleArray::New())
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLDiffusionWeightedVolumeNode", "Diffusion Weighted Volume");
+
   this->DiffusionGradients->SetNumberOfComponents(3);
   this->SetNumberOfGradientsInternal(7); // 6 gradients + 1 baseline
 

--- a/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeNode.h
@@ -56,10 +56,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "DiffusionWeightedVolume"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLDiffusionWeightedVolumeNode", "Diffusion Weighted Volume"); };
-
   ///
   void SetNumberOfGradients(int val);
   int GetNumberOfGradients();

--- a/Libs/MRML/Core/vtkMRMLDisplayableHierarchyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDisplayableHierarchyNode.cxx
@@ -32,6 +32,8 @@ vtkMRMLNodeNewMacro(vtkMRMLDisplayableHierarchyNode);
 //----------------------------------------------------------------------------
 vtkMRMLDisplayableHierarchyNode::vtkMRMLDisplayableHierarchyNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLDisplayableHierarchyNode", "Displayable Hierarchy");
+
   this->DisplayNodeID = nullptr;
   this->DisplayNode = nullptr;
   this->HideFromEditors = 1;

--- a/Libs/MRML/Core/vtkMRMLDisplayableHierarchyNode.h
+++ b/Libs/MRML/Core/vtkMRMLDisplayableHierarchyNode.h
@@ -118,10 +118,6 @@ public:
     DisplayModifiedEvent = 17000
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLDisplayableHierarchyNode", "Displayable Hierarchy"); };
-
 protected:
   vtkMRMLDisplayableHierarchyNode();
   ~vtkMRMLDisplayableHierarchyNode() override;

--- a/Libs/MRML/Core/vtkMRMLFolderDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLFolderDisplayNode.cxx
@@ -30,7 +30,10 @@
 vtkMRMLNodeNewMacro(vtkMRMLFolderDisplayNode);
 
 //-----------------------------------------------------------------------------
-vtkMRMLFolderDisplayNode::vtkMRMLFolderDisplayNode() = default;
+vtkMRMLFolderDisplayNode::vtkMRMLFolderDisplayNode()
+{
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLFolderDisplayNode", "Folder Display");
+}
 
 //-----------------------------------------------------------------------------
 vtkMRMLFolderDisplayNode::~vtkMRMLFolderDisplayNode() = default;

--- a/Libs/MRML/Core/vtkMRMLFolderDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLFolderDisplayNode.h
@@ -120,10 +120,6 @@ private:
   /// displayable nodes in the subject hierarchy branch under the item that
   /// has the display node associated.
   bool ApplyDisplayPropertiesOnBranch{ false };
-
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLFolderDisplayNode", "Folder Display"); };
 };
 
 #endif

--- a/Libs/MRML/Core/vtkMRMLGlyphableVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLGlyphableVolumeDisplayNode.cxx
@@ -34,6 +34,8 @@ vtkMRMLNodeNewMacro(vtkMRMLGlyphableVolumeDisplayNode);
 //----------------------------------------------------------------------------
 vtkMRMLGlyphableVolumeDisplayNode::vtkMRMLGlyphableVolumeDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLGlyphableVolumeDisplayNode", "Glyphable Volume Display");
+
   // Strings
 
   this->GlyphColorNodeID = nullptr;

--- a/Libs/MRML/Core/vtkMRMLGlyphableVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLGlyphableVolumeDisplayNode.h
@@ -68,10 +68,6 @@ public:
     visModeBoth = 2
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLGlyphableVolumeDisplayNode", "Glyphable Volume Display"); };
-
   vtkGetMacro(VisualizationMode, int);
   vtkSetMacro(VisualizationMode, int);
 

--- a/Libs/MRML/Core/vtkMRMLGlyphableVolumeSliceDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLGlyphableVolumeSliceDisplayNode.cxx
@@ -29,6 +29,8 @@ vtkMRMLNodeNewMacro(vtkMRMLGlyphableVolumeSliceDisplayNode);
 //----------------------------------------------------------------------------
 vtkMRMLGlyphableVolumeSliceDisplayNode::vtkMRMLGlyphableVolumeSliceDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLGlyphableVolumeSliceDisplayNode", "Glyphable Volume Slice Display Node");
+
   this->ColorMode = this->colorModeScalar;
 
   this->SliceImagePort = nullptr;

--- a/Libs/MRML/Core/vtkMRMLGlyphableVolumeSliceDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLGlyphableVolumeSliceDisplayNode.h
@@ -134,10 +134,6 @@ public:
     colorModeUseCellScalars = 3
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLGlyphableVolumeSliceDisplayNode", "Glyphable Volume Slice Display Node"); };
-
   //--------------------------------------------------------------------------
   /// Display Information: ColorMode for ALL nodes
   //--------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLGridTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLGridTransformNode.cxx
@@ -30,6 +30,8 @@ vtkMRMLNodeNewMacro(vtkMRMLGridTransformNode);
 //----------------------------------------------------------------------------
 vtkMRMLGridTransformNode::vtkMRMLGridTransformNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLGridTransformNode", "Grid Transform");
+
   // Set up the node with a dummy displacement field (that contains one single
   // null-vector) to make sure the node is valid and can be saved
   vtkNew<vtkImageData> emptyDisplacementField;

--- a/Libs/MRML/Core/vtkMRMLGridTransformNode.h
+++ b/Libs/MRML/Core/vtkMRMLGridTransformNode.h
@@ -46,10 +46,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "GridTransform"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLGridTransformNode", "Grid Transform"); };
-
 protected:
   vtkMRMLGridTransformNode();
   ~vtkMRMLGridTransformNode() override;

--- a/Libs/MRML/Core/vtkMRMLHierarchyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLHierarchyNode.cxx
@@ -55,6 +55,8 @@ vtkMRMLNodeNewMacro(vtkMRMLHierarchyNode);
 //----------------------------------------------------------------------------
 vtkMRMLHierarchyNode::vtkMRMLHierarchyNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLHierarchyNode", "Hierarchy");
+
   this->HideFromEditors = 0;
 
   this->ParentNodeIDReference = nullptr;

--- a/Libs/MRML/Core/vtkMRMLHierarchyNode.h
+++ b/Libs/MRML/Core/vtkMRMLHierarchyNode.h
@@ -119,10 +119,6 @@ public:
     ChildNodeRemovedEvent = 15551
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLHierarchyNode", "Hierarchy"); };
-
   //// Associated node methods ////////////////
 
   ///

--- a/Libs/MRML/Core/vtkMRMLHierarchyStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLHierarchyStorageNode.cxx
@@ -25,6 +25,8 @@ vtkMRMLNodeNewMacro(vtkMRMLHierarchyStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLHierarchyStorageNode::vtkMRMLHierarchyStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLHierarchyStorageNode", "Hierarchy Storage");
+
   this->DefaultWriteFileExtension = "txt";
 }
 

--- a/Libs/MRML/Core/vtkMRMLHierarchyStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLHierarchyStorageNode.h
@@ -35,10 +35,6 @@ public:
   // Get node XML tag name (like Storage, Model)
   const char* GetNodeTagName() override { return "HierarchyStorage"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLHierarchyStorageNode", "Hierarchy Storage"); };
-
   /// Return true if reference node can be read in
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
 

--- a/Libs/MRML/Core/vtkMRMLInteractionNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLInteractionNode.cxx
@@ -13,6 +13,8 @@ vtkMRMLNodeNewMacro(vtkMRMLInteractionNode);
 //----------------------------------------------------------------------------
 vtkMRMLInteractionNode::vtkMRMLInteractionNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLInteractionNode", "Interaction");
+
   this->HideFromEditors = 1;
 
   this->SetSingletonTag("Singleton");

--- a/Libs/MRML/Core/vtkMRMLInteractionNode.h
+++ b/Libs/MRML/Core/vtkMRMLInteractionNode.h
@@ -54,13 +54,7 @@ public:
     Select = 4,
     AdjustWindowLevel,
     User = 1000
-  };
-
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLInteractionNode", "Interaction"); };
-
-  /// events
+  }; /// events
   enum
   {
     InteractionModeChangedEvent = 19001,

--- a/Libs/MRML/Core/vtkMRMLLabelMapVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLabelMapVolumeDisplayNode.cxx
@@ -33,6 +33,8 @@ vtkMRMLNodeNewMacro(vtkMRMLLabelMapVolumeDisplayNode);
 //----------------------------------------------------------------------------
 vtkMRMLLabelMapVolumeDisplayNode::vtkMRMLLabelMapVolumeDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLLabelMapVolumeDisplayNode", "Label Map Volume Display");
+
   this->MapToColors = vtkImageMapToColors::New();
   this->MapToColors->SetOutputFormatToRGBA();
 

--- a/Libs/MRML/Core/vtkMRMLLabelMapVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLLabelMapVolumeDisplayNode.h
@@ -58,10 +58,6 @@ public:
 
   void UpdateImageDataPipeline() override;
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLLabelMapVolumeDisplayNode", "Label Map Volume Display"); };
-
 protected:
   vtkMRMLLabelMapVolumeDisplayNode();
   ~vtkMRMLLabelMapVolumeDisplayNode() override;

--- a/Libs/MRML/Core/vtkMRMLLabelMapVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLabelMapVolumeNode.cxx
@@ -34,7 +34,10 @@
 vtkMRMLNodeNewMacro(vtkMRMLLabelMapVolumeNode);
 
 //----------------------------------------------------------------------------
-vtkMRMLLabelMapVolumeNode::vtkMRMLLabelMapVolumeNode() = default;
+vtkMRMLLabelMapVolumeNode::vtkMRMLLabelMapVolumeNode()
+{
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLLabelMapVolumeNode", "Label Map Volume");
+}
 
 //----------------------------------------------------------------------------
 vtkMRMLLabelMapVolumeNode::~vtkMRMLLabelMapVolumeNode() = default;

--- a/Libs/MRML/Core/vtkMRMLLabelMapVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLLabelMapVolumeNode.h
@@ -43,13 +43,7 @@ public:
 
   ///
   /// Get node XML tag name (like Volume, Model)
-  const char* GetNodeTagName() override { return "LabelMapVolume"; }
-
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLLabelMapVolumeNode", "Label Map Volume"); };
-
-  ///
+  const char* GetNodeTagName() override { return "LabelMapVolume"; } ///
   /// Make a 'None' volume node with blank image data
   static void CreateNoneNode(vtkMRMLScene* scene);
 

--- a/Libs/MRML/Core/vtkMRMLLayoutNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLayoutNode.cxx
@@ -16,6 +16,8 @@ vtkMRMLNodeNewMacro(vtkMRMLLayoutNode);
 //----------------------------------------------------------------------------
 vtkMRMLLayoutNode::vtkMRMLLayoutNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLLayoutNode", "Layout");
+
   this->GUIPanelVisibility = 1;
   this->BottomPanelVisibility = 1;
   this->GUIPanelLR = 0;

--- a/Libs/MRML/Core/vtkMRMLLayoutNode.h
+++ b/Libs/MRML/Core/vtkMRMLLayoutNode.h
@@ -132,10 +132,6 @@ public:
     SlicerLayoutUserView = 100
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLLayoutNode", "Layout"); };
-
   /// Adds a layout description with integer identifier
   /// "layout". Returns false without making any modifications if the
   /// integer identifier "layout" has already been added.

--- a/Libs/MRML/Core/vtkMRMLLinearTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLinearTransformNode.cxx
@@ -29,6 +29,8 @@ vtkMRMLNodeNewMacro(vtkMRMLLinearTransformNode);
 //----------------------------------------------------------------------------
 vtkMRMLLinearTransformNode::vtkMRMLLinearTransformNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLLinearTransformNode", "Linear Transform");
+
   vtkNew<vtkMatrix4x4> matrix;
   this->SetMatrixTransformToParent(matrix.GetPointer());
 

--- a/Libs/MRML/Core/vtkMRMLLinearTransformNode.h
+++ b/Libs/MRML/Core/vtkMRMLLinearTransformNode.h
@@ -53,10 +53,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "LinearTransform"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLLinearTransformNode", "Linear Transform"); };
-
   ///
   /// Create default storage node or nullptr if does not have one
   vtkMRMLStorageNode* CreateDefaultStorageNode() override { return Superclass::CreateDefaultStorageNode(); };

--- a/Libs/MRML/Core/vtkMRMLLinearTransformSequenceStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLinearTransformSequenceStorageNode.cxx
@@ -44,7 +44,10 @@ static const char NODE_BASE_NAME_SEPARATOR[] = "-";
 vtkMRMLNodeNewMacro(vtkMRMLLinearTransformSequenceStorageNode);
 
 //----------------------------------------------------------------------------
-vtkMRMLLinearTransformSequenceStorageNode::vtkMRMLLinearTransformSequenceStorageNode() = default;
+vtkMRMLLinearTransformSequenceStorageNode::vtkMRMLLinearTransformSequenceStorageNode()
+{
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLLinearTransformSequenceStorageNode", "Linear Transform Sequence Storage");
+}
 
 //----------------------------------------------------------------------------
 vtkMRMLLinearTransformSequenceStorageNode::~vtkMRMLLinearTransformSequenceStorageNode() = default;

--- a/Libs/MRML/Core/vtkMRMLLinearTransformSequenceStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLLinearTransformSequenceStorageNode.h
@@ -39,10 +39,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   const char* GetNodeTagName() override { return "LinearTransformSequenceStorage"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLLinearTransformSequenceStorageNode", "Linear Transform Sequence Storage"); };
-
   /// Return true if the node can be read in.
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsAngleNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsAngleNode.h
@@ -67,10 +67,6 @@ public:
   /// Get markup type internal name
   const char* GetMarkupType() override { return "Angle"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsAngleNode", "Markups Angle"); };
-
   /// Read node attributes from XML file
   void ReadXMLAttributes(const char** atts) override;
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsClosedCurveNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsClosedCurveNode.h
@@ -53,10 +53,6 @@ public:
   /// Get markup type internal name
   const char* GetMarkupType() override { return "ClosedCurve"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsClosedCurveNode", "Markups Closed Curve"); };
-
   /// Copy node content (excludes basic data, such as name and node references).
   /// \sa vtkMRMLNode::CopyContent
   vtkMRMLCopyContentDefaultMacro(vtkMRMLMarkupsClosedCurveNode);

--- a/Libs/MRML/Core/vtkMRMLMarkupsCurveNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsCurveNode.h
@@ -108,10 +108,6 @@ public:
   /// Get markup type internal name
   const char* GetMarkupType() override { return "Curve"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsCurveNode", "Markups Curve"); };
-
   /// Read node attributes from XML file
   void ReadXMLAttributes(const char** atts) override;
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.cxx
@@ -45,6 +45,8 @@ vtkMRMLNodeNewMacro(vtkMRMLMarkupsDisplayNode);
 //----------------------------------------------------------------------------
 vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLMarkupsDisplayNode", "Markups Display");
+
   // Markups display node settings
   this->Visibility = 1;
   this->Visibility2D = 1;

--- a/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.h
@@ -67,10 +67,6 @@ public:
   /// Get node XML tag name (like Volume, Markups)
   const char* GetNodeTagName() override { return "MarkupsDisplay"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsDisplayNode", "Markups Display"); };
-
   /// Finds the storage node and read the data
   void UpdateScene(vtkMRMLScene* scene) override;
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsFiducialDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsFiducialDisplayNode.cxx
@@ -31,6 +31,8 @@ vtkMRMLNodeNewMacro(vtkMRMLMarkupsFiducialDisplayNode);
 //----------------------------------------------------------------------------
 vtkMRMLMarkupsFiducialDisplayNode::vtkMRMLMarkupsFiducialDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLMarkupsFiducialDisplayNode", "Markups Fiducial Display");
+
   // Markups display node settings
   this->PropertiesLabelVisibility = false;
   this->PointLabelsVisibility = true;

--- a/Libs/MRML/Core/vtkMRMLMarkupsFiducialDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsFiducialDisplayNode.h
@@ -45,10 +45,6 @@ public:
   // Get node XML tag name (like Volume, Markups)
   const char* GetNodeTagName() override { return "MarkupsFiducialDisplay"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsFiducialDisplayNode", "Markups Fiducial Display"); };
-
   /// Copy node content (excludes basic data, such as name and node references).
   /// \sa vtkMRMLNode::CopyContent
   vtkMRMLCopyContentDefaultMacro(vtkMRMLMarkupsFiducialDisplayNode);

--- a/Libs/MRML/Core/vtkMRMLMarkupsFiducialNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsFiducialNode.h
@@ -58,10 +58,6 @@ public:
   /// Get markup type internal name
   const char* GetMarkupType() override { return "Fiducial"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsFiducialNode", "Markups Fiducial"); };
-
   /// Read node attributes from XML file
   void ReadXMLAttributes(const char** atts) override;
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -244,6 +244,8 @@ vtkMRMLNodeNewMacro(vtkMRMLMarkupsFiducialStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLMarkupsFiducialStorageNode::vtkMRMLMarkupsFiducialStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLMarkupsFiducialStorageNode", "Markups Fiducial Storage");
+
   this->DefaultWriteFileExtension = "fcsv";
   this->FieldDelimiterCharacters = ",";
 }

--- a/Libs/MRML/Core/vtkMRMLMarkupsFiducialStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsFiducialStorageNode.h
@@ -44,10 +44,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   const char* GetNodeTagName() override { return "MarkupsFiducialStorage"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsFiducialStorageNode", "Markups Fiducial Storage"); };
-
   /// Read node attributes from XML file
   void ReadXMLAttributes(const char** atts) override;
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsLineNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsLineNode.h
@@ -55,10 +55,6 @@ public:
   /// Get markup type internal name
   const char* GetMarkupType() override { return "Line"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsLineNode", "Markups Line"); };
-
   /// Read node attributes from XML file
   void ReadXMLAttributes(const char** atts) override;
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.cxx
@@ -527,16 +527,6 @@ void vtkMRMLMarkupsNode::SetLocked(int locked)
   this->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::LockModifiedEvent);
 }
 
-//----------------------------------------------------------------------------
-std::string vtkMRMLMarkupsNode::GetTypeDisplayName()
-{
-  if (this->TypeDisplayName.empty())
-  {
-    this->TypeDisplayName = vtkMRMLTr("vtkMRMLMarkupsNode", "Markup");
-  }
-  return this->TypeDisplayName;
-}
-
 //---------------------------------------------------------------------------
 vtkMRMLMarkupsDisplayNode* vtkMRMLMarkupsNode::GetMarkupsDisplayNode()
 {

--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.cxx
@@ -60,6 +60,9 @@
 //----------------------------------------------------------------------------
 vtkMRMLMarkupsNode::vtkMRMLMarkupsNode()
 {
+  this->DefaultNodeNamePrefix = vtkMRMLTr("vtkMRMLMarkupsNode", "M");
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLMarkupsNode", "Markup");
+
   this->TextList = vtkSmartPointer<vtkStringArray>::New();
 
   this->CenterOfRotation.Set(0, 0, 0);
@@ -522,17 +525,6 @@ void vtkMRMLMarkupsNode::SetLocked(int locked)
 
   this->Modified();
   this->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::LockModifiedEvent);
-}
-
-//----------------------------------------------------------------------------
-std::string vtkMRMLMarkupsNode::GetDefaultNodeNamePrefix()
-{
-  if (this->DefaultNodeNamePrefix.empty())
-  {
-    //: This is the default node name prefix for markups nodes.
-    return vtkMRMLTr("vtkMRMLMarkupsNode", "M");
-  }
-  return this->DefaultNodeNamePrefix;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.h
@@ -1033,9 +1033,6 @@ protected:
 
   std::string PropertiesLabelText;
 
-  /// Store markup type GUI display name. Translated to the application language.
-  std::string TypeDisplayName;
-
   /// Transform that moves the xyz unit vectors and origin of the interaction handles to local coordinates
   vtkSmartPointer<vtkMatrix4x4> InteractionHandleToWorldMatrix;
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.h
@@ -38,10 +38,6 @@
 # define VTK_PROPEXCLUDE
 #endif
 
-// This can be used for writing code that is backward-compatible with older Slicer versions
-// where vtkMRMLMarkupsNode::GetDefaultNodeNamePrefix() returned const char* (instead of std::string).
-#define DEFAULT_NODE_NAME_PREFIX_IS_STD_STRING 1
-
 class vtkMatrix3x3;
 class vtkMRMLUnitNode;
 
@@ -155,13 +151,6 @@ public:
   /// Get markup type internal name. This type name is the same regardless of the
   /// chosen application language and should not be displayed to end users.
   virtual const char* GetMarkupType() { return "Markup"; };
-
-  /// Get markup short name.
-  /// This may be displayed to the user and therefore it is translated to the application language.
-  std::string GetDefaultNodeNamePrefix() override;
-  /// Get markup type GUI display name
-  /// This may be displayed to the user and therefore it is translated to the application language.
-  std::string GetTypeDisplayName() override;
 
   /// Read node attributes from XML file
   void ReadXMLAttributes(const char** atts) override;
@@ -1046,9 +1035,6 @@ protected:
 
   /// Store markup type GUI display name. Translated to the application language.
   std::string TypeDisplayName;
-
-  /// Store markup short name. Translated to the application language.
-  std::string DefaultNodeNamePrefix;
 
   /// Transform that moves the xyz unit vectors and origin of the interaction handles to local coordinates
   vtkSmartPointer<vtkMatrix4x4> InteractionHandleToWorldMatrix;

--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.h
@@ -158,8 +158,7 @@ public:
 
   /// Get markup short name.
   /// This may be displayed to the user and therefore it is translated to the application language.
-  virtual std::string GetDefaultNodeNamePrefix();
-
+  std::string GetDefaultNodeNamePrefix() override;
   /// Get markup type GUI display name
   /// This may be displayed to the user and therefore it is translated to the application language.
   std::string GetTypeDisplayName() override;

--- a/Libs/MRML/Core/vtkMRMLMarkupsPlaneDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsPlaneDisplayNode.cxx
@@ -27,6 +27,8 @@ vtkMRMLNodeNewMacro(vtkMRMLMarkupsPlaneDisplayNode);
 //----------------------------------------------------------------------------
 vtkMRMLMarkupsPlaneDisplayNode::vtkMRMLMarkupsPlaneDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLMarkupsPlaneDisplayNode", "Markups Plane Display");
+
   this->HandlesInteractive = true;
   this->TranslationHandleVisibility = false;
   this->RotationHandleVisibility = false;

--- a/Libs/MRML/Core/vtkMRMLMarkupsPlaneDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsPlaneDisplayNode.h
@@ -44,10 +44,6 @@ public:
   // Get node XML tag name (like Volume, Markups)
   const char* GetNodeTagName() override { return "MarkupsPlaneDisplay"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsPlaneDisplayNode", "Markups Plane Display"); };
-
   /// Copy node content (excludes basic data, such as name and node references).
   /// \sa vtkMRMLNode::CopyContent
   vtkMRMLCopyContentDefaultMacro(vtkMRMLMarkupsPlaneDisplayNode);

--- a/Libs/MRML/Core/vtkMRMLMarkupsPlaneNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsPlaneNode.h
@@ -91,10 +91,6 @@ public:
   /// Get markup type internal name
   const char* GetMarkupType() override { return "Plane"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsPlaneNode", "Markups Plane"); };
-
   /// Read node attributes from XML file
   void ReadXMLAttributes(const char** atts) override;
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsROIDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsROIDisplayNode.cxx
@@ -27,6 +27,8 @@ vtkMRMLNodeNewMacro(vtkMRMLMarkupsROIDisplayNode);
 //----------------------------------------------------------------------------
 vtkMRMLMarkupsROIDisplayNode::vtkMRMLMarkupsROIDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLMarkupsROIDisplayNode", "Markups ROI Display");
+
   this->FillOpacity = 0.2;
   this->HandlesInteractive = true;
   this->TranslationHandleVisibility = true;

--- a/Libs/MRML/Core/vtkMRMLMarkupsROIDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsROIDisplayNode.h
@@ -43,10 +43,6 @@ public:
   // Get node XML tag name (like Volume, Markups)
   const char* GetNodeTagName() override { return "MarkupsROIDisplay"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsROIDisplayNode", "Markups ROI Display"); };
-
   /// Copy node content (excludes basic data, such as name and node references).
   /// \sa vtkMRMLNode::CopyContent
   vtkMRMLCopyContentDefaultMacro(vtkMRMLMarkupsROIDisplayNode);

--- a/Libs/MRML/Core/vtkMRMLMarkupsROINode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsROINode.h
@@ -77,10 +77,6 @@ public:
   /// Get markup type internal name
   const char* GetMarkupType() override { return "ROI"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsROINode", "Markups ROI"); };
-
   /// Copy node content (excludes basic data, such as name and node references).
   /// \sa vtkMRMLNode::CopyContent
   vtkMRMLCopyContentMacro(vtkMRMLMarkupsROINode);

--- a/Libs/MRML/Core/vtkMRMLModelDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelDisplayNode.cxx
@@ -41,6 +41,8 @@ static const char* SliceDistanceEncodedProjectionColorNodeReferenceRole = "dista
 //-----------------------------------------------------------------------------
 vtkMRMLModelDisplayNode::vtkMRMLModelDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLModelDisplayNode", "Model Display");
+
   this->PassThrough = vtkPassThrough::New();
   this->PassThrough->AllowNullInputOn();
   this->AssignAttribute = vtkAssignAttribute::New();

--- a/Libs/MRML/Core/vtkMRMLModelDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelDisplayNode.h
@@ -233,10 +233,6 @@ protected:
   double BackfaceColorHSVOffset[3];
 
   bool ClippingCapSurface{ false };
-
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLModelDisplayNode", "Model Display"); };
   double ClippingCapOpacity{ 1.0 };
   bool ClippingOutline{ false };
   double ClippingCapColorHSVOffset[3];

--- a/Libs/MRML/Core/vtkMRMLModelHierarchyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelHierarchyNode.cxx
@@ -28,6 +28,8 @@ vtkMRMLNodeNewMacro(vtkMRMLModelHierarchyNode);
 //----------------------------------------------------------------------------
 vtkMRMLModelHierarchyNode::vtkMRMLModelHierarchyNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLModelHierarchyNode", "Model Hierarchy");
+
   this->ModelDisplayNode = nullptr;
   this->HideFromEditors = 0;
 }

--- a/Libs/MRML/Core/vtkMRMLModelHierarchyNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelHierarchyNode.h
@@ -71,10 +71,6 @@ public:
   /// Need this for tcl wrapping to call ReferenceStringMacro methods
   void SetModelNodeIDReference(const char* ref) { this->SetModelNodeID(ref); };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLModelHierarchyNode", "Model Hierarchy"); };
-
   ///
   /// Get associated model MRML node
   vtkMRMLModelNode* GetModelNode();

--- a/Libs/MRML/Core/vtkMRMLModelNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelNode.cxx
@@ -50,6 +50,8 @@ vtkMRMLNodeNewMacro(vtkMRMLModelNode);
 //----------------------------------------------------------------------------
 vtkMRMLModelNode::vtkMRMLModelNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLModelNode", "Model");
+
   this->MeshConnection = nullptr;
   this->DataEventForwarder = nullptr;
 

--- a/Libs/MRML/Core/vtkMRMLModelNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelNode.h
@@ -56,10 +56,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "Model"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLModelNode", "Model"); };
-
   /// Copy node content (excludes basic data, such as name and node references).
   /// \sa vtkMRMLNode::CopyContent
   vtkMRMLCopyContentMacro(vtkMRMLModelNode);

--- a/Libs/MRML/Core/vtkMRMLModelStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelStorageNode.cxx
@@ -95,6 +95,8 @@ vtkMRMLNodeNewMacro(vtkMRMLModelStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLModelStorageNode::vtkMRMLModelStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLModelStorageNode", "Model Storage");
+
   this->DefaultWriteFileExtension = "vtk";
   this->CoordinateSystem = vtkMRMLStorageNode::CoordinateSystemLPS;
 }

--- a/Libs/MRML/Core/vtkMRMLModelStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelStorageNode.h
@@ -36,10 +36,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   const char* GetNodeTagName() override { return "ModelStorage"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLModelStorageNode", "Model Storage"); };
-
   /// Read node attributes from XML file
   void ReadXMLAttributes(const char** atts) override;
 

--- a/Libs/MRML/Core/vtkMRMLNRRDStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNRRDStorageNode.cxx
@@ -41,6 +41,8 @@ vtkMRMLNodeNewMacro(vtkMRMLNRRDStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLNRRDStorageNode::vtkMRMLNRRDStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLNRRDStorageNode", "NRRD Storage");
+
   this->CenterImage = 0;
   this->DefaultWriteFileExtension = "nhdr";
 

--- a/Libs/MRML/Core/vtkMRMLNRRDStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLNRRDStorageNode.h
@@ -69,9 +69,6 @@ public:
   /// Compression parameter corresponding to minimum compression (fast)
   std::string GetCompressionParameterFastest() { return "gzip_fastest"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLNRRDStorageNode", "NRRD Storage"); };
   /// Compression parameter corresponding to normal compression
   std::string GetCompressionParameterNormal() { return "gzip_normal"; };
   /// Compression parameter corresponding to maximum compression (slow)

--- a/Libs/MRML/Core/vtkMRMLNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNode.cxx
@@ -116,6 +116,10 @@ void vtkMRMLNode::Copy(vtkMRMLNode* node)
   {
     vtkMRMLCopyStringMacro(Name);
   }
+  if (!node->DefaultNodeNamePrefix.empty())
+  {
+    vtkMRMLCopyStdStringMacro(DefaultNodeNamePrefix);
+  }
   vtkMRMLCopyBooleanMacro(HideFromEditors);
   vtkMRMLCopyBooleanMacro(AddToScene);
   if (node->GetSingletonTag())
@@ -948,6 +952,22 @@ void vtkMRMLNode::GetAttributeNames(vtkStringArray* attributeNames)
   {
     attributeNames->InsertNextValue(iter->first);
   }
+}
+
+//----------------------------------------------------------------------------
+std::string vtkMRMLNode::GetDefaultNodeNamePrefix()
+{
+  if (vtkMRMLNode::GetDefaultNodeNamePrefix().empty())
+  {
+    return this->GetNodeTagName();
+  }
+  return this->DefaultNodeNamePrefix;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLNode::SetDefaultNodeNamePrefix(const std::string& prefix)
+{
+  this->DefaultNodeNamePrefix = prefix;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNode.cxx
@@ -116,6 +116,10 @@ void vtkMRMLNode::Copy(vtkMRMLNode* node)
   {
     vtkMRMLCopyStringMacro(Name);
   }
+  if (!node->TypeDisplayName.empty())
+  {
+    vtkMRMLCopyStdStringMacro(TypeDisplayName);
+  }
   if (!node->DefaultNodeNamePrefix.empty())
   {
     vtkMRMLCopyStdStringMacro(DefaultNodeNamePrefix);
@@ -957,7 +961,7 @@ void vtkMRMLNode::GetAttributeNames(vtkStringArray* attributeNames)
 //----------------------------------------------------------------------------
 std::string vtkMRMLNode::GetDefaultNodeNamePrefix()
 {
-  if (vtkMRMLNode::GetDefaultNodeNamePrefix().empty())
+  if (this->DefaultNodeNamePrefix.empty())
   {
     return this->GetNodeTagName();
   }
@@ -968,6 +972,22 @@ std::string vtkMRMLNode::GetDefaultNodeNamePrefix()
 void vtkMRMLNode::SetDefaultNodeNamePrefix(const std::string& prefix)
 {
   this->DefaultNodeNamePrefix = prefix;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkMRMLNode::GetTypeDisplayName()
+{
+  if (this->TypeDisplayName.empty())
+  {
+    return this->GetNodeTagName();
+  }
+  return this->TypeDisplayName;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLNode::SetTypeDisplayName(const std::string& name)
+{
+  this->TypeDisplayName = name;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -211,6 +211,10 @@ class vtkCallbackCommand;
    }
 #endif
 
+// This can be used for writing code that is backward-compatible with older Slicer versions
+// where GetDefaultNodeNamePrefix() returned const char* (instead of std::string).
+#define DEFAULT_NODE_NAME_PREFIX_IS_STD_STRING 1
+
 /// \brief Abstract Superclass for all specific types of MRML nodes.
 ///
 /// This node encapsulates the functionality common to all types of MRML nodes.
@@ -386,9 +390,12 @@ public:
 
   /// Get default node name prefix used when generating unique node names.
   ///
-  /// \note Subclasses can override this method to provide a more appropriate prefix for node names.
-  /// By default, this returns the node tag name.
-  virtual const char* GetDefaultNodeNamePrefix() { return this->GetNodeTagName(); }
+  /// \note If DefaultNodeNamePrefix has not been set then GetDefaultNodeNamePrefix will return the node tag name.
+  virtual std::string GetDefaultNodeNamePrefix();
+
+
+  /// Set default node name prefix used when generating unique node names.
+  virtual void SetDefaultNodeNamePrefix(const std::string& prefix);
 
   /// \brief Set a name value pair attribute.
   ///
@@ -1116,6 +1123,7 @@ protected:
   char* ID{ nullptr };
   char* Name{ nullptr };
   char* Description{ nullptr };
+  std::string DefaultNodeNamePrefix;
   int HideFromEditors{ 0 };
   int Selectable{ 1 };
   int Selected{ 0 };

--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -384,6 +384,12 @@ public:
   /// \note Subclasses should override this method to provide a more appropriate and translatable name.
   virtual std::string GetTypeDisplayName() { return this->GetNodeTagName(); }
 
+  /// Get default node name prefix used when generating unique node names.
+  ///
+  /// \note Subclasses can override this method to provide a more appropriate prefix for node names.
+  /// By default, this returns the node tag name.
+  virtual const char* GetDefaultNodeNamePrefix() { return this->GetNodeTagName(); }
+
   /// \brief Set a name value pair attribute.
   ///
   /// Fires a vtkCommand::ModifiedEvent.

--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -383,18 +383,28 @@ public:
   /// \note Subclasses should implement this method.
   virtual const char* GetNodeTagName() = 0;
 
-  /// Get node type display name (like "Closed Curve", "Markup", etc).
+  /// Get node type display name (like "Closed Curve", "Markup", etc) that may be displayed to the user.
   ///
-  /// \note Subclasses should override this method to provide a more appropriate and translatable name.
-  virtual std::string GetTypeDisplayName() { return this->GetNodeTagName(); }
+  /// \note If TypeDisplayName has not been set then GetTypeDisplayName will return the node tag name.
+  virtual std::string GetTypeDisplayName();
+
+  /// Set node type display name (that may be displayed to the user)
+  ///
+  /// The value is included in copy operations (so it can be used in default nodes),
+  /// but not saved into the scene (as the name should follow the current application language
+  /// and not the language that was used when the scene was saved).
+  virtual void SetTypeDisplayName(const std::string& name);
 
   /// Get default node name prefix used when generating unique node names.
   ///
   /// \note If DefaultNodeNamePrefix has not been set then GetDefaultNodeNamePrefix will return the node tag name.
   virtual std::string GetDefaultNodeNamePrefix();
 
-
   /// Set default node name prefix used when generating unique node names.
+  ///
+  /// The value is included in copy operations (so it can be used in default nodes),
+  /// but not saved into the scene (as the prefix should follow the current application language
+  /// and not the language that was used when the scene was saved).
   virtual void SetDefaultNodeNamePrefix(const std::string& prefix);
 
   /// \brief Set a name value pair attribute.
@@ -1123,12 +1133,14 @@ protected:
   char* ID{ nullptr };
   char* Name{ nullptr };
   char* Description{ nullptr };
-  std::string DefaultNodeNamePrefix;
   int HideFromEditors{ 0 };
   int Selectable{ 1 };
   int Selected{ 0 };
   int AddToScene{ 1 };
   bool UndoEnabled{ false };
+
+  std::string TypeDisplayName;
+  std::string DefaultNodeNamePrefix;
 
   int SaveWithScene{ true };
 

--- a/Libs/MRML/Core/vtkMRMLPETProceduralColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLPETProceduralColorNode.cxx
@@ -11,6 +11,7 @@ vtkMRMLNodeNewMacro(vtkMRMLPETProceduralColorNode);
 //----------------------------------------------------------------------------
 vtkMRMLPETProceduralColorNode::vtkMRMLPETProceduralColorNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLPETProceduralColorNode", "PET Procedural Color");
 
   // all this is done in the superclass...
   // this->Name = nullptr;

--- a/Libs/MRML/Core/vtkMRMLPETProceduralColorNode.h
+++ b/Libs/MRML/Core/vtkMRMLPETProceduralColorNode.h
@@ -49,10 +49,6 @@ public:
   ///
   //};
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLPETProceduralColorNode", "PET Procedural Color"); };
-
   /// DisplayModifiedEvent is generated when display node parameters is changed
   enum
   {

--- a/Libs/MRML/Core/vtkMRMLPlotChartNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLPlotChartNode.cxx
@@ -47,6 +47,8 @@ vtkMRMLNodeNewMacro(vtkMRMLPlotChartNode);
 //----------------------------------------------------------------------------
 vtkMRMLPlotChartNode::vtkMRMLPlotChartNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLPlotChartNode", "Plot Chart");
+
   this->HideFromEditors = 0;
 
   this->SetFontType("Arial");

--- a/Libs/MRML/Core/vtkMRMLPlotChartNode.h
+++ b/Libs/MRML/Core/vtkMRMLPlotChartNode.h
@@ -60,10 +60,6 @@ public:
   /// Get node XML tag name (like Volume, Model).
   const char* GetNodeTagName() override { return "PlotChart"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLPlotChartNode", "Plot Chart"); };
-
   ///
   /// Method to propagate events generated in mrml.
   void ProcessMRMLEvents(vtkObject* caller, unsigned long event, void* callData) override;

--- a/Libs/MRML/Core/vtkMRMLPlotSeriesNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLPlotSeriesNode.cxx
@@ -56,6 +56,8 @@ vtkMRMLNodeNewMacro(vtkMRMLPlotSeriesNode);
 //----------------------------------------------------------------------------
 vtkMRMLPlotSeriesNode::vtkMRMLPlotSeriesNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLPlotSeriesNode", "Plot Series");
+
   this->HideFromEditors = 0;
   this->Color[0] = 0.0;
   this->Color[1] = 0.0;

--- a/Libs/MRML/Core/vtkMRMLPlotSeriesNode.h
+++ b/Libs/MRML/Core/vtkMRMLPlotSeriesNode.h
@@ -99,10 +99,6 @@ public:
   /// Get node XML tag name (like Volume, Model).
   const char* GetNodeTagName() override { return "PlotSeries"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLPlotSeriesNode", "Plot Series"); };
-
   ///
   /// Set and observe Table node ID.
   /// \sa TableNodeID, GetTableNodeID(), SetInputData()

--- a/Libs/MRML/Core/vtkMRMLPlotViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLPlotViewNode.cxx
@@ -45,6 +45,8 @@ vtkMRMLNodeNewMacro(vtkMRMLPlotViewNode);
 //----------------------------------------------------------------------------
 vtkMRMLPlotViewNode::vtkMRMLPlotViewNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLPlotViewNode", "Plot View");
+
   vtkNew<vtkIntArray> events;
   events->InsertNextValue(vtkCommand::ModifiedEvent);
   events->InsertNextValue(vtkMRMLPlotViewNode::PlotChartNodeChangedEvent);

--- a/Libs/MRML/Core/vtkMRMLPlotViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLPlotViewNode.h
@@ -66,10 +66,6 @@ public:
   /// Get node XML tag name (like Volume, Model).
   const char* GetNodeTagName() override { return "PlotView"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLPlotViewNode", "Plot View"); };
-
   ///
   /// Set and Update the PlotChart node id displayed in this PlotView.
   virtual void SetPlotChartNodeID(const char* PlotChartNodeID);

--- a/Libs/MRML/Core/vtkMRMLProceduralColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLProceduralColorNode.cxx
@@ -32,6 +32,8 @@ vtkMRMLNodeNewMacro(vtkMRMLProceduralColorNode);
 //----------------------------------------------------------------------------
 vtkMRMLProceduralColorNode::vtkMRMLProceduralColorNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLProceduralColorNode", "Procedural Color");
+
   this->ColorTransferFunction = nullptr;
   vtkNew<vtkColorTransferFunction> ctf;
   this->SetAndObserveColorTransferFunction(ctf);

--- a/Libs/MRML/Core/vtkMRMLProceduralColorNode.h
+++ b/Libs/MRML/Core/vtkMRMLProceduralColorNode.h
@@ -53,10 +53,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "ProceduralColor"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLProceduralColorNode", "Procedural Color"); };
-
   ///
   ///
   void UpdateScene(vtkMRMLScene* scene) override;

--- a/Libs/MRML/Core/vtkMRMLProceduralColorStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLProceduralColorStorageNode.cxx
@@ -32,6 +32,8 @@ vtkMRMLNodeNewMacro(vtkMRMLProceduralColorStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLProceduralColorStorageNode::vtkMRMLProceduralColorStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLProceduralColorStorageNode", "Procedural Color Storage");
+
   this->DefaultWriteFileExtension = "txt";
 }
 

--- a/Libs/MRML/Core/vtkMRMLProceduralColorStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLProceduralColorStorageNode.h
@@ -34,10 +34,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   const char* GetNodeTagName() override { return "ProceduralColorStorage"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLProceduralColorStorageNode", "Procedural Color Storage"); };
-
   /// Return true if the node can be read in
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
 

--- a/Libs/MRML/Core/vtkMRMLROIListNode.h
+++ b/Libs/MRML/Core/vtkMRMLROIListNode.h
@@ -104,10 +104,6 @@ public:
     ROIModifiedEvent = 21002
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLROIListNode", "ROI List"); };
-
   ///
   /// Get/Set for list visibility
   void SetVisibility(int visible);

--- a/Libs/MRML/Core/vtkMRMLROINode.h
+++ b/Libs/MRML/Core/vtkMRMLROINode.h
@@ -39,10 +39,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "MRMLROINode"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLROINode", "MRMLROI Node"); };
-
   ///
   ///
   void UpdateScene(vtkMRMLScene* scene) override;

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
@@ -47,6 +47,8 @@ vtkMRMLNodeNewMacro(vtkMRMLScalarVolumeDisplayNode);
 //----------------------------------------------------------------------------
 vtkMRMLScalarVolumeDisplayNode::vtkMRMLScalarVolumeDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLScalarVolumeDisplayNode", "Volume Display");
+
   // Strings
   this->Interpolate = 1;
   this->AutoWindowLevel = 1;

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
@@ -76,9 +76,6 @@ public:
     return false;
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLScalarVolumeDisplayNode", "Volume Display"); };
   /// \deprecated
   virtual void SetWindowLevelLocked(bool)
   {

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
@@ -34,6 +34,8 @@ vtkCxxSetObjectMacro(vtkMRMLScalarVolumeNode, VoxelValueUnits, vtkCodedEntry);
 //----------------------------------------------------------------------------
 vtkMRMLScalarVolumeNode::vtkMRMLScalarVolumeNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLScalarVolumeNode", "Volume");
+
   this->DefaultSequenceStorageNodeClassName = "vtkMRMLVolumeSequenceStorageNode";
 }
 

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
@@ -92,9 +92,6 @@ protected:
 
   vtkCodedEntry* VoxelValueQuantity{ nullptr };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLScalarVolumeNode", "Volume"); };
   vtkCodedEntry* VoxelValueUnits{ nullptr };
 };
 

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -2623,7 +2623,7 @@ std::string vtkMRMLScene::GenerateUniqueName(vtkMRMLNode* node)
     vtkErrorMacro("vtkMRMLScene::GenerateUniqueName: input node is invalid");
     return "";
   }
-  return this->GenerateUniqueName(node->GetNodeTagName());
+  return this->GenerateUniqueName(node->GetDefaultNodeNamePrefix());
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
@@ -39,6 +39,8 @@ vtkMRMLNodeNewMacro(vtkMRMLSceneViewNode);
 //----------------------------------------------------------------------------
 vtkMRMLSceneViewNode::vtkMRMLSceneViewNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLSceneViewNode", "Scene View");
+
   this->HideFromEditors = 0;
 
   this->SnapshotScene = nullptr;

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.h
@@ -56,10 +56,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "SceneView"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLSceneViewNode", "Scene View"); };
-
   ///
   /// Updates scene nodes
   void UpdateScene(vtkMRMLScene* scene) override;

--- a/Libs/MRML/Core/vtkMRMLSceneViewStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewStorageNode.cxx
@@ -43,6 +43,8 @@ vtkMRMLNodeNewMacro(vtkMRMLSceneViewStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLSceneViewStorageNode::vtkMRMLSceneViewStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLSceneViewStorageNode", "Scene View Storage");
+
   this->DefaultWriteFileExtension = "png";
 }
 

--- a/Libs/MRML/Core/vtkMRMLSceneViewStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLSceneViewStorageNode.h
@@ -33,10 +33,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   const char* GetNodeTagName() override { return "SceneViewStorage"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLSceneViewStorageNode", "Scene View Storage"); };
-
   /// Initialize all the supported read file types
   void InitializeSupportedReadFileTypes() override;
 

--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
@@ -60,6 +60,8 @@ vtkMRMLNodeNewMacro(vtkMRMLSegmentationDisplayNode);
 //----------------------------------------------------------------------------
 vtkMRMLSegmentationDisplayNode::vtkMRMLSegmentationDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLSegmentationDisplayNode", "Segmentation Display");
+
   this->SetBackfaceCulling(0); // segment models are not necessarily closed surfaces (e.g., ribbon models)
   this->Visibility2D = 1;      // show slice intersections by default
 

--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.h
@@ -352,10 +352,6 @@ protected:
   /// if exists. If does not exist, then source representation is displayed.
   char* PreferredDisplayRepresentationName2D{ nullptr };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLSegmentationDisplayNode", "Segmentation Display"); };
-
   /// Name of representation that is displayed as poly data in the 3D view.
   /// If does not exist, then source representation is displayed if poly data,
   /// otherwise the first poly data representation if any.

--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
@@ -66,6 +66,8 @@ vtkMRMLNodeNewMacro(vtkMRMLSegmentationNode);
 //----------------------------------------------------------------------------
 vtkMRMLSegmentationNode::vtkMRMLSegmentationNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLSegmentationNode", "Segmentation");
+
   this->SegmentationModifiedCallbackCommand = vtkSmartPointer<vtkCallbackCommand>::New();
   this->SegmentationModifiedCallbackCommand->SetClientData(reinterpret_cast<void*>(this));
   this->SegmentationModifiedCallbackCommand->SetCallback(vtkMRMLSegmentationNode::SegmentationModifiedCallback);

--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.h
@@ -75,10 +75,6 @@ public:
   /// Get unique node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "Segmentation"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLSegmentationNode", "Segmentation"); };
-
   /// Get bounding box in global RAS form (xmin,xmax, ymin,ymax, zmin,zmax).
   /// This method returns the bounds of the object with any transforms that may
   /// be applied to it.

--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -103,6 +103,8 @@ vtkMRMLSegmentationStorageNode::~vtkMRMLSegmentationStorageNode() = default;
 //----------------------------------------------------------------------------
 void vtkMRMLSegmentationStorageNode::PrintSelf(ostream& os, vtkIndent indent)
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLSegmentationStorageNode", "Segmentation Storage");
+
   Superclass::PrintSelf(os, indent);
   vtkMRMLPrintBeginMacro(os, indent);
   vtkMRMLPrintBooleanMacro(CropToMinimumExtent);

--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.h
@@ -179,10 +179,6 @@ protected:
 protected:
   bool CropToMinimumExtent{ false };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLSegmentationStorageNode", "Segmentation Storage"); };
-
 protected:
   vtkMRMLSegmentationStorageNode();
   ~vtkMRMLSegmentationStorageNode() override;

--- a/Libs/MRML/Core/vtkMRMLSelectionNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSelectionNode.cxx
@@ -40,6 +40,8 @@ vtkMRMLNodeNewMacro(vtkMRMLSelectionNode);
 //----------------------------------------------------------------------------
 vtkMRMLSelectionNode::vtkMRMLSelectionNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLSelectionNode", "Selection");
+
   this->HideFromEditors = 1;
 
   this->SetSingletonTag("Singleton");

--- a/Libs/MRML/Core/vtkMRMLSelectionNode.h
+++ b/Libs/MRML/Core/vtkMRMLSelectionNode.h
@@ -58,10 +58,6 @@ public:
   /// \deprecated Use SetActiveVolumeID instead
   void SetReferenceActiveVolumeID(const char* id) { this->SetActiveVolumeID(id); };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLSelectionNode", "Selection"); };
-
   /// the ID of a MRMLVolumeNode (typically foreground)
   const char* GetSecondaryVolumeID();
   void SetSecondaryVolumeID(const char* id);

--- a/Libs/MRML/Core/vtkMRMLSequenceNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSequenceNode.cxx
@@ -60,6 +60,8 @@ vtkCxxSetVariableInDataAndStorageNodeMacro(NumericIndexValueTolerance, double);
 //----------------------------------------------------------------------------
 vtkMRMLSequenceNode::vtkMRMLSequenceNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLSequenceNode", "Sequence");
+
   this->SetIndexName("time");
   this->SetIndexUnit("s");
   this->HideFromEditorsOff();

--- a/Libs/MRML/Core/vtkMRMLSequenceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSequenceNode.h
@@ -73,10 +73,6 @@ public:
   /// Get unique node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "Sequence"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLSequenceNode", "Sequence"); };
-
   /// Set index name (example: time)
   void SetIndexName(const std::string& str);
   /// Get index name (example: time)

--- a/Libs/MRML/Core/vtkMRMLSequenceStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSequenceStorageNode.cxx
@@ -35,7 +35,10 @@ static const char NODE_BASE_NAME_SEPARATOR[] = "-";
 vtkMRMLNodeNewMacro(vtkMRMLSequenceStorageNode);
 
 //----------------------------------------------------------------------------
-vtkMRMLSequenceStorageNode::vtkMRMLSequenceStorageNode() = default;
+vtkMRMLSequenceStorageNode::vtkMRMLSequenceStorageNode()
+{
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLSequenceStorageNode", "Sequence Storage");
+}
 
 //----------------------------------------------------------------------------
 vtkMRMLSequenceStorageNode::~vtkMRMLSequenceStorageNode() = default;

--- a/Libs/MRML/Core/vtkMRMLSequenceStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLSequenceStorageNode.h
@@ -38,10 +38,6 @@ public:
   /// Get node XML tag name (like Storage, Sequence)
   const char* GetNodeTagName() override { return "SequenceStorage"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLSequenceStorageNode", "Sequence Storage"); };
-
   /// Return a default file extension for writing
   const char* GetDefaultWriteFileExtension() override;
 

--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
@@ -42,6 +42,8 @@ vtkMRMLNodeNewMacro(vtkMRMLSliceCompositeNode);
 //----------------------------------------------------------------------------
 vtkMRMLSliceCompositeNode::vtkMRMLSliceCompositeNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLSliceCompositeNode", "Slice Composite");
+
   this->HideFromEditors = 1;
 
   this->AddNodeReferenceRole(BackgroundVolumeNodeReferenceRole, BackgroundVolumeNodeReferenceMRMLAttributeName);

--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
@@ -80,10 +80,6 @@ public:
     Layer_Last // must be last
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLSliceCompositeNode", "Slice Composite"); };
-
   int GetNumberOfAdditionalLayers();
 
   /// @{

--- a/Libs/MRML/Core/vtkMRMLSliceDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceDisplayNode.cxx
@@ -26,6 +26,8 @@ vtkMRMLNodeNewMacro(vtkMRMLSliceDisplayNode);
 //-----------------------------------------------------------------------------
 vtkMRMLSliceDisplayNode::vtkMRMLSliceDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLSliceDisplayNode", "Slice Display");
+
   // Set active component defaults for mouse (identified by empty string)
   this->ActiveComponents[GetDefaultContextName()] = ComponentInfo();
 }

--- a/Libs/MRML/Core/vtkMRMLSliceDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceDisplayNode.h
@@ -51,9 +51,6 @@ public:
   /// Toggles visibility of intersections of other slices in the slice viewer
   bool GetIntersectingSlicesVisibility() { return this->GetVisibility2D(); };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLSliceDisplayNode", "Slice Display"); };
   void SetIntersectingSlicesVisibility(bool visible) { this->SetVisibility2D(visible); };
   vtkBooleanMacro(IntersectingSlicesVisibility, bool);
   //@}

--- a/Libs/MRML/Core/vtkMRMLSliceNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.cxx
@@ -44,6 +44,8 @@ vtkMRMLNodeNewMacro(vtkMRMLSliceNode);
 // Constructor
 vtkMRMLSliceNode::vtkMRMLSliceNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLSliceNode", "Slice");
+
   // set by user
   this->SliceToRAS = vtkSmartPointer<vtkMatrix4x4>::New();
   this->SliceToRAS->Identity();

--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -67,10 +67,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "Slice"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLSliceNode", "Slice"); };
-
   ///
   /// Mapping from RAS space onto the slice plane
   /// This matrix is allowed to be modified from outside, for example

--- a/Libs/MRML/Core/vtkMRMLSnapshotClipNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSnapshotClipNode.cxx
@@ -30,6 +30,8 @@ vtkMRMLNodeNewMacro(vtkMRMLSnapshotClipNode);
 //----------------------------------------------------------------------------
 vtkMRMLSnapshotClipNode::vtkMRMLSnapshotClipNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLSnapshotClipNode", "Snapshot Clip");
+
   this->HideFromEditors = 1;
 
   this->SceneSnapshotNodes = vtkCollection::New();

--- a/Libs/MRML/Core/vtkMRMLSnapshotClipNode.h
+++ b/Libs/MRML/Core/vtkMRMLSnapshotClipNode.h
@@ -51,10 +51,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "SnapshotClip"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLSnapshotClipNode", "Snapshot Clip"); };
-
   ///
   /// Updates this node if it depends on other nodes
   /// when the node is deleted in the scene

--- a/Libs/MRML/Core/vtkMRMLStreamingVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStreamingVolumeNode.cxx
@@ -46,6 +46,8 @@ vtkMRMLStreamingVolumeNode::vtkMRMLStreamingVolumeNode()
   , Frame(nullptr)
   , FrameModifiedCallbackCommand(vtkSmartPointer<vtkCallbackCommand>::New())
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLStreamingVolumeNode", "Streaming Volume");
+
   this->FrameModifiedCallbackCommand->SetClientData(reinterpret_cast<void*>(this));
   this->FrameModifiedCallbackCommand->SetCallback(vtkMRMLStreamingVolumeNode::FrameModifiedCallback);
 }

--- a/Libs/MRML/Core/vtkMRMLStreamingVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLStreamingVolumeNode.h
@@ -78,10 +78,6 @@ public:
   /// Returns a pointer to the current frame
   vtkStreamingVolumeFrame* GetFrame() { return this->Frame.GetPointer(); };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLStreamingVolumeNode", "Streaming Volume"); };
-
   /// Encodes the current vtkImageData as a compressed frame using the specified codec
   /// Returns true if the image is successfully encoded
   virtual bool EncodeImageData(bool forceKeyFrame = false);

--- a/Libs/MRML/Core/vtkMRMLTableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableNode.cxx
@@ -63,6 +63,8 @@ vtkMRMLNodeNewMacro(vtkMRMLTableNode);
 //----------------------------------------------------------------------------
 vtkMRMLTableNode::vtkMRMLTableNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLTableNode", "Table");
+
   this->Table = nullptr;
   this->Schema = nullptr;
   this->Locked = false;

--- a/Libs/MRML/Core/vtkMRMLTableNode.h
+++ b/Libs/MRML/Core/vtkMRMLTableNode.h
@@ -74,10 +74,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "Table"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLTableNode", "Table"); };
-
   ///
   /// Method to propagate events generated in mrml
   void ProcessMRMLEvents(vtkObject* caller, unsigned long event, void* callData) override;

--- a/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.cxx
@@ -47,6 +47,8 @@ vtkMRMLNodeNewMacro(vtkMRMLTableSQLiteStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLTableSQLiteStorageNode::vtkMRMLTableSQLiteStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLTableSQLiteStorageNode", "SQLite Table Storage");
+
   this->TableName = nullptr;
   this->Password = nullptr;
   this->DefaultWriteFileExtension = "sqlite3";

--- a/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.h
@@ -46,10 +46,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   const char* GetNodeTagName() override { return "TableSQLightStorage"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLTableSQLiteStorageNode", "Table SQ Light Storage"); };
-
   /// Return true if the node can be read in
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
 

--- a/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx
@@ -77,6 +77,8 @@ const char* COMPONENT_SEPERATOR = "_";
 //----------------------------------------------------------------------------
 vtkMRMLTableStorageNode::vtkMRMLTableStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLTableStorageNode", "Table Storage");
+
   this->DefaultWriteFileExtension = "tsv";
   this->AutoFindSchema = true;
   this->ReadLongNameAsTitle = false;

--- a/Libs/MRML/Core/vtkMRMLTableStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLTableStorageNode.h
@@ -112,9 +112,6 @@ protected:
     std::string NullValueString;
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLTableStorageNode", "Table Storage"); };
   using ColumnInfo = struct StructColumnInfo;
 
   /// Determines information about the columns in the table, including column name,

--- a/Libs/MRML/Core/vtkMRMLTensorVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTensorVolumeNode.cxx
@@ -29,6 +29,8 @@ vtkMRMLNodeNewMacro(vtkMRMLTensorVolumeNode);
 //----------------------------------------------------------------------------
 vtkMRMLTensorVolumeNode::vtkMRMLTensorVolumeNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLTensorVolumeNode", "Tensor Volume");
+
   for (int i = 0; i < 3; i++)
   {
     for (int j = 0; j < 3; j++)

--- a/Libs/MRML/Core/vtkMRMLTensorVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLTensorVolumeNode.h
@@ -56,10 +56,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "TensorVolume"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLTensorVolumeNode", "Tensor Volume"); };
-
   ///
   /// Updates this node if it depends on other nodes
   /// when the node is deleted in the scene

--- a/Libs/MRML/Core/vtkMRMLTextNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTextNode.cxx
@@ -31,6 +31,8 @@ vtkMRMLNodeNewMacro(vtkMRMLTextNode);
 //-----------------------------------------------------------------------------
 vtkMRMLTextNode::vtkMRMLTextNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLTextNode", "Text");
+
   this->ContentModifiedEvents->InsertNextValue(vtkMRMLTextNode::TextModifiedEvent);
 }
 

--- a/Libs/MRML/Core/vtkMRMLTextNode.h
+++ b/Libs/MRML/Core/vtkMRMLTextNode.h
@@ -50,10 +50,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "Text"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLTextNode", "Text"); };
-
   /// Set text node contents and encoding.
   /// If the encoding is not specified, then it will not be changed from the current value.
   /// \sa SetEncoding()

--- a/Libs/MRML/Core/vtkMRMLTextStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTextStorageNode.cxx
@@ -39,7 +39,10 @@
 vtkMRMLNodeNewMacro(vtkMRMLTextStorageNode);
 
 //----------------------------------------------------------------------------
-vtkMRMLTextStorageNode::vtkMRMLTextStorageNode() = default;
+vtkMRMLTextStorageNode::vtkMRMLTextStorageNode()
+{
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLTextStorageNode", "Text Storage");
+}
 
 //----------------------------------------------------------------------------
 vtkMRMLTextStorageNode::~vtkMRMLTextStorageNode() = default;

--- a/Libs/MRML/Core/vtkMRMLTextStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLTextStorageNode.h
@@ -46,10 +46,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   const char* GetNodeTagName() override { return "TextStorage"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLTextStorageNode", "Text Storage"); };
-
   /// Return true if the node can be read in.
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
 

--- a/Libs/MRML/Core/vtkMRMLTransformDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformDisplayNode.cxx
@@ -52,6 +52,8 @@ vtkMRMLNodeNewMacro(vtkMRMLTransformDisplayNode);
 vtkMRMLTransformDisplayNode::vtkMRMLTransformDisplayNode()
   : vtkMRMLDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLTransformDisplayNode", "Transform Display Node");
+
   // Don't show transform nodes by default
   // to allow the users to adjust visualization parameters first
   this->Visibility = 0;

--- a/Libs/MRML/Core/vtkMRMLTransformDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformDisplayNode.h
@@ -202,10 +202,6 @@ public:
     TransformUpdateEditorBoundsEvent = 2750
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLTransformDisplayNode", "Transform Display Node"); };
-
   /// Set the default color table
   /// Create and a procedural color node with default colors and use it for visualization.
   void SetDefaultColors();

--- a/Libs/MRML/Core/vtkMRMLTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.cxx
@@ -51,6 +51,8 @@ vtkMRMLNodeNewMacro(vtkMRMLTransformNode);
 //----------------------------------------------------------------------------
 vtkMRMLTransformNode::vtkMRMLTransformNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLTransformNode", "Transform");
+
   this->TransformToParent = nullptr;
   this->TransformFromParent = nullptr;
   this->ReadAsTransformToParent = 0;

--- a/Libs/MRML/Core/vtkMRMLTransformNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.h
@@ -55,10 +55,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "Transform"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLTransformNode", "Transform"); };
-
   ///
   /// Finds the storage node and read the data
   void UpdateScene(vtkMRMLScene* scene) override { Superclass::UpdateScene(scene); };

--- a/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
@@ -38,6 +38,8 @@ bool vtkMRMLTransformStorageNode::RegisterInverseTransformTypesCompleted = false
 //----------------------------------------------------------------------------
 vtkMRMLTransformStorageNode::vtkMRMLTransformStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLTransformStorageNode", "Transform Storage");
+
   this->PreferITKv3CompatibleTransforms = 0;
   this->DefaultWriteFileExtension = "h5";
 

--- a/Libs/MRML/Core/vtkMRMLTransformStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformStorageNode.h
@@ -44,10 +44,6 @@ public:
   /// Get node XML tag name (like Storage, Transform)
   const char* GetNodeTagName() override { return "TransformStorage"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLTransformStorageNode", "Transform Storage"); };
-
   ///
   /// Copy the node's attributes to this object
   void Copy(vtkMRMLNode* node) override;

--- a/Libs/MRML/Core/vtkMRMLUnitNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLUnitNode.cxx
@@ -35,6 +35,8 @@ vtkMRMLNodeNewMacro(vtkMRMLUnitNode);
 //----------------------------------------------------------------------------
 vtkMRMLUnitNode::vtkMRMLUnitNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLUnitNode", "Unit");
+
   this->HideFromEditors = 1;
 
   this->Prefix = nullptr;

--- a/Libs/MRML/Core/vtkMRMLUnitNode.h
+++ b/Libs/MRML/Core/vtkMRMLUnitNode.h
@@ -58,10 +58,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "Unit"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLUnitNode", "Unit"); };
-
   /// Reimplemented to prevent reset if unit node is a singleton.
   void Reset(vtkMRMLNode* defaultNode) override;
 

--- a/Libs/MRML/Core/vtkMRMLVectorVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVectorVolumeDisplayNode.cxx
@@ -36,6 +36,8 @@ vtkMRMLNodeNewMacro(vtkMRMLVectorVolumeDisplayNode);
 //----------------------------------------------------------------------------
 vtkMRMLVectorVolumeDisplayNode::vtkMRMLVectorVolumeDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLVectorVolumeDisplayNode", "Vector Volume Display");
+
   this->ScalarMode = this->scalarModeMagnitude;
   this->GlyphMode = this->glyphModeLines;
 

--- a/Libs/MRML/Core/vtkMRMLVectorVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLVectorVolumeDisplayNode.h
@@ -66,9 +66,6 @@ public:
     scalarModeMagnitude = 0
   };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLVectorVolumeDisplayNode", "Vector Volume Display"); };
   vtkGetMacro(ScalarMode, int);
   vtkSetMacro(ScalarMode, int);
 

--- a/Libs/MRML/Core/vtkMRMLVectorVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVectorVolumeNode.cxx
@@ -33,6 +33,8 @@ vtkMRMLVectorVolumeNode::~vtkMRMLVectorVolumeNode() = default;
 //----------------------------------------------------------------------------
 void vtkMRMLVectorVolumeNode::WriteXML(ostream& of, int nIndent)
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLVectorVolumeNode", "Vector Volume");
+
   Superclass::WriteXML(of, nIndent);
 }
 

--- a/Libs/MRML/Core/vtkMRMLVectorVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLVectorVolumeNode.h
@@ -51,10 +51,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "VectorVolume"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLVectorVolumeNode", "Vector Volume"); };
-
   ///
   /// Associated display MRML node
   virtual vtkMRMLVectorVolumeDisplayNode* GetVectorVolumeDisplayNode();

--- a/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
@@ -57,6 +57,8 @@ vtkMRMLNodeNewMacro(vtkMRMLVolumeArchetypeStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLVolumeArchetypeStorageNode::vtkMRMLVolumeArchetypeStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLVolumeArchetypeStorageNode", "Volume Archetype Storage");
+
   this->CenterImage = 0;
   this->SingleFile = 0;
   this->UseOrientationFromFile = 1;

--- a/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.h
@@ -60,10 +60,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   const char* GetNodeTagName() override { return "VolumeArchetypeStorage"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLVolumeArchetypeStorageNode", "Volume Archetype Storage"); };
-
   ///
   /// Center image on read
   vtkGetMacro(CenterImage, int);

--- a/Libs/MRML/Core/vtkMRMLVolumeHeaderlessStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeHeaderlessStorageNode.cxx
@@ -40,6 +40,8 @@ vtkMRMLNodeNewMacro(vtkMRMLVolumeHeaderlessStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLVolumeHeaderlessStorageNode::vtkMRMLVolumeHeaderlessStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLVolumeHeaderlessStorageNode", "Volume Headerless Storage");
+
   this->FileScanOrder = nullptr;
   this->FileScalarType = VTK_SHORT;
   this->FileNumberOfScalarComponents = 0;

--- a/Libs/MRML/Core/vtkMRMLVolumeHeaderlessStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeHeaderlessStorageNode.h
@@ -70,9 +70,6 @@ public:
 
   void SetFileScalarTypeToUnsignedChar() { this->SetFileScalarType(VTK_UNSIGNED_CHAR); };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLVolumeHeaderlessStorageNode", "Volume Headerless Storage"); };
   void SetFileScalarTypeToChar() { this->SetFileScalarType(VTK_CHAR); };
   void SetFileScalarTypeToShort() { this->SetFileScalarType(VTK_SHORT); };
   void SetFileScalarTypeToUnsignedShort() { this->SetFileScalarType(VTK_UNSIGNED_SHORT); };

--- a/Libs/MRML/Core/vtkMRMLVolumeSequenceStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeSequenceStorageNode.h
@@ -30,10 +30,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   const char* GetNodeTagName() override { return "VolumeSequenceStorage"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLVolumeSequenceStorageNode", "Volume Sequence Storage"); };
-
   /// Return true if the node can be read in.
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
 

--- a/Libs/MRML/Core/vtkMRMLdGEMRICProceduralColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLdGEMRICProceduralColorNode.cxx
@@ -25,6 +25,7 @@ vtkMRMLNodeNewMacro(vtkMRMLdGEMRICProceduralColorNode);
 //----------------------------------------------------------------------------
 vtkMRMLdGEMRICProceduralColorNode::vtkMRMLdGEMRICProceduralColorNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLdGEMRICProceduralColorNode", "d GEMRIC Procedural Color");
 
   // all this is done in the superclass...
   // this->Name = nullptr;

--- a/Libs/MRML/Core/vtkMRMLdGEMRICProceduralColorNode.h
+++ b/Libs/MRML/Core/vtkMRMLdGEMRICProceduralColorNode.h
@@ -68,10 +68,6 @@ public:
   ///
   //};
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLdGEMRICProceduralColorNode", "d GEMRIC Procedural Color"); };
-
   /// DisplayModifiedEvent is generated when display node parameters is changed
   enum
   {

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest8.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest8.cxx
@@ -104,6 +104,7 @@ int qMRMLNodeComboBoxTest8(int argc, char* argv[])
 
   // test a conflict with one of the default actions
   QAction* action2 = new QAction("Create new type of action that conflicts with create new node", &nodeSelector);
+  action2->setData("CREATE/vtkMRMLScalarVolumeNode");
   nodeSelector.addMenuAction(action2);
 
   actionsPlusOne = sceneModel->postItems(sceneModel->mrmlSceneItem()).size();
@@ -225,18 +226,22 @@ int qMRMLNodeComboBoxTest8(int argc, char* argv[])
   }
 
   // add a custom actions
-  const QStringList actionPrefixes = {
-    "Create new ",
-    "Delete current ",
-    "Edit current ",
-    "Rename current ",
+  const QStringList actionPrefixesData = {
+    "Create new |CREATE",
+    "Delete current |DELETE",
+    "Edit current |EDIT",
+    "Rename current |RENAME",
   };
-  for (const QString& actionPrefix : actionPrefixes)
+  for (const QString& actionPrefixData : actionPrefixesData)
   {
+    QStringList parts = actionPrefixData.split("|");
+    QString actionPrefix = parts[0];
+    QString actionData = parts[1];
     startingActions = sceneModel->postItems(sceneModel->mrmlSceneItem()).size();
 
     QString actionName = QString("%1node using custom action").arg(actionPrefix);
     QAction* action = new QAction(actionName, &nodeSelector);
+    action->setData(actionData);
     nodeSelector.addMenuAction(action);
 
     expected = startingActions + 1;
@@ -341,6 +346,7 @@ int qMRMLNodeComboBoxTest8(int argc, char* argv[])
   qMRMLSceneModel* sceneModel2 = nodeSelector2.sceneModel();
 
   QAction* action = new QAction("Rename current node using custom action", &nodeSelector2);
+  action->setData("RENAME");
 
   startingActions = sceneModel2->postItems(sceneModel2->mrmlSceneItem()).size();
   nodeSelector2.addMenuAction(action);

--- a/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
@@ -369,7 +369,7 @@ void qMRMLNodeComboBoxPrivate::updateDelegate(bool force)
 // --------------------------------------------------------------------------
 bool qMRMLNodeComboBoxPrivate::hasPostItem(const QString& name) const
 {
-  for (const QString& item : this->MRMLSceneModel->postItems(this->MRMLSceneModel->mrmlSceneItem()))
+  for (const QString& item : this->MRMLSceneModel->postItemsData(this->MRMLSceneModel->mrmlSceneItem()))
   {
     if (item.startsWith(name))
     {

--- a/Libs/MRML/Widgets/qMRMLNodeFactory.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeFactory.cxx
@@ -76,17 +76,16 @@ vtkMRMLNode* qMRMLNodeFactory::createNode(const QString& className)
 
   emit this->nodeInstantiated(node);
 
-  QString baseName;
-  if (d->BaseNames.contains(className) && //
-      !d->BaseNames[className].isEmpty())
+  QString baseName = d->BaseNames.value(className);
+  if (baseName.isEmpty() && //
+      !node->GetName())     // Keep default node name if the base name is empty
   {
-    baseName = d->BaseNames[className];
+    baseName = node->GetDefaultNodeNamePrefix();
   }
-  else
+  if (!baseName.isEmpty())
   {
-    baseName = d->MRMLScene->GetTagByClassName(className.toUtf8());
+    node->SetName(d->MRMLScene->GetUniqueNameByString(baseName.toUtf8()));
   }
-  node->SetName(d->MRMLScene->GetUniqueNameByString(baseName.toUtf8()));
 
   // Set node attributes
   // Attributes must be set before adding the node into the scene as the node

--- a/Libs/MRML/Widgets/qMRMLNodeFactory.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeFactory.cxx
@@ -80,7 +80,7 @@ vtkMRMLNode* qMRMLNodeFactory::createNode(const QString& className)
   if (baseName.isEmpty() && //
       !node->GetName())     // Keep default node name if the base name is empty
   {
-    baseName = node->GetDefaultNodeNamePrefix();
+    baseName = QString::fromStdString(node->GetDefaultNodeNamePrefix());
   }
   if (!baseName.isEmpty())
   {

--- a/Modules/Loadable/Colors/MRML/vtkMRMLColorLegendDisplayNode.cxx
+++ b/Modules/Loadable/Colors/MRML/vtkMRMLColorLegendDisplayNode.cxx
@@ -41,6 +41,8 @@ vtkMRMLNodeNewMacro(vtkMRMLColorLegendDisplayNode);
 //-----------------------------------------------------------------------------
 vtkMRMLColorLegendDisplayNode::vtkMRMLColorLegendDisplayNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLColorLegendDisplayNode", "Color Legend Display");
+
   this->LabelFormat = this->GetDefaultNumericLabelFormat();
 
   vtkNew<vtkTextProperty> titleTextProperty;

--- a/Modules/Loadable/Colors/MRML/vtkMRMLColorLegendDisplayNode.h
+++ b/Modules/Loadable/Colors/MRML/vtkMRMLColorLegendDisplayNode.h
@@ -181,9 +181,6 @@ protected:
 private:
   OrientationType Orientation{ vtkMRMLColorLegendDisplayNode::Vertical }; // Vertical or Horizontal
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLColorLegendDisplayNode", "Color Legend Display"); };
   double Position[2]{ 0.95, 0.5 }; // color legend position within view
   double Size[2]{ 0.15, 0.5 };     // color legend width within view
   std::string TitleText;           // color legend title

--- a/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.cxx
+++ b/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.cxx
@@ -37,6 +37,8 @@ vtkMRMLNodeNewMacro(vtkMRMLCropVolumeParametersNode);
 //----------------------------------------------------------------------------
 vtkMRMLCropVolumeParametersNode::vtkMRMLCropVolumeParametersNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLCropVolumeParametersNode", "Crop Volume Parameters");
+
   this->HideFromEditors = 1;
 
   vtkNew<vtkIntArray> inputVolumeEvents;

--- a/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.h
+++ b/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.h
@@ -54,10 +54,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "CropVolumeParameters"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLCropVolumeParametersNode", "Crop Volume Parameters"); };
-
   /// Set volume node to be cropped
   void SetInputVolumeNodeID(const char* nodeID);
   /// Get volume node to be cropped

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -698,7 +698,14 @@ vtkMRMLMarkupsNode* vtkSlicerMarkupsLogic::AddNewMarkupsNode(std::string classNa
   // Set node name
   if (nodeName.empty())
   {
-    nodeName = scene->GenerateUniqueName(markupsNode->GetDefaultNodeNamePrefix());
+    if (node->GetName())
+    {
+      nodeName = node->GetName(); // use default node name exactly as given
+    }
+    else
+    {
+      nodeName = scene->GenerateUniqueName(markupsNode->GetDefaultNodeNamePrefix());
+    }
   }
   markupsNode->SetName(nodeName.c_str());
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
@@ -56,6 +56,8 @@ vtkMRMLNodeNewMacro(vtkMRMLMarkupsJsonStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLMarkupsJsonStorageNode::vtkMRMLMarkupsJsonStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLMarkupsJsonStorageNode", "Markups JSON Storage");
+
   this->DefaultWriteFileExtension = "mrk.json";
 }
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.h
@@ -48,10 +48,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   const char* GetNodeTagName() override { return "MarkupsJsonStorage"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsJsonStorageNode", "Markups Json Storage"); };
-
   /// Read node attributes from XML file
   void ReadXMLAttributes(const char** atts) override;
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneJsonStorageNode.cxx
@@ -34,7 +34,10 @@
 vtkMRMLNodeNewMacro(vtkMRMLMarkupsPlaneJsonStorageNode);
 
 //----------------------------------------------------------------------------
-vtkMRMLMarkupsPlaneJsonStorageNode::vtkMRMLMarkupsPlaneJsonStorageNode() {}
+vtkMRMLMarkupsPlaneJsonStorageNode::vtkMRMLMarkupsPlaneJsonStorageNode()
+{
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLMarkupsPlaneJsonStorageNode", "Markups Plane JSON Storage");
+}
 
 //----------------------------------------------------------------------------
 vtkMRMLMarkupsPlaneJsonStorageNode::~vtkMRMLMarkupsPlaneJsonStorageNode() = default;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneJsonStorageNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneJsonStorageNode.h
@@ -44,9 +44,6 @@ public:
   vtkMRMLNode* CreateNodeInstance() override;
   const char* GetNodeTagName() override { return "MarkupsPlaneJsonStorage"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsPlaneJsonStorageNode", "Markups Plane Json Storage"); };
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
 
 protected:

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIJsonStorageNode.cxx
@@ -33,7 +33,10 @@
 vtkMRMLNodeNewMacro(vtkMRMLMarkupsROIJsonStorageNode);
 
 //----------------------------------------------------------------------------
-vtkMRMLMarkupsROIJsonStorageNode::vtkMRMLMarkupsROIJsonStorageNode() {}
+vtkMRMLMarkupsROIJsonStorageNode::vtkMRMLMarkupsROIJsonStorageNode()
+{
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLMarkupsROIJsonStorageNode", "Markups ROI JSON Storage");
+}
 
 //----------------------------------------------------------------------------
 vtkMRMLMarkupsROIJsonStorageNode::~vtkMRMLMarkupsROIJsonStorageNode() = default;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIJsonStorageNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIJsonStorageNode.h
@@ -44,9 +44,6 @@ public:
   vtkMRMLNode* CreateNodeInstance() override;
   const char* GetNodeTagName() override { return "MarkupsROIJsonStorage"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  virtual std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsROIJsonStorageNode", "Markups ROI Json Storage"); };
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
 
 protected:

--- a/Modules/Loadable/Markups/Testing/Python/CMakeLists.txt
+++ b/Modules/Loadable/Markups/Testing/Python/CMakeLists.txt
@@ -55,6 +55,10 @@ slicer_add_python_test(SCRIPT MarkupsCurveCoordinateFrameTest.py
 slicer_add_python_test(SCRIPT MarkupsMeasurementsTest.py
                        SLICER_ARGS --disable-cli-modules)
 
+# Test markup node names
+slicer_add_python_test(SCRIPT MarkupsNodeNameTest.py
+                       SLICER_ARGS --disable-cli-modules)
+
 # Test markups pluggable architecture
 slicerMacroBuildScriptedModule(
   NAME PluggableMarkupsSelfTest

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsNodeNameTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsNodeNameTest.py
@@ -1,0 +1,132 @@
+import slicer
+
+#
+# Test markups node name with no custom default node added to the scene
+#
+
+# Start from fresh scene
+slicer.mrmlScene.Clear()
+# Create node with AddNewNodeByClass (x2) to see how name iterates
+markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode")
+if markup_node.GetName() != "L":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode")
+if markup_node.GetName() != "L_1":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+# Create node through qMRMLNodeFactory with no baseName set to see how name iterates
+node_factory = slicer.qMRMLNodeFactory()
+node_factory.setMRMLScene(slicer.mrmlScene)
+markup_node = node_factory.createNode("vtkMRMLMarkupsLineNode")
+if markup_node.GetName() != "L_2":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+# Create node with AddNewNodeByClass with Name prespecified (x2) to see how name iterates
+markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
+if markup_node.GetName() != "UseThisDefaultNameExactly":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
+if markup_node.GetName() != "UseThisDefaultNameExactly":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+# Create node with Markups module logic (x2) to see how name iterates
+markup_node = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode")
+if markup_node.GetName() != "L_3":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+markup_node = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode")
+if markup_node.GetName() != "L_4":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+# Create node with Markups module logic with Name prespecified (x2) to see how name iterates
+markup_node = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
+if markup_node.GetName() != "UseThisDefaultNameExactly":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+markup_node = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
+if markup_node.GetName() != "UseThisDefaultNameExactly":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+
+#
+# Test markups node name, but with a default node added to the scene
+#
+
+# Start from fresh scene
+slicer.mrmlScene.Clear()
+# Define a default Markups Line node with a default node name
+default_markups_line_node = slicer.vtkMRMLMarkupsLineNode()
+default_markups_line_node.SetName("DefaultNodeName")  # Default names are to be used exactly and to not be manipulated through GenerateUniqueName()
+slicer.mrmlScene.AddDefaultNode(default_markups_line_node)
+# Create node with AddNewNodeByClass (x2) to see how name iterates
+markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode")
+if markup_node.GetName() != "DefaultNodeName":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode")
+if markup_node.GetName() != "DefaultNodeName":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+# Create node through qMRMLNodeFactory with no baseName set to see how name iterates
+node_factory = slicer.qMRMLNodeFactory()
+node_factory.setMRMLScene(slicer.mrmlScene)
+markup_node = node_factory.createNode("vtkMRMLMarkupsLineNode")
+if markup_node.GetName() != "DefaultNodeName":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+# Create node with AddNewNodeByClass with Name prespecified (x2) to see how name iterates
+markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
+if markup_node.GetName() != "UseThisDefaultNameExactly":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
+if markup_node.GetName() != "UseThisDefaultNameExactly":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+# Create node with Markups module logic (x2) to see how name iterates
+markup_node = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode")
+if markup_node.GetName() != "DefaultNodeName":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+markup_node = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode")
+if markup_node.GetName() != "DefaultNodeName":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+# Create node with Markups module logic with Name prespecified (x2) to see how name iterates
+markup_node = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
+if markup_node.GetName() != "UseThisDefaultNameExactly":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+markup_node = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
+if markup_node.GetName() != "UseThisDefaultNameExactly":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+
+#
+# Test markups node name, but with DefaultNodeNamePrefix customized
+#
+
+# Start from fresh scene
+slicer.mrmlScene.Clear()
+# Define a default Markups Angle node with a default node name prefix
+default_markups_angle_node = slicer.vtkMRMLMarkupsAngleNode()
+default_markups_angle_node.SetDefaultNodeNamePrefix("Angle")
+slicer.mrmlScene.AddDefaultNode(default_markups_angle_node)
+# Create node with AddNewNodeByClass (x2) to see how name iterates
+markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsAngleNode")
+if markup_node.GetName() != "Angle":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsAngleNode")
+if markup_node.GetName() != "Angle_1":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+# Create node through qMRMLNodeFactory with no baseName set to see how name iterates
+node_factory = slicer.qMRMLNodeFactory()
+node_factory.setMRMLScene(slicer.mrmlScene)
+markup_node = node_factory.createNode("vtkMRMLMarkupsAngleNode")
+if markup_node.GetName() != "Angle_2":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+# Create node with AddNewNodeByClass with Name prespecified (x2) to see how name iterates
+markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsAngleNode", "UseThisDefaultNameExactly")
+if markup_node.GetName() != "UseThisDefaultNameExactly":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsAngleNode", "UseThisDefaultNameExactly")
+if markup_node.GetName() != "UseThisDefaultNameExactly":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+# Create node with Markups module logic (x2) to see how name iterates
+markup_node = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsAngleNode")
+if markup_node.GetName() != "Angle_3":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+markup_node = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsAngleNode")
+if markup_node.GetName() != "Angle_4":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+# Create node with Markups module logic with Name prespecified (x2) to see how name iterates
+markup_node = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsAngleNode", "UseThisDefaultNameExactly")
+if markup_node.GetName() != "UseThisDefaultNameExactly":
+    raise Exception("Unexpected node name: " + markup_node.GetName())
+markup_node = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsAngleNode", "UseThisDefaultNameExactly")
+if markup_node.GetName() != "UseThisDefaultNameExactly":
+    raise Exception("Unexpected node name: " + markup_node.GetName())

--- a/Modules/Loadable/Segmentations/MRML/vtkMRMLSegmentEditorNode.cxx
+++ b/Modules/Loadable/Segmentations/MRML/vtkMRMLSegmentEditorNode.cxx
@@ -47,6 +47,8 @@ vtkMRMLNodeNewMacro(vtkMRMLSegmentEditorNode);
 //----------------------------------------------------------------------------
 vtkMRMLSegmentEditorNode::vtkMRMLSegmentEditorNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLSegmentEditorNode", "Segment Editor");
+
   this->SetHideFromEditors(true);
   this->SourceVolumeIntensityMaskRange[0] = 0.0;
   this->SourceVolumeIntensityMaskRange[1] = 0.0;

--- a/Modules/Loadable/Segmentations/MRML/vtkMRMLSegmentEditorNode.h
+++ b/Modules/Loadable/Segmentations/MRML/vtkMRMLSegmentEditorNode.h
@@ -216,10 +216,6 @@ protected:
   /// Selected segment ID
   char* SelectedSegmentID{ nullptr };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLSegmentEditorNode", "Segment Editor"); };
-
   /// Active effect name
   char* ActiveEffectName{ nullptr };
 

--- a/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.cxx
+++ b/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.cxx
@@ -137,6 +137,8 @@ vtkMRMLNodeNewMacro(vtkMRMLSequenceBrowserNode);
 vtkMRMLSequenceBrowserNode::vtkMRMLSequenceBrowserNode()
   : IndexDisplayFormat("%.2f")
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLSequenceBrowserNode", "Sequence Browser");
+
   this->SetHideFromEditors(false);
   this->RecordingTimeOffsetSec = vtkTimerLog::GetUniversalTime();
   this->LastSaveProxyNodesStateTimeSec = vtkTimerLog::GetUniversalTime();

--- a/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.h
+++ b/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.h
@@ -98,10 +98,6 @@ public:
   /// Get unique node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "SequenceBrowser"; };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLSequenceBrowserNode", "Sequence Browser"); };
-
   /// Set the sequence data node.
   /// Returns the new proxy node postfix.
   std::string SetAndObserveMasterSequenceNodeID(const char* sequenceNodeID);

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLCPURayCastVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLCPURayCastVolumeRenderingDisplayNode.cxx
@@ -31,7 +31,10 @@
 vtkMRMLNodeNewMacro(vtkMRMLCPURayCastVolumeRenderingDisplayNode);
 
 //----------------------------------------------------------------------------
-vtkMRMLCPURayCastVolumeRenderingDisplayNode::vtkMRMLCPURayCastVolumeRenderingDisplayNode() = default;
+vtkMRMLCPURayCastVolumeRenderingDisplayNode::vtkMRMLCPURayCastVolumeRenderingDisplayNode()
+{
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLCPURayCastVolumeRenderingDisplayNode", "CPU Ray-Cast Volume Rendering");
+}
 
 //----------------------------------------------------------------------------
 vtkMRMLCPURayCastVolumeRenderingDisplayNode::~vtkMRMLCPURayCastVolumeRenderingDisplayNode() = default;

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLCPURayCastVolumeRenderingDisplayNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLCPURayCastVolumeRenderingDisplayNode.h
@@ -51,10 +51,6 @@ public:
   // Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "CPURayCastVolumeRendering"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLCPURayCastVolumeRenderingDisplayNode", "CPU Ray Cast Volume Rendering"); };
-
 protected:
   vtkMRMLCPURayCastVolumeRenderingDisplayNode();
   ~vtkMRMLCPURayCastVolumeRenderingDisplayNode() override;

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx
@@ -31,7 +31,10 @@
 vtkMRMLNodeNewMacro(vtkMRMLGPURayCastVolumeRenderingDisplayNode);
 
 //----------------------------------------------------------------------------
-vtkMRMLGPURayCastVolumeRenderingDisplayNode::vtkMRMLGPURayCastVolumeRenderingDisplayNode() = default;
+vtkMRMLGPURayCastVolumeRenderingDisplayNode::vtkMRMLGPURayCastVolumeRenderingDisplayNode()
+{
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLGPURayCastVolumeRenderingDisplayNode", "GPU Ray-Cast Volume Rendering");
+}
 
 //----------------------------------------------------------------------------
 vtkMRMLGPURayCastVolumeRenderingDisplayNode::~vtkMRMLGPURayCastVolumeRenderingDisplayNode() = default;

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.h
@@ -51,10 +51,6 @@ public:
   // Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "GPURayCastVolumeRendering"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLGPURayCastVolumeRenderingDisplayNode", "GPU Ray Cast Volume Rendering"); };
-
 protected:
   vtkMRMLGPURayCastVolumeRenderingDisplayNode();
   ~vtkMRMLGPURayCastVolumeRenderingDisplayNode() override;

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.cxx
@@ -32,7 +32,10 @@
 vtkMRMLNodeNewMacro(vtkMRMLMultiVolumeRenderingDisplayNode);
 
 //----------------------------------------------------------------------------
-vtkMRMLMultiVolumeRenderingDisplayNode::vtkMRMLMultiVolumeRenderingDisplayNode() = default;
+vtkMRMLMultiVolumeRenderingDisplayNode::vtkMRMLMultiVolumeRenderingDisplayNode()
+{
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLMultiVolumeRenderingDisplayNode", "Multi Volume Rendering");
+}
 
 //----------------------------------------------------------------------------
 vtkMRMLMultiVolumeRenderingDisplayNode::~vtkMRMLMultiVolumeRenderingDisplayNode() = default;

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.h
@@ -49,10 +49,6 @@ public:
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override { return "MultiVolumeRendering"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMultiVolumeRenderingDisplayNode", "Multi Volume Rendering"); };
-
 protected:
   vtkMRMLMultiVolumeRenderingDisplayNode();
   ~vtkMRMLMultiVolumeRenderingDisplayNode() override;

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.cxx
@@ -36,6 +36,8 @@ vtkMRMLNodeNewMacro(vtkMRMLShaderPropertyNode);
 //----------------------------------------------------------------------------
 vtkMRMLShaderPropertyNode::vtkMRMLShaderPropertyNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLShaderPropertyNode", "Shader Property");
+
   this->ObservedEvents = vtkIntArray::New();
   this->ObservedEvents->InsertNextValue(vtkCommand::ModifiedEvent);
 

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.h
@@ -91,10 +91,6 @@ protected:
   /// Main parameters for visualization
   vtkShaderProperty* ShaderProperty{ nullptr };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLShaderPropertyNode", "Shader Property"); };
-
 private:
   vtkMRMLShaderPropertyNode(const vtkMRMLShaderPropertyNode&) = delete;
   void operator=(const vtkMRMLShaderPropertyNode&) = delete;

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyStorageNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyStorageNode.cxx
@@ -46,6 +46,8 @@ vtkMRMLNodeNewMacro(vtkMRMLShaderPropertyStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLShaderPropertyStorageNode::vtkMRMLShaderPropertyStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLShaderPropertyStorageNode", "Shader Property Storage");
+
   this->DefaultWriteFileExtension = "sp";
 }
 

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyStorageNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyStorageNode.h
@@ -45,10 +45,6 @@ public:
   /// Get node XML tag name (like Storage, Transform)
   const char* GetNodeTagName() override { return "ShaderPropertyStorage"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLShaderPropertyStorageNode", "Shader Property Storage"); };
-
   /// Return true if the node can be read in
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
 

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyJsonStorageNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyJsonStorageNode.cxx
@@ -52,6 +52,8 @@ vtkMRMLNodeNewMacro(vtkMRMLVolumePropertyJsonStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLVolumePropertyJsonStorageNode::vtkMRMLVolumePropertyJsonStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLVolumePropertyJsonStorageNode", "Volume Property Json Storage");
+
   this->DefaultWriteFileExtension = "vp.json";
 }
 

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyJsonStorageNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyJsonStorageNode.h
@@ -51,10 +51,6 @@ public:
   /// Get node XML tag name (like Storage, Transform)
   const char* GetNodeTagName() override { return "VolumePropertyJsonStorage"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLVolumePropertyJsonStorageNode", "Volume Property Json Storage"); };
-
   /// Return true if the node can be read in
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
 

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.cxx
@@ -26,6 +26,8 @@ vtkMRMLNodeNewMacro(vtkMRMLVolumePropertyNode);
 vtkMRMLVolumePropertyNode::vtkMRMLVolumePropertyNode()
   : EffectiveRange{ 0.0, -1.0 }
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLVolumePropertyNode", "Volume Property");
+
   this->ObservedEvents = vtkSmartPointer<vtkIntArray>::New();
   this->ObservedEvents->InsertNextValue(vtkCommand::StartEvent);
   this->ObservedEvents->InsertNextValue(vtkCommand::ModifiedEvent);

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.h
@@ -200,10 +200,6 @@ protected:
   /// when the property is set into the volume.
   bool IgnoreVolumePropertyChanges{ false };
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLVolumePropertyNode", "Volume Property"); };
-
   /// Main parameters for visualization
   vtkVolumeProperty* VolumeProperty{ nullptr };
 

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyStorageNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyStorageNode.cxx
@@ -31,6 +31,8 @@ vtkMRMLNodeNewMacro(vtkMRMLVolumePropertyStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLVolumePropertyStorageNode::vtkMRMLVolumePropertyStorageNode()
 {
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLVolumePropertyStorageNode", "Volume Property Storage");
+
   this->DefaultWriteFileExtension = "vp";
 }
 

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyStorageNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyStorageNode.h
@@ -39,10 +39,6 @@ public:
   /// Get node XML tag name (like Storage, Transform)
   const char* GetNodeTagName() override { return "VolumePropertyStorage"; }
 
-  /// Get node type to be displayed to the user.
-  /// It is translated to the application language.
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLVolumePropertyStorageNode", "Volume Property Storage"); };
-
   /// Return true if the node can be read in
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
 

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/MRML/vtkMRMLMarkupsTestLineNode.cxx
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/MRML/vtkMRMLMarkupsTestLineNode.cxx
@@ -28,7 +28,10 @@
 vtkMRMLNodeNewMacro(vtkMRMLMarkupsTestLineNode);
 
 //--------------------------------------------------------------------------------
-vtkMRMLMarkupsTestLineNode::vtkMRMLMarkupsTestLineNode() {}
+vtkMRMLMarkupsTestLineNode::vtkMRMLMarkupsTestLineNode()
+{
+  this->TypeDisplayName = vtkMRMLTr("vtkMRMLMarkupsTestLineNode", "Test Line");
+}
 
 //--------------------------------------------------------------------------------
 vtkMRMLMarkupsTestLineNode::~vtkMRMLMarkupsTestLineNode() = default;

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/MRML/vtkMRMLMarkupsTestLineNode.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/MRML/vtkMRMLMarkupsTestLineNode.h
@@ -48,9 +48,6 @@ public:
   /// Get markup type internal name
   const char* GetMarkupType() override { return "TestLine"; }
 
-  // Get markup type GUI display name
-  std::string GetTypeDisplayName() override { return vtkMRMLTr("vtkMRMLMarkupsTestLineNode", "Test Line"); };
-
   /// Get markup short name
   std::string GetDefaultNodeNamePrefix() override { return vtkMRMLTr("vtkMRMLMarkupsTestLineNode", "TL"); }
 


### PR DESCRIPTION
This PR is a collection of commits that aims for default node usage to be respected by various places of Slicer core that create nodes (programmatically through AddNewNodeByClass, GUI through qMRMLNodeComboBox, GUI through Markups Module node creation buttons). I originally started working on these changes after beginning to use a default markups node, but noticing that the Markups module that I was using was not respecting this new default.

I've created the following code snippet to test the various changed logic.

```python
# Start from fresh scene
slicer.mrmlScene.Clear()
# Create node with AddNewNodeByClass (x2) to see how name iterates
markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode")
print(markup_node.GetName())
markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode")
print(markup_node.GetName())
# Create node with AddNewNodeByClass with Name prespecified (x2) to see how name iterates
markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
print(markup_node.GetName())
markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
print(markup_node.GetName())
# Create node with Markups module logic (x2) to see how name iterates
markup_node_from_module = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode")
print(markup_node_from_module.GetName())
markup_node_from_module = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode")
print(markup_node_from_module.GetName())
# Create node with Markups module logic with Name prespecified (x2) to see how name iterates
markup_node_from_module = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
print(markup_node_from_module.GetName())
markup_node_from_module = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
print(markup_node_from_module.GetName())
```

The printed output shows the differences :

|| `main` | This PR |
|-|--------|----------|
|AddNewNodeByClass|MarkupsLine|L|
|AddNewNodeByClass|MarkupsLine_1|L_1|
|AddNewNodeByClass; name specified|UseThisDefaultNameExactly|UseThisDefaultNameExactly|
|AddNewNodeByClass; name specified|UseThisDefaultNameExactly|UseThisDefaultNameExactly|
|Markups Module|L|L_2|
|Markups Module|L_1|L_3|
|Markups Module; name specified|UseThisDefaultNameExactly|UseThisDefaultNameExactly
|Markups Module; name specified|UseThisDefaultNameExactly|UseThisDefaultNameExactly|


-------------------------------------------------

The printed output shows the differences when there is a DEFAULT NODE added:
```python
slicer.mrmlScene.Clear()
# Define a default Markups Line node with a default node name
default_markups_line_node = slicer.vtkMRMLMarkupsLineNode()
default_markups_line_node.SetName("DefaultNodeName")  # Default names are to be used exactly and to not be manipulated through GenerateUniqueName()
slicer.mrmlScene.AddDefaultNode(default_markups_line_node)
# Create node with AddNewNodeByClass (x2) to see how name iterates
markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode")
print(markup_node.GetName())
markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode")
print(markup_node.GetName())
# Create node with AddNewNodeByClass with Name prespecified (x2) to see how name iterates
markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
print(markup_node.GetName())
markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
print(markup_node.GetName())
# Create node with Markups module logic (x2) to see how name iterates
markup_node_from_module = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode")
print(markup_node_from_module.GetName())
markup_node_from_module = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode")
print(markup_node_from_module.GetName())
# Create node with Markups module logic with Name prespecified (x2) to see how name iterates
markup_node_from_module = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
print(markup_node_from_module.GetName())
markup_node_from_module = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsLineNode", "UseThisDefaultNameExactly")
print(markup_node_from_module.GetName())
```

|| `main` | This PR |
|-|--------|----------|
|AddNewNodeByClass|DefaultNodeName|DefaultNodeName|
|AddNewNodeByClass|DefaultNodeName|DefaultNodeName|
|AddNewNodeByClass; name specified|UseThisDefaultNameExactly|UseThisDefaultNameExactly|
|AddNewNodeByClass; name specified|UseThisDefaultNameExactly|UseThisDefaultNameExactly|
|Markups Module|L|DefaultNodeName|
|Markups Module|L_1|DefaultNodeName|
|Markups Module; name specified|UseThisDefaultNameExactly|UseThisDefaultNameExactly|
|Markups Module; name specified|UseThisDefaultNameExactly|UseThisDefaultNameExactly|

---------------------------------------------------
`ENH: Support customizing markups default node prefix` is an additional commit to support customizing Markups objects node prefix. In the example below I change the `DefaultNodeNamePrefix` from "A" to "Angle" for a vtkMRMLMarkupsAngleNode object.

```python
# Start from fresh scene
slicer.mrmlScene.Clear()
# Define a default Markups Angle node with a default node name prefix
default_markups_angle_node = slicer.vtkMRMLMarkupsAngleNode()
default_markups_angle_node.SetDefaultNodeNamePrefix("Angle")
slicer.mrmlScene.AddDefaultNode(default_markups_angle_node)
# Create node with AddNewNodeByClass (x2) to see how name iterates
markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsAngleNode")
print(markup_node.GetName())
markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsAngleNode")
print(markup_node.GetName())
# Create node with AddNewNodeByClass with Name prespecified (x2) to see how name iterates
markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsAngleNode", "UseThisDefaultNameExactly")
print(markup_node.GetName())
markup_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsAngleNode", "UseThisDefaultNameExactly")
print(markup_node.GetName())
# Create node with Markups module logic (x2) to see how name iterates
markup_node_from_module = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsAngleNode")
print(markup_node_from_module.GetName())
markup_node_from_module = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsAngleNode")
print(markup_node_from_module.GetName())
# Create node with Markups module logic with Name prespecified (x2) to see how name iterates
markup_node_from_module = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsAngleNode", "UseThisDefaultNameExactly")
print(markup_node_from_module.GetName())
markup_node_from_module = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsAngleNode", "UseThisDefaultNameExactly")
print(markup_node_from_module.GetName())
```

`main` does not support customizing DefaultNodeNamePrefix, but below is the output using the changes in this PR:

||This PR|
|-|--------|
|AddNewNodeByClass|Angle|
|AddNewNodeByClass|Angle_1|
|AddNewNodeByClass; name specified|UseThisDefaultNameExactly|
|AddNewNodeByClass; name specified|UseThisDefaultNameExactly|
|Markups Module|Angle_2|
|Markups Module|Angle_3|
|Markups Module; name specified|UseThisDefaultNameExactly|
|Markups Module; name specified|UseThisDefaultNameExactly|