### PR TITLE
BUG: Update CTK to improve ctkAxesWidget styling and support CMake 4+

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "26688b15fb86e8ddef172ec7b34a09ae7d65338c"
+    "ca28a23b93671114c419ab46930919c10756b1fc"
     QUIET
     )
 


### PR DESCRIPTION
List of CTK changes:

```
$ git shortlog 26688b15f..ca28a23b9 --no-merges
Hans Johnson (1):
      COMP: Support build using CMake 4+ by consistently requiring CMake 3.16.3 (#1236)

Pierre Bour (1):
      ENH: Draw ctkAxesWidget axes based on widget state
```