### PR TITLE
COMP: Remove obsolete includes from vtkSlicerApplicationLogic

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogic.cxx
+++ b/Base/Logic/vtkSlicerApplicationLogic.cxx
@@ -8,9 +8,7 @@
 
 // Slicer includes
 #include "vtkSlicerApplicationLogic.h"
-#include "vtkMRMLColorLogic.h"
 // For:
-//  - Slicer_BUILD_CLI_SUPPORT
 //  - Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
 //  - Slicer_EXTENSIONS_DIRBASENAME
 //  - Slicer_ORGANIZATION_DOMAIN
@@ -21,9 +19,6 @@
 // MRML includes
 #include <vtkCacheManager.h>
 #include <vtkDataIOManagerLogic.h>
-#ifdef Slicer_BUILD_CLI_SUPPORT
-# include <vtkMRMLCommandLineModuleNode.h>
-#endif
 #include <vtkMRMLRemoteIOLogic.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLSelectionNode.h>

--- a/Base/Logic/vtkSlicerApplicationLogicRequests.h
+++ b/Base/Logic/vtkSlicerApplicationLogicRequests.h
@@ -11,6 +11,13 @@
 #ifndef __vtkSlicerApplicationLogicRequests_h
 #define __vtkSlicerApplicationLogicRequests_h
 
+// For:
+//  - Slicer_BUILD_CLI_SUPPORT
+#include "vtkSlicerConfigure.h"
+
+#ifdef Slicer_BUILD_CLI_SUPPORT
+#include <vtkMRMLCommandLineModuleNode.h>
+#endif
 #include <vtkMRMLDisplayNode.h>
 #include <vtkMRMLLabelMapVolumeNode.h>
 #include <vtkMRMLModelHierarchyNode.h>


### PR DESCRIPTION
These includes are obsolete since 591c567ace8 ("ENH: Simplified vtkSlicerApplicationLogic", 2015-11-30)

---

Related pull request:
* https://github.com/Slicer/Slicer/pull/8004