### PR TITLE
BUG: Fix basename not incrementing for AddNewNodeByClass

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -1453,7 +1453,7 @@ vtkMRMLNode* vtkMRMLScene::AddNewNodeByClass(
   }
   if (!nodeBaseName.empty())
   {
-    nodeToAdd->SetName(nodeBaseName.c_str());
+    nodeToAdd->SetName(this->GenerateUniqueName(nodeBaseName).c_str());
   }
   return this->AddNode(nodeToAdd);
 }
@@ -1499,7 +1499,7 @@ vtkMRMLNode* vtkMRMLScene::AddNewNodeByClassWithID(std::string className, std::s
   nodeToAdd->SetID(nodeID.c_str());
   if (!nodeBaseName.empty())
   {
-    nodeToAdd->SetName(nodeBaseName.c_str());
+    nodeToAdd->SetName(this->GenerateUniqueName(nodeBaseName).c_str());
   }
 
   return this->AddNode(nodeToAdd);


### PR DESCRIPTION
As originally pointed out in https://discourse.slicer.org/t/addnewnodebyclass-basename-does-not-increment/34386.

This logic setting the name in `AddNewNodeByClass` has seemingly been the same since it was introduced in https://github.com/Slicer/Slicer/commit/31551523b242a03c0f8f5fa17999f0eb7b7cd360. This PR has been made under the assumption that the input argument of "nodeBaseName" means that the intention is for the specified name to serve as a base and increment to provide a unique name.

https://github.com/Slicer/Slicer/blob/673ddca536801eedfdc3287dbc6ab110c494382c/Libs/MRML/Core/vtkMRMLScene.h#L211-L214

It appears that developers have worked around this issue of the name not incrementing by calling `GenerateUniqueName` manually.
https://github.com/Slicer/Slicer/blob/673ddca536801eedfdc3287dbc6ab110c494382c/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py#L460-L464
https://github.com/Slicer/Slicer/blob/673ddca536801eedfdc3287dbc6ab110c494382c/Modules/Scripted/Endoscopy/Endoscopy.py#L878-L881

However in some places it is unclear if the specified `nodeBaseName` has instead been used as a `nodeName` with expectation that it would not increment and be used exactly as specified. If this is the desire then we could instead change the `AddNewNodeByClass` method to name the input argument `nodeName` instead of `nodeBaseName`.
https://github.com/Slicer/Slicer/blob/673ddca536801eedfdc3287dbc6ab110c494382c/Docs/developer_guide/script_repository/markups.md?plain=1#L687-L689
https://github.com/Slicer/Slicer/blob/673ddca536801eedfdc3287dbc6ab110c494382c/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx#L168-L177