### PR TITLE
COMP: Move unreferenced node cleanup methods from MRMLLogic to MRMLScene 

### DIFF
--- a/Libs/MRML/Core/vtkMRMLLogic.cxx
+++ b/Libs/MRML/Core/vtkMRMLLogic.cxx
@@ -1,10 +1,4 @@
 
-// MRML includes
-#include "vtkMRMLScene.h"
-#include "vtkMRMLStorageNode.h"
-#include "vtkMRMLDisplayableNode.h"
-#include "vtkMRMLDisplayNode.h"
-
 // MRMLLogic includes
 #include "vtkMRMLLogic.h"
 
@@ -21,123 +15,10 @@ vtkStandardNewMacro(vtkMRMLLogic);
 //------------------------------------------------------------------------------
 vtkMRMLLogic::vtkMRMLLogic()
 {
-  this->Scene = nullptr;
 }
 
 //------------------------------------------------------------------------------
 vtkMRMLLogic::~vtkMRMLLogic() = default;
-
-void vtkMRMLLogic::RemoveUnreferencedStorageNodes()
-{
-  if (this->Scene == nullptr)
-  {
-    return;
-  }
-  std::set<vtkMRMLNode *> referencedNodes;
-  std::set<vtkMRMLNode *>::iterator iter;
-  std::vector<vtkMRMLNode *> storableNodes;
-  std::vector<vtkMRMLNode *> storageNodes;
-  this->Scene->GetNodesByClass("vtkMRMLStorableNode", storableNodes);
-  this->Scene->GetNodesByClass("vtkMRMLStorageNode", storageNodes);
-
-  vtkMRMLNode *node = nullptr;
-  vtkMRMLStorableNode *storableNode = nullptr;
-  vtkMRMLStorageNode *storageNode = nullptr;
-  unsigned int i;
-  for (i=0; i<storableNodes.size(); i++)
-  {
-    node = storableNodes[i];
-    if (node)
-    {
-      storableNode = vtkMRMLStorableNode::SafeDownCast(node);
-    }
-    else
-    {
-      continue;
-    }
-    storageNode = storableNode->GetStorageNode();
-    if (storageNode)
-    {
-      referencedNodes.insert(storageNode);
-    }
-  }
-
-  for (i=0; i<storageNodes.size(); i++)
-  {
-    node = storageNodes[i];
-    if (node)
-    {
-      storageNode = vtkMRMLStorageNode::SafeDownCast(node);
-    }
-    else
-    {
-      continue;
-    }
-    iter = referencedNodes.find(storageNode);
-    if (iter == referencedNodes.end())
-    {
-      this->Scene->RemoveNode(storageNode);
-    }
-  }
-}
-
-void vtkMRMLLogic::RemoveUnreferencedDisplayNodes()
-{
-  if (this->Scene == nullptr)
-  {
-    return;
-  }
-  std::set<vtkMRMLNode *> referencedNodes;
-  std::set<vtkMRMLNode *>::iterator iter;
-  std::vector<vtkMRMLNode *> displayableNodes;
-  std::vector<vtkMRMLNode *> displayNodes;
-  this->Scene->GetNodesByClass("vtkMRMLDisplayableNode", displayableNodes);
-  this->Scene->GetNodesByClass("vtkMRMLDisplayNode", displayNodes);
-
-  vtkMRMLNode *node = nullptr;
-  vtkMRMLDisplayableNode *displayableNode = nullptr;
-  vtkMRMLDisplayNode *displayNode = nullptr;
-  unsigned int i;
-  for (i=0; i<displayableNodes.size(); i++)
-  {
-    node = displayableNodes[i];
-    if (node)
-    {
-      displayableNode = vtkMRMLDisplayableNode::SafeDownCast(node);
-    }
-    else
-    {
-      continue;
-    }
-    int numDisplayNodes = displayableNode->GetNumberOfDisplayNodes();
-    for (int n=0; n<numDisplayNodes; n++)
-    {
-      displayNode = displayableNode->GetNthDisplayNode(n);
-      if (displayNode)
-      {
-        referencedNodes.insert(displayNode);
-      }
-    }
-  }
-
-  for (i=0; i<displayNodes.size(); i++)
-  {
-    node = displayNodes[i];
-    if (node)
-    {
-      displayNode = vtkMRMLDisplayNode::SafeDownCast(node);
-    }
-    else
-    {
-      continue;
-    }
-    iter = referencedNodes.find(displayNode);
-    if (iter == referencedNodes.end())
-    {
-      this->Scene->RemoveNode(displayNode);
-    }
-  }
-}
 
 //----------------------------------------------------------------------------
 std::string vtkMRMLLogic::GetApplicationHomeDirectory()

