### PR TITLE
ENH: Bump doc dependency pygments version to resolve vulnerability

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,7 +2,7 @@ docutils
 linkify-it-py
 lxml>=4.9.1
 myst-parser
-pygments>=2.15.0
+pygments>=2.15.1
 # Workaround for readthedocs bug (https://github.com/readthedocs/sphinx_rtd_theme/issues/1343)
 sphinx>=5.0,!=5.2.0.post0
 sphinx-issues


### PR DESCRIPTION
This is a follow-up to https://github.com/Slicer/Slicer/pull/8478.

pygments issue:
https://osv.dev/vulnerability/PYSEC-2023-117