### PR TITLE
ENH: Make it easier to render large volumes on macOS

### DIFF
--- a/Docs/user_guide/modules/volumerendering.md
+++ b/Docs/user_guide/modules/volumerendering.md
@@ -118,12 +118,11 @@ See [video demo/tutorial of these steps](https://youtu.be/xZwyW6SaoM4?t=12) for 
 - To reduce staircase artifacts during rendering, choose enable "Surface smoothing" in Advanced/Techniques/Advanced rendering properties section, or choose "Normal" or "Maximum" as quality.
 - The volume must not be under a warping (affine or non-linear) transformation. To render a warped volume, the transform must be hardened on the volume. (see [related issue](https://github.com/Slicer/Slicer/issues/6648))
 - If the application crashes when rotating or zooming a volume: This indicates that you get a TDR error, i.e., the operating system shuts down applications that keep the graphics card busy for too long. This happens because the size of the volume is too large for your GPU to comfortably handle. There are several ways to work around this:
-  - Option A: Run the code snippet in the Python console (<kbd>Ctrl</kbd>-<kbd>3</kbd>) to split the volume to smaller chunks (that way you have a better chance that the graphics card will not be unresponsive for too long) _after_ enabling volume rendering.
+  - Option A: Run the code snippet in the Python console (<kbd>Ctrl</kbd>-<kbd>3</kbd>) to split the volume to smaller chunks (that way you have a better chance that the graphics card will not be unresponsive for too long).
     ```python
-    threeDViewWidget = slicer.app.layoutManager().threeDWidget(0)
-    vrDisplayableManager = threeDViewWidget.threeDView().displayableManagerByClassName('vtkMRMLVolumeRenderingDisplayableManager')
-    vrMapper = vrDisplayableManager.GetVolumeMapper(getNode('skull'))
-    vrMapper.SetPartitions(1,1,2)
+    slicer.vtkMRMLVolumeRenderingDisplayableManager.SetMaximum3DTextureSize(400)
+    for vrDisplayNode in getNodesByClass('vtkMRMLVolumeRenderingDisplayNode'):
+        slicer.util.arrayFromVolumeModified(vrDisplayNode.GetVolumeNode())
     ```
   - Option B: Crop and downsample your volume using Crop volume and volume render this smaller volume.
   - Option C: Increase TDR delay value in registry (see details [here](https://docs.microsoft.com/en-us/windows-hardware/drivers/display/tdr-registry-keys))

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.h
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.h
@@ -65,6 +65,15 @@ public:
   /// Get the MRML ID of the picked node, returns empty string if no pick
   const char* GetPickedNodeID() override;
 
+  /// @{
+  /// Experimental function to adjust the maximum 3D texture size.
+  /// Along each axis, the volume will be split up so that each partition is not larger than this maximum size.
+  /// Default is 2048 on macOS (as Apple hardware typically is limited to this maximum texture size)
+  /// and 4096 on other systems (so that most volumes will not be split up by default).
+  static int GetMaximum3DTextureSize();
+  static void SetMaximum3DTextureSize(int size);
+  /// @}
+
 public:
   static int DefaultGPUMemorySize;
 
@@ -84,6 +93,7 @@ protected:
 
 protected:
   vtkSlicerVolumeRenderingLogic *VolumeRenderingLogic{nullptr};
+  static int Maximum3DTextureSize;
 
 protected:
   vtkMRMLVolumeRenderingDisplayableManager(const vtkMRMLVolumeRenderingDisplayableManager&); // Not implemented


### PR DESCRIPTION
On macOS graphics hardware, maximum 3D texture size (along any axis) is typically 2048. This commit sets volume partitioning partitioned to not exceed this size by default.

On other systems volume is maximum size is set to 4096 by default, which will not split up the volume in most cases (which was the behavior before this commit).