### PR TITLE
ENH: Bump docs dependencies to resolve vulnerability alerts

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,8 +1,8 @@
 docutils
 linkify-it-py
-lxml
+lxml>=4.9.1
 myst-parser
-pygments
+pygments>=2.15.0
 # Workaround for readthedocs bug (https://github.com/readthedocs/sphinx_rtd_theme/issues/1343)
 sphinx>=5.0,!=5.2.0.post0
 sphinx-issues
@@ -10,6 +10,6 @@ sphinx-jsonschema
 sphinx_markdown_tables>=0.0.17
 sphinx-notfound-page
 sphinx_rtd_theme>=0.5.2
-requests>=2.32.2 # not directly required, pinned by Snyk to avoid a vulnerability
+requests>=2.32.4 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
This PR will help boost the OpenSSF score for Slicer (https://securityscorecards.dev/viewer/?uri=github.com/Slicer/Slicer) which is currently getting docked for vulnerabilities in the Slicer documents requirements file. These issues are being warned in https://github.com/Slicer/Slicer/security/code-scanning/29.

This addresses issues for the following packages:

lxml issues:
https://github.com/advisories/GHSA-55x5-fj6c-h6m8
https://github.com/advisories/GHSA-57qw-cc2g-pv5p
https://github.com/advisories/GHSA-jq4v-f5q6-mjqq
https://github.com/advisories/GHSA-pgww-xf46-h92r
https://github.com/advisories/GHSA-wrxv-2j5q-m38w
https://github.com/advisories/GHSA-xp26-p53h-6h2p

pygments issue:
https://github.com/advisories/GHSA-mrwq-x4v8-fh7p

requests issue:
https://github.com/advisories/GHSA-9hjg-9r4m-mvj7