### PR TITLE
COMP: Update python packages to latest

### DIFF
--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -44,36 +44,36 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   pydicom==2.4.4 --hash=sha256:f9f8e19b78525be57aa6384484298833e4d06ac1d6226c79459131ddb0bd7c42
   # [/pydicom]
   # [six]
-  six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
+  six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
   # [/six]
   # [pillow]
   # Hashes correspond to the following packages:
-  #  - pillow-10.3.0-cp39-cp39-macosx_10_10_x86_64.whl
-  #  - pillow-10.3.0-cp39-cp39-macosx_11_0_arm64.whl
-  #  - pillow-10.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - pillow-10.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - pillow-10.3.0-cp39-cp39-manylinux_2_28_aarch64.whl
-  #  - pillow-10.3.0-cp39-cp39-manylinux_2_28_x86_64.whl
-  #  - pillow-10.3.0-cp39-cp39-musllinux_1_1_aarch64.whl
-  #  - pillow-10.3.0-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - pillow-10.3.0-cp39-cp39-win_amd64.whl
-  #  - pillow-10.3.0-cp39-cp39-win_arm64.whl
-  pillow==10.3.0 --hash=sha256:2ed854e716a89b1afcedea551cd85f2eb2a807613752ab997b9974aaa0d56936 \
-                 --hash=sha256:dc1a390a82755a8c26c9964d457d4c9cbec5405896cba94cf51f36ea0d855002 \
-                 --hash=sha256:4203efca580f0dd6f882ca211f923168548f7ba334c189e9eab1178ab840bf60 \
-                 --hash=sha256:3102045a10945173d38336f6e71a8dc71bcaeed55c3123ad4af82c52807b9375 \
-                 --hash=sha256:6fb1b30043271ec92dc65f6d9f0b7a830c210b8a96423074b15c7bc999975f57 \
-                 --hash=sha256:1dfc94946bc60ea375cc39cff0b8da6c7e5f8fcdc1d946beb8da5c216156ddd8 \
-                 --hash=sha256:b09b86b27a064c9624d0a6c54da01c1beaf5b6cadfa609cf63789b1d08a797b9 \
-                 --hash=sha256:d3b2348a78bc939b4fed6552abfd2e7988e0f81443ef3911a4b8498ca084f6eb \
-                 --hash=sha256:0ba26351b137ca4e0db0342d5d00d2e355eb29372c05afd544ebf47c0956ffeb \
-                 --hash=sha256:50fd3f6b26e3441ae07b7c979309638b72abc1a25da31a81a7fbd9495713ef4f
+  #  - pillow-11.2.1-cp39-cp39-macosx_10_10_x86_64.whl
+  #  - pillow-11.2.1-cp39-cp39-macosx_11_0_arm64.whl
+  #  - pillow-11.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - pillow-11.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - pillow-11.2.1-cp39-cp39-manylinux_2_28_aarch64.whl
+  #  - pillow-11.2.1-cp39-cp39-manylinux_2_28_x86_64.whl
+  #  - pillow-11.2.1-cp39-cp39-musllinux_1_2_aarch64.whl
+  #  - pillow-11.2.1-cp39-cp39-musllinux_1_2_x86_64.whl
+  #  - pillow-11.2.1-cp39-cp39-win_amd64.whl
+  #  - pillow-11.2.1-cp39-cp39-win_arm64.whl
+  pillow==11.2.1 --hash=sha256:7491cf8a79b8eb867d419648fff2f83cb0b3891c8b36da92cc7f1931d46108c8 \
+                 --hash=sha256:8b02d8f9cb83c52578a0b4beadba92e37d83a4ef11570a8688bbf43f4ca50909 \
+                 --hash=sha256:014ca0050c85003620526b0ac1ac53f56fc93af128f7546623cc8e31875ab928 \
+                 --hash=sha256:3692b68c87096ac6308296d96354eddd25f98740c9d2ab54e1549d6c8aea9d79 \
+                 --hash=sha256:f781dcb0bc9929adc77bad571b8621ecb1e4cdef86e940fe2e5b5ee24fd33b35 \
+                 --hash=sha256:2b490402c96f907a166615e9a5afacf2519e28295f157ec3a2bb9bd57de638cb \
+                 --hash=sha256:dd6b20b93b3ccc9c1b597999209e4bc5cf2853f9ee66e3fc9a400a78733ffc9a \
+                 --hash=sha256:4b835d89c08a6c2ee7781b8dd0a30209a8012b5f09c0a665b65b0eb3560b6f36 \
+                 --hash=sha256:6ebce70c3f486acf7591a3d73431fa504a4e18a9b97ff27f5f47b7368e4b9dd1 \
+                 --hash=sha256:c27476257b2fdcd7872d54cfd119b3a9ce4610fb85c8e32b70b42e3680a29a1e
   # [/pillow]
   # [retrying]
   retrying==1.3.4 --hash=sha256:8cc4d43cb8e1125e0ff3344e9de678fefd85db3b750b81b2240dc0183af37b35
   # [/retrying]
   # [dicomweb-client]
-  dicomweb-client==0.59.1 --hash=sha256:ad4af95e1bdeb3691841cf8b28894fc6d9ba7ac5b7892bff70a506eedbd20d79
+  dicomweb-client==0.60.0 --hash=sha256:fde6743036f9c9da74580dd643c66121a1650d16737184695bfbe076f3875e71
   # [/dicomweb-client]
   ]===])
 

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -40,16 +40,16 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   couchdb==1.2 --hash=sha256:13a28a1159c49f8346732e8724b9a4d65cba54bec017c4a7eeb1499fe88151d1
   # [/CouchDB]
   # [gitdb]
-  gitdb==4.0.11 --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4
+  gitdb==4.0.12 --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
   # [/gitdb]
   # [smmap]
