### PR TITLE
ENH: Replace deprecated imp module with importlib to support Python 3.12+

### DIFF
--- a/Base/Python/slicer/__init__.py
+++ b/Base/Python/slicer/__init__.py
@@ -128,13 +128,12 @@
 
 # -----------------------------------------------------------------------------
 def _createModule(name, globals, docstring):
-    import imp
     import sys
+    import types
 
     moduleName = name.split(".")[-1]
-    module = imp.new_module(moduleName)
+    module = types.ModuleType(moduleName, docstring)
     module.__file__ = __file__
-    module.__doc__ = docstring
     sys.modules[name] = module
     globals[moduleName] = module
 

--- a/Base/QTCore/qSlicerScriptedFileReader.cxx
+++ b/Base/QTCore/qSlicerScriptedFileReader.cxx
@@ -124,12 +124,13 @@ bool qSlicerScriptedFileReader::setPythonSource(const QString& filePath, const Q
 
   d->PythonCppAPI.setObjectName(className);
 
-  // Get a reference (or create if needed) the <moduleName> python module
-  PyObject * module = PyImport_AddModule(moduleName.toUtf8());
+  // Get actual module from sys.modules
+  PyObject* sysModules = PyImport_GetModuleDict();
+  PyObject* module = PyDict_GetItemString(sysModules, moduleName.toUtf8());
 
   // Get a reference to the python module class to instantiate
   PythonQtObjectPtr classToInstantiate;
-  if (PyObject_HasAttrString(module, className.toUtf8()))
+  if (module && PyObject_HasAttrString(module, className.toUtf8()))
   {
     classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));
   }

--- a/Base/QTCore/qSlicerScriptedFileWriter.cxx
+++ b/Base/QTCore/qSlicerScriptedFileWriter.cxx
@@ -124,12 +124,13 @@ bool qSlicerScriptedFileWriter::setPythonSource(const QString& filePath, const Q
 
   d->PythonCppAPI.setObjectName(className);
 
-  // Get a reference (or create if needed) the <moduleName> python module
-  PyObject * module = PyImport_AddModule(moduleName.toUtf8());
+  // Get actual module from sys.modules
+  PyObject* sysModules = PyImport_GetModuleDict();
+  PyObject* module = PyDict_GetItemString(sysModules, moduleName.toUtf8());
 
   // Get a reference to the python module class to instantiate
   PythonQtObjectPtr classToInstantiate;
-  if (PyObject_HasAttrString(module, className.toUtf8()))
+  if (module && PyObject_HasAttrString(module, className.toUtf8()))
   {
     classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));
   }

--- a/Base/QTGUI/qSlicerScriptedFileDialog.cxx
+++ b/Base/QTGUI/qSlicerScriptedFileDialog.cxx
@@ -127,12 +127,13 @@ bool qSlicerScriptedFileDialog::setPythonSource(const QString& filePath, const Q
   d->PythonCppAPI.setObjectName(className);
   d->PythonClassName = className;
 
-  // Get a reference (or create if needed) the <moduleName> python module
-  PyObject * module = PyImport_AddModule(moduleName.toUtf8());
+  // Get actual module from sys.modules
+  PyObject* sysModules = PyImport_GetModuleDict();
+  PyObject* module = PyDict_GetItemString(sysModules, moduleName.toUtf8());
 
   // Get a reference to the python module class to instantiate
   PythonQtObjectPtr classToInstantiate;
-  if (PyObject_HasAttrString(module, className.toUtf8()))
+  if (module && PyObject_HasAttrString(module, className.toUtf8()))
   {
     classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));
   }

--- a/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
@@ -126,8 +126,9 @@ bool qSlicerScriptedLoadableModule::setPythonSource(const QString& filePath)
   PyObject * main_module = PyImport_AddModule("__main__");
   PyObject * global_dict = PyModule_GetDict(main_module);
 
-  // Get a reference (or create if needed) the <moduleName> python module
-  PyObject * module = PyImport_AddModule(moduleName.toUtf8());
+  // Get actual module from sys.modules
+  PyObject* sysModules = PyImport_GetModuleDict();
+  PyObject* module = PyDict_GetItemString(sysModules, moduleName.toUtf8());
 
   // Get a reference to the python module class to instantiate
   PythonQtObjectPtr classToInstantiate;
