### PR TITLE
ENH: Add component selector to volume property node widget

### DIFF
--- a/Modules/Loadable/VolumeRendering/Resources/UI/qMRMLVolumePropertyNodeWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qMRMLVolumePropertyNodeWidget.ui
@@ -6,19 +6,48 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>240</width>
-    <height>338</height>
+    <width>363</width>
+    <height>362</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Volume Property Node</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
     <number>0</number>
    </property>
-   <item>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="ComponentLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Component:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
     <widget class="ctkVTKVolumePropertyWidget" name="VolumePropertyWidget"/>
+   </item>
+   <item row="0" column="1">
+    <widget class="QSpinBox" name="ComponentSpinBox">
+     <property name="maximum">
+      <number>2</number>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/Modules/Loadable/VolumeRendering/Widgets/qMRMLVolumePropertyNodeWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qMRMLVolumePropertyNodeWidget.cxx
@@ -47,6 +47,7 @@ public:
   virtual void setupUi();
 
   vtkWeakPointer<vtkMRMLVolumePropertyNode> VolumePropertyNode;
+  int ComponentCount{ 1 };
 };
 
 // --------------------------------------------------------------------------
@@ -69,6 +70,8 @@ void qMRMLVolumePropertyNodeWidgetPrivate::setupUi()
                    q, SIGNAL(chartsExtentChanged()));
   QObject::connect(this->VolumePropertyWidget, SIGNAL(thresholdEnabledChanged(bool)),
                    q, SIGNAL(thresholdChanged(bool)));
+  QObject::connect(this->ComponentSpinBox, SIGNAL(valueChanged(int)),
+                   this->VolumePropertyWidget, SLOT(setCurrentComponent(int)));
 }
 
 // --------------------------------------------------------------------------
@@ -177,4 +180,22 @@ void qMRMLVolumePropertyNodeWidget::spreadAllPoints(double factor, bool dontSpre
 {
   Q_D(const qMRMLVolumePropertyNodeWidget);
   return d->VolumePropertyWidget->spreadAllPoints(factor, dontSpreadFirstAndLast);
+}
+
+// --------------------------------------------------------------------------
+int qMRMLVolumePropertyNodeWidget::componentCount()const
+{
+  Q_D(const qMRMLVolumePropertyNodeWidget);
+  return d->ComponentCount;
+}
+
+// --------------------------------------------------------------------------
+void qMRMLVolumePropertyNodeWidget::setComponentCount(int componentCount)
+{
+  Q_D(qMRMLVolumePropertyNodeWidget);
+  d->ComponentCount = componentCount;
+  int currentComponent = d->VolumePropertyWidget->currentComponent();
+  currentComponent = std::clamp(currentComponent, 0, componentCount);
+  d->VolumePropertyWidget->setCurrentComponent(currentComponent);
+  d->ComponentSpinBox->setRange(0, componentCount - 1);
 }

--- a/Modules/Loadable/VolumeRendering/Widgets/qMRMLVolumePropertyNodeWidget.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qMRMLVolumePropertyNodeWidget.h
@@ -45,6 +45,7 @@ class Q_SLICER_MODULE_VOLUMERENDERING_WIDGETS_EXPORT qMRMLVolumePropertyNodeWidg
   Q_OBJECT
   QVTK_OBJECT
   Q_PROPERTY(bool threshold READ hasThreshold WRITE setThreshold)
+  Q_PROPERTY(int componentCount READ componentCount WRITE setComponentCount)
 
 public:
   /// Constructors
@@ -79,10 +80,14 @@ public slots:
   void setChartsExtent(double extent[2]);
   void setChartsExtent(double min, double max);
 
+  int componentCount()const;
+  void setComponentCount(int component);
+
 signals:
   void thresholdChanged(bool enabled);
   void volumePropertyChanged();
   void chartsExtentChanged();
+  void componentChanged(int component);
 
 protected slots:
   void updateFromVolumePropertyNode();

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.cxx
@@ -39,6 +39,7 @@
 #include "vtkMRMLMarkupsROINode.h"
 
 // VTK includes
+#include <vtkImageData.h>
 #include <vtkVolumeProperty.h>
 
 // STD includes
@@ -334,6 +335,17 @@ void qSlicerVolumeRenderingModuleWidget::onCurrentMRMLVolumeNodeChanged(vtkMRMLN
     d->PresetComboBox->setCurrentNode(presetNode);
     d->PresetComboBox->blockSignals(wasBlocking);
   }
+
+  int numberOfComponents = 1;
+  if (volumeNode)
+  {
+    vtkImageData* imageData = volumeNode->GetImageData();
+    if (imageData)
+    {
+      numberOfComponents = imageData->GetNumberOfScalarComponents();
+    }
+  }
+  d->VolumePropertyNodeWidget->setComponentCount(numberOfComponents);
 
   // Update widget from display node of the volume node
   this->updateWidgetFromMRML();


### PR DESCRIPTION
This commit adds a spinbox to select the current component in qMRMLVolumePropertyNodeWidget, allowing individually transfer functions to be modified for each scalar component.