--- a/Libs/MRML/Core/vtkMRMLLogic.h
+++ b/Libs/MRML/Core/vtkMRMLLogic.h
@@ -17,16 +17,10 @@
 
 // MRML includes
 #include "vtkMRML.h"
-class vtkMRMLScene;
 
 // VTK includes
 #include <vtkObject.h>
 
-/// \brief Class that manages adding and deleting of observers with events.
-///
-/// Class that manages adding and deleting of observers with events
-/// This class keeps track of observers and events added to each vtk object.
-/// It caches tags returned by AddObserver method so that observers can be removed properly.
 class VTK_MRML_EXPORT vtkMRMLLogic : public vtkObject
 {
 public:
@@ -34,13 +28,6 @@ public:
   static vtkMRMLLogic *New();
   vtkTypeMacro(vtkMRMLLogic,vtkObject);
   void PrintSelf(ostream& os, vtkIndent indent) override { this->Superclass::PrintSelf(os, indent); }
-
-  vtkMRMLScene* GetScene() {return this->Scene;};
-  void SetScene(vtkMRMLScene* scene) {this->Scene = scene;};
-
-  void RemoveUnreferencedStorageNodes();
-
-  void RemoveUnreferencedDisplayNodes();
 
   /// Get application home directory.
   /// The path is retrieved from the environment variable defined by MRML_APPLICATION_HOME_DIR_ENV.
@@ -55,8 +42,6 @@ protected:
   ~vtkMRMLLogic() override;
   vtkMRMLLogic(const vtkMRMLLogic&);
   void operator=(const vtkMRMLLogic&);
-
-  vtkMRMLScene *Scene;
 };
 
 #endif

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -1714,22 +1714,13 @@ void vtkMRMLScene::RemoveUnreferencedStorageNodes()
   std::vector<vtkMRMLNode*> storableNodes;
   this->GetNodesByClass("vtkMRMLStorableNode", storableNodes);
 
