### PR TITLE
COMP: Update python-cmake-buildsystem anticipating python version update

### DIFF
--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -131,7 +131,7 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "29b4e0f16c54afd64fcb33f02a8c26fbc229ae7a"
+    "f807c34cee2eccc434bad9f363915a5eeff7a2b8"
     QUIET
     )
 


### PR DESCRIPTION
This is a follow-up of 97d8a03b5ed ("COMP: Update python-cmake-buildsystem anticipating python version update", 2025-06-05) integrating fixes to address macOS and windows specific build error related to Python 3.12.

List of changes:

```
$ git shortlog \
  --group=author --group=trailer:co-authored-by \
  --no-merges \
  29b4e0f16..f807c34ce
Jean-Christophe Fillion-Robin (10):
      ConfigureChecks: Fix lookup of ffi symbols
      ConfigureChecks: Avoid false positive remove USE_SYSTEM_LibFFI warning
      fix(extension_ctypes): Define FFI_BUILDING for static libffi on Windows
      chore: Privately associate compile definitions to _freeze_importlib and pgen executables
      fix: Work around CMake issue #26993 explicitly propagating extension definitions
      fix: Define PY3_DLLNAME as wide string to fix C4133 warnings
      feat(PythonExtractVersionInfo): Add python_compute_release_field3_value
      feat: Add support for building windows python launchers
      fix(cmake): Update _add_executable_without_windows to avoid modifying global flags
      fix: Require Python >= 3.9 to build venvlauncher
```

---

Related pull requests:
* https://github.com/Slicer/Slicer/pull/8454
* https://github.com/Slicer/Slicer/pull/8467
* https://github.com/Slicer/Slicer/pull/8466