### PR TITLE
ENH: Update JsonCpp from 0.10.6 to 1.9.6

### DIFF
--- a/SuperBuild/External_JsonCpp.cmake
+++ b/SuperBuild/External_JsonCpp.cmake
@@ -25,7 +25,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "73b8e172d6615251ef851d883ef02f163e7075b2" # slicer-v0.10.6-2016-04-22
+    "89e2973c754a9c02a49974d839779b151e95afd6" # slicer-v1.9.6-2024-09-09
     QUIET
     )
 
@@ -54,6 +54,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       -DJSONCPP_WITH_CMAKE_PACKAGE:BOOL=ON
       -DBUILD_SHARED_LIBS:BOOL=ON
       -DBUILD_STATIC_LIBS:BOOL=OFF
+      -DCMAKE_INSTALL_LIBDIR:STRING=lib  # Override value set in GNUInstallDirs CMake module
       -DLIBRARY_INSTALL_DIR:PATH=${Slicer_INSTALL_LIB_DIR}
       -DRUNTIME_INSTALL_DIR:PATH=${Slicer_INSTALL_LIB_DIR}
       -DARCHIVE_INSTALL_DIR:PATH=${Slicer_INSTALL_LIB_DIR}
@@ -80,12 +81,12 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
   else()
     set(lib_cfg_dir ".")
   endif()
-  set(${proj}_LIBRARY ${${proj}_DIR}/src/lib_json/${lib_cfg_dir}/${lib_prefix}jsoncpp.${lib_ext})
+  set(${proj}_LIBRARY ${${proj}_DIR}/lib/${lib_cfg_dir}/${lib_prefix}jsoncpp.${lib_ext})
 
   #-----------------------------------------------------------------------------
   # Launcher setting specific to build tree
 