-  smmap==5.0.1 --hash=sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da
+  smmap==5.0.2 --hash=sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e
   # [/smmap]
   # [GitPython]
-  GitPython==3.1.43 --hash=sha256:eec7ec56b92aad751f9912a73404bc02ba212a23adb2c7098ee668417051a1ff
+  GitPython==3.1.44 --hash=sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110
   # [/GitPython]
   # [six]
-  six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
+  six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
   # [/six]
   ]===])
 

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -34,93 +34,95 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [cryptography]
   # Hashes correspond to the following packages:
-  #  - cryptography-42.0.7-cp37-abi3-macosx_10_12_universal2.whl
-  #  - cryptography-42.0.7-cp37-abi3-macosx_10_12_x86_64.whl
-  #  - cryptography-42.0.7-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - cryptography-42.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - cryptography-42.0.7-cp37-abi3-manylinux_2_28_aarch64.whl
-  #  - cryptography-42.0.7-cp37-abi3-manylinux_2_28_x86_64.whl
-  #  - cryptography-42.0.7-cp37-abi3-musllinux_1_1_aarch64.whl
-  #  - cryptography-42.0.7-cp37-abi3-musllinux_1_1_x86_64.whl
-  #  - cryptography-42.0.7-cp37-abi3-musllinux_1_2_aarch64.whl
-  #  - cryptography-42.0.7-cp37-abi3-musllinux_1_2_x86_64.whl
-  #  - cryptography-42.0.7-cp37-abi3-win_amd64.whl
-  #  - cryptography-42.0.7-cp39-abi3-macosx_10_12_universal2.whl
-  #  - cryptography-42.0.7-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - cryptography-42.0.7-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - cryptography-42.0.7-cp39-abi3-manylinux_2_28_aarch64.whl
-  #  - cryptography-42.0.7-cp39-abi3-manylinux_2_28_x86_64.whl
-  #  - cryptography-42.0.7-cp39-abi3-musllinux_1_1_aarch64.whl
-  #  - cryptography-42.0.7-cp39-abi3-musllinux_1_1_x86_64.whl
-  #  - cryptography-42.0.7-cp39-abi3-musllinux_1_2_aarch64.whl
-  #  - cryptography-42.0.7-cp39-abi3-musllinux_1_2_x86_64.whl
-  #  - cryptography-42.0.7-cp39-abi3-win_amd64.whl
-  cryptography==42.0.7 --hash=sha256:a987f840718078212fdf4504d0fd4c6effe34a7e4740378e59d47696e8dfb477 \
-                       --hash=sha256:bd13b5e9b543532453de08bcdc3cc7cebec6f9883e886fd20a92f26940fd3e7a \
-                       --hash=sha256:a79165431551042cc9d1d90e6145d5d0d3ab0f2d66326c201d9b0e7f5bf43604 \
-                       --hash=sha256:a47787a5e3649008a1102d3df55424e86606c9bae6fb77ac59afe06d234605f8 \
-                       --hash=sha256:02c0eee2d7133bdbbc5e24441258d5d2244beb31da5ed19fbb80315f4bbbff55 \
-                       --hash=sha256:5e44507bf8d14b36b8389b226665d597bc0f18ea035d75b4e53c7b1ea84583cc \
-                       --hash=sha256:7f8b25fa616d8b846aef64b15c606bb0828dbc35faf90566eb139aa9cff67af2 \
-                       --hash=sha256:93a3209f6bb2b33e725ed08ee0991b92976dfdcf4e8b38646540674fc7508e13 \
-                       --hash=sha256:e6b8f1881dac458c34778d0a424ae5769de30544fc678eac51c1c8bb2183e9da \
-                       --hash=sha256:3de9a45d3b2b7d8088c3fbf1ed4395dfeff79d07842217b38df14ef09ce1d8d7 \
-                       --hash=sha256:8cb8ce7c3347fcf9446f201dc30e2d5a3c898d009126010cbd1f443f28b52678 \
-                       --hash=sha256:a3a5ac8b56fe37f3125e5b72b61dcde43283e5370827f5233893d461b7360cd4 \
-                       --hash=sha256:779245e13b9a6638df14641d029add5dc17edbef6ec915688f3acb9e720a5858 \
-                       --hash=sha256:0d563795db98b4cd57742a78a288cdbdc9daedac29f2239793071fe114f13785 \
-                       --hash=sha256:31adb7d06fe4383226c3e963471f6837742889b3c4caa55aac20ad951bc8ffda \
-                       --hash=sha256:efd0bf5205240182e0f13bcaea41be4fdf5c22c5129fc7ced4a0282ac86998c9 \
-                       --hash=sha256:a9bc127cdc4ecf87a5ea22a2556cab6c7eda2923f84e4f3cc588e8470ce4e42e \
-                       --hash=sha256:3577d029bc3f4827dd5bf8bf7710cac13527b470bbf1820a3f394adb38ed7d5f \
-                       --hash=sha256:2e47577f9b18723fa294b0ea9a17d5e53a227867a0a4904a1a076d1646d45ca1 \
-                       --hash=sha256:1a58839984d9cb34c855197043eaae2c187d930ca6d644612843b4fe8513c886 \
-                       --hash=sha256:16268d46086bb8ad5bf0a2b5544d8a9ed87a0e33f5e77dd3c3301e63d941a83b
+  #  - cryptography-45.0.3-cp311-abi3-macosx_10_9_universal2.whl
+  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_28_aarch64.whl
+  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_28_x86_64.whl
+  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_34_aarch64.whl
+  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_34_x86_64.whl
+  #  - cryptography-45.0.3-cp311-abi3-musllinux_1_2_aarch64.whl
+  #  - cryptography-45.0.3-cp311-abi3-musllinux_1_2_x86_64.whl
+  #  - cryptography-45.0.3-cp311-abi3-win_amd64.whl
+  #  - cryptography-45.0.3-cp37-abi3-macosx_10_9_universal2.whl
+  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_28_aarch64.whl
+  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_28_x86_64.whl
+  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_34_aarch64.whl
+  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_34_x86_64.whl
+  #  - cryptography-45.0.3-cp37-abi3-musllinux_1_2_aarch64.whl
+  #  - cryptography-45.0.3-cp37-abi3-musllinux_1_2_x86_64.whl
+  #  - cryptography-45.0.3-cp37-abi3-win_amd64.whl
+  cryptography==45.0.3 --hash=sha256:7573d9eebaeceeb55285205dbbb8753ac1e962af3d9640791d12b36864065e71 \
+                       --hash=sha256:d377dde61c5d67eb4311eace661c3efda46c62113ff56bf05e2d679e02aebb5b \
+                       --hash=sha256:fae1e637f527750811588e4582988932c222f8251f7b7ea93739acb624e1487f \
+                       --hash=sha256:ca932e11218bcc9ef812aa497cdf669484870ecbcf2d99b765d6c27a86000942 \
+                       --hash=sha256:2f8f8f0b73b885ddd7f3d8c2b2234a7d3ba49002b0223f58cfde1bedd9563c56 \
+                       --hash=sha256:9cc80ce69032ffa528b5e16d217fa4d8d4bb7d6ba8659c1b4d74a1b0f4235fca \
+                       --hash=sha256:c824c9281cb628015bfc3c59335163d4ca0540d49de4582d6c2637312907e4b1 \
+                       --hash=sha256:5833bb4355cb377ebd880457663a972cd044e7f49585aee39245c0d592904578 \
+                       --hash=sha256:9bb5bf55dcb69f7067d80354d0a348368da907345a2c448b0babc4215ccd3497 \
+                       --hash=sha256:97787952246a77d77934d41b62fb1b6f3581d83f71b44796a4158d93b8f5c490 \
+                       --hash=sha256:c92519d242703b675ccefd0f0562eb45e74d438e001f8ab52d628e885751fb06 \
+                       --hash=sha256:c5edcb90da1843df85292ef3a313513766a78fbbb83f584a5a58fb001a5a9d57 \
+                       --hash=sha256:38deed72285c7ed699864f964a3f4cf11ab3fb38e8d39cfcd96710cd2b5bb716 \
+                       --hash=sha256:5555365a50efe1f486eed6ac7062c33b97ccef409f5970a0b6f205a7cfab59c8 \
+                       --hash=sha256:cfd84777b4b6684955ce86156cfb5e08d75e80dc2585e10d69e47f014f0a5342 \
+                       --hash=sha256:a2b56de3417fd5f48773ad8e91abaa700b678dc7fe1e0c757e1ae340779acf7b \
+                       --hash=sha256:57a6500d459e8035e813bd8b51b671977fb149a8c95ed814989da682314d0782 \
+                       --hash=sha256:f22af3c78abfbc7cbcdf2c55d23c3e022e1a462ee2481011d518c7fb9c9f3d65 \
+                       --hash=sha256:232954730c362638544758a8160c4ee1b832dc011d2c41a306ad8f7cccc5bb0b \
+                       --hash=sha256:d54ae41e6bd70ea23707843021c778f151ca258081586f0cfa31d936ae43d1b2
   # [/cryptography]
   # Specifying "[crypto]" is required since PyGithub 1.58.1
   # See https://github.com/Slicer/Slicer/issues/7112
   # [PyJWT]
