### PR TITLE
ENH: Always show context selector in terminology navigator

### DIFF
--- a/Modules/Loadable/Terminologies/Widgets/Resources/UI/qSlicerTerminologyNavigatorWidget.ui
+++ b/Modules/Loadable/Terminologies/Widgets/Resources/UI/qSlicerTerminologyNavigatorWidget.ui
@@ -609,21 +609,5 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>CategoryExpandButton</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>frame</receiver>
-   <slot>setVisible(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>111</x>
-     <y>110</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>120</x>
-     <y>34</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
 </ui>


### PR DESCRIPTION
In the terminology navigator widget, the terminology context selector (to choose between general anatomy list, DICOM list, or custom color tables) was only shown when the category selector section was displayed (the small arrow button on the left was depressed). This made the navigator widget look simpler and nicer, but made it more difficult to switch to a different context.

This pull request makes the context selector always visible.

Old:

![image](https://github.com/user-attachments/assets/92df1ae6-a99c-45ea-a6d6-43be072accd9)

New:

![image](https://github.com/user-attachments/assets/c4cb8016-e5ee-43ef-97af-0d7bdd286a32)

@muratmaga 