### PR TITLE
BUG: Fix reordering of subject hierarchy nodes

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.h
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.h
@@ -73,6 +73,8 @@ public:
     SubjectHierarchyItemDisplayModifiedEvent,
     SubjectHierarchyItemTransformModifiedEvent,
     SubjectHierarchyItemReparentedEvent,
+    /// Event invoked when order of child items of an item is modified.
+    SubjectHierarchyItemChildrenReorderedEvent,
     /// Event invoked when UID is added to subject hierarchy item. Useful when using UIDs
     /// to find related nodes, and the nodes are loaded sequentially in unspecified order.
     SubjectHierarchyItemUIDAddedEvent,
@@ -279,6 +281,14 @@ public:
   /// \param beforeItemID Item to move given item before. If INVALID_ITEM_ID then insert to the end
   /// \return Success flag
   bool MoveItem(vtkIdType itemID, vtkIdType beforeItemID);
+
+  /// Reorder child items of a subject hierarchy item
+  /// If a child item was under a different parent then the item is moved under the new parent.
+  /// Current children of the parent item that are not listed in childIDs are moved to the end.
+  /// \param itemID Parent item where the children will be moved to, in the specified order.
+  /// \param childIDs New order of the children.
+  /// \return Success flag
+  bool ReorderItemChildren(vtkIdType parentItemID, vtkIdList* childIDs);
 
   // Item finder methods
 public:

--- a/Libs/vtkSegmentationCore/vtkSegmentation.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.cxx
@@ -913,6 +913,15 @@ void vtkSegmentation::ReorderSegments(std::vector<std::string> segmentIdsToMove,
     return;
   }
 
+  if (insertBeforeSegmentId.empty())
+  {
+    // This may be a full update. If the requested segments are the same then no change is needed.
+    if (std::equal(segmentIdsToMove.begin(), segmentIdsToMove.end(), this->SegmentIds.begin()))
+    {
+      return;
+    }
+  }
+
   // Remove all segmentIdsToMove from the segment ID list
   for (std::deque<std::string>::iterator segmentIdIt = this->SegmentIds.begin(); segmentIdIt != this->SegmentIds.end();
        /*upon deletion the increment is done already, so don't increment here*/)

--- a/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.h
+++ b/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.h
@@ -134,6 +134,10 @@ public slots:
   ///  Called when segmentation display node is modified
   void onDisplayNodeModified(vtkObject* caller);
 
+  /// Called when segments order is modified in an observed segmentation node.
+  /// Updates subject hierarchy items order to match the segments order
+  void onSegmentsOrderModified(vtkObject* caller, void* callData);
+
   /// Called when a subject hierarchy item is modified.
   /// Renames segment if the modified item belongs to a segment
   void onSubjectHierarchyItemModified(vtkObject* caller, void* callData);
@@ -141,6 +145,8 @@ public slots:
   /// Called when a subject hierarchy item is about to be removed.
   /// Removes segment from parent segmentation if the removed item belongs to a segment
   void onSubjectHierarchyItemAboutToBeRemoved(vtkObject* caller, void* callData);
+
+  void onSubjectHierarchyItemChildrenReordered(vtkObject* caller, void* callData);
 
 protected slots:
   /// Export to binary labelmap

--- a/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentsPlugin.cxx
+++ b/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentsPlugin.cxx
@@ -211,6 +211,13 @@ bool qSlicerSubjectHierarchySegmentsPlugin::reparentItemInsideSubjectHierarchy(v
     return false;
   }
 
+  if (fromSegmentationNode == toSegmentationNode)
+  {
+    // If source and target segmentation are the same, then no reparenting is needed.
+    // The segmentation plugin has already taken care of the item reordering.
+    return true;
+  }
+
   // Get segment ID
   std::string segmentId(shNode->GetItemAttribute(itemID, vtkMRMLSegmentationNode::GetSegmentIDAttributeName()));
 

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -2288,23 +2288,10 @@ void qMRMLSegmentEditorWidget::onSwitchToSegmentations()
     return;
   }
 