-  PyJWT[crypto]==2.8.0 --hash=sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320
+  PyJWT==2.10.1 --hash=sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb
   # [/PyJWT]
   # [wrapt]
   # Hashes correspond to the following packages:
-  #  - wrapt-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - wrapt-1.16.0-cp39-cp39-macosx_11_0_arm64.whl
-  #  - wrapt-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - wrapt-1.16.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - wrapt-1.16.0-cp39-cp39-musllinux_1_1_aarch64.whl
-  #  - wrapt-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - wrapt-1.16.0-cp39-cp39-win_amd64.whl
-  #  - wrapt-1.16.0-py3-none-any.whl
-  wrapt==1.16.0 --hash=sha256:9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2 \
-                --hash=sha256:2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb \
-                --hash=sha256:c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8 \
-                --hash=sha256:f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a \
-                --hash=sha256:5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664 \
-                --hash=sha256:edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537 \
-                --hash=sha256:eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35 \
-                --hash=sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1
+  #  - wrapt-1.17.2-cp39-cp39-macosx_10_9_universal2.whl
+  #  - wrapt-1.17.2-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - wrapt-1.17.2-cp39-cp39-macosx_11_0_arm64.whl
+  #  - wrapt-1.17.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - wrapt-1.17.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - wrapt-1.17.2-cp39-cp39-musllinux_1_2_aarch64.whl
+  #  - wrapt-1.17.2-cp39-cp39-musllinux_1_2_x86_64.whl
+  #  - wrapt-1.17.2-cp39-cp39-win_amd64.whl
+  #  - wrapt-1.17.2-py3-none-any.whl
+  wrapt==1.17.2 --hash=sha256:99039fa9e6306880572915728d7f6c24a86ec57b0a83f6b2491e1d8ab0235b9a \
+                --hash=sha256:2696993ee1eebd20b8e4ee4356483c4cb696066ddc24bd70bcbb80fa56ff9061 \
+                --hash=sha256:612dff5db80beef9e649c6d803a8d50c409082f1fedc9dbcdfde2983b2025b82 \
+                --hash=sha256:62c2caa1585c82b3f7a7ab56afef7b3602021d6da34fbc1cf234ff139fed3cd9 \
+                --hash=sha256:fc78a84e2dfbc27afe4b2bd7c80c8db9bca75cc5b85df52bfe634596a1da846b \
+                --hash=sha256:ba0f0eb61ef00ea10e00eb53a9129501f52385c44853dbd6c4ad3f403603083f \
+                --hash=sha256:c86563182421896d73858e08e1db93afdd2b947a70064b813d515d66549e15f9 \
+                --hash=sha256:36ccae62f64235cf8ddb682073a60519426fdd4725524ae38874adf72b5f2aeb \
+                --hash=sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8
   # [/wrapt]
   # [Deprecated]
