### PR TITLE
ENH: Upgrade from python 3.9.10 to 3.12.10

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,6 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.9"
+          python-version: "3.12"
 
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.12"
 
 sphinx:
   builder: html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ mark_as_superbuild(Slicer_REQUIRED_QT_VERSION)
 # Python requirements
 #-----------------------------------------------------------------------------
 if(NOT DEFINED Slicer_REQUIRED_PYTHON_VERSION)
-  set(Slicer_REQUIRED_PYTHON_VERSION "3.9.10")
+  set(Slicer_REQUIRED_PYTHON_VERSION "3.12.10")
 endif()
 mark_as_superbuild(Slicer_REQUIRED_PYTHON_VERSION)
 

--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -48,26 +48,26 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [/six]
   # [pillow]
   # Hashes correspond to the following packages:
-  #  - pillow-11.2.1-cp39-cp39-macosx_10_10_x86_64.whl
-  #  - pillow-11.2.1-cp39-cp39-macosx_11_0_arm64.whl
-  #  - pillow-11.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - pillow-11.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - pillow-11.2.1-cp39-cp39-manylinux_2_28_aarch64.whl
-  #  - pillow-11.2.1-cp39-cp39-manylinux_2_28_x86_64.whl
-  #  - pillow-11.2.1-cp39-cp39-musllinux_1_2_aarch64.whl
-  #  - pillow-11.2.1-cp39-cp39-musllinux_1_2_x86_64.whl
-  #  - pillow-11.2.1-cp39-cp39-win_amd64.whl
-  #  - pillow-11.2.1-cp39-cp39-win_arm64.whl
-  pillow==11.2.1 --hash=sha256:7491cf8a79b8eb867d419648fff2f83cb0b3891c8b36da92cc7f1931d46108c8 \
-                 --hash=sha256:8b02d8f9cb83c52578a0b4beadba92e37d83a4ef11570a8688bbf43f4ca50909 \
-                 --hash=sha256:014ca0050c85003620526b0ac1ac53f56fc93af128f7546623cc8e31875ab928 \
-                 --hash=sha256:3692b68c87096ac6308296d96354eddd25f98740c9d2ab54e1549d6c8aea9d79 \
-                 --hash=sha256:f781dcb0bc9929adc77bad571b8621ecb1e4cdef86e940fe2e5b5ee24fd33b35 \
-                 --hash=sha256:2b490402c96f907a166615e9a5afacf2519e28295f157ec3a2bb9bd57de638cb \
-                 --hash=sha256:dd6b20b93b3ccc9c1b597999209e4bc5cf2853f9ee66e3fc9a400a78733ffc9a \
-                 --hash=sha256:4b835d89c08a6c2ee7781b8dd0a30209a8012b5f09c0a665b65b0eb3560b6f36 \
-                 --hash=sha256:6ebce70c3f486acf7591a3d73431fa504a4e18a9b97ff27f5f47b7368e4b9dd1 \
-                 --hash=sha256:c27476257b2fdcd7872d54cfd119b3a9ce4610fb85c8e32b70b42e3680a29a1e
+  #  - pillow-11.2.1-cp312-cp312-macosx_10_13_x86_64.whl
+  #  - pillow-11.2.1-cp312-cp312-macosx_11_0_arm64.whl
+  #  - pillow-11.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - pillow-11.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - pillow-11.2.1-cp312-cp312-manylinux_2_28_aarch64.whl
+  #  - pillow-11.2.1-cp312-cp312-manylinux_2_28_x86_64.whl
+  #  - pillow-11.2.1-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - pillow-11.2.1-cp312-cp312-musllinux_1_2_x86_64.whl
+  #  - pillow-11.2.1-cp312-cp312-win_amd64.whl
+  #  - pillow-11.2.1-cp312-cp312-win_arm64.whl
+  pillow==11.2.1 --hash=sha256:78afba22027b4accef10dbd5eed84425930ba41b3ea0a86fa8d20baaf19d807f \
+                 --hash=sha256:78092232a4ab376a35d68c4e6d5e00dfd73454bd12b230420025fbe178ee3b0b \
+                 --hash=sha256:25a5f306095c6780c52e6bbb6109624b95c5b18e40aab1c3041da3e9e0cd3e2d \
+                 --hash=sha256:0c7b29dbd4281923a2bfe562acb734cee96bbb129e96e6972d315ed9f232bef4 \
+                 --hash=sha256:3e645b020f3209a0181a418bffe7b4a93171eef6c4ef6cc20980b30bebf17b7d \
+                 --hash=sha256:b2dbea1012ccb784a65349f57bbc93730b96e85b42e9bf7b01ef40443db720b4 \
+                 --hash=sha256:da3104c57bbd72948d75f6a9389e6727d2ab6333c3617f0a89d72d4940aa0443 \
+                 --hash=sha256:598174aef4589af795f66f9caab87ba4ff860ce08cd5bb447c6fc553ffee603c \
+                 --hash=sha256:14e33b28bf17c7a38eede290f77db7c664e4eb01f7869e37fa98a5aa95978941 \
+                 --hash=sha256:21e1470ac9e5739ff880c211fc3af01e3ae505859392bf65458c224d0bf283eb
   # [/pillow]
   # [retrying]
   retrying==1.3.4 --hash=sha256:8cc4d43cb8e1125e0ff3344e9de678fefd85db3b750b81b2240dc0183af37b35

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -82,23 +82,23 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [/PyJWT]
   # [wrapt]
   # Hashes correspond to the following packages:
