### PR TITLE
ENH: Bump docs dependency urllib3 to resolve vulnerability alert

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -11,5 +11,5 @@ sphinx_markdown_tables>=0.0.17
 sphinx-notfound-page
 sphinx_rtd_theme>=0.5.2
 requests>=2.32.4 # not directly required, pinned by Snyk to avoid a vulnerability
-urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
+urllib3>=2.5.0 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
This PR will help boost the OpenSSF score for Slicer (https://securityscorecards.dev/viewer/?uri=github.com/Slicer/Slicer) which is currently getting docked for vulnerabilities in the Slicer documents requirements file. These issues are being warned in https://github.com/Slicer/Slicer/security/code-scanning/29.


This addresses:
https://github.com/advisories/GHSA-pq67-6m6q-mj2v
https://github.com/advisories/GHSA-48p4-8xcf-vxj5