### PR TITLE
COMP: Update CTK to fix build when using VTK 9.5

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "9c9c1495dd5f1a83236fe0e43636558d66f192b4"
+    "26688b15fb86e8ddef172ec7b34a09ae7d65338c"
     QUIET
     )
 


### PR DESCRIPTION
This work has been pulled out of https://github.com/Slicer/Slicer/pull/8427 for separate integration.
```
List of CTK changes:

$ git shortlog 9c9c149..26688b1
James Butler (1):
      COMP: Fix build error with VTK 9.5
```

Related pull requests:
* https://github.com/commontk/CTK/pull/1234