### PR TITLE
ENH: Remove old deprecation warning

### DIFF
--- a/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
@@ -509,21 +509,6 @@ void qMRMLNodeComboBox::addAttribute(const QString& nodeType,
                                      const QVariant& attributeValue)
 {
   Q_D(qMRMLNodeComboBox);
-
-  // Add a warning to make it easier to detect issue in obsolete modules that have not been updated
-  // since the "LabelMap" attribute was replaced by vtkMRMLLabelMapVolumeNode.
-  // The "LabelMap" attribute filter is not applied to make obsolete modules still usable (if we
-  // applied the filter then no volume would show up in the selector; as we ignore it both scalar
-  // and labelmap volumes show up, which is just a slight inconvenience).
-  // Probably this check can be removed by Summer 2016 (one year after the vtkMRMLLabelMapVolumeNode
-  // was introduced).
-  if (nodeType=="vtkMRMLScalarVolumeNode" && attributeName=="LabelMap")
-  {
-    qWarning("vtkMRMLScalarVolumeNode does not have a LabelMap attribute anymore. Update your code according to "
-      "https://www.slicer.org/w/index.php/Documentation/Labs/Segmentations#Module_update_instructions");
-    return;
-  }
-
   d->MRMLNodeFactory->addAttribute(attributeName, attributeValue.toString());
   this->sortFilterProxyModel()->addAttribute(nodeType, attributeName, attributeValue);
 }


### PR DESCRIPTION
As indicated by the comment, enough time has passed for developers to update their code accordingly as part of understanding that vtkMRMLScalarVolumeNode does not have a LabelMap attribute anymore.

This warning was originally added in 2015 through https://github.com/Slicer/Slicer/commit/d071d05cd7c4ef91eeced7a9c1ef003bf9751710.