### PR TITLE
ENH: Replace deprecated pydicom API usage

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -93,7 +93,7 @@ class DICOMPlugin:
     def findPrivateTag(self, ds, group, element, privateCreator):
         """Helper function to get private tag from private creator name.
         Example:
-            ds = pydicom.read_file(...)
+            ds = pydicom.dcmread(...)
             tag = self.findPrivateTag(ds, 0x0021, 0x40, "General Electric Company 01")
             value = ds[tag].value
         """

--- a/Modules/Scripted/DICOMPatcher/DICOMPatcher.py
+++ b/Modules/Scripted/DICOMPatcher/DICOMPatcher.py
@@ -752,7 +752,7 @@ class DICOMPatcherLogic(ScriptedLoadableModuleLogic):
                     continue
 
                 try:
-                    ds = pydicom.read_file(filePath)
+                    ds = pydicom.dcmread(filePath)
                 except (OSError, pydicom.filereader.InvalidDicomError):
                     self.addLog("  Not DICOM file. Skipped.")
                     continue
@@ -774,7 +774,7 @@ class DICOMPatcherLogic(ScriptedLoadableModuleLogic):
                     os.makedirs(dirName)
 
                 self.addLog("  Writing DICOM...")
-                pydicom.write_file(patchedFilePath, ds)
+                pydicom.dcmwrite(patchedFilePath, ds)
                 self.addLog("  Created DICOM file: %s" % patchedFilePath)
 
         self.addLog(f"DICOM patching completed. Patched files are written to:\n{outputDirPath}")

--- a/Modules/Scripted/DICOMPlugins/DICOMGeAbusPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMGeAbusPlugin.py
@@ -83,7 +83,7 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
                 pass
 
             try:
-                ds = dicom.read_file(filePath, stop_before_pixels=True)
+                ds = dicom.dcmread(filePath, stop_before_pixels=True)
             except Exception as e:
                 logging.debug(f"Failed to parse DICOM file: {str(e)}")
                 continue
@@ -125,7 +125,7 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
 
     def getMetadata(self, filePath):
         try:
-            ds = dicom.read_file(filePath, stop_before_pixels=True)
+            ds = dicom.dcmread(filePath, stop_before_pixels=True)
         except Exception as e:
             raise ValueError(f"Failed to parse DICOM file: {str(e)}")
 

--- a/Modules/Scripted/DICOMPlugins/DICOMImageSequencePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMImageSequencePlugin.py
@@ -154,7 +154,7 @@ class DICOMImageSequencePluginClass(DICOMPlugin):
                     # Read image spacing from SequenceOfUltrasoundRegions
                     loadable.spacingMmPerPixel = None
                     if modality == "US":
-                        ds = dicom.read_file(filePath, stop_before_pixels=True)
+                        ds = dicom.dcmread(filePath, stop_before_pixels=True)
                         if hasattr(ds, "SequenceOfUltrasoundRegions"):
                             if len(ds.SequenceOfUltrasoundRegions) == 1:
                                 region = ds.SequenceOfUltrasoundRegions[0]
@@ -189,7 +189,7 @@ class DICOMImageSequencePluginClass(DICOMPlugin):
 
         if canBeCineMri and len(cineMriInstanceNumberToFilenameIndex) > 1:
             # Get description from first
-            ds = dicom.read_file(cineMriInstanceNumberToFilenameIndex[next(iter(cineMriInstanceNumberToFilenameIndex))], stop_before_pixels=True)
+            ds = dicom.dcmread(cineMriInstanceNumberToFilenameIndex[next(iter(cineMriInstanceNumberToFilenameIndex))], stop_before_pixels=True)
             name = ""
             if hasattr(ds, "SeriesNumber") and ds.SeriesNumber:
                 name = f"{ds.SeriesNumber}:"
@@ -309,7 +309,7 @@ class DICOMImageSequencePluginClass(DICOMPlugin):
         if singleFileInLoadable:
             outputSequenceNode.SetName(name)
         else:
-            ds = dicom.read_file(filePath, stop_before_pixels=True)
+            ds = dicom.dcmread(filePath, stop_before_pixels=True)
             if hasattr(ds, "PositionerPrimaryAngle") and hasattr(ds, "PositionerSecondaryAngle"):
                 outputSequenceNode.SetName(f"{name} ({ds.PositionerPrimaryAngle}/{ds.PositionerSecondaryAngle})")
             else:


### PR DESCRIPTION
read_file and write_file were marked deprecated as of pydicom 2.2.0 and were removed in pydicom 3.0.0. See https://github.com/pydicom/pydicom/blob/dbe9192d2d8407bc1ea62bfab67d4c2e7a384bef/doc/release_notes/v2.2.0.rst?plain=1#L27-L30.