### PR TITLE
ENH: Enforce python 3.12 and newer syntax

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     rev: v3.20.0
     hooks:
       - id: pyupgrade
-        args: [--py39-plus]
+        args: [--py310-plus]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v4.0.0-alpha.8"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     rev: v3.20.0
     hooks:
       - id: pyupgrade
-        args: [--py310-plus]
+        args: [--py312-plus]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v4.0.0-alpha.8"

--- a/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
@@ -8,7 +8,6 @@ import dataclasses
 import enum
 import logging
 import pathlib
-from typing import Union
 
 import ctk
 import qt
@@ -45,7 +44,7 @@ class Decimals:
 class SingleStep:
     """Annotation for Qt's setSingleStep methods for spinboxes and sliders."""
 
-    value: Union[float, int]
+    value: float | int
 
 
 class GuiConnector(abc.ABC):

--- a/Base/Python/slicer/parameterNodeWrapper/wrapper.py
+++ b/Base/Python/slicer/parameterNodeWrapper/wrapper.py
@@ -2,7 +2,6 @@
 
 import logging
 import typing
-from typing import Optional
 import weakref
 
 import qt
@@ -29,7 +28,7 @@ SlicerParameterNamePropertyName = "SlicerParameterName"
 
 
 class _Parameter:
-    def __init__(self, parameterInfo: ParameterInfo, prefix: Optional[str] = None):
+    def __init__(self, parameterInfo: ParameterInfo, prefix: str | None = None):
         self.name: str = f"{prefix or ''}{parameterInfo.basename}"
         self.serializer: Serializer = parameterInfo.serializer
         self.default = parameterInfo.default
@@ -127,7 +126,7 @@ def _makeProperty(name: str):
     )
 
 
-def _initMethod(self, parameterNode, prefix: Optional[str] = None):
+def _initMethod(self, parameterNode, prefix: str | None = None):
     self.parameterNode = parameterNode
     self._parameterGUIs = dict()
     self._nextParameterGUIsTag = 0

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
@@ -797,8 +797,8 @@ class TypedParameterNodeTest(unittest.TestCase):
     def test_union_simple(self):
         @parameterNodeWrapper
         class ParameterNodeType:
-            intOrStr: typing.Union[int, str]
-            optBool: typing.Optional[bool]
+            intOrStr: int | str
+            optBool: bool | None
 
         param = ParameterNodeType(newParameterNode())
         self.assertTrue(param.isCached("intOrStr"))
@@ -828,7 +828,7 @@ class TypedParameterNodeTest(unittest.TestCase):
     def test_union_many(self):
         @parameterNodeWrapper
         class ParameterNodeType:
-            value: typing.Union[bool, str, int, vtkMRMLModelNode]
+            value: bool | str | int | vtkMRMLModelNode
 
         param = ParameterNodeType(newParameterNode())
         self.assertTrue(param.isCached("value"))
@@ -851,7 +851,7 @@ class TypedParameterNodeTest(unittest.TestCase):
     def test_union_multiple_nodes(self):
         @parameterNodeWrapper
         class ParameterNodeType:
-            value: typing.Union[vtkMRMLModelNode, vtkMRMLLabelMapVolumeNode, None]
+            value: vtkMRMLModelNode | vtkMRMLLabelMapVolumeNode | None
 
         param = ParameterNodeType(newParameterNode())
         self.assertTrue(param.isCached("value"))
@@ -873,10 +873,10 @@ class TypedParameterNodeTest(unittest.TestCase):
     def test_validated_union(self):
         @parameterNodeWrapper
         class ParameterNodeType:
-            value: Annotated[typing.Union[
-                Annotated[int, Minimum(5)],
-                Annotated[str, Choice(["q", "r", "s"])],
-            ], Default(7)]
+            value: Annotated[(
+                Annotated[int, Minimum(5)] |
+                Annotated[str, Choice(["q", "r", "s"])]
+            ), Default(7)]
 
         param = ParameterNodeType(newParameterNode())
         self.assertTrue(param.isCached("value"))

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
@@ -1,7 +1,7 @@
 import enum
 import pathlib
 import unittest
