### PR TITLE
BUG: Do not attempt to import obsolete qSlicerBaseQTCLIPython module

### DIFF
--- a/Base/Python/CMakeLists.txt
+++ b/Base/Python/CMakeLists.txt
@@ -44,7 +44,6 @@ if(Slicer_BUILD_CLI_SUPPORT)
     )
   set(Slicer_PYTHON_MODULES_CONFIG "${Slicer_PYTHON_MODULES_CONFIG},
 # CLI logic (Slicer_BUILD_CLI_SUPPORT:ON)
-'qSlicerBaseQTCLIPython',
 'qSlicerBaseQTCLIPythonQt',
 "
   )


### PR DESCRIPTION
Prevents the following warning from being reported on startup:

```
No module named 'qSlicerBaseQTCLIPython'
```

Follow-up of 2b3a9c19a11 ("COMP: Fix macOS build removing obsolete VTK wrapping of qSlicerBaseQTCLI", 2025-06-11)


---

Related pull requests:
* https://github.com/Slicer/Slicer/pull/8475
* https://github.com/Slicer/Slicer/pull/8004