### PR TITLE
COMP: Make vtkSlicerTerminologiesModuleLogic API backward compatible

### DIFF
--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyEntry.cxx
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyEntry.cxx
@@ -214,3 +214,31 @@ void vtkSlicerTerminologyEntry::Copy(vtkSlicerTerminologyEntry* aEntry)
   this->RegionObject->Copy(aEntry->GetRegionObject());
   this->RegionModifierObject->Copy(aEntry->GetRegionModifierObject());
 }
+
+//----------------------------------------------------------------------------
+const char* vtkSlicerTerminologyEntry::GetAnatomicContextName()
+{
+  vtkWarningMacro("GetAnatomicContextName is deprecated. Use GetRegionContextName instead.");
+  return this->GetRegionContextName();
+}
+
+//----------------------------------------------------------------------------
+void vtkSlicerTerminologyEntry::SetAnatomicContextName(const char* name)
+{
+  vtkWarningMacro("SetAnatomicContextName is deprecated. Use SetRegionContextName instead.");
+  this->SetRegionContextName(name);
+}
+
+//----------------------------------------------------------------------------
+vtkSlicerTerminologyType* vtkSlicerTerminologyEntry::GetAnatomicRegionObject()
+{
+  vtkWarningMacro("GetAnatomicRegionObject is deprecated. Use GetRegionObject instead.");
+  return this->GetRegionObject();
+}
+
+//----------------------------------------------------------------------------
+vtkSlicerTerminologyType* vtkSlicerTerminologyEntry::GetAnatomicRegionModifierObject()
+{
+  vtkWarningMacro("GetAnatomicRegionModifierObject is deprecated. Use GetRegionObject instead.");
+  return this->GetRegionModifierObject();
+}

--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyEntry.h
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyEntry.h
@@ -66,6 +66,15 @@ public:
   /// Returns true if all fields are empty.
   bool IsEmpty();
 
+  /// \deprecated Use GetRegionContextName instead.
+  const char* GetAnatomicContextName();
+  /// \deprecated Use SetRegionContextName instead.
+  void SetAnatomicContextName(const char* name);
+  /// \deprecated Use GetRegionObject instead.
+  vtkSlicerTerminologyType* GetAnatomicRegionObject();
+  /// \deprecated Use GetRegionModifierObject instead.
+  vtkSlicerTerminologyType* GetAnatomicRegionModifierObject();
+
 protected:
   vtkSetObjectMacro(CategoryObject, vtkSlicerTerminologyCategory);
   vtkSetObjectMacro(TypeObject, vtkSlicerTerminologyType);


### PR DESCRIPTION
Recently vtkSlicerTerminologiesModuleLogic methods were renamed to make the API more consistent (mostly using "region" instead of somewhat randomly using anatomicalRegion/anatomy/region in their name). This change caused runtime error in QuantitativeReporting extension.

This commit restores the remaining removed methods. They are deprecated methods, which will be removed in the future, but for now they log a warning message and then call the corresponding new method.

fixes #8324