-  set(${proj}_LIBRARY_PATHS_LAUNCHER_BUILD ${JsonCpp_DIR}/src/lib_json/<CMAKE_CFG_INTDIR>)
+  set(${proj}_LIBRARY_PATHS_LAUNCHER_BUILD ${JsonCpp_DIR}/lib/<CMAKE_CFG_INTDIR>)
   mark_as_superbuild(
     VARS ${proj}_LIBRARY_PATHS_LAUNCHER_BUILD
     LABELS "LIBRARY_PATHS_LAUNCHER_BUILD"


### PR DESCRIPTION
<details><summary>List of JsonCpp changes:</summary>
<p>

```
$ git shortlog 0.10.6..1.9.6 --no-merges

Aaron Jacobs (1):
      Remove undefined behavior from a left shift of a negative value.

Abigail Bunyan (1):
      Add missing classes to forwards.h

Adam Boseley (1):
      By default use <prefix> relative paths when installing

Alex Beregszaszi (2):
      Document skipBom in CharReaderBuilder (#1332)
      Introduce CharReaderBuilder::ecma404Mode (#1333)

Alexander Gazarov (1):
      Replaced the template-based solution for avoiding calls to localeconv() with a macro-based one (fixes #527)

Alexander V. Brezgin (4):
      Remove repeated condition
      Optimize value range check
      Optimize value check
      Optimize Value::isIntegral() method

Andrea Pappacoda (1):
      build(meson): use find_program('python3') (#1386)

Andrew Childs (1):
      json_writer: fix inverted sense in isAnyCharRequiredQuoting (#1120)

Andrey Okoshkin (3):
      Fix Value::copyPayload() and Value::copy() (#704)
      Add basic test for Value::copy() (#704)
      Make Value copy constructor simplier

Anton Indrawan (2):
      Compiles jsoncpp with QNX 6.6
      Fix QNX build: QNX defines sprintf under the std namespace. Use snprintf instead

Autofuzz team (1):
      Add a simple fuzz test for jsoncpp.

Baptiste Jonglez (1):
      Fix compilation errors for downstream projects caused by incorrect pkgconfig paths

Bartosz Brachaczek (1):
      Opportunistically take advantage of C++20 move-in/out-of stringstream (#1457)

Ben Boeckel (5):
      reader: export CharReader::Factory
      json_writer: improve isfinite support on *nix
      amalgamate: add version.h and allocator.h to the forwards header
      version.h: fix the version number in the header
      test: ensure the version numbers agree

Ben Wolsieffer (1):
      Fix generation of pkg-config file with absolute includedir/libdir. (#1199)

Benjamin Knecht (3):
      Create format string with sprintf.
      making precision unsigned int adding precision as settings value for StreamBuilder
      Add test code for precision

Bernd Kuhls (1):
      CMakeLists.txt: Treat conversion warning as error only with JSONCPP_WITH_WARNING_AS_ERROR=On

Bernhard Hartleb (1):
      Fix issue #567 in writing real values in different locales

Billy Donahue (36):
      expanded Infinity test
      prettier test
      don't need out field of TestData
      Remove std::swap<Json::Value> in favor of ADL
      formatting refactor
      whitespace cleanup
      single-arg string ctor
      Improvements in writing precision and json_tool.h helpers
      fix string construction
      json_tool missing include
      Apply the formatting specified in .clang-format file.
      Reapply clang-format.
      convert JSONCPP_STRING etc from macros to typedefs
      Jsoncpp aliases 2 (#868)
      switch .clang-format to C++11
      apply the C++11 style change in .clang-format
      Issue #872: add json/allocator.h in the amalgamated header.
      pack the {type,allocated} bitfield (#876)
      refactor comments_ into a class
      VS2013 doesn't allow move ops to be =default
      remove JSON_HAS_RVALUE_REFERENCES
      Add WideString test for Issue #756
      Improve code comment formatting (Issue #985)
      Explicitly specify hexfloat in TestResult operator<< (#1078)
      Issue 1066 (#1080)
      some test coverage for Value::iterator (#1093)
      eliminate some redundancy in test_lib_json/main.cpp (#1104)
      tweak to avoid implicit narrowing warning. (#1114)
      spot fix #1171: isprint argument must be representable as unsigned char (#1173)
      Escape control chars even if emitting UTF8 (#1178)
      avoid isprint, because it is locale specific (#1189)
      Billy donahue avoid isprint (#1191)
      `Json::ValueIterator` operators `*` and `->` need to be const
      Fix Value::resize to fill all array elements (#1265)
      fix sign-conversion warning (#1268)
      Rearrange Comments::set (#1278)

Brad King (1):
      reader: fix signed overflow when parsing negative value

Brendan Drew (1):
      Ensure that the fact that a float was provided on input is preserved when writing output; update tests to reflect this fact

Brian W. Mulligan (1):
      Add comment to README giving instructions on how to install to a directory other than /usr/local (#694)

Chen (13):
      Add an insert overload function (#1110)
      Run Clang-tidy with modernize-use-auto (#1077)
      Add test cases for Reader  (#1108)
      fix Reader bug and add testcase (#1122)
      Replace Raw Unicode in Testcase (#1127)
      fix compile warnning using cmake (#1132)
      revert trailing comma in old Reader (#1126)
      Ignore byte order mark in the head of UTF-8 text. (#1149)
      allowBom -> skipBom (#1162)
      Bump soversion to 24 (#1167)
      Update README.md and add dota17 to AUTHORS list. (#1168)
      Enhance cmake script (#1197)
      hot fix for building static lib (#1203)

Christian Ledergerber (1):
      Fix c++20 compilation problem for clang10 and fix potential bug due to compiler optimization

Christof Krüger (1):
      Do not deprecate whole class but only constructors of Json::Reader.

Christopher Dawes (1):
      Fixing up for #define instead of typedef in secure allocators

Christopher Dunn (100):
      normalized some windows VS stuff
      add .gitattributes
      Fully init OurReader
      Fix VS warnings
      Support ccache
      Some indentation
      Minor
      In case cmake is run in root-dir
      Fix conversion warnings/errors
      Try to find ptrdiff_t for GNUC 4.9.2
      More conversion fixes for gcc
      1.7.0 < 1.6.5
      For gcc>=6 JSON_USE_INT64_DOUBLE_CONVERSION
      Errors for sign-compare, since gcc6 is stricter
      Fix a sign-compare
      Drop -Wno-sign-conversion suppression
      This *might* fix the last gcc-6 error.
      JSONCPP_STRING
      JSONCPP_OSTREAM
      JSONCPP_OSTRINGSTREAM
      JSONCPP_ISTRINGSTREAM
      JSONCPP_ISTREAM
      Another shot at #411
      Fix amalgamate.py
      JSONCPP_USING_SECURE_MEMORY default is 0
      Use macro for `override`
      1.7.1 <- 1.7.0
      Fix a clang warning
      1.7.2 <- 1.7.1
      Exclude allocator.h from amalgamated header
      fix warning
      Fix int->char conv warn
      Make internal func anon
      Use a Myers Singleton for null
      1.7.3
      1.7.4 <- 1.7.3
      Allow dtor for nullSingleton
      Avoid null for stringValue
      Remove needless if.
      Optional space after comma
      Use int64_t for 64bit ints
      Fix locale for decimal points
      Reject extra chars if strictRoot
      1.7.5 <- 1.7.4
      1.7.6 <- 1.7.5
      Bump SOVERSION, separate from MAJOR.MINOR.MICRO
      1.7.7
      Require cmake>=3.1
      Path for pkg-config
      std::min<unsigned>, for VS2015
      1.8.1
      Avoid memory error
      Drop scons support
      1.8.2 <- 1.8.1
      Update README
      Move amalgamated source details to wiki
      Drop NEWS.txt
      Suppress GCC deprecated-declarations warning for tests
      Fix writeCommentBeforeValue() iter deref
      Bump to soversion=19, 1.8.3
      Try adding python-3.5 in TravisCI
      Do not write to stderr
      Generated new footer.html
      Generated new header.html
      Update header.html
      rsync less
      Drop timestamp from HTML doxygen
      Link classes and namespace
      Drop TITLE from Doxygen docs
      More VS warning prevention
      Try Travis support suggestion for py3
      Use move ctor in append()
      Use non-deprecated removeMember()
      rm unused func
      pyenv install (#713)
      replace code point in range(0xD800, 0xDFFF) to replacement mark (#714)
      1.8.4; soversion=20
      -std=c++11 (#715)
      Try to use default python on Trusty, for speed
      pyenv global 3.6
      Minor changes for static analysis (#749)
      Try to avoid empty string
      Tell meson/ninja versions
      Try the way I build locally
      In travis-ci, build for osx also
      Update meson/python
      Avoid deprecated Meson feature
      Remove deprecated makerelease.py
      ninja test
      Stop checking status; raise instead
      Do not run colliding tests at same time
      clang-format
      Try meson/ninja from pypi
      Do not allow failures on osx
      Remove trailing space characters (#1256)
      Update version in dox
      Avoid getline(s, EOF)
      clang-format is not available by default
      Drop compile-time deprecation warning
      Bump micro version

Claus Klein (1):
      Use ccache right (#1139)

Cristóvão B da Cruz e Silva (1):
      Small fix for strict compilers (using the flag -Werror for instance)

Daniel Engberg (1):
      meson: Don't specifically look for python3

Darcy Beurle (1):
      CZString as public when using NVCC, see issue #486

David Demelier (3):
      Fix build with libc++, closes #910
      Use version.md in dev.makefile
      Rename version.md to version.txt

David Gobbi (1):
      Remove '=delete' from template methods for Xcode 8 (#1133)

David Seifert (6):
      Replace current install variables with GNUInstallDirs
      Update Travis requirements for modern CMake
      Use full CMake paths in pkg-config template
      Add initial Meson build file
      Update Travis configuration
      Meson updates (#1124)

Derick Vigne (1):
      Fixed pkg-config Version

Devin Jeanpierre (2):
      Refactor authorship information for more technical accuracy.
      Restore BL's authorship attribution, and add "The Jsoncpp Authors" where it was missing.

Dhruv Paranjape (3):
      add move assignment operator for Json::Value class.
      overload append function for R value references.
      add move assignment operator for CZString and change copy assignment to const reference.

Dmitry Marakasov (1):
      Specify float constant as float

Edward Brey (1):
      Added current dir specifier for PowerShell (#1169)

Evince (1):
      json_reader throwRuntimeError return error details instead of hard-coded message

Francisco Javier Trujillo Mata (1):
      Fix cmake config for POSITION_INDEPENDENT_CODE enabling it just when BUILD_SHARED_LIBS is ON

Frank Dana (1):
      CMake: Remove ancient version checks (#1299)

Frank Richter (9):
      tests: Add small checks for find()
      Value::find(): Fix assert message
      Implement Value::demand()
      tests: Add a comment
      Cast to unsigned char in Value::setType() to appease gcc (issue #888)
      Bump minor version, SOVERSION
      Explicitly set JSON_API to 'default' visibility on clang & gcc
      tests: Improve CharReaderFailIfExtraTest (#1011)
      Do not allow tokenError tokens after input if failIfExtra is set. (#1014)

Gaurav (16):
      C++11: override keyword
      Add default value of stackLimit couple of places
      Remove conditional check for isMultiLine
      parseCommandLine also throws
      Make OurFeatures ctor as default.
      Avoid passing Null to memcmp
      MinGW support while building as DLL
      MinGW support while building as DLL
      Supporting GCC 6.0
      Supporting GCC 6.0
      Added NORETURN for throw functions.
      Added NORETURN for throw functions.
      Fix crash issue due to NULL value.
      Fix warning issue with gcc flags.
      Fix Cmake build issue
      Fix uninitialized value detected by valgrind

Gergely Nagy (1):
      Fix poss SEGV

GermanAizek (1):
      minor fixes for 64 bits and refactor code

Gida Pataki (1):
      Workaround for missing lconv::decimal_point on android

Google AutoFuzz Team (24):
      Updated header and fixed the bug
      Updated fuzz.h
      Update fuzz.cpp
      Update fuzz.h
      Update fuzz.h
      Update fuzz.cpp
      Update fuzz.h
      Update fuzz.cpp
      Update fuzz.h
      Update fuzz.cpp
      fix llvm
      added llvm
      Added include fuzz.cpp
      Update main.cpp
      Update main.cpp
      Update main.cpp
      Update CMakeLists.txt
      Update CMakeLists.txt
      Update jsontest.cpp
      Update jsontest.cpp
      Update jsontest.cpp
      Update main.cpp
      Add fuzz.cpp to jsoncpp_test
      Add dictionary for fuzzing (#1020)

Google-Autofuzz (1):
      added fuzz.cpp to macro in main.cpp

Griffin Downs (1):
      Add vcpkg installation instructions (#1037)

Hans Johnson (33):
      COMP: Use nullptr instead of 0 or NULL
      PERF: Replace explicit return calls of constructor
      ENH: MSVS 2013 snprintf compatible substitute
      COMP: Prefer the C++ headers over the C99 headers
      STYLE: Replace integer literals which are cast to bool.
      STYLE: Convert CMake-language commands to lower case
      ENH: Use cmake builtin versioning capabilities
      ENH: Provide range for non-warned cmake versions
      COMP: Provide C++11 feature testing during config
      BUG: Fix bug in CI where failure during homebrew update occured.
      ENH: Use recommended homebrew addon for travis.
      ENH: move travis support scripts to .travis_scripts
      ENH: Refactor and enhance the CI testing infrastructure
      COMP:  Use C++11 override directly
      ENH: Remove conditionals for unsupported VS compilers
      PERF: readability container size empty
      STYLE: Use range-based loops from C++11
      STYLE: Use auto for variable type matches the type of the initializer expression
      PERF: Allow compiler to choose best way to construct a copy
      STYLE: Use default member initialization
      STYLE: Pefer = default to explicitly trivial implementations
      STYLE: Pefer = delete to explicitly trivial implementations
      STYLE: Avoid unnecessary conversions from size_t to unsigned int
      STYLE: FATAL_ERROR ignored in cmake_required_minimum since 2.6.0
      BUG: VERSION_LESS_EQUAL introduced in cmake 3.7
      COMP: Remove build files for unsupported IDE's
      COMP: Remove visual studio specialization in favor of meson or cmake
      BUG: New CMake features used that break backward compatibility
      COMP: Improve const correctness for ValueIterators (#1056)
      COMP: Fix type mismatch ambiguity
      COMP: Remove shadow variable warning
      ENH: Move to requiring python 3
      ENH: Prevent cmake in source builds (#1091)

Hugh Bellamy (1):
      Fix unknown pragma warnings with clang

Iñaki Baz Castillo (1):
      README: Give some love.

Jacco (2):
      std::snprintf fix for MinGW32 c++11
      std::snprintf fix for MinGW32 c++11

Jack Ullery (1):
      minor fix for code examples (#1317)

Jacob Bundgaard (5):
      Fix dead link in CONTRIBUTING.md (#1044)
      Fix link to Amalgamated wiki article (#1064)
      Allow trailing comma in objects
      Allow trailing comma in arrays if dropped null placeholders are not allowed
      Run clang-format

Jakob Widauer (1):
      feat: adds front and back methods to Value type (#1458)

James Clarke (4):
      Add support for VS2017
      Add amd64 support
      Fix bogus asm setting
      Switch to the VCPP dll

Jason S Zang (1):
      Fix meson.build to allow using jsoncpp as a subproject

Jean-Christophe Fillion-Robin (1):
      json/config.h: Generalize setting of JSONCPP_OVERRIDE to all compilers

Jessica Clarke (1):
      Use default rather than hard-coded 8 for maximum aggregate member alignment (#1378)

Joel Johnson (11):
      Don't use unique variable for postfix
      Consolidate setting of jsoncpp target properties
      Only set CMAKE_BUILD_TYPE for single config generators
      Not needed to specify CMAKE_MACOSX_RPATH
      Always use consistent CXX_STANDARD
      Check compiler using CMAKE_CXX_COMPILER_ID
      Add Clang support, be explicit about MSVC flags
      Remove unused CMake variable
      Use non-version checked add_compile_options
      Use internal CMake compiler version directly
      Remove redundant cmake_minimum_required from example

Jordan Bayles (61):
      Fix JSON_USE_EXCEPTION=0 use case
      Update AUTHORS
      Update meson build requirement
      Create CONTRIBUTING.md
      Update README.md
      Update CONTRIBUTING.md
      Run clang format
      Update issue templates
      Update issue templates
      Modernize Travis and Appveyor configs
      Update travis scripts
      Update appveyor to use build images
      Issue 920: Fix android build with casting fix
      Run clang-format on the repository
      Issue #633: Fix issue with maxInt
      Update minimum CMake version requirement
      Fix comments on Json Reader
      Update version.h.in header comments
      \#964 Delete JSONCPP_NORETURN for [[noreturn]]
      Add new JSON_USE_NULLREF flag
      \#979 Fix parseFromStream definition
      Fix definition check for GNUC
      Cleanup versioning strategy (#989)
      Revert "Cleanup versioning strategy (#989)" (#996)
      Cleanup versioning strategy relanding (#989) (#997)
      Issue 1021: Fix clang 10 compilation (#1023)
      Just run clang format (#1025)
      Issue #970: Rename features.h to json_features.h (#1024)
      Fixup Json::Value append methods, run clang format. (#1022)
      Issue #958: Travis CI should enforce clang-format standards (#1026)
      Fix fuzzer off by one error (#1047)
      Improve performance for comment parsing (#1052)
      Number fixes (#1053)
      Issue 1100: Drop CPPTL support
      Readd some overzealously removed code
      Issue 1102: Fixup test suite, fix broken tests
      Cleanup test configurations
      Issue 1182: Fix fuzzing bug (#1183)
      Roll version numbers for 1.9.4 release (#1223)
      Create c-cpp.yml
      Create meson_build_and_run (#1553)
      Rename meson_build_and_run to meson.yml
      Delete .github/workflows/c-cpp.yml
      Fix clang format issues (#1555)
      Delete .travis.yml (#1557)
      Delete .travis_scripts directory (#1556)
      add comment space directive (#1558)
      Create clang-format.yml
      Update clang-format.yml
      Update clang-format.yml
      Clang format updates (#1560)
      Update meson.yml (#1554)
      Update meson.yml
      Update clang-format.yml
      Update clang-format.yml
      Add code coverage (#1561)
      Update meson.yml (#1562)
      Update clang-format.yml
      Create cmake.yml (#1563)
      Update meson.yml (#1564)
      Update cmake.yml

Josh Soref (1):
      Spelling (#703)

Julien Schueller (7):
      Cleanup appveyor script
      Enable shared libs on appveyor
      Avoid import/static libs name clash
      Unique lib target name
      Remove useless BUILD_STATIC_LIBS option
      Use CMAKE_CROSSCOMPILING_EMULATOR to run tests
      Set CMAKE_BUILD_TYPE default on win32 too

Jörg Krause (3):
      Remove Werror
      Add option JSONCPP_WITH_STRICT_ISO
      Enable -Werror with JSONCPP_WITH_WARNING_AS_ERROR

Kamel CHAOUCHE (1):
      Add position independent code feature to CMakeList.txt

Kapandaria (1):
      Update readFromString.cpp (#1477)

Kerem TAN (1):
      include/json/value.h is changed (#1462)

Kirill V. Lyadvinsky (3):
      Added stack overflow test
      Make it a bit more multithreading friendly
      Use clang-3.5 since the Travis version has a conflict with gcc (check this issue https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=11;bug=744872)

Kostiantyn Ponomarenko (1):
      Add Meson related info to README

Lars Müller (1):
      Use current source / binary dir when assuring out of source builds (#1527)

Lei (1):
      Fix a precision bug of valueToString, prevent to give an error result… (#1246)

Louis Dionne (1):
      [CMake] Generate CMake config files by default

Magnus Bjerke Vik (2):
      Check for locale support in CMake
      Rename NO_LOCALE_SUPPORT to JSONCPP_NO_LOCALE_SUPPORT

Marcel Opprecht (1):
      Fix clang-tidy warnings (#1231)

Marcel Raad (2):
      MSVC warning fixes in tests
      Fix macro redefinition warning with clang-cl

Marian Klymov (8):
      Fix improper format specifier in printf
      Pass string as a const reference.
      Make several methods static.
      Remove unused private function in TestResult class
      Reduce scope of variable.
      Fix different names for parameters in declaration and definition
      Apply the formatting specified in .clang-format file.
      Fix typo in previous fix.

Mariusz Glebocki (1):
      Add support for Bazel build system (#1275)

Martin Dagarin (2):
      Fixed swiched parameters in install
      Fixed compile bug

Mathias L. Baumann (1):
      JsonValue documentation: Rephrase confusing sentence

Maxim Ky (2):
      Value::removeMember moves the existing value to "removed" now
      Value::removeMember arg "removed" is optional now (could be nullptr)

Merlyn Morgan-Graham (1):
      Add RPATH to dynamic library build on OSX

Michael Shields (1):
      Fix cases where the most negative signed integer was negated, causing undefined behavior.

Mike R (1):
      Add setting precision for json writers and also add decimal places precision type. (#752)

Motti (1):
      move ctors

Motti Lanzkron (1):
      Update writer.h

Mykola (1):
      Avoid using cmake glob vars if we are a subproject (#1459)

NotWearingPants (1):
      Update link in amalgamate.py (#1335)

Olivier LIESS (4):
      added cmake config version file for proper cmake delivery
      cmake fixes
      fixed typos
      version.h : wrong file was deployed, added required include path and

Omkar Wagh (1):
      change throw() to noexcept to conform to c++11

Orivej Desh (1):
      Update removeMember docs after #693

Pavel Tsynk (2):
      Fix compile on windows with clang (#1480)
      Fixed setting JSONCPP_USE_SECURE_MEMORY definition (#1479)

Paweł Bylica (1):
      Rename variable empty to emptyString

Paweł Kierski (1):
      Serialize UTF-8 string with Unicode escapes (#687)

Pedro Kaj Kjellerup Nacht (1):
      Add security policy (#1484)

Peter Spiess-Knafl (1):
      Fix for #798

Philip Top (1):
      add a valueToQuotedString overload  (#1397)

PinkD (1):
      add comment for emitUTF8 in header

Radoslav Atanasov (1):
      Fix MSVC 15.9 (2017) warning C4866

Remy Jette (1):
      Fix sign mismatch in `valueToString`

Riccardo Corsi (1):
      Disable also Visual Studio warning C4275 (std::exception used as base class in dll-interface class) when building as DLL and JSONCPP_DISABLE_DLL_INTERFACE_WARNING is defined.

Robert Dailey (4):
      Add .gitattributes file
      Normalize line endings
      Clean up cmake END*
      Clean up cmake END* (again)

Roelof Oomen (1):
      Protect target JsonCpp::JsonCpp against multi-include (#1435)

Rosen Penev (6):
      pkgconfig: Fix for cross compilation (#1027)
      clang-tidy fixes (#1033)
      clang-tidy cleanups 2 (#1048)
      clang-tidy fixes again (#1087)
      clang-tidy fixes again (#1155)
      clang-tidy + any_of usage (#1171)

Rudi Heitbaum (1):
      meson.build: fix the version number (#1432)

Sascha Zelzer (1):
      Suppress implicit-fallthrough warnings from GCC 7 (#697)

Scotty1701 (1):
      Don't use build dir build interfaces (#1419)

Sergey Rachev (6):
      - exported targets go to separate generated file and package config file generated from template to use automatic package resolving and resolution logic
      - declare namespaced export target to simplify the library usage
      - empty line at end of file
      - narrowed lines to be aligned with overall file line width
      - workaround for CMake < 3.18 ALIAS target limitation to not point to non-GLOBAL IMPORTED target
      - isolated namespace targets into separate file

Sergiy80 (1):
      Add pragma pack directive

SpaceIm (2):
      conversion errors only if warnings as errors enabled (#1284)
      remove ccache micro management (#1448)

Stefano Fiorentino (2):
      issue_836: Check if `removed' is a valid pointer before copy data to it
      adding myself to AUTHORS as per commits (#1109)

Steven Hahn (1):
      Use override keyword with Visual Studio.

Sven Köhler (1):
      only append _static suffix for microsoft toolchains

Sylvestre Ledru (1):
      Allocate the proper memory for formatString. Fix a warning with gcc 7.1

Techwolf (1):
      std::snprintf fix for Cygwin

Tero Kinnunen (1):
      Parse large floats as infinity (#1349) (#1353)

Thomas Jandecka (1):
      fix: byte shift when interpreting 32-bit utf-8 codepoints

Timo Röhling (1):
      Bump CMake policy version to avoid deprecation warning (#1499)

Timofey (1):
      Added Value::find with String key (#1467)

Tomasz Maciejewski (1):
      remove C-style casting

Tomáš Malý (1):
      allow out-of-source build

Vicente Olivert Riera (1):
      Include stdint.h necessary for int64_t and uint64_t

Vincent (3):
      add a testcase in ValueTest:CopyObject (#1028)
      Supplement the testcase for comparing the Array and Null (#1031)
      Supplement the testcase for comparing object (#1032)

Willem (1):
      Update README.md

Wolfram Rösler (3):
      Add value_type to improve integration with boost
      Un-deprecate removeMember overloads, return void (#693)
      Allow Json::Value to be used in a boolean context (#695)

Woodrow Douglass (1):
      Create a jsoncppConfig.cmake file, even if building under meson (#1486)

YantaoZhao (1):
      allow nullptr when not care the removed array value

Yixing Lao (1):
      allow selection of Windows MSVC runtime

aliha (1):
      Fix a coupe of typos (#1007)

bcsgh (1):
      Make throwRuntimeError/throwLogicError print msg when built with JSON_USE_EXCEPTION=0

binyangl (1):
      Disable warning "C4702" when compiling json cpp using vs2013 and above

chason (1):
      fix a bug about Json::Path

chenguoping (2):
      repair a typo error
      add testcase for json_value.cpp to improve coverage [90+%]

cmlchen (3):
      use fpclassify to test a float number is zero or nan
      fix compile problem
      extract variable

damiram (1):
      Fixing warnings. Added JSONCPP_DEPRECATED definition for clang. Also updating .gitignore to ignore .DS_Store files (Mac OS Finder generated)

dawesc (3):
      .gitignore for eclipse
      allocator.h
      -DJSONCPP_USE_SECURE_MEMORY=1 for cmake

dota17 (23):
      Delete JSONCPP_DEPRECATED, use [[deprecated]] instead. (#978)
      change Value::null to Value::nullSingleton() (#1000)
      Add some test cases in ValueTest (#1010)
      change the returned value (#1003)
      add some testcases: WriteTest, StreamWriterTest (#1015)
      [Language Conformance] Use constexpr restriction in jsoncpp (#1005)
      Improving Code Readability (#1004)
      Check the comments array boundry. (#993)
      Modify code comments in write.h (#987)
      reinforce readToken function and add simple tests (#1012)
      Create an example directory and add some code examples. (#944)
      fix clang-format error for ci (#1036)
      add testcases for writerTest [improve coverage] (#1039)
      fix clang-format (#1049)
      Test Framework Modify : Remove JSONTEST_REGISTER_FIXTURE (#1050)
      add a new method to insert a new value in an array at specific index. (#949)
      add coveralls to test coverage (#1060)
      update testcases to improve coverage (#1061)
      remove pushError in CharReader (#1055)
      modify README.md: add some badges (#1070)
      add coverage badge in readme (#1072)
      Update coverage badge (#1088)
      Add some testcases for charReader (#1095)

drgler (7):
      Floating-point NaN or Infinity values should be allowed as a feature #209
      Floating-point NaN or Infinity values should be allowed as a feature #209
      Adjust whitespace formatting
      Fix number reading in the presence of Infinity: Only check for infinity if we have a leading sign character.
      __cplusplus value should not be used to decide for std::unique_ptr #350:
      Remove defaulted default constructor
      Issue #731: Provide new JSONCPP_OP_EXPLICIT macro to restore VS 2012 support after recent introduction of explicit conversion function in JSON::Value.

ds283 (2):
      Change ${CMAKE_BINARY_DIR} to ${CMAKE_CURRENT_BINARY_DIR}
      Add CMAKE_CXX_FLAGS for Intel compiler

es1x (1):
      Re-add JSONCPP_NORETURN (#1041)

fangguo (1):
      fiexd “Cannot take the address of a bit field.”

fo40225 (4):
      fix ValueTest/specialFloats test failure when fp:fast on msvc
      fix ValueTest/integers, CharReaderAllowSpecialFloatsTest/issue209 test failure when fp:fast on msvc
      corss compiler isnan
      refactoring cross compiler macro

jedav (1):
      Move removeIndex's result instead of copying (#1516)

kabeer27 (1):
      Fixes Oss-Fuzz issue: 21916 (#1180)

lilinchao (2):
      adjust some codes position
      pop the root node after readValue()

luzpaz (2):
      Misc-typos (#741)
      Fix various typos (#1350)

m-gupta (1):
      jsoncpp: Define JSON_USE_INT64_DOUBLE_CONVERSION for clang as well. (#1002)

manang (1):
      Update json_writer.cpp

martinduffy1 (1):
      CharReader: Add StructuredError (#1409)

matthieugleg (1):
      Update CMakeLists.txt (#1528)

mwestphal (1):
      Fix wrong usage of doxygen groups (#1417)

nathanruiz (1):
      Delete nullptr Json::Value constructor (#1194)

nicolaswilson (1):
      Added emitUTF8 setting. (#1045)

nnkur (2):
      Add files via upload
      Renamed JSONCPP_STACK_LIMIT to JSONCPP_DEPRECATED_STACK_LIMIT

paulo (1):
      Including instructions in how to use jsonCpp with conan

pavel.pimenov (4):
      Fix V815:Decreased performance
      strstr -> strchr https://www.viva64.com/en/w/V817/print/
      Fix #782
      "\n" -> '\n'

terrycz126 (1):
      Fix redefined(_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES) warning

theirix (1):
      Add option JSONCPP_WITH_EXAMPLE (#1099)

uvok cheetah (1):
      Clarify documentation regarding indentation / newline

vslashg (3):
      Fix a parser bug where tokens are misidentified as commas. (#1502)
      Fix out-of-bounds read. (#1503)
      Fix asserts in Value::setComment (#1445)

xkszltl (1):
      Put ".exe" and ".dll" together to make test usable in build dir. (#1166)

ycqiu (2):
      add test code
      fix

yiqiju (1):
      Fix typo

zeroxia (1):
      cmake export configuration: allow repeating find_package(jsoncpp) calls (#1491)

Александр Малинин (1):
      Fix non-rvalue Json::Value assignment operator (should copy, not move)
```

</p>
</details> 