-from typing import Annotated, Union
+from typing import Annotated
 
 import ctk
 import qt
@@ -828,7 +828,7 @@ class ParameterNodeWrapperGuiTest(unittest.TestCase):
         @parameterNodeWrapper
         class ParameterNodeWrapper:
             alpha: vtkMRMLModelNode
-            bravo: Union[vtkMRMLModelNode, vtkMRMLScalarVolumeNode, None]
+            bravo: vtkMRMLModelNode | vtkMRMLScalarVolumeNode | None
 
         param = ParameterNodeWrapper(newParameterNode())
 

--- a/Base/Python/slicer/tests/test_slicer_parameter_pack.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_pack.py
@@ -447,7 +447,7 @@ class TypedParameterNodeTest(unittest.TestCase):
         class ParameterPack:
             box: BoundingBox
             value: int
-            union: Union[int, str]
+            union: int | str
             annotated: Annotated[bool, Default(True)]
             annotatedBox: BoundingBox = BoundingBox(Point(-99, 8), Point(11, 10))
             annotatedSub: AnnotatedSub

--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -3,7 +3,8 @@ import os
 import requests
 import subprocess
 import time
-from typing import Callable, Optional
+
+from collections.abc import Callable
 from requests.auth import HTTPBasicAuth
 
 import ctk
@@ -621,7 +622,7 @@ class DICOMSender:
 
     def _parseKheopsView(
         self, destinationURL: qt.QUrl,
-    ) -> Optional[tuple[qt.QUrl, HTTPBasicAuth]]:
+    ) -> tuple[qt.QUrl, HTTPBasicAuth] | None:
         """
         Parse parameters for specific Kheops server implementation.
 

--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import requests
-from typing import Optional
 
 import ctk
 import qt
@@ -916,7 +915,7 @@ GLOBAL_DICOMWEB_PASSWORD_KEY = "GLOBAL_DICOMWEB_PASSWORD_KEY"
 
 
 # ------------------------------------------------------------------------------
-def getGlobalDICOMAuth() -> Optional[requests.auth.HTTPBasicAuth]:
+def getGlobalDICOMAuth() -> requests.auth.HTTPBasicAuth | None:
     """Get the global authentication settings for DICOM networking, if initialized."""
     user = slicer.util.settingsValue(GLOBAL_DICOMWEB_USER_KEY, "")
     pwd = slicer.util.settingsValue(GLOBAL_DICOMWEB_PASSWORD_KEY, "")

--- a/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
+++ b/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager
 import logging
-from typing import Optional
 import qt
 import vtk
 import enum
@@ -115,7 +114,7 @@ class VectorToScalarVolumeWidget(ScriptedLoadableModuleWidget, VTKObservationMix
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
-    _parameterNode: Optional[VectorToScalarVolumeParameterNode]
+    _parameterNode: VectorToScalarVolumeParameterNode | None
 
     def __init__(self, parent=None):
         """Called when the user opens the module the first time and the widget is initialized."""

--- a/Modules/Scripted/WebServer/WebServer.py
+++ b/Modules/Scripted/WebServer/WebServer.py
@@ -4,7 +4,8 @@ import sys
 import socket
 import urllib
 from http.server import HTTPServer
-from typing import Callable, Optional
+
+from collections.abc import Callable
 
 import ctk
 import qt
@@ -591,13 +592,13 @@ class WebServerLogic:
     """
 
     def __init__(self,
-                 port:Optional[int]=None,
+                 port:int | None=None,
                  enableSlicer:bool=True,
                  enableExec:bool=False,
                  enableDICOM:bool=True,
                  enableStaticPages:bool=True,
                  requestHandlers:list[BaseRequestHandler]=None,
-                 logMessage:Optional[BaseRequestLoggingFunction]=None,
+                 logMessage:BaseRequestLoggingFunction | None=None,
                  enableCORS:bool=False):
         self.logMessage = logMessage or self.defaultLogMessage
         self.port = port or 2016

