### PR TITLE
ENH: Fix build-tree environment variables in additional settings

### DIFF
--- a/CMake/SlicerExtensionGenerateConfig.cmake
+++ b/CMake/SlicerExtensionGenerateConfig.cmake
@@ -4,7 +4,7 @@
 # This file is based on SlicerGenerateSlicerConfig.cmake.
 #
 # Example:
-#
+
 # Add these lines near the end of top-level CMakeLists.txt in Sequences extension
 # to allow other extensions to use it.
 #
@@ -99,7 +99,7 @@ set(EXTENSION_SOURCE_DIR_CONFIG "set(${EXTENSION_NAME}_SOURCE_DIR \"${${EXTENSIO
 # Variables that will be used for populating AdditionalLauncherSettings.ini.
 set(EXTENSION_ADDITIONAL_LAUNCHER_SETTINGS_FILE_CONTENT_CONFIG "set(${EXTENSION_NAME}_LIBRARY_PATHS_LAUNCHER_BUILD \"${EXTENSION_LIBRARY_PATHS_BUILD}\")
 set(${EXTENSION_NAME}_PATHS_LAUNCHER_BUILD \"${EXTENSION_PATHS_BUILD}\")
-set(${EXTENSION_NAME}_ENVVARS_LAUNCHER_BUILD \"${EXTENSION_LAUNCHER_SETTINGS_ENVVARS}\")
+set(${EXTENSION_NAME}_ENVVARS_LAUNCHER_BUILD \"${EXTENSION_ENVVARS_BUILD}\")
 set(${EXTENSION_NAME}_PYTHONPATH_LAUNCHER_BUILD \"${EXTENSION_PYTHONPATH_BUILD}\")")
 
 # Allow extensions to add some custom content.

--- a/Extensions/CMake/SlicerBlockAdditionalLauncherSettings.cmake
+++ b/Extensions/CMake/SlicerBlockAdditionalLauncherSettings.cmake
@@ -1,8 +1,8 @@
 
 
 #
-# In case the extension is build using a multi-configuration system, the build
-# type will be know at build. For that reason, a script allowing to configure
+# In case the extension is built using a multi-configuration system, the build
+# type will be known at build. For that reason, a script allowing to configure
 # the "additional launcher settings" at build time will be generated.
 #
 
@@ -136,20 +136,20 @@ if(NOT TARGET ConfigureAdditionalLauncherSettings AND _configure_additional_laun
   # ENVVARS
   #-----------------------------------------------------------------------------
 
-  set(EXTENSION_LAUNCHER_SETTINGS_ENVVARS)
+  set(EXTENSION_ENVVARS_BUILD)
 
   # External projects - environment variables
   foreach(varname IN LISTS ${SUPERBUILD_TOPLEVEL_PROJECT}_EP_LABEL_ENVVARS_LAUNCHER_BUILD)
     set(value ${${varname}})
     list(TRANSFORM value REPLACE "<CMAKE_CFG_INTDIR>" "\${CMAKE_CFG_INTDIR}")
-    list(APPEND EXTENSION_LAUNCHER_SETTINGS_ENVVARS ${value})
+    list(APPEND EXTENSION_ENVVARS_BUILD ${value})
   endforeach()
 
   # Extension dependencies - environment variables
   foreach(dep ${EXTENSION_DEPENDS})
     set(paths ${${dep}_ENVVARS_LAUNCHER_BUILD})
     list(TRANSFORM paths REPLACE "\\$\\(Configuration\\)" "\${CMAKE_CFG_INTDIR}")
-    list(APPEND EXTENSION_LAUNCHER_SETTINGS_ENVVARS ${paths})
+    list(APPEND EXTENSION_ENVVARS_BUILD ${paths})
   endforeach()
 
   #-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes the generation of `AdditionalLauncherSettings.ini` file for the build tree. The problem, as documented in [https://discourse.slicer.org/t/configuring-the-running-environment-for-an-extension-build-tree/43103](https://discourse.slicer.org/t/configuring-the-running-environment-for-an-extension-build-tree/43103), is that environment varibles were not included, as opposed to e.g., `PYTHONPATH` .

There seems to be an error when referring to the correct variable in the CMake infrastructure. This PR fixes the variable naming for both the `SlicerBlockAdditionalLauncherSettings.ini`, as well as the `SlicerExtensionGenerateConfig.cmake`. These changes has been tested successfully against the SlicerSOFA extension, which requires the `SOFA_ROOT` environment variable to be set by the launcher. 