### PR TITLE
COMP: Remove obsolete MRML logic functions related to unreferenced nodes cleanup

### DIFF
--- a/Libs/MRML/Core/vtkMRMLLogic.cxx
+++ b/Libs/MRML/Core/vtkMRMLLogic.cxx
@@ -1,10 +1,4 @@
 
-// MRML includes
-#include "vtkMRMLScene.h"
-#include "vtkMRMLStorageNode.h"
-#include "vtkMRMLDisplayableNode.h"
-#include "vtkMRMLDisplayNode.h"
-
 // MRMLLogic includes
 #include "vtkMRMLLogic.h"
 
@@ -21,123 +15,10 @@ vtkStandardNewMacro(vtkMRMLLogic);
 //------------------------------------------------------------------------------
 vtkMRMLLogic::vtkMRMLLogic()
 {
-  this->Scene = nullptr;
 }
 
 //------------------------------------------------------------------------------
 vtkMRMLLogic::~vtkMRMLLogic() = default;
-
-void vtkMRMLLogic::RemoveUnreferencedStorageNodes()
-{
-  if (this->Scene == nullptr)
-  {
-    return;
-  }
-  std::set<vtkMRMLNode *> referencedNodes;
-  std::set<vtkMRMLNode *>::iterator iter;
-  std::vector<vtkMRMLNode *> storableNodes;
-  std::vector<vtkMRMLNode *> storageNodes;
-  this->Scene->GetNodesByClass("vtkMRMLStorableNode", storableNodes);
-  this->Scene->GetNodesByClass("vtkMRMLStorageNode", storageNodes);
-
-  vtkMRMLNode *node = nullptr;
-  vtkMRMLStorableNode *storableNode = nullptr;
-  vtkMRMLStorageNode *storageNode = nullptr;
-  unsigned int i;
-  for (i=0; i<storableNodes.size(); i++)
-  {
-    node = storableNodes[i];
-    if (node)
-    {
-      storableNode = vtkMRMLStorableNode::SafeDownCast(node);
-    }
-    else
-    {
-      continue;
-    }
-    storageNode = storableNode->GetStorageNode();
-    if (storageNode)
-    {
-      referencedNodes.insert(storageNode);
-    }
-  }
-
-  for (i=0; i<storageNodes.size(); i++)
-  {
-    node = storageNodes[i];
-    if (node)
-    {
-      storageNode = vtkMRMLStorageNode::SafeDownCast(node);
-    }
-    else
-    {
-      continue;
-    }
-    iter = referencedNodes.find(storageNode);
-    if (iter == referencedNodes.end())
-    {
-      this->Scene->RemoveNode(storageNode);
-    }
-  }
-}
-
-void vtkMRMLLogic::RemoveUnreferencedDisplayNodes()
-{
-  if (this->Scene == nullptr)
-  {
-    return;
-  }
-  std::set<vtkMRMLNode *> referencedNodes;
-  std::set<vtkMRMLNode *>::iterator iter;
-  std::vector<vtkMRMLNode *> displayableNodes;
-  std::vector<vtkMRMLNode *> displayNodes;
-  this->Scene->GetNodesByClass("vtkMRMLDisplayableNode", displayableNodes);
-  this->Scene->GetNodesByClass("vtkMRMLDisplayNode", displayNodes);
-
-  vtkMRMLNode *node = nullptr;
-  vtkMRMLDisplayableNode *displayableNode = nullptr;
-  vtkMRMLDisplayNode *displayNode = nullptr;
-  unsigned int i;
-  for (i=0; i<displayableNodes.size(); i++)
-  {
-    node = displayableNodes[i];
-    if (node)
-    {
-      displayableNode = vtkMRMLDisplayableNode::SafeDownCast(node);
-    }
-    else
-    {
-      continue;
-    }
-    int numDisplayNodes = displayableNode->GetNumberOfDisplayNodes();
-    for (int n=0; n<numDisplayNodes; n++)
-    {
-      displayNode = displayableNode->GetNthDisplayNode(n);
-      if (displayNode)
-      {
-        referencedNodes.insert(displayNode);
-      }
-    }
-  }
-
-  for (i=0; i<displayNodes.size(); i++)
-  {
-    node = displayNodes[i];
-    if (node)
-    {
-      displayNode = vtkMRMLDisplayNode::SafeDownCast(node);
-    }
-    else
-    {
-      continue;
-    }
-    iter = referencedNodes.find(displayNode);
-    if (iter == referencedNodes.end())
-    {
-      this->Scene->RemoveNode(displayNode);
-    }
-  }
-}
 
 //----------------------------------------------------------------------------
 std::string vtkMRMLLogic::GetApplicationHomeDirectory()

--- a/Libs/MRML/Core/vtkMRMLLogic.h
+++ b/Libs/MRML/Core/vtkMRMLLogic.h
@@ -17,16 +17,10 @@
 
 // MRML includes
 #include "vtkMRML.h"
-class vtkMRMLScene;
 
 // VTK includes
 #include <vtkObject.h>
 
-/// \brief Class that manages adding and deleting of observers with events.
-///
-/// Class that manages adding and deleting of observers with events
-/// This class keeps track of observers and events added to each vtk object.
-/// It caches tags returned by AddObserver method so that observers can be removed properly.
 class VTK_MRML_EXPORT vtkMRMLLogic : public vtkObject
 {
 public:
@@ -34,13 +28,6 @@ public:
   static vtkMRMLLogic *New();
   vtkTypeMacro(vtkMRMLLogic,vtkObject);
   void PrintSelf(ostream& os, vtkIndent indent) override { this->Superclass::PrintSelf(os, indent); }
-
-  vtkMRMLScene* GetScene() {return this->Scene;};
-  void SetScene(vtkMRMLScene* scene) {this->Scene = scene;};
-
-  void RemoveUnreferencedStorageNodes();
-
-  void RemoveUnreferencedDisplayNodes();
 
   /// Get application home directory.
   /// The path is retrieved from the environment variable defined by MRML_APPLICATION_HOME_DIR_ENV.
@@ -55,8 +42,6 @@ protected:
   ~vtkMRMLLogic() override;
   vtkMRMLLogic(const vtkMRMLLogic&);
   void operator=(const vtkMRMLLogic&);
-
-  vtkMRMLScene *Scene;
 };
 
 #endif


### PR DESCRIPTION
The MRML logic functions `RemoveUnreferencedStorageNodes` and `RemoveUnreferencedDisplayNodes` were first introduced in e6ae7b96b16 ("BUG_FIXED: 744 Remove unreferenced storage and display nodes before saving a scene", 2010-04-17) and their last use removed in f8fb837370b ("ENH: SaveData dialog uses qSlicerFileWriters for improved scalability", 2012-06-07)