### PR TITLE
BUG: Fix invalid typing usage in parameter node following pyupgrade

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,4 @@
-target-version = "py39"
+target-version = "py312"
 line-length = 550
 
 extend-exclude = [
@@ -46,6 +46,8 @@ extend-ignore = [
   "B028",    # No explicit `stacklevel` keyword argument found
   "B904",    # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None`
              # to distinguish them from errors in exception handling
+  "B905",    # zip without explicit strict
+
   "C413",    # Unnecessary `reversed` call around `sorted()`
   "C408",    # Unnecessary `dict` call (rewrite as a literal)
   "C418",    # Unnecessary `dict` literal passed to `dict()` (remove the outer call to `dict()`)
@@ -107,6 +109,7 @@ extend-ignore = [
   "RET508", # Unnecessary {branch} after break statement
 
   "RUF005",  # Consider {expression} instead of concatenation
+  "RUF007",  # Consider pairwise instead of zip
   "RUF010",  # Use explicit conversion flag
   "RUF012",  # Mutable class attributes should be annotated with typing.ClassVar
   "RUF013",  # PEP 484 prohibits implicit `Optional`
@@ -117,10 +120,12 @@ extend-ignore = [
   "SIM101",  # Duplicate isinstance call
   "SIM115",  # Use context handler for opening files
 
+  "UP007",   # non-pep604 annotation union
   "UP018",   # Unnecessary `int` call (rewrite as a literal)
   "UP030",   # Use implicit references for positional format fields
   "UP031",   # Use format specifiers instead of percent format
   "UP032",   # Use f-string instead of `format` call
+  "UP038",   # non-pep604 isinstance
 ]
 
 [lint.pydocstyle]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -109,7 +109,6 @@ extend-ignore = [
   "RET508", # Unnecessary {branch} after break statement
 
   "RUF005",  # Consider {expression} instead of concatenation
-  "RUF007",  # Consider pairwise instead of zip
   "RUF010",  # Use explicit conversion flag
   "RUF012",  # Mutable class attributes should be annotated with typing.ClassVar
   "RUF013",  # PEP 484 prohibits implicit `Optional`

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -46,7 +46,6 @@ extend-ignore = [
   "B028",    # No explicit `stacklevel` keyword argument found
   "B904",    # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None`
              # to distinguish them from errors in exception handling
-  "B905",    # zip without explicit strict
 
   "C413",    # Unnecessary `reversed` call around `sorted()`
   "C408",    # Unnecessary `dict` call (rewrite as a literal)

--- a/Applications/SlicerApp/Testing/Python/SlicerBoundsTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerBoundsTest.py
@@ -47,7 +47,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
         slicer.mrmlScene.Clear(0)
 
     def assertListAlmostEquals(self, list, expected):
-        for list_item, expected_item in zip(list, expected):
+        for list_item, expected_item in zip(list, expected, strict=True):
             self.assertAlmostEqual(list_item, expected_item)
 
     def runTest(self):

--- a/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
@@ -764,7 +764,7 @@ def _extractCorrectWidgets(widget):
     # Remove stacks that are completely contained within other stacks.
     # note: just doing `sorted(parentStacks, key=lambda x: id(x))` wasn't sorting it right
     ids = [[id(w) for w in ww] for ww in parentStacks]
-    parentStacks, _ = zip(*sorted(zip(parentStacks, ids), key=lambda w: w[1]))
+    parentStacks, _ = zip(*sorted(zip(parentStacks, ids, strict=True), key=lambda w: w[1]), strict=True)
 
     leafParentStacks = [i for i, j in pairwise(parentStacks) if not i == j[:len(i)]] \
         + [parentStacks[-1]]

--- a/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
@@ -8,6 +8,8 @@ import dataclasses
 import enum
 import logging
 import pathlib
+import types
+import typing
 
 import ctk
 import qt
@@ -125,6 +127,10 @@ def createGuiConnector(widget, datatype) -> GuiConnector:
     Creates an appropriate GuiConnector for the given widget object and possibly annotated datatype.
     Raises a RuntimeError if no appropriate GuiConnector is found.
     """
+    if hasattr(types, "UnionType") and isinstance(datatype, types.UnionType):
+        # Convert types.UnionType to typing.Union for connector compatibility
+        datatype = typing.Union[tuple(typing.get_args(datatype))]
+
     for possibleConnectorType in _registeredGuiConnectors:
         if possibleConnectorType.canRepresent(widget, datatype):
             return possibleConnectorType.create(widget, datatype)

--- a/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
@@ -10,6 +10,7 @@ import logging
 import pathlib
 import types
 import typing
+from itertools import pairwise
 
 import ctk
 import qt
@@ -765,7 +766,7 @@ def _extractCorrectWidgets(widget):
     ids = [[id(w) for w in ww] for ww in parentStacks]
     parentStacks, _ = zip(*sorted(zip(parentStacks, ids), key=lambda w: w[1]))
 
-    leafParentStacks = [i for i, j in zip(parentStacks[:-1], parentStacks[1:]) if not i == j[:len(i)]] \
+    leafParentStacks = [i for i, j in pairwise(parentStacks) if not i == j[:len(i)]] \
         + [parentStacks[-1]]
     return leafParentStacks
 

--- a/Base/Python/slicer/parameterNodeWrapper/guiCreation.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiCreation.py
@@ -7,6 +7,8 @@ import abc
 import dataclasses
 import enum
 import pathlib
+import types
+import typing
 
 import ctk
 import qt
@@ -84,6 +86,9 @@ def _processGuiCreator(classtype):
 
 def createGui(datatype) -> qt.QWidget:
     """Creates the most appropriate widget to represent the given, possibly annotated, data type."""
+    if hasattr(types, "UnionType") and isinstance(datatype, types.UnionType):
+        datatype = typing.Union[tuple(typing.get_args(datatype))]
+
     values = [(creator.representationValue(datatype), creator) for creator in _registeredGuiCreators]
     best = max(values, key=lambda v: v[0])
     if best[0] > 0:

--- a/Base/Python/slicer/parameterNodeWrapper/serializers.py
+++ b/Base/Python/slicer/parameterNodeWrapper/serializers.py
@@ -735,7 +735,7 @@ class TupleSerializer(Serializer):
             raise ValueError("Unexpected number of tuple values")
 
         with slicer.util.NodeModify(parameterNode):
-            for index, (value, serializer) in enumerate(zip(values, self._serializers)):
+            for index, (value, serializer) in enumerate(zip(values, self._serializers, strict=True)):
                 serializer.write(parameterNode, self._paramName(name, index), value)
 
     def read(self, parameterNode, name: str) -> None:

--- a/Base/Python/slicer/parameterNodeWrapper/wrapper.py
+++ b/Base/Python/slicer/parameterNodeWrapper/wrapper.py
@@ -3,6 +3,7 @@
 import logging
 import typing
 import weakref
+import types
 
 import qt
 
@@ -302,6 +303,10 @@ def _processClass(classtype):
     allParameters: dict[str, ParameterInfo] = dict()
     for name, nametype in members.items():
         membertype, annotations = splitAnnotations(nametype)
+
+        if hasattr(types, "UnionType") and isinstance(membertype, types.UnionType):
+            # Convert types.UnionType to typing.Union for serializer compatibility
+            membertype = typing.Union[tuple(typing.get_args(membertype))]
 
         try:
             serializer, annotations = createSerializer(membertype, annotations)

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_gui_creation.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_gui_creation.py
@@ -1,6 +1,6 @@
 import pathlib
 import unittest
-from typing import Annotated, Union, Optional
+from typing import Annotated
 
 import ctk
 import qt
@@ -67,8 +67,8 @@ class ParameterNodeWrapperGuiCreationTest(unittest.TestCase):
     def test_guiCreations_nodes(self):
         self.assertIsInstance(createGui(vtkMRMLNode), slicer.qMRMLNodeComboBox)
         self.assertIsInstance(createGui(vtkMRMLModelNode), slicer.qMRMLNodeComboBox)
-        self.assertIsInstance(createGui(Union[vtkMRMLModelNode, vtkMRMLScalarVolumeNode, None]), slicer.qMRMLNodeComboBox)
-        self.assertIsInstance(createGui(Optional[vtkMRMLModelNode]), slicer.qMRMLNodeComboBox)
+        self.assertIsInstance(createGui(vtkMRMLModelNode | vtkMRMLScalarVolumeNode | None), slicer.qMRMLNodeComboBox)
+        self.assertIsInstance(createGui(vtkMRMLModelNode | None), slicer.qMRMLNodeComboBox)
 
     def test_guiCreations_parameter_packs(self):
         @parameterPack

--- a/Base/Python/slicer/tests/test_slicer_parameter_pack.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_pack.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Annotated, Any, Union
+from typing import Annotated, Any
 
 import slicer
 from slicer import vtkMRMLModelNode
@@ -456,7 +456,7 @@ class TypedParameterNodeTest(unittest.TestCase):
         self.assertEqual(ParameterPack.dataType("box.topLeft"), Point)
         self.assertEqual(ParameterPack.dataType("box.topLeft.x"), float)
         self.assertEqual(ParameterPack.dataType("value"), int)
-        self.assertEqual(ParameterPack.dataType("union"), Union[int, str])
+        self.assertEqual(ParameterPack.dataType("union"), int | str)
         self.assertEqual(ParameterPack.dataType("annotated"), Annotated[bool, Default(True)])
         self.assertEqual(ParameterPack.dataType("annotatedBox"), BoundingBox)
         self.assertEqual(ParameterPack.dataType("annotatedBox.topLeft"), Point)
@@ -468,7 +468,7 @@ class TypedParameterNodeTest(unittest.TestCase):
         self.assertEqual(param.dataType("box.topLeft"), Point)
         self.assertEqual(param.dataType("box.topLeft.x"), float)
         self.assertEqual(param.dataType("value"), int)
-        self.assertEqual(param.dataType("union"), Union[int, str])
+        self.assertEqual(param.dataType("union"), int | str)
         self.assertEqual(param.dataType("annotated"), Annotated[bool, Default(True)])
         self.assertEqual(param.dataType("annotatedBox"), BoundingBox)
         self.assertEqual(param.dataType("annotatedBox.topLeft"), Point)

--- a/Modules/Scripted/DICOMLib/DICOMBrowser.py
+++ b/Modules/Scripted/DICOMLib/DICOMBrowser.py
@@ -511,7 +511,7 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
                 except Exception:
                     pass
                 isEqual = True
-                for pair in zip(inputFileListCopy, loadableFileListCopy):
+                for pair in zip(inputFileListCopy, loadableFileListCopy, strict=True):
                     if pair[0] != pair[1]:
                         print(f"{pair[0]} != {pair[1]}")
                         isEqual = False

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -557,7 +557,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
                             raise ValueError(f"Number of window width/center values do not match ({windowWidthList}/{windowCenterList}).")
 
                         # Iterate over the pairs and add window level presets
-                        for windowCenter, windowWidth in zip(windowCenterList, windowWidthList):
+                        for windowCenter, windowWidth in zip(windowCenterList, windowWidthList, strict=True):
                             # Convert the values to float
                             windowCenter = float(windowCenter)
                             windowWidth = float(windowWidth)

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -227,7 +227,7 @@ class SampleDataSource:
             "",
         ]
         for fileName, uri, nodeName, loadFile, fileType, checksum in zip(
-            self.fileNames, self.uris, self.nodeNames, self.loadFiles, self.loadFileTypes, self.checksums):
+            self.fileNames, self.uris, self.nodeNames, self.loadFiles, self.loadFileTypes, self.checksums, strict=True):
 
             output.extend([
                 " fileName     : %s" % fileName,
@@ -673,7 +673,7 @@ class SampleDataLogic:
         list of file paths for the results
         """
         filePaths = []
-        for uri, fileName, checksum in zip(source.uris, source.fileNames, source.checksums):
+        for uri, fileName, checksum in zip(source.uris, source.fileNames, source.checksums, strict=False):
             filePaths.append(self.downloadFileIntoCache(uri, fileName, checksum))
         return filePaths
 
@@ -701,7 +701,7 @@ class SampleDataLogic:
         resultFilePaths = []
 
         for uri, fileName, nodeName, checksum, loadFile, loadFileType in zip(
-            source.uris, source.fileNames, source.nodeNames, source.checksums, source.loadFiles, source.loadFileTypes):
+            source.uris, source.fileNames, source.nodeNames, source.checksums, source.loadFiles, source.loadFileTypes, strict=False):
 
             if nodeName is None or fileName is None:
                 import urllib

--- a/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
@@ -533,7 +533,7 @@ class SegmentStatisticsLogic(ScriptedLoadableModuleLogic):
     def makeUnique(names, suffixes, differentiators=None):
         # Add suffix to name if name+differentiator is not unique in the list
         if differentiators:
-            fullNames = [f"{name} & {differentiator}" for name, differentiator in zip(names, differentiators)]
+            fullNames = [f"{name} & {differentiator}" for name, differentiator in zip(names, differentiators, strict=True)]
         else:
             fullNames = names
         uniqueNames = []

--- a/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
+++ b/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
@@ -38,7 +38,7 @@ def MyObjectsBlockSignals(*qobjects):
         # blockedSignal returns the previous value of signalsBlocked()
         previousValues.append(qobject.blockSignals(True))
     yield
-    for qobject, previousValue in zip(qobjects, previousValues):
+    for qobject, previousValue in zip(qobjects, previousValues, strict=True):
         qobject.blockSignals(previousValue)
 
 

--- a/Utilities/Scripts/python_package_updater.py
+++ b/Utilities/Scripts/python_package_updater.py
@@ -5,6 +5,7 @@ import sys
 from argparse import ArgumentParser
 
 import requests
+from itertools import batched
 
 
 def execute_pip_list(installation_path=None, outdated=False):
@@ -75,14 +76,6 @@ def validate_external_project_python_package_hints(directory):
     Return list of mismatches if any. Each mismatch corresponds to a tuple of the
     form ``(filepath, hint_left_packagename, hint_right_packagename)``.
     """
-
-    def _pairwise(iterable):
-        """s -> (s0, s1), (s2, s3), (s4, s5), ...
-        See https://stackoverflow.com/questions/5389507/iterating-over-every-two-elements-in-a-list/5389547#5389547
-        """
-        a = iter(iterable)
-        return zip(a, a)
-
     mismatches = []
 
     for filepath in external_project_filepaths(directory):
@@ -92,7 +85,7 @@ def validate_external_project_python_package_hints(directory):
         regex = r"^\s*# \[(\/?[\w\-\])\])]+)\]$"
         # Collect hints as a list of the form: ("package1", "/package1", "package2", "/package2", ...)
         hint_pairs = re.findall(regex, file_text, flags=re.MULTILINE)
-        for first, second in _pairwise(hint_pairs):
+        for first, second in batched(hint_pairs, 2):
             if first != second[1:]:
                 mismatches.append((filepath, first, second[1:]))
 


### PR DESCRIPTION
This is a follow-up to https://github.com/Slicer/Slicer/commit/52d00b16ee868031029b5cf5f942eb6c24677ab9 where Python syntax was upgraded to a new version automatically through pyupgrade.

Additionally it follows up by defining py312 linting in the ruff configuration.

Local tests have been run confirming that the tests mentioned in https://github.com/Slicer/Slicer/pull/8489#issuecomment-2988233751 are no longer failing.