-  Deprecated==1.2.14 --hash=sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c
+  Deprecated==1.2.18 --hash=sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec
   # [/Deprecated]
   # [pycparser]
   pycparser==2.22 --hash=sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
   # [/pycparser]
   # [cffi]
   # Hashes correspond to the following packages:
-  #  - cffi-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - cffi-1.16.0-cp39-cp39-macosx_11_0_arm64.whl
-  #  - cffi-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - cffi-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - cffi-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - cffi-1.16.0-cp39-cp39-win_amd64.whl
-  cffi==1.16.0 --hash=sha256:582215a0e9adbe0e379761260553ba11c58943e4bbe9c36430c4ca6ac74b15ed \
-               --hash=sha256:b29ebffcf550f9da55bec9e02ad430c992a87e5f512cd63388abb76f1036d8d2 \
-               --hash=sha256:9cb4a35b3642fc5c005a6755a5d17c6c8b6bcb6981baf81cea8bfbc8903e8ba8 \
-               --hash=sha256:8f8e709127c6c77446a8c0a8c8bf3c8ee706a06cd44b1e827c3e6a2ee6b8c098 \
-               --hash=sha256:8895613bcc094d4a1b2dbe179d88d7fb4a15cee43c052e8885783fac397d91fe \
-               --hash=sha256:3686dffb02459559c74dd3d81748269ffb0eb027c39a6fc99502de37d501faa8
+  #  - cffi-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - cffi-1.17.1-cp39-cp39-macosx_11_0_arm64.whl
+  #  - cffi-1.17.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - cffi-1.17.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - cffi-1.17.1-cp39-cp39-musllinux_1_1_aarch64.whl
+  #  - cffi-1.17.1-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - cffi-1.17.1-cp39-cp39-win_amd64.whl
+  cffi==1.17.1 --hash=sha256:b2ab587605f4ba0bf81dc0cb08a41bd1c0a5906bd59243d56bad7668a6fc6c16 \
+               --hash=sha256:28b16024becceed8c6dfbc75629e27788d8a3f9030691a1dbf9821a128b22c36 \
+               --hash=sha256:ca74b8dbe6e8e8263c0ffd60277de77dcee6c837a3d0881d8c1ead7268c9e576 \
+               --hash=sha256:cdf5ce3acdfd1661132f2a9c19cac174758dc2352bfe37d98aa7512c6b7178b3 \
+               --hash=sha256:9755e4345d1ec879e3849e62222a18c7174d65a6a92d5b346b1863912168b595 \
+               --hash=sha256:c03e868a0b3bc35839ba98e74211ed2b05d2119be4e8a0f224fba9384f1fe02e \
+               --hash=sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662
   # [/cffi]
   # [PyNaCl]
   # Hashes correspond to the following packages:
@@ -145,13 +147,13 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   python-dateutil==2.9.0.post0 --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
   # [/python-dateutil]
   # [six]
-  six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
+  six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
   # [/six]
   # [typing_extensions]
-  typing_extensions==4.12.1 --hash=sha256:6024b58b69089e5a89c347397254e35f1bf02a907728ec7fee9bf0fe837d203a
+  typing_extensions==4.14.0 --hash=sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af
   # [/typing_extensions]
   # [PyGithub]
-  PyGithub==2.3.0 --hash=sha256:65b499728be3ce7b0cd2cd760da3b32f0f4d7bc55e5e0677617f90f6564e793e
+  PyGithub==2.6.1 --hash=sha256:6f2fa6d076ccae475f9fc392cc6cdbd54db985d4f69b8833a28397de75ed6ca3
   # [/PyGithub]
   ]===])
 

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -31,20 +31,24 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [numpy]
   # Hashes correspond to the following packages:
-  #  - numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl
-  #  - numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl
-  #  - numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - numpy-1.26.4-cp39-cp39-win_amd64.whl
-  numpy==1.26.4 --hash=sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c \
-                --hash=sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be \
-                --hash=sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764 \
-                --hash=sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3 \
-                --hash=sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd \
-                --hash=sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c \
-                --hash=sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea
+  #  - numpy-2.0.2-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - numpy-2.0.2-cp39-cp39-macosx_11_0_arm64.whl
+  #  - numpy-2.0.2-cp39-cp39-macosx_14_0_arm64.whl
+  #  - numpy-2.0.2-cp39-cp39-macosx_14_0_x86_64.whl
+  #  - numpy-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - numpy-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - numpy-2.0.2-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - numpy-2.0.2-cp39-cp39-musllinux_1_2_aarch64.whl
+  #  - numpy-2.0.2-cp39-cp39-win_amd64.whl
+  numpy==2.0.2 --hash=sha256:9059e10581ce4093f735ed23f3b9d283b9d517ff46009ddd485f1747eb22653c \
+               --hash=sha256:423e89b23490805d2a5a96fe40ec507407b8ee786d66f7328be214f9679df6dd \
+               --hash=sha256:2b2955fa6f11907cf7a70dab0d0755159bca87755e831e47932367fc8f2f2d0b \
+               --hash=sha256:97032a27bd9d8988b9a97a8c4d2c9f2c15a81f61e2f21404d7e8ef00cb5be729 \
+               --hash=sha256:1e795a8be3ddbac43274f18588329c72939870a16cae810c2b73461c40718ab1 \
+               --hash=sha256:f26b258c385842546006213344c50655ff1555a9338e2e5e02a0756dc3e803dd \
+               --hash=sha256:5fec9451a7789926bcf7c2b8d187292c9f93ea30284802a0ab3f5be8ab36865d \
+               --hash=sha256:9189427407d88ff25ecf8f12469d4d39d35bee1db5d39fc5c168c6f088a6956d \
+               --hash=sha256:a3f4ab0caa7f053f6797fcd4e1e25caee367db3112ef2b6ef82d749530768c73
   # [/numpy]
   ]===])
 

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pip]
-  pip==24.0 --hash=sha256:ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc
+  pip==25.1.1 --hash=sha256:2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af
   # [/pip]
   ]===])
 

