### PR TITLE
ENH: Remove Slicer mention from Markups save to default display tooltip

### DIFF
--- a/Modules/Loadable/Markups/Resources/UI/qSlicerMarkupsModule.ui
+++ b/Modules/Loadable/Markups/Resources/UI/qSlicerMarkupsModule.ui
@@ -110,7 +110,7 @@
           <item>
            <widget class="QPushButton" name="saveToDefaultDisplayPropertiesPushButton">
             <property name="toolTip">
-             <string>Save current display property settings to defaults, will be saved for when Slicer restarts (see Application Settings)</string>
+             <string>Save current display properties to defaults. These properties will be used even after application restart.</string>
             </property>
             <property name="text">
              <string>Save to Defaults</string>


### PR DESCRIPTION
Removing the "Slicer" mention is to support the usage in a Slicer custom application which generally has a different application name.

This string exists in a UI file, so I re-worded it to remove the application name entirely rather than setting the tooltip from the code and utilizing `slicer.app.mainApplicationName`.