-  #  - wrapt-1.17.2-cp39-cp39-macosx_10_9_universal2.whl
-  #  - wrapt-1.17.2-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - wrapt-1.17.2-cp39-cp39-macosx_11_0_arm64.whl
-  #  - wrapt-1.17.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - wrapt-1.17.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - wrapt-1.17.2-cp39-cp39-musllinux_1_2_aarch64.whl
-  #  - wrapt-1.17.2-cp39-cp39-musllinux_1_2_x86_64.whl
-  #  - wrapt-1.17.2-cp39-cp39-win_amd64.whl
+  #  - wrapt-1.17.2-cp312-cp312-macosx_10_13_universal2.whl
+  #  - wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl
+  #  - wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl
+  #  - wrapt-1.17.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - wrapt-1.17.2-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - wrapt-1.17.2-cp312-cp312-musllinux_1_2_x86_64.whl
+  #  - wrapt-1.17.2-cp312-cp312-win_amd64.whl
   #  - wrapt-1.17.2-py3-none-any.whl
-  wrapt==1.17.2 --hash=sha256:99039fa9e6306880572915728d7f6c24a86ec57b0a83f6b2491e1d8ab0235b9a \
-                --hash=sha256:2696993ee1eebd20b8e4ee4356483c4cb696066ddc24bd70bcbb80fa56ff9061 \
-                --hash=sha256:612dff5db80beef9e649c6d803a8d50c409082f1fedc9dbcdfde2983b2025b82 \
-                --hash=sha256:62c2caa1585c82b3f7a7ab56afef7b3602021d6da34fbc1cf234ff139fed3cd9 \
-                --hash=sha256:fc78a84e2dfbc27afe4b2bd7c80c8db9bca75cc5b85df52bfe634596a1da846b \
-                --hash=sha256:ba0f0eb61ef00ea10e00eb53a9129501f52385c44853dbd6c4ad3f403603083f \
-                --hash=sha256:c86563182421896d73858e08e1db93afdd2b947a70064b813d515d66549e15f9 \
-                --hash=sha256:36ccae62f64235cf8ddb682073a60519426fdd4725524ae38874adf72b5f2aeb \
+  wrapt==1.17.2 --hash=sha256:d5e2439eecc762cd85e7bd37161d4714aa03a33c5ba884e26c81559817ca0925 \
+                --hash=sha256:3fc7cb4c1c744f8c05cd5f9438a3caa6ab94ce8344e952d7c45a8ed59dd88392 \
+                --hash=sha256:8fdbdb757d5390f7c675e558fd3186d590973244fab0c5fe63d373ade3e99d40 \
+                --hash=sha256:5bb1d0dbf99411f3d871deb6faa9aabb9d4e744d67dcaaa05399af89d847a91d \
+                --hash=sha256:bc570b5f14a79734437cb7b0500376b6b791153314986074486e0b0fa8d71d98 \
+                --hash=sha256:6d9187b01bebc3875bac9b087948a2bccefe464a7d8f627cf6e48b1bbae30f82 \
+                --hash=sha256:e8b2816ebef96d83657b56306152a93909a83f23994f4b30ad4573b00bd11bb9 \
+                --hash=sha256:ec89ed91f2fa8e3f52ae53cd3cf640d6feff92ba90d62236a81e4e563ac0e991 \
                 --hash=sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8
   # [/wrapt]
   # [Deprecated]