--- a/Modules/Scripted/WebServer/WebServerLib/BaseRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/BaseRequestHandler.py
@@ -1,7 +1,8 @@
 """Base interface(s) for the Slicer WebServer module."""
 
 import abc
-from typing import Callable, Optional
+
+from collections.abc import Callable
 
 
 BaseRequestLoggingFunction = Callable[[list[any]], None]
@@ -25,7 +26,7 @@ class BaseRequestHandler(abc.ABC):
     """
 
     @abc.abstractmethod
-    def __init__(self, logMessage: Optional[BaseRequestLoggingFunction], **kwargs):
+    def __init__(self, logMessage: BaseRequestLoggingFunction | None, **kwargs):
         """
         Initialize a new request handler instance.
         :param logMessage: An optional external handle for message logging.

--- a/Modules/Scripted/WebServer/WebServerLib/DICOMRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/DICOMRequestHandler.py
@@ -1,7 +1,6 @@
 import logging
 import pydicom
 import urllib
-from typing import Optional
 
 import slicer
 from .BaseRequestHandler import BaseRequestHandler, BaseRequestLoggingFunction
@@ -25,7 +24,7 @@ class DICOMRequestHandler(BaseRequestHandler):
         logger.debug(*args)
 
     def __init__(self,
-                 logMessage:Optional[BaseRequestLoggingFunction]=None):
+                 logMessage:BaseRequestLoggingFunction | None = None):
         """
         Initialize a new request handler instance.
         :param logMessage: An optional external handle for message logging.

--- a/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
@@ -10,7 +10,6 @@ import numpy
 import os
 import time
 import urllib
-from typing import Optional
 
 import qt
 import vtk.util.numpy_support
@@ -32,7 +31,7 @@ class SlicerRequestHandler(BaseRequestHandler):
         """
         logger.debug(*args)
 
-    def __init__(self, enableExec=False, logMessage: Optional[BaseRequestLoggingFunction] = None):
+    def __init__(self, enableExec=False, logMessage: BaseRequestLoggingFunction | None = None):
         """
         Initialize a new request handler instance.
         :param enableExec: Whether this instance is permitted to execute arbitrary code.

--- a/Modules/Scripted/WebServer/WebServerLib/StaticPagesRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/StaticPagesRequestHandler.py
@@ -2,7 +2,6 @@ import logging
 import mimetypes
 import os
 import re
-from typing import Optional
 
 from .BaseRequestHandler import BaseRequestHandler, BaseRequestLoggingFunction
 
@@ -26,7 +25,7 @@ class StaticPagesRequestHandler(BaseRequestHandler):
         """
         logger.debug(*args)
 
-    def __init__(self, docroot, logMessage: Optional[BaseRequestLoggingFunction] = None):
+    def __init__(self, docroot, logMessage: BaseRequestLoggingFunction | None = None):
         """
         Initialize a new request handler instance.
         :param docroot: directory path of static pages content

--- a/Utilities/Templates/Modules/Scripted/TemplateKey.py
+++ b/Utilities/Templates/Modules/Scripted/TemplateKey.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Annotated, Optional
+from typing import Annotated
 
 import vtk
 
@@ -214,7 +214,7 @@ class TemplateKeyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             if firstVolumeNode:
                 self._parameterNode.inputVolume = firstVolumeNode
 
-    def setParameterNode(self, inputParameterNode: Optional[TemplateKeyParameterNode]) -> None:
+    def setParameterNode(self, inputParameterNode: TemplateKeyParameterNode | None) -> None:
         """
         Set and observe parameter node.
         Observation is needed because when the parameter node is changed then the GUI must be updated immediately.


### PR DESCRIPTION
This follows up Slicer's switch from Python 3.9 to Python 3.12 in https://github.com/Slicer/Slicer/commit/5e952f7c5b031dd32858f245e18719e09099117c.

Changes were automatically applied by running:
`python -m pre_commit run --all-files`