--- a/SuperBuild/External_python-pythonqt-requirements.cmake
+++ b/SuperBuild/External_python-pythonqt-requirements.cmake
@@ -32,13 +32,13 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [packaging]
-  packaging==24.0 --hash=sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5
+  packaging==25.0 --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484
   # [/packaging]
   # [pyparsing]
-  pyparsing==3.1.2 --hash=sha256:f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742
+  pyparsing==3.2.3 --hash=sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf
   # [/pyparsing]
   # [six]
-  six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
+  six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
   # [/six]
   ]===])
 

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -27,34 +27,30 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [certifi]
-  certifi==2024.2.2 --hash=sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
+  certifi==2025.4.26 --hash=sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3
   # [/certifi]
   # [idna]
-  idna==3.7 --hash=sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
+  idna==3.10 --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
   # [/idna]
   # [charset-normalizer]
   # Hashes correspond to the following packages:
-  #  - charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl
-  #  - charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl
-  #  - charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl
-  #  - charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl
-  #  - charset_normalizer-3.3.2-py3-none-any.whl
-  charset-normalizer==3.3.2 --hash=sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4 \
-                            --hash=sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d \
-                            --hash=sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0 \
-                            --hash=sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269 \
-                            --hash=sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796 \
-                            --hash=sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c \
-                            --hash=sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561 \
-                            --hash=sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d \
-                            --hash=sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc
+  #  - charset_normalizer-3.4.2-cp39-cp39-macosx_10_9_universal2.whl
+  #  - charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_aarch64.whl
+  #  - charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_x86_64.whl
+  #  - charset_normalizer-3.4.2-cp39-cp39-win_amd64.whl
+  #  - charset_normalizer-3.4.2-py3-none-any.whl
+  charset-normalizer==3.4.2 --hash=sha256:005fa3432484527f9732ebd315da8da8001593e2cf46a3d817669f062c3d9ed4 \
+                            --hash=sha256:e92fca20c46e9f5e1bb485887d074918b13543b1c2a1185e69bb8d17ab6236a7 \
+                            --hash=sha256:82d8fd25b7f4675d0c47cf95b594d4e7b158aca33b76aa63d07186e13c0e0ab7 \
+                            --hash=sha256:dccab8d5fa1ef9bfba0590ecf4d46df048d18ffe3eec01eeb73a42e0d9e7a8ba \
+                            --hash=sha256:982bb1e8b4ffda883b3d0a521e23abcd6fd17418f6d2c4118d257a10199c0ce3 \
+                            --hash=sha256:d11b54acf878eef558599658b0ffca78138c8c3655cf4f3a4a673c437e67732e \
+                            --hash=sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0
   # [/charset-normalizer]
   # [urllib3]
-  urllib3==2.2.1 --hash=sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d
+  urllib3==2.4.0 --hash=sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813
   # [/urllib3]
   # [requests]
   requests==2.32.3 --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -26,7 +26,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [setuptools]
-  setuptools==70.0.0 --hash=sha256:54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4
+  setuptools==80.9.0 --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922
   # [/setuptools]
   ]===])
 

--- a/SuperBuild/External_python-wheel.cmake
+++ b/SuperBuild/External_python-wheel.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [wheel]
-  wheel==0.43.0 --hash=sha256:55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81
+  wheel==0.45.1 --hash=sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248
   # [/wheel]
   ]===])
 