@@ -143,6 +144,10 @@ bool qSlicerScriptedLoadableModule::setPythonSource(const QString& filePath)
     {
       return false;
     }
+
+    // After loading, re-fetch actual module from sys.modules
+    module = PyDict_GetItemString(PyImport_GetModuleDict(), moduleName.toUtf8());
+
     if (PyObject_HasAttrString(module, className.toUtf8()))
     {
       classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));

--- a/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.cxx
@@ -294,22 +294,18 @@ void vtkMRMLScriptedDisplayableManager::SetPythonSource(const std::string& fileP
   PyObject * classToInstantiate = PyDict_GetItemString(global_dict, className.c_str());
   if (!classToInstantiate)
   {
-    PyObject * pyRes = nullptr;
-    if (filePath.find(".py") != std::string::npos)
-    {
-      std::string pyRunStr = std::string("exec(open('") + filePath + std::string("').read())");
-      pyRes = PyRun_String(pyRunStr.c_str(),
-                           Py_file_input, global_dict, global_dict);
-    }
-    else if (filePath.find(".pyc") != std::string::npos)
-    {
-      std::string pyRunStr = std::string("with open('") + filePath +
-          std::string("', 'rb') as f:import imp;imp.load_module('__main__', f, '") + filePath +
-          std::string("', ('.pyc', 'rb', 2))");
-      pyRes = PyRun_String(
-            pyRunStr.c_str(),
-            Py_file_input, global_dict, global_dict);
-    }
+    std::ostringstream pyRunStream;
+
+    // Use importlib to load the module dynamically
+    pyRunStream
+      << "import importlib.util;"
+      << "import sys;"
+      << "spec = importlib.util.spec_from_file_location('__main__', r'" << filePath << "');"
+      << "module = importlib.util.module_from_spec(spec);"
+      << "sys.modules['__main__'] = module;"
+      << "spec.loader.exec_module(module)";
+
+    PyObject* pyRes = PyRun_String(pyRunStream.str().c_str(), Py_file_input, global_dict, global_dict);
     if (!pyRes)
     {
       vtkErrorMacro(<< "setPythonSource - Failed to execute file" << filePath << "!");

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedEffect.cxx
@@ -158,12 +158,13 @@ bool qSlicerSegmentEditorScriptedEffect::setPythonSource(const QString newPython
   PyObject * main_module = PyImport_AddModule("__main__");
   PyObject * global_dict = PyModule_GetDict(main_module);
 
-  // Get a reference (or create if needed) the <moduleName> python module
-  PyObject * module = PyImport_AddModule(moduleName.toUtf8());
+  // Get actual module from sys.modules
+  PyObject* sysModules = PyImport_GetModuleDict();
+  PyObject* module = PyDict_GetItemString(sysModules, moduleName.toUtf8());
 
   // Get a reference to the python module class to instantiate
   PythonQtObjectPtr classToInstantiate;
-  if (PyObject_HasAttrString(module, className.toUtf8()))
+  if (module && PyObject_HasAttrString(module, className.toUtf8()))
   {
     classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));
   }
@@ -175,6 +176,10 @@ bool qSlicerSegmentEditorScriptedEffect::setPythonSource(const QString newPython
     {
       return false;
     }
+
+    // After loading, re-fetch actual module from sys.modules
+    module = PyDict_GetItemString(PyImport_GetModuleDict(), moduleName.toUtf8());
+
     if (PyObject_HasAttrString(module, className.toUtf8()))
     {
       classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedLabelEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedLabelEffect.cxx
@@ -152,12 +152,13 @@ bool qSlicerSegmentEditorScriptedLabelEffect::setPythonSource(const QString file
   PyObject * main_module = PyImport_AddModule("__main__");
   PyObject * global_dict = PyModule_GetDict(main_module);
 
-  // Get a reference (or create if needed) the <moduleName> python module
-  PyObject * module = PyImport_AddModule(moduleName.toUtf8());
+  // Get actual module from sys.modules
+  PyObject* sysModules = PyImport_GetModuleDict();
+  PyObject* module = PyDict_GetItemString(sysModules, moduleName.toUtf8());
 
   // Get a reference to the python module class to instantiate
   PythonQtObjectPtr classToInstantiate;
-  if (PyObject_HasAttrString(module, className.toUtf8()))
+  if (module && PyObject_HasAttrString(module, className.toUtf8()))
   {
     classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));
   }
@@ -169,6 +170,10 @@ bool qSlicerSegmentEditorScriptedLabelEffect::setPythonSource(const QString file
     {
       return false;
     }
+
+    // After loading, re-fetch actual module from sys.modules
+    module = PyDict_GetItemString(PyImport_GetModuleDict(), moduleName.toUtf8());
+
     if (PyObject_HasAttrString(module, className.toUtf8()))
     {
       classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedPaintEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScriptedPaintEffect.cxx
@@ -144,12 +144,13 @@ bool qSlicerSegmentEditorScriptedPaintEffect::setPythonSource(const QString file
   PyObject * main_module = PyImport_AddModule("__main__");
   PyObject * global_dict = PyModule_GetDict(main_module);
 
-  // Get a reference (or create if needed) the <moduleName> python module
-  PyObject * module = PyImport_AddModule(moduleName.toUtf8());
+  // Get actual module from sys.modules
+  PyObject* sysModules = PyImport_GetModuleDict();
+  PyObject* module = PyDict_GetItemString(sysModules, moduleName.toUtf8());
 
   // Get a reference to the python module class to instantiate
   PythonQtObjectPtr classToInstantiate;
-  if (PyObject_HasAttrString(module, className.toUtf8()))
+  if (module && PyObject_HasAttrString(module, className.toUtf8()))
   {
     classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));
   }
@@ -161,6 +162,10 @@ bool qSlicerSegmentEditorScriptedPaintEffect::setPythonSource(const QString file
     {
       return false;
     }
+
+    // After loading, re-fetch actual module from sys.modules
+    module = PyDict_GetItemString(PyImport_GetModuleDict(), moduleName.toUtf8());
+
     if (PyObject_HasAttrString(module, className.toUtf8()))
     {
       classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.cxx
@@ -156,12 +156,13 @@ bool qSlicerSubjectHierarchyScriptedPlugin::setPythonSource(const QString filePa
   PyObject * main_module = PyImport_AddModule("__main__");
   PyObject * global_dict = PyModule_GetDict(main_module);
 
-  // Get a reference (or create if needed) the <moduleName> python module
-  PyObject * module = PyImport_AddModule(moduleName.toUtf8());
+  // Get actual module from sys.modules
+  PyObject* sysModules = PyImport_GetModuleDict();
+  PyObject* module = PyDict_GetItemString(sysModules, moduleName.toUtf8());
 
   // Get a reference to the python module class to instantiate
   PythonQtObjectPtr classToInstantiate;
-  if (PyObject_HasAttrString(module, className.toUtf8()))
+  if (module && PyObject_HasAttrString(module, className.toUtf8()))
   {
     classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));
   }
@@ -173,6 +174,10 @@ bool qSlicerSubjectHierarchyScriptedPlugin::setPythonSource(const QString filePa
     {
       return false;
     }
+
+    // After loading, re-fetch actual module from sys.modules
+    module = PyDict_GetItemString(PyImport_GetModuleDict(), moduleName.toUtf8());
+
     if (PyObject_HasAttrString(module, className.toUtf8()))
     {
       classToInstantiate.setNewRef(PyObject_GetAttrString(module, className.toUtf8()));


### PR DESCRIPTION
This commit replaces usage of the deprecated imp module with modern importlib-based APIs. The `imp` module was deprecated in Python 3.4 and removed[^1] in Python 3.12.

[^1]: https://docs.python.org/3/library/imp.html#module-imp

Key updates:
- Use `importlib.util.spec_from_file_location` and `module_from_spec` for loading modules from file paths.
- Use `types.ModuleType` instead of `imp.new_module`.
- Ensure modules are registered and accessed via `sys.modules`.
- Avoid `PyImport_AddModule` when retrieving modules loaded with `importlib`.