-  // Get segmentation selector combobox and set segmentation
-  qMRMLNodeComboBox* nodeSelector = moduleWidget->findChild<qMRMLNodeComboBox*>("MRMLNodeComboBox_Segmentation");
-  if (!nodeSelector)
-  {
-    qCritical() << Q_FUNC_INFO << ": MRMLNodeComboBox_Segmentation is not found in Segmentations module";
-    return;
-  }
-  nodeSelector->setCurrentNode(segmentationNode);
-
-  // Get segments table and select segment
-  qMRMLSegmentsTableView* segmentsTable = moduleWidget->findChild<qMRMLSegmentsTableView*>("SegmentsTableView");
-  if (!segmentsTable)
-  {
-    qCritical() << Q_FUNC_INFO << ": SegmentsTableView is not found in Segmentations module";
-    return;
-  }
-  segmentsTable->setSelectedSegmentIDs(d->SegmentsTableView->selectedSegmentIDs());
+  // Go to Segmentations module and select the current segment
+  QStringList selectedSegmentIDs = d->SegmentsTableView->selectedSegmentIDs();
+  QString selectedSegmentID = selectedSegmentIDs.isEmpty() ? QString() : selectedSegmentIDs[0];
+  qSlicerApplication::application()->openNodeModule(segmentationNode, "SegmentID", selectedSegmentID);
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModule.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModule.cxx
@@ -242,6 +242,7 @@ void qSlicerSegmentationsModule::onNodeAdded(vtkObject* sceneObject, vtkObject* 
     qvtkConnect(segmentationNode, vtkSegmentation::SegmentRemoved, segmentationsPlugin, SLOT(onSegmentRemoved(vtkObject*, void*)));
     qvtkConnect(segmentationNode, vtkSegmentation::SegmentModified, segmentationsPlugin, SLOT(onSegmentModified(vtkObject*, void*)));
     qvtkConnect(segmentationNode, vtkMRMLSegmentationNode::DisplayModifiedEvent, segmentationsPlugin, SLOT(onDisplayNodeModified(vtkObject*)));
+    qvtkConnect(segmentationNode, vtkSegmentation::SegmentsOrderModified, segmentationsPlugin, SLOT(onSegmentsOrderModified(vtkObject*, void*)));
   }
 
   // Connect subject hierarchy modified event to handle renaming segments from subject hierarchy
@@ -253,6 +254,10 @@ void qSlicerSegmentationsModule::onNodeAdded(vtkObject* sceneObject, vtkObject* 
                 vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemAboutToBeRemovedEvent,
                 segmentationsPlugin,
                 SLOT(onSubjectHierarchyItemAboutToBeRemoved(vtkObject*, void*)));
+    qvtkConnect(subjectHierarchyNode,
+                vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemChildrenReorderedEvent,
+                segmentationsPlugin,
+                SLOT(onSubjectHierarchyItemChildrenReordered(vtkObject*, void*)));
   }
 }
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.h
@@ -195,6 +195,7 @@ protected slots:
   virtual void onSubjectHierarchyItemAboutToBeRemoved(vtkIdType itemID);
   virtual void onSubjectHierarchyItemRemoved(vtkIdType itemID);
   virtual void onSubjectHierarchyItemModified(vtkIdType itemID);
+  virtual void onSubjectHierarchyItemChildrenReordered(vtkIdType itemID);
 
   virtual void onMRMLSceneImported(vtkMRMLScene* scene);
   virtual void onMRMLSceneClosed(vtkMRMLScene* scene);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel_p.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel_p.h
@@ -53,6 +53,7 @@
 
 class QStandardItemModel;
 class vtkSlicerTerminologiesModuleLogic;
+class qSlicerSubjectHierarchyAbstractPlugin;
 
 //------------------------------------------------------------------------------
 // qMRMLSubjectHierarchyModelPrivate
@@ -82,6 +83,22 @@ public:
 
   /// Get extra item identifier
   const QString extraItemIdentifier() { return QString("ExtraItem"); };
+
+  /// Information about a drag-and-drop operation of an item. It can be used to undo the drag-and-drop
+  /// by placing back the item into its original position.
+  struct ItemDragInfo
+  {
+    vtkIdType parentItemID{ 0 };
+    vtkIdType originalParentItemID{ 0 };
+    int originalIndexUnderParent{ -1 };
+    qSlicerSubjectHierarchyAbstractPlugin* plugin{ nullptr };
+    bool revert{ false };
+  };
+
+  // Undo drag-and-drop of each item that has 'revert' set to true and remove from the itemsDragInfo.
+  void completePendingDragAndDropReverts(QMap<vtkIdType, qMRMLSubjectHierarchyModelPrivate::ItemDragInfo>& itemsDragInfo);
+
+  qSlicerSubjectHierarchyAbstractPlugin* pluginForReparenting(vtkIdType itemID, vtkIdType oldParentID, vtkIdType newParentID) const;
 
 public:
   vtkSmartPointer<vtkCallbackCommand> CallBack;


### PR DESCRIPTION
Subject hierarchy item order are now synchronized between:
- subject hierarchy singleton node in the scene
- subject hierarchy item model of all subject hierarchy Widgets
- segments of each segmentation node

This is implemented by two-way synchronization between: qMRMLSubjectHierarchyModel <-> subject hierarchy node (in qMRMLSubjectHierarchyModel) and subject hierarchy node <-> segmentation nodes (in qSlicerSubjectHierarchySegmentationsPlugin).

fixes #8421

@muratmaga 