@@ -109,20 +109,20 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [/pycparser]
   # [cffi]
   # Hashes correspond to the following packages:
-  #  - cffi-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - cffi-1.17.1-cp39-cp39-macosx_11_0_arm64.whl
-  #  - cffi-1.17.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - cffi-1.17.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - cffi-1.17.1-cp39-cp39-musllinux_1_1_aarch64.whl
-  #  - cffi-1.17.1-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - cffi-1.17.1-cp39-cp39-win_amd64.whl
-  cffi==1.17.1 --hash=sha256:b2ab587605f4ba0bf81dc0cb08a41bd1c0a5906bd59243d56bad7668a6fc6c16 \
-               --hash=sha256:28b16024becceed8c6dfbc75629e27788d8a3f9030691a1dbf9821a128b22c36 \
-               --hash=sha256:ca74b8dbe6e8e8263c0ffd60277de77dcee6c837a3d0881d8c1ead7268c9e576 \
-               --hash=sha256:cdf5ce3acdfd1661132f2a9c19cac174758dc2352bfe37d98aa7512c6b7178b3 \
-               --hash=sha256:9755e4345d1ec879e3849e62222a18c7174d65a6a92d5b346b1863912168b595 \
-               --hash=sha256:c03e868a0b3bc35839ba98e74211ed2b05d2119be4e8a0f224fba9384f1fe02e \
-               --hash=sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662
+  #  - cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl
+  #  - cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl
+  #  - cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl
+  #  - cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl
+  #  - cffi-1.17.1-cp312-cp312-win_amd64.whl
+  cffi==1.17.1 --hash=sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4 \
+               --hash=sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c \
+               --hash=sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5 \
+               --hash=sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93 \
+               --hash=sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3 \
+               --hash=sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8 \
+               --hash=sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903
   # [/cffi]
   # [PyNaCl]
   # Hashes correspond to the following packages:

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -31,24 +31,24 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [numpy]
   # Hashes correspond to the following packages:
-  #  - numpy-2.0.2-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - numpy-2.0.2-cp39-cp39-macosx_11_0_arm64.whl
-  #  - numpy-2.0.2-cp39-cp39-macosx_14_0_arm64.whl
-  #  - numpy-2.0.2-cp39-cp39-macosx_14_0_x86_64.whl
-  #  - numpy-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - numpy-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - numpy-2.0.2-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - numpy-2.0.2-cp39-cp39-musllinux_1_2_aarch64.whl
-  #  - numpy-2.0.2-cp39-cp39-win_amd64.whl
-  numpy==2.0.2 --hash=sha256:9059e10581ce4093f735ed23f3b9d283b9d517ff46009ddd485f1747eb22653c \
-               --hash=sha256:423e89b23490805d2a5a96fe40ec507407b8ee786d66f7328be214f9679df6dd \
-               --hash=sha256:2b2955fa6f11907cf7a70dab0d0755159bca87755e831e47932367fc8f2f2d0b \
-               --hash=sha256:97032a27bd9d8988b9a97a8c4d2c9f2c15a81f61e2f21404d7e8ef00cb5be729 \
-               --hash=sha256:1e795a8be3ddbac43274f18588329c72939870a16cae810c2b73461c40718ab1 \
-               --hash=sha256:f26b258c385842546006213344c50655ff1555a9338e2e5e02a0756dc3e803dd \
-               --hash=sha256:5fec9451a7789926bcf7c2b8d187292c9f93ea30284802a0ab3f5be8ab36865d \
-               --hash=sha256:9189427407d88ff25ecf8f12469d4d39d35bee1db5d39fc5c168c6f088a6956d \
-               --hash=sha256:a3f4ab0caa7f053f6797fcd4e1e25caee367db3112ef2b6ef82d749530768c73
+  #  - numpy-2.0.2-cp312-cp312-macosx_10_9_x86_64.whl
+  #  - numpy-2.0.2-cp312-cp312-macosx_11_0_arm64.whl
+  #  - numpy-2.0.2-cp312-cp312-macosx_14_0_arm64.whl
+  #  - numpy-2.0.2-cp312-cp312-macosx_14_0_x86_64.whl
+  #  - numpy-2.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - numpy-2.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - numpy-2.0.2-cp312-cp312-musllinux_1_1_x86_64.whl
+  #  - numpy-2.0.2-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - numpy-2.0.2-cp312-cp312-win_amd64.whl
+  numpy==2.0.2 --hash=sha256:df55d490dea7934f330006d0f81e8551ba6010a5bf035a249ef61a94f21c500b \
+               --hash=sha256:8df823f570d9adf0978347d1f926b2a867d5608f434a7cff7f7908c6570dcf5e \
+               --hash=sha256:9a92ae5c14811e390f3767053ff54eaee3bf84576d99a2456391401323f4ec2c \
+               --hash=sha256:a842d573724391493a97a62ebbb8e731f8a5dcc5d285dfc99141ca15a3302d0c \
+               --hash=sha256:c05e238064fc0610c840d1cf6a13bf63d7e391717d247f1bf0318172e759e692 \
+               --hash=sha256:0123ffdaa88fa4ab64835dcbde75dcdf89c453c922f18dced6e27c90d1d0ec5a \
+               --hash=sha256:96a55f64139912d61de9137f11bf39a55ec8faec288c75a54f93dfd39f7eb40c \
+               --hash=sha256:ec9852fb39354b5a45a80bdab5ac02dd02b15f44b3804e9f00c556bf24b4bded \
+               --hash=sha256:cfd41e13fdc257aa5778496b8caa5e856dc4896d4ccf01841daee1d96465467a
   # [/numpy]
   ]===])
 

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -34,19 +34,19 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [/idna]
   # [charset-normalizer]
   # Hashes correspond to the following packages:
-  #  - charset_normalizer-3.4.2-cp39-cp39-macosx_10_9_universal2.whl
-  #  - charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_aarch64.whl
-  #  - charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_x86_64.whl
-  #  - charset_normalizer-3.4.2-cp39-cp39-win_amd64.whl
+  #  - charset_normalizer-3.4.2-cp312-cp312-macosx_10_13_universal2.whl
+  #  - charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_x86_64.whl
+  #  - charset_normalizer-3.4.2-cp312-cp312-win_amd64.whl
   #  - charset_normalizer-3.4.2-py3-none-any.whl
-  charset-normalizer==3.4.2 --hash=sha256:005fa3432484527f9732ebd315da8da8001593e2cf46a3d817669f062c3d9ed4 \
-                            --hash=sha256:e92fca20c46e9f5e1bb485887d074918b13543b1c2a1185e69bb8d17ab6236a7 \
-                            --hash=sha256:82d8fd25b7f4675d0c47cf95b594d4e7b158aca33b76aa63d07186e13c0e0ab7 \
-                            --hash=sha256:dccab8d5fa1ef9bfba0590ecf4d46df048d18ffe3eec01eeb73a42e0d9e7a8ba \
-                            --hash=sha256:982bb1e8b4ffda883b3d0a521e23abcd6fd17418f6d2c4118d257a10199c0ce3 \
-                            --hash=sha256:d11b54acf878eef558599658b0ffca78138c8c3655cf4f3a4a673c437e67732e \
+  charset-normalizer==3.4.2 --hash=sha256:0c29de6a1a95f24b9a1aa7aefd27d2487263f00dfd55a77719b530788f75cff7 \
+                            --hash=sha256:cddf7bd982eaa998934a91f69d182aec997c6c468898efe6679af88283b498d3 \
+                            --hash=sha256:4e594135de17ab3866138f496755f302b72157d115086d100c3f19370839dd3a \
+                            --hash=sha256:a370b3e078e418187da8c3674eddb9d983ec09445c99a3a263c2011993522981 \
+                            --hash=sha256:dedb8adb91d11846ee08bec4c8236c8549ac721c245678282dcb06b221aab59f \
+                            --hash=sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e \
                             --hash=sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0
   # [/charset-normalizer]
   # [urllib3]