-  vtkMRMLNode* node = nullptr;
-  vtkMRMLStorableNode* storableNode = nullptr;
-  vtkMRMLStorageNode* storageNode = nullptr;
-  unsigned int i;
-  for (i=0; i < storableNodes.size(); i++)
+  for (vtkMRMLNode* node: storableNodes)
   {
-    node = storableNodes[i];
-    if (node)
-    {
-      storableNode = vtkMRMLStorableNode::SafeDownCast(node);
-    }
-    else
+    if (!node)
     {
       continue;
     }
-    storageNode = storableNode->GetStorageNode();
+    vtkMRMLStorageNode* storageNode = vtkMRMLStorableNode::SafeDownCast(node)->GetStorageNode();
     if (storageNode)
     {
       referencedNodes.insert(storageNode);
@@ -1739,17 +1730,13 @@ void vtkMRMLScene::RemoveUnreferencedStorageNodes()
   std::vector<vtkMRMLNode*> storageNodes;
   this->GetNodesByClass("vtkMRMLStorageNode", storageNodes);
 
-  for (i=0; i < storageNodes.size(); i++)
+  for (vtkMRMLNode* node: storageNodes)
   {
-    node = storageNodes[i];
-    if (node)
-    {
-      storageNode = vtkMRMLStorageNode::SafeDownCast(node);
-    }
-    else
+    if (!node)
     {
       continue;
     }
+    vtkMRMLStorageNode* storageNode = vtkMRMLStorageNode::SafeDownCast(node);
     std::set<vtkMRMLNode*>::iterator iter = referencedNodes.find(storageNode);
     if (iter == referencedNodes.end())
     {
@@ -1766,25 +1753,17 @@ void vtkMRMLScene::RemoveUnreferencedDisplayNodes()
   std::vector<vtkMRMLNode*> displayableNodes;
   this->GetNodesByClass("vtkMRMLDisplayableNode", displayableNodes);
 
-  vtkMRMLNode* node = nullptr;
-  vtkMRMLDisplayableNode* displayableNode = nullptr;
-  vtkMRMLDisplayNode* displayNode = nullptr;
-  unsigned int i;
-  for (i=0; i < displayableNodes.size(); i++)
+  for (vtkMRMLNode* node: displayableNodes)
   {
-    node = displayableNodes[i];
-    if (node)
-    {
-      displayableNode = vtkMRMLDisplayableNode::SafeDownCast(node);
-    }
-    else
+    if (!node)
     {
       continue;
     }
+    vtkMRMLDisplayableNode* displayableNode = vtkMRMLDisplayableNode::SafeDownCast(node);
     int numDisplayNodes = displayableNode->GetNumberOfDisplayNodes();
     for (int n=0; n < numDisplayNodes; n++)
     {
-      displayNode = displayableNode->GetNthDisplayNode(n);
+      vtkMRMLDisplayNode* displayNode = displayableNode->GetNthDisplayNode(n);
       if (displayNode)
       {
         referencedNodes.insert(displayNode);
@@ -1795,17 +1774,13 @@ void vtkMRMLScene::RemoveUnreferencedDisplayNodes()
   std::vector<vtkMRMLNode*> displayNodes;
   this->GetNodesByClass("vtkMRMLDisplayNode", displayNodes);
 
-  for (i=0; i < displayNodes.size(); i++)
+  for (vtkMRMLNode* node: displayNodes)
   {
-    node = displayNodes[i];
-    if (node)
-    {
-      displayNode = vtkMRMLDisplayNode::SafeDownCast(node);
-    }
-    else
+    if (!node)
     {
       continue;
     }
+    vtkMRMLDisplayNode* displayNode = vtkMRMLDisplayNode::SafeDownCast(node);
     std::set<vtkMRMLNode*>::iterator iter = referencedNodes.find(displayNode);
     if (iter == referencedNodes.end())
     {

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -1707,6 +1707,114 @@ void vtkMRMLScene::RemoveUnusedNodeReferences()
 }
 
 //------------------------------------------------------------------------------
+void vtkMRMLScene::RemoveUnreferencedStorageNodes()
+{
+  std::set<vtkMRMLNode*> referencedNodes;
+
+  std::vector<vtkMRMLNode*> storableNodes;
+  this->GetNodesByClass("vtkMRMLStorableNode", storableNodes);
+
+  vtkMRMLNode* node = nullptr;
+  vtkMRMLStorableNode* storableNode = nullptr;
+  vtkMRMLStorageNode* storageNode = nullptr;
+  unsigned int i;
+  for (i=0; i < storableNodes.size(); i++)
+  {
+    node = storableNodes[i];
+    if (node)
+    {
+      storableNode = vtkMRMLStorableNode::SafeDownCast(node);
+    }
+    else
+    {
+      continue;
+    }
+    storageNode = storableNode->GetStorageNode();
+    if (storageNode)
+    {
+      referencedNodes.insert(storageNode);
+    }
+  }
+
+  std::vector<vtkMRMLNode*> storageNodes;
+  this->GetNodesByClass("vtkMRMLStorageNode", storageNodes);
+
+  for (i=0; i < storageNodes.size(); i++)
+  {
+    node = storageNodes[i];
+    if (node)
+    {
+      storageNode = vtkMRMLStorageNode::SafeDownCast(node);
+    }
+    else
+    {
+      continue;
+    }
+    std::set<vtkMRMLNode*>::iterator iter = referencedNodes.find(storageNode);
+    if (iter == referencedNodes.end())
+    {
+      this->RemoveNode(storageNode);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLScene::RemoveUnreferencedDisplayNodes()
+{
+  std::set<vtkMRMLNode*> referencedNodes;
+
+  std::vector<vtkMRMLNode*> displayableNodes;
+  this->GetNodesByClass("vtkMRMLDisplayableNode", displayableNodes);
+
+  vtkMRMLNode* node = nullptr;
+  vtkMRMLDisplayableNode* displayableNode = nullptr;
+  vtkMRMLDisplayNode* displayNode = nullptr;
+  unsigned int i;
+  for (i=0; i < displayableNodes.size(); i++)
+  {
+    node = displayableNodes[i];
+    if (node)
+    {
+      displayableNode = vtkMRMLDisplayableNode::SafeDownCast(node);
+    }
+    else
+    {
+      continue;
+    }
+    int numDisplayNodes = displayableNode->GetNumberOfDisplayNodes();
+    for (int n=0; n < numDisplayNodes; n++)
+    {
+      displayNode = displayableNode->GetNthDisplayNode(n);
+      if (displayNode)
+      {
+        referencedNodes.insert(displayNode);
+      }
+    }
+  }
+
+  std::vector<vtkMRMLNode*> displayNodes;
+  this->GetNodesByClass("vtkMRMLDisplayNode", displayNodes);
+
+  for (i=0; i < displayNodes.size(); i++)
+  {
+    node = displayNodes[i];
+    if (node)
+    {
+      displayNode = vtkMRMLDisplayNode::SafeDownCast(node);
+    }
+    else
+    {
+      continue;
+    }
+    std::set<vtkMRMLNode*>::iterator iter = referencedNodes.find(displayNode);
+    if (iter == referencedNodes.end())
+    {
+      this->RemoveNode(displayNode);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
 void vtkMRMLScene::RemoveReferencesToNode(vtkMRMLNode *n)
 {
   if (n == nullptr || n->GetID() == nullptr)

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -458,6 +458,26 @@ public:
 
   void RemoveUnusedNodeReferences();
 
+  /// \brief Remove all vtkMRMLStorageNode instances not referenced by any vtkMRMLStorableNode.
+  ///
+  /// This function iterates through all storage and storable nodes in the scene.
+  /// Any storage node that is not referenced by at least one storable node is
+  /// considered unreferenced and will be removed from the scene.
+  ///
+  /// This can help reduce scene size and prevent accumulation of orphaned nodes
+  /// due to improperly implemented modules or bugs.
+  void RemoveUnreferencedStorageNodes();
+
+  /// \brief Remove all vtkMRMLDisplayNode instances not referenced by any vtkMRMLDisplayableNode.
+  ///
+  /// This function traverses all displayable and display nodes in the scene.
+  /// Any display node that is not used by at least one displayable node is
+  /// deemed unreferenced and will be deleted from the scene.
+  ///
+  /// This function is useful for cleaning up leftover nodes and ensuring
+  /// consistency in the scene structure.
+  void RemoveUnreferencedDisplayNodes();
+
   bool IsReservedID(const std::string& id);
 
   void AddReservedID(const char *id);


### PR DESCRIPTION
The utility methods `RemoveUnreferencedStorageNodes` and `RemoveUnreferencedDisplayNodes` were originally introduced in commit https://github.com/Slicer/Slicer/commit/e6ae7b96b162aad2866e488d7ddc8a89392e6e0b (2010-04-17) to support cleanup before scene serialization. They became unused after commit https://github.com/Slicer/Slicer/commit/f8fb837370b5fd1d3b12e78eccad62ab9c67f183 (2012-06-07) but remain useful for debugging or manual scene maintenance.

To improve cohesion, these functions are now part of vtkMRMLScene, where their behavior is more semantically appropriate.

Keeping these methods available helps address issues with orphaned nodes that occasionally appear in scenes, possibly due to misbehaving modules or bugs elsewhere in the pipeline.

---

Related pull request:
* https://github.com/Slicer/Slicer/pull/8004