### PR TITLE
BUG: Fix incorrect expected warnings in vtkMRMLAnnotationSceneTest

### DIFF
--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMarkupsAnnotationSceneTest.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMarkupsAnnotationSceneTest.cxx
@@ -103,7 +103,7 @@ int vtkMarkupsAnnotationSceneTest(int argc, char * argv[] )
   TESTING_OUTPUT_IGNORE_WARNINGS_ERRORS_BEGIN();
   bool readSuccess = (scene->Connect() != 0);
   TESTING_OUTPUT_ASSERT_ERRORS(0);
-  TESTING_OUTPUT_ASSERT_WARNINGS(2);  // warning about view tag/layout name, because we read an old scene
+  TESTING_OUTPUT_ASSERT_WARNINGS(0);
   TESTING_OUTPUT_IGNORE_WARNINGS_ERRORS_END();
 
   CHECK_BOOL(readSuccess, true);


### PR DESCRIPTION
As of https://github.com/Slicer/Slicer/commit/a2c948e33eb216d8649ee52007d4ebc9459a1c5b, SetActiveTag deprecation is no longer warned upon reading old scenes.

@Sunderlandkyl The vtkMRMLAnnotationSceneTest is still failing after this fix from me. As seen at https://slicer.cdash.org/tests/29823763?graph=status the test began failing on 2025-03-24 which would correspond to changes you made in https://github.com/Slicer/Slicer/commit/fb6fb19ef37f60abc7c021c688560fedd1ccfebe the day prior.
```
Line 155 - scene->GetNumberOfNodesByClass("vtkMRMLAnnotationPointDisplayNode") != 0 : CheckInt failed
	current :10
	expected:0
```