--- a/SuperBuild/External_python-scipy.cmake
+++ b/SuperBuild/External_python-scipy.cmake
@@ -31,18 +31,18 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [scipy]
   # Hashes correspond to the following packages:
-  #  - scipy-1.13.1-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - scipy-1.13.1-cp39-cp39-macosx_12_0_arm64.whl
-  #  - scipy-1.13.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - scipy-1.13.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - scipy-1.13.1-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - scipy-1.13.1-cp39-cp39-win_amd64.whl
-  scipy==1.13.1 --hash=sha256:436bbb42a94a8aeef855d755ce5a465479c721e9d684de76bf61a62e7c2b81d5 \
-                --hash=sha256:8335549ebbca860c52bf3d02f80784e91a004b71b059e3eea9678ba994796a24 \
-                --hash=sha256:d533654b7d221a6a97304ab63c41c96473ff04459e404b83275b60aa8f4b7004 \
-                --hash=sha256:637e98dcf185ba7f8e663e122ebf908c4702420477ae52a04f9908707456ba4d \
-                --hash=sha256:a014c2b3697bde71724244f63de2476925596c24285c7a637364761f8710891c \
-                --hash=sha256:392e4ec766654852c25ebad4f64e4e584cf19820b980bc04960bca0b0cd6eaa2
+  #  - scipy-1.13.1-cp312-cp312-macosx_10_9_x86_64.whl
+  #  - scipy-1.13.1-cp312-cp312-macosx_12_0_arm64.whl
+  #  - scipy-1.13.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - scipy-1.13.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - scipy-1.13.1-cp312-cp312-musllinux_1_1_x86_64.whl
+  #  - scipy-1.13.1-cp312-cp312-win_amd64.whl
+  scipy==1.13.1 --hash=sha256:5d72782f39716b2b3509cd7c33cdc08c96f2f4d2b06d51e52fb45a19ca0c86a1 \
+                --hash=sha256:017367484ce5498445aade74b1d5ab377acdc65e27095155e448c88497755a5d \
+                --hash=sha256:949ae67db5fa78a86e8fa644b9a6b07252f449dcf74247108c50e1d20d2b4627 \
+                --hash=sha256:de3ade0e53bc1f21358aa74ff4830235d716211d7d077e340c7349bc3542e884 \
+                --hash=sha256:2ac65fb503dad64218c228e2dc2d0a0193f7904747db43014645ae139c8fad16 \
+                --hash=sha256:cdd7dacfb95fea358916410ec61bbc20440f7860333aee6d882bb8046264e949
   # [/scipy]
   ]===])
 

--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -51,8 +51,8 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
 
   set(python_SOURCE_DIR "${CMAKE_BINARY_DIR}/Python-${Slicer_REQUIRED_PYTHON_VERSION}")
 
-  set(_download_3.9.10_url "https://www.python.org/ftp/python/3.9.10/Python-3.9.10.tgz")
-  set(_download_3.9.10_md5 "1440acb71471e2394befdb30b1a958d1")
+  set(_download_3.12.10_url "https://www.python.org/ftp/python/3.12.10/Python-3.12.10.tgz")
+  set(_download_3.12.10_md5 "35c03f014408e26e2b06d576c19cac54")
 
   set(EXTERNAL_PROJECT_OPTIONAL_ARGS)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")


### PR DESCRIPTION
This pull request was created to include the changes originally integrated through this pull requests:
* https://github.com/Slicer/Slicer/pull/8456

For the sake of having a clean history and considering the updated `main` branch has not been referenced externally, `main` was forced push to https://github.com/Slicer/Slicer/commit/4b1666ec317ab1885f1b02354ac2f78708cb29f4

---- 

> [!IMPORTANT]
> This pull request should be rebased & integrated *only* after the pull requests referenced below are themselves reviewed & integrated:
> * https://github.com/Slicer/Slicer/pull/8454
> * https://github.com/Slicer/Slicer/pull/8457
> * https://github.com/Slicer/Slicer/pull/8459
> * https://github.com/Slicer/Slicer/pull/8461
> * https://github.com/Slicer/Slicer/pull/8467
> * https://github.com/Slicer/Slicer/pull/8479