### PR TITLE
COMP: Update vtkAddon to fix wrapping error reported when using VTK 9.5

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -203,7 +203,7 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG b5aa0615a6486b6bdceeb13bd59c2fb9f89cce42
+  GIT_TAG b1fa5034077fc04b10457fe25004c65af6091a37
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_vtkAddon Slicer_REMOTE_DEPENDENCIES vtkAddon)


### PR DESCRIPTION
Follow-up of kitware/VTK@d2176e7405 ("Remove obsolete PythonInitImpl.cxx file", 2025-01-13)

List of vtkAddon changes:

```
$ git shortlog b5aa0615a..b1fa50340 --no-merges
James Butler (1):
      BUG: Fix wrapping error when using VTK 9.5

Jean-Christophe Fillion-Robin (1):
      DOC: Update History section adding "VTK module Python wrapping"
```