### PR TITLE
ENH: Replace deprecated assertRegexpMatches with assertRegex to support Python 3.12+

### DIFF
--- a/Base/QTCore/Testing/Python/qSlicerModuleGenericTest.py.in
+++ b/Base/QTCore/Testing/Python/qSlicerModuleGenericTest.py.in
@@ -9,7 +9,7 @@ class qSlicer@MODULENAME@ModuleGenericTest(unittest.TestCase):
     self.module = slicer.modules.@MODULENAME_LC@
 
   def test_file_attribute(self):
-    self.assertRegexpMatches(__file__, r'qSlicer@MODULENAME@ModuleGenericTest.py[c]?$')
+    self.assertRegex(__file__, r'qSlicer@MODULENAME@ModuleGenericTest.py[c]?$')
 
   def test_name_attribute(self):
     self.assertEqual(__name__, 'qSlicer@MODULENAME@ModuleGenericTest')


### PR DESCRIPTION
The `unittest.assertRegexpMatches` function was deprecated in Python 3.2 and removed[^1] in Python 3.12.

[^1]: https://docs.python.org/3.12/library/unittest.html#unittest.TestCase.assertRegex