### PR TITLE
COMP: Update python-cmake-buildsystem anticipating python version update

### DIFF
--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -131,7 +131,7 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "aa6971962f8e9ca4ddf7092ab70e956dac542ddc"
+    "29b4e0f16c54afd64fcb33f02a8c26fbc229ae7a"
     QUIET
     )
 


### PR DESCRIPTION
This is a follow-up of f615c8335d1 ("COMP: Update python-cmake-buildsystem anticipating python version update", 2025-06-02) integrating a fix windows specific build error related to Python 3.12.

List of changes:

```
$ git shortlog \
  --group=author --group=trailer:co-authored-by \
  --no-merges \
  aa6971962..29b4e0f16
Andras Lasso (1):
      extension_testcapi: Ensure `python3.lib` is generated before linking on Windows

Jean-Christophe Fillion-Robin (1):
      extension_testcapi: Ensure `python3.lib` is generated before linking on Windows
```

---

Related pull requests:
* https://github.com/Slicer/Slicer/pull/8466
* https://github.com/Slicer/Slicer/pull/8454