### PR DESCRIPTION
Python packages were last updated on June 3rd 2024 (https://github.com/Slicer/Slicer/commit/584372940bde14d1ffd95b75c556658f8a25362e) through https://github.com/Slicer/Slicer/pull/7776. This PR updates python packages to their latest versions. This type of update is something I usually do on about a quarterly cadence (every 3 months).

Packages built from sources:
* SimpleITK isn't being updated here as we build it from source rather than using the provided whl on pypi. The SimpleITK version has also already being updated by @dzenanz in https://github.com/Slicer/Slicer/pull/7771.
* VTK is also not being updated because we build it from source rather than using the provided whl on pypi.

Python packages with more than just a patch release update (newest release date to oldest):

```
Package            Version      Latest    Type
------------------ ------------ --------- -----
certifi            2024.2.2     2025.4.26 wheel
cffi               1.16.0       1.17.1    wheel
charset-normalizer 3.3.2        3.4.2     wheel
cryptography       42.0.7       45.0.3    wheel
dicomweb-client    0.59.1       0.60.0    wheel
idna               3.7          3.10      wheel
numpy              1.26.4       2.0.2     wheel
packaging          24.0         25.0      wheel
pillow             10.3.0       11.2.1    wheel
pip                24.0         25.1.1    wheel
PyGithub           2.3.0        2.6.1     wheel
PyJWT              2.8.0        2.10.1    wheel
pyparsing          3.1.2        3.2.3     wheel
setuptools         70.0.0       80.9.0    wheel
six                1.16.0       1.17.0    wheel
typing_extensions  4.12.1       4.14.0    wheel
urllib3            2.2.1        2.4.0     wheel
wheel              0.43.0       0.45.1    wheel
wrapt              1.16.0       1.17.2    wheel
```

### Details


```bash
../Slicer-Release/python-install/bin/PythonSlicer ./Utilities/Scripts/python_package_updater.py 
Searching external projects in /home/jcfr/Projects/Slicer/./SuperBuild 
Validate external projects
Package            Version      Latest    Type
------------------ ------------ --------- -----
certifi            2024.2.2     2025.4.26 wheel
cffi               1.16.0       1.17.1    wheel
charset-normalizer 3.3.2        3.4.2     wheel
cryptography       42.0.7       45.0.3    wheel
Deprecated         1.2.14       1.2.18    wheel
dicomweb-client    0.59.1       0.60.0    wheel
gitdb              4.0.11       4.0.12    wheel
GitPython          3.1.43       3.1.44    wheel
idna               3.7          3.10      wheel
numpy              1.26.4       2.0.2     wheel
packaging          24.0         25.0      wheel
pillow             10.3.0       11.2.1    wheel
pip                24.0         25.1.1    wheel
PyGithub           2.3.0        2.6.1     wheel
PyJWT              2.8.0        2.10.1    wheel
pyparsing          3.1.2        3.2.3     wheel
setuptools         70.0.0       80.9.0    wheel
SimpleITK          2.4.0.dev213 2.5.0     wheel
six                1.16.0       1.17.0    wheel
smmap              5.0.1        5.0.2     wheel
typing_extensions  4.12.1       4.14.0    wheel
urllib3            2.2.1        2.4.0     wheel
vtk                9.4.1        9.4.2     wheel
wheel              0.43.0       0.45.1    wheel
wrapt              1.16.0       1.17.2    wheel

  certifi==2025.4.26 --hash=sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3
  # Hashes correspond to the following packages:
  #  - cffi-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl
  #  - cffi-1.17.1-cp39-cp39-macosx_11_0_arm64.whl
  #  - cffi-1.17.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - cffi-1.17.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - cffi-1.17.1-cp39-cp39-musllinux_1_1_aarch64.whl
  #  - cffi-1.17.1-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - cffi-1.17.1-cp39-cp39-win_amd64.whl
  cffi==1.17.1 --hash=sha256:b2ab587605f4ba0bf81dc0cb08a41bd1c0a5906bd59243d56bad7668a6fc6c16 \
               --hash=sha256:28b16024becceed8c6dfbc75629e27788d8a3f9030691a1dbf9821a128b22c36 \
               --hash=sha256:ca74b8dbe6e8e8263c0ffd60277de77dcee6c837a3d0881d8c1ead7268c9e576 \
               --hash=sha256:cdf5ce3acdfd1661132f2a9c19cac174758dc2352bfe37d98aa7512c6b7178b3 \
               --hash=sha256:9755e4345d1ec879e3849e62222a18c7174d65a6a92d5b346b1863912168b595 \
               --hash=sha256:c03e868a0b3bc35839ba98e74211ed2b05d2119be4e8a0f224fba9384f1fe02e \
               --hash=sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662
  # Hashes correspond to the following packages:
  #  - charset_normalizer-3.4.2-cp39-cp39-macosx_10_9_universal2.whl
  #  - charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_aarch64.whl
  #  - charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_x86_64.whl
  #  - charset_normalizer-3.4.2-cp39-cp39-win_amd64.whl
  #  - charset_normalizer-3.4.2-py3-none-any.whl
  charset-normalizer==3.4.2 --hash=sha256:005fa3432484527f9732ebd315da8da8001593e2cf46a3d817669f062c3d9ed4 \
                            --hash=sha256:e92fca20c46e9f5e1bb485887d074918b13543b1c2a1185e69bb8d17ab6236a7 \
                            --hash=sha256:82d8fd25b7f4675d0c47cf95b594d4e7b158aca33b76aa63d07186e13c0e0ab7 \
                            --hash=sha256:dccab8d5fa1ef9bfba0590ecf4d46df048d18ffe3eec01eeb73a42e0d9e7a8ba \
                            --hash=sha256:982bb1e8b4ffda883b3d0a521e23abcd6fd17418f6d2c4118d257a10199c0ce3 \
                            --hash=sha256:d11b54acf878eef558599658b0ffca78138c8c3655cf4f3a4a673c437e67732e \
                            --hash=sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0
  # Hashes correspond to the following packages:
  #  - cryptography-45.0.3-cp311-abi3-macosx_10_9_universal2.whl
  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_28_aarch64.whl
  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_28_x86_64.whl
  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_34_aarch64.whl
  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_34_x86_64.whl
  #  - cryptography-45.0.3-cp311-abi3-musllinux_1_2_aarch64.whl
  #  - cryptography-45.0.3-cp311-abi3-musllinux_1_2_x86_64.whl
  #  - cryptography-45.0.3-cp311-abi3-win_amd64.whl
  #  - cryptography-45.0.3-cp37-abi3-macosx_10_9_universal2.whl
  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_28_aarch64.whl
  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_28_x86_64.whl
  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_34_aarch64.whl
  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_34_x86_64.whl
  #  - cryptography-45.0.3-cp37-abi3-musllinux_1_2_aarch64.whl
  #  - cryptography-45.0.3-cp37-abi3-musllinux_1_2_x86_64.whl
  #  - cryptography-45.0.3-cp37-abi3-win_amd64.whl
  cryptography==45.0.3 --hash=sha256:7573d9eebaeceeb55285205dbbb8753ac1e962af3d9640791d12b36864065e71 \
                       --hash=sha256:d377dde61c5d67eb4311eace661c3efda46c62113ff56bf05e2d679e02aebb5b \
                       --hash=sha256:fae1e637f527750811588e4582988932c222f8251f7b7ea93739acb624e1487f \
                       --hash=sha256:ca932e11218bcc9ef812aa497cdf669484870ecbcf2d99b765d6c27a86000942 \
                       --hash=sha256:2f8f8f0b73b885ddd7f3d8c2b2234a7d3ba49002b0223f58cfde1bedd9563c56 \
                       --hash=sha256:9cc80ce69032ffa528b5e16d217fa4d8d4bb7d6ba8659c1b4d74a1b0f4235fca \
                       --hash=sha256:c824c9281cb628015bfc3c59335163d4ca0540d49de4582d6c2637312907e4b1 \
                       --hash=sha256:5833bb4355cb377ebd880457663a972cd044e7f49585aee39245c0d592904578 \
                       --hash=sha256:9bb5bf55dcb69f7067d80354d0a348368da907345a2c448b0babc4215ccd3497 \
                       --hash=sha256:97787952246a77d77934d41b62fb1b6f3581d83f71b44796a4158d93b8f5c490 \
                       --hash=sha256:c92519d242703b675ccefd0f0562eb45e74d438e001f8ab52d628e885751fb06 \
                       --hash=sha256:c5edcb90da1843df85292ef3a313513766a78fbbb83f584a5a58fb001a5a9d57 \
                       --hash=sha256:38deed72285c7ed699864f964a3f4cf11ab3fb38e8d39cfcd96710cd2b5bb716 \
                       --hash=sha256:5555365a50efe1f486eed6ac7062c33b97ccef409f5970a0b6f205a7cfab59c8 \
                       --hash=sha256:cfd84777b4b6684955ce86156cfb5e08d75e80dc2585e10d69e47f014f0a5342 \
                       --hash=sha256:a2b56de3417fd5f48773ad8e91abaa700b678dc7fe1e0c757e1ae340779acf7b \
                       --hash=sha256:57a6500d459e8035e813bd8b51b671977fb149a8c95ed814989da682314d0782 \
                       --hash=sha256:f22af3c78abfbc7cbcdf2c55d23c3e022e1a462ee2481011d518c7fb9c9f3d65 \
                       --hash=sha256:232954730c362638544758a8160c4ee1b832dc011d2c41a306ad8f7cccc5bb0b \
                       --hash=sha256:d54ae41e6bd70ea23707843021c778f151ca258081586f0cfa31d936ae43d1b2
  Deprecated==1.2.18 --hash=sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec
  dicomweb-client==0.60.0 --hash=sha256:fde6743036f9c9da74580dd643c66121a1650d16737184695bfbe076f3875e71
  gitdb==4.0.12 --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
  GitPython==3.1.44 --hash=sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110
  idna==3.10 --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
  # Hashes correspond to the following packages:
  #  - numpy-2.0.2-cp39-cp39-macosx_10_9_x86_64.whl
  #  - numpy-2.0.2-cp39-cp39-macosx_11_0_arm64.whl
  #  - numpy-2.0.2-cp39-cp39-macosx_14_0_arm64.whl
  #  - numpy-2.0.2-cp39-cp39-macosx_14_0_x86_64.whl
  #  - numpy-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - numpy-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - numpy-2.0.2-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - numpy-2.0.2-cp39-cp39-musllinux_1_2_aarch64.whl
  #  - numpy-2.0.2-cp39-cp39-win_amd64.whl
  numpy==2.0.2 --hash=sha256:9059e10581ce4093f735ed23f3b9d283b9d517ff46009ddd485f1747eb22653c \
               --hash=sha256:423e89b23490805d2a5a96fe40ec507407b8ee786d66f7328be214f9679df6dd \
               --hash=sha256:2b2955fa6f11907cf7a70dab0d0755159bca87755e831e47932367fc8f2f2d0b \
               --hash=sha256:97032a27bd9d8988b9a97a8c4d2c9f2c15a81f61e2f21404d7e8ef00cb5be729 \
               --hash=sha256:1e795a8be3ddbac43274f18588329c72939870a16cae810c2b73461c40718ab1 \
               --hash=sha256:f26b258c385842546006213344c50655ff1555a9338e2e5e02a0756dc3e803dd \
               --hash=sha256:5fec9451a7789926bcf7c2b8d187292c9f93ea30284802a0ab3f5be8ab36865d \
               --hash=sha256:9189427407d88ff25ecf8f12469d4d39d35bee1db5d39fc5c168c6f088a6956d \
               --hash=sha256:a3f4ab0caa7f053f6797fcd4e1e25caee367db3112ef2b6ef82d749530768c73
  packaging==25.0 --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484
  # Hashes correspond to the following packages:
  #  - pillow-11.2.1-cp39-cp39-macosx_10_10_x86_64.whl
  #  - pillow-11.2.1-cp39-cp39-macosx_11_0_arm64.whl
  #  - pillow-11.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - pillow-11.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - pillow-11.2.1-cp39-cp39-manylinux_2_28_aarch64.whl
  #  - pillow-11.2.1-cp39-cp39-manylinux_2_28_x86_64.whl
  #  - pillow-11.2.1-cp39-cp39-musllinux_1_2_aarch64.whl
  #  - pillow-11.2.1-cp39-cp39-musllinux_1_2_x86_64.whl
  #  - pillow-11.2.1-cp39-cp39-win_amd64.whl
  #  - pillow-11.2.1-cp39-cp39-win_arm64.whl
  pillow==11.2.1 --hash=sha256:7491cf8a79b8eb867d419648fff2f83cb0b3891c8b36da92cc7f1931d46108c8 \
                 --hash=sha256:8b02d8f9cb83c52578a0b4beadba92e37d83a4ef11570a8688bbf43f4ca50909 \
                 --hash=sha256:014ca0050c85003620526b0ac1ac53f56fc93af128f7546623cc8e31875ab928 \
                 --hash=sha256:3692b68c87096ac6308296d96354eddd25f98740c9d2ab54e1549d6c8aea9d79 \
                 --hash=sha256:f781dcb0bc9929adc77bad571b8621ecb1e4cdef86e940fe2e5b5ee24fd33b35 \
                 --hash=sha256:2b490402c96f907a166615e9a5afacf2519e28295f157ec3a2bb9bd57de638cb \
                 --hash=sha256:dd6b20b93b3ccc9c1b597999209e4bc5cf2853f9ee66e3fc9a400a78733ffc9a \
                 --hash=sha256:4b835d89c08a6c2ee7781b8dd0a30209a8012b5f09c0a665b65b0eb3560b6f36 \
                 --hash=sha256:6ebce70c3f486acf7591a3d73431fa504a4e18a9b97ff27f5f47b7368e4b9dd1 \
                 --hash=sha256:c27476257b2fdcd7872d54cfd119b3a9ce4610fb85c8e32b70b42e3680a29a1e
  pip==25.1.1 --hash=sha256:2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af
  PyGithub==2.6.1 --hash=sha256:6f2fa6d076ccae475f9fc392cc6cdbd54db985d4f69b8833a28397de75ed6ca3
  PyJWT==2.10.1 --hash=sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb
  pyparsing==3.2.3 --hash=sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf
  setuptools==80.9.0 --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922
  # Hashes correspond to the following packages:
  #  - simpleitk-2.5.0-cp311-abi3-macosx_10_9_x86_64.whl
  #  - simpleitk-2.5.0-cp311-abi3-macosx_11_0_arm64.whl
  #  - simpleitk-2.5.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - simpleitk-2.5.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - simpleitk-2.5.0-cp311-abi3-win_amd64.whl
  #  - simpleitk-2.5.0-cp39-cp39-macosx_10_9_x86_64.whl
  #  - simpleitk-2.5.0-cp39-cp39-macosx_11_0_arm64.whl
  #  - simpleitk-2.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - simpleitk-2.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - simpleitk-2.5.0-cp39-cp39-win_amd64.whl
  SimpleITK==2.5.0 --hash=sha256:c4039e136fa7aee3367c0c3380721ae423ed99995ee7d1a16cbba8ca1f741589 \
                   --hash=sha256:9039e1bc7988594ef73cfa911925eee1a647d1ced81613565607bc56b16a7fbc \
                   --hash=sha256:2a96296e33661a8911d4f73d14a8d26eed387beb681327706bbe7e4a53893d48 \
                   --hash=sha256:e5bb0e50e9fa5e3102d8bd7f243376743592bc25ecdd5aa738f63e6bfb11dd76 \
                   --hash=sha256:348ee9ae6b81ea9173701f726308ac2dac2ff22dcae7afdbdf67d037c0bd431f \
                   --hash=sha256:db6d28785de2a97f3bc71fdecb6ef65894f7378c63c64e1791085b30d127a222 \
                   --hash=sha256:e1660d054d01d2b422f05b36b0d1c8c3d458ee5c86d7833169c73b791951b1c5 \
                   --hash=sha256:c73dbd1786042ad2667004bc3e24e847cdec11e23ee0635f438cafcb98dc0e5a \
                   --hash=sha256:80ac24ced63a6e66fc14b988f74a31a1472918aca2aa8901b285bd6f4788003d \
                   --hash=sha256:0883784ea6a01985adec39847a73a2acee0fc985ab0300ae4d4b85ea753b06ef
  six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
  smmap==5.0.2 --hash=sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e
  typing_extensions==4.14.0 --hash=sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af
  urllib3==2.4.0 --hash=sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813
  wheel==0.45.1 --hash=sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248
  # Hashes correspond to the following packages:
  #  - wrapt-1.17.2-cp39-cp39-macosx_10_9_universal2.whl
  #  - wrapt-1.17.2-cp39-cp39-macosx_10_9_x86_64.whl
  #  - wrapt-1.17.2-cp39-cp39-macosx_11_0_arm64.whl
  #  - wrapt-1.17.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - wrapt-1.17.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - wrapt-1.17.2-cp39-cp39-musllinux_1_2_aarch64.whl
  #  - wrapt-1.17.2-cp39-cp39-musllinux_1_2_x86_64.whl
  #  - wrapt-1.17.2-cp39-cp39-win_amd64.whl
  #  - wrapt-1.17.2-py3-none-any.whl
  wrapt==1.17.2 --hash=sha256:99039fa9e6306880572915728d7f6c24a86ec57b0a83f6b2491e1d8ab0235b9a \
                --hash=sha256:2696993ee1eebd20b8e4ee4356483c4cb696066ddc24bd70bcbb80fa56ff9061 \
                --hash=sha256:612dff5db80beef9e649c6d803a8d50c409082f1fedc9dbcdfde2983b2025b82 \
                --hash=sha256:62c2caa1585c82b3f7a7ab56afef7b3602021d6da34fbc1cf234ff139fed3cd9 \
                --hash=sha256:fc78a84e2dfbc27afe4b2bd7c80c8db9bca75cc5b85df52bfe634596a1da846b \
                --hash=sha256:ba0f0eb61ef00ea10e00eb53a9129501f52385c44853dbd6c4ad3f403603083f \
                --hash=sha256:c86563182421896d73858e08e1db93afdd2b947a70064b813d515d66549e15f9 \
                --hash=sha256:36ccae62f64235cf8ddb682073a60519426fdd4725524ae38874adf72b5f2aeb \
                --hash=sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8

```