### PR TITLE
ENH: Update teem from r6245 to r7265

### DIFF
--- a/SuperBuild/External_teem.cmake
+++ b/SuperBuild/External_teem.cmake
@@ -46,7 +46,7 @@ if(NOT DEFINED Teem_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "e4746083c0e1dc0c137124c41eca5d23adf73bfa"
+    "bb7eebe62411f6a3dcb0bbf8471edad6b82ff5d9" # slicer-2025-05-18-r7265
     QUIET
     )
 


### PR DESCRIPTION
The major and minor version remain 1.12.

This update includes a Slicer-specific patch that addresses `-Werror` build failures caused by unsafe string functions (e.g., replacing `sprintf` with `snprintf`). The patch was sent via email to Gordon L. Kindlmann <glk@uchicago.edu> on 2025-06-19 for considered for integration into the upstream project.

Summary of upstream changes:

* Update CMake minimum required version from 2.8 to 3.13
* Propagation of `AIR_STRLEN -> AIR_STRLEN+1` across structs (API changes with size adjustments)
* Introduction of type-safe, non-varargs alternatives to `hestOptAdd_*` in the `hest` CLI API
* Enhanced stdin/stdout safety via `nrrdHestNrrdNoTTY` and support for `-=` as a synonym for `-`
* Expansion of `NrrdIoState` and `seekContext` structures with new fields for I/O control and metadata
* Significant improvements and bug fixes to `limnCbf` fitting routines and related debugging tools
* Code formatting updates and annotation fixes (e.g., `static` qualifiers, `biff` message handling)
* Improved inline comments and CLI usage documentation across modules

<details><summary>List of changes:</summary>
<p>


```
$ git shortlog b83e546..bb7eebe6 --no-merges
Hans Johnson (1):
      [Backport PATCH] COMP: -Werror causes build failure on security warning

kindlmann (232):
      if hestParm->respectDashDashHelp, disallow --help being an explicit option
      Two changes in preparation for non-var-arg alternatives to hestOptAdd:
      fixing comment
      Now that we've already done an API CHANGE with hestOpt->helpWanted, another API CHANGE added two more things to hestOpt:   unsigned int arrAlloc and arrLen. (also reformatted many comments in hest.h)
      fixing typo in comment
      adding informative comment, and improving specificity of comment
      adding adders.c, the new place for option type-specific and kind-specific versions of hestOptAdd
      clarifying info about Teem versions in comment
      adding more adders
      Since r4961 2011-07-18, GLK has noted that the AIR_STRLEN #defines are illogical: they contain STRLEN but are not consistent with the results of strlen(). This was noted as something that would be fixed for Teem v2, so here we are.  This is an API CHANGE: you will likely have to modify code that uses the AIR_STRLEN #defines (but because how the values are adjusted, it might just manage to not be an ABI change, but lets not get too clever). This change has yet to be propagated to other Teem libraries
      more work on type-checked adders, and, propagating AIR_STRLEN change
      hestOpt->parmStr was added recently
      propagating spirit of AIR_STRLEN update
      Propagating recent AIR_STRLEN --> AIR_STRLEN+1 change, which leads to API CHANGEs: In these structs' elements' sizes:   NrrdFormat:     char name[AIR_STRLEN_SMALL + 1]; /* short identifying string */   NrrdEncoding:     char name[AIR_STRLEN_SMALL + 1], /* short identifying string */       suffix[AIR_STRLEN_SMALL + 1];  /* customary filename suffix */   NrrdKernel:     char name[AIR_STRLEN_SMALL + 1];
      propagating AIR_STRLEN --> AIR_STRLEN+1 change
      propagating AIR_STRLEN --> AIR_STRLEN+1 change
      propagating AIR_STRLEN --> AIR_STRLEN+1 change
      propagating AIR_STRLEN --> AIR_STRLEN+1 change
      Propagating AIR_STRLEN --> AIR_STRLEN+1 change, with these API CHANGEs to these functions:   int gageStackBlurParmSprint(char str[AIR_STRLEN_LARGE + 1],                               const gageStackBlurParm *sbp,                               int extraFlag[256],                               char *extraParm);   int gageStackBlurParmCompare(const gageStackBlurParm *sbpA,                                const char *nameA,                                const gageStackBlurParm *sbpB,                                const char *nameB,                                int *differ,                                char explain[AIR_STRLEN_LARGE + 1]); and to these struct members:   gageKind_t:     char name[AIR_STRLEN_SMALL + 1]; /* short identifying string for kind */   gageContext:     char errStr[AIR_STRLEN_LARGE + 1];
      propagating AIR_STRLEN --> AIR_STRLEN+1 change
      propagating AIR_STRLEN --> AIR_STRLEN+1 change
      propagating AIR_STRLEN --> AIR_STRLEN+1 change
      Propaging AIR_STRLEN --> AIR_STRLEN+1, with API CHANGEs to these structs:   tenModel:     char name[AIR_STRLEN_SMALL + 1];     char *(*sprint)(char str[AIR_STRLEN_MED + 1], const double *parm);   tenModelParmDesc:     char name[AIR_STRLEN_SMALL + 1]; /* name */
      Propgating AIR_STRLEN --> AIR_STRLEN+1, with these API CHANGEs for structs:   pullEnergy     char name[AIR_STRLEN_SMALL + 1]; and functions:   int pullInfoSpecSprint(char str[AIR_STRLEN_LARGE + 1],                          const pullContext *pctx,                          const pullInfoSpec *ispec);
      Propagating AIR_STRLEN --> AIR_STRLEN+1, with these API CHANGEs to structs: coilMethod:   char name[AIR_STRLEN_SMALL + 1]; coilKind:   char name[AIR_STRLEN_SMALL + 1]; /* short identifying string for kind */
      Propagating AIR_STRLEN --> AIR_STRLEN +1, with this API CHANGE to struct: pushEnergy:   char name[AIR_STRLEN_SMALL + 1];
      Propagating AIR_STRLEN --> AIR_STRLEN+1, with API CHANGE to struct: miteUser   char shadeStr[AIR_STRLEN_MED + 1], /* how to do shading */   normalStr[AIR_STRLEN_MED + 1];   /* what is the "surface normal" */
      Propagating AIR_STRLEN --> AIR_STRLEN+1, with this API CHANGE to function:   int meetPullVolLeechable(const meetPullVol *lchr,                            const meetPullVol *orig,                            int *can,                            char explain[AIR_STRLEN_HUGE + 1]);
      clarifying descriptive comment
      simplifiying declarations of string arrays
      avoiding needless string copy
      fixing sloppy propgation of AIR_STRLEN --> AIR_STRLEN+1
      Propagating AIR_STRLEN --> AIR_STRLEN+1 with API CHANGES to structs: baneRange:   char name[AIR_STRLEN_SMALL + 1]; baneInc:   char name[AIR_STRLEN_SMALL + 1]; baneClip:   char name[AIR_STRLEN_SMALL + 1]; baneMeasr:   char name[AIR_STRLEN_SMALL + 1];
      fixing sloppy propagation of AIR_STRLEN --> AIR_STRLEN+1
      now done, with hestOpt->parmStr
      syncing with source
      addressing warning from gcc
      fixing warning
      fixing warnings: isnan isn't C89, and using correct conversion format for unsigned
      trailing commas arent c89
      fixing warning
      better descriptive comment
      fixing long-standing bug in what was being checked for non-NULL-ity with a hestCB
      type-specific kinds 1, 2, and 3 now all finished
      progress made
      notes on type safety
      the min argument to hestOptAdd and friends is now an unsigned int, as it should have been as soon as hestOpt->min was unsigned. ALSO: API NEW: 85 new type-specific hestOptAdd_N_T functions, created by some macro magic
      crude fix to buffer overflow problem
      correct name strings
      (a previous commit should have had this message; this commit is just for this information added to hest.h)
      alternative hest API done!
      correcting me[] in _biffMoveVL
      weird biffMsg-related functions have already been removed from biff.h (as of 2022-08-04 22:09:25 +0000 (Thu, 04 Aug 2022) Revision: 6691)
      Start of shifting hest usage to non-var-args typed functions
      tweaks to comments
      the functions never did the signed->unsigned switch, even if the struct did
      trimming down how many EXPERIMENTAL_APPS there are
      using new typed non-var-args functions in hest
      some things missed the signed -> unsigned int switch
      preserving for posterity version of puller with the Deft UI code
      removing Deft code and updating hest usage
      fixing wording in comment
      updated hest usage
      fixed use of hestOptAdd_1_Enum
      Some bug fixes related to updating "unu head":
      updating hest usage, and clarifying usage info
      oops left in a debugging printf
      API NEW: nrrdHestNrrdNoTTY for parsing a Nrrd via hest callbacks (hestCB), but with the restriction that - does not work as a synonym for stdin if stdin is a terminal: we only want to try to read from files being piped in.  This enables some LONG-wanted functionality in unu, wherein the -i input can default to -, while still allowing 'unu cmd' to trigger some usage info
      updating hest usage, and exploting hparm->noArgsIsNoProblem and either isatty(STDIN_FILENO) or nrrdHestNrrdNoTTY to gracefully handle being invoked with no args, while not being piped to
      make USAGE macro play better with hestParm->noArgsIsNoProblem
      updating hest usage
      make some more things unsigned that should always have been so
      make some more things unsigned that should always have been so
      turning OFF hparm->elideSingleOtherDefault (or, no longer turning it on), since it needlessly obscured what the -i input option to most unu commands was
      copying from unu new handling of hparm->noArgsIsNoProblem so that commands can have defaults for all options
      using new hparm->noArgsIsNoProblem and nrrdHestNrrdNoTTY
      updating how multi-line piping works to move away from csh towards bash and friends, making output respect hparm->columns
      more comments about the new functions
      clarifying comment
      like in unu:  the PARSE (and the tend-specific JUSTPARSE) macros now take the INFO string, because it is part of how they respond to --help
      upating hest usage
      updating hest usage
      missed one call to hestOptAdd in previous update
      really do have to use hestOptAdd here, better explaining why
      updating hest usage
      restoring block and unblock commands, but they are hidden
      fixing one oversight in hest usage update
      fixing function name in comment
      syncing with source
      AIR_CAST(size_t, _) is so common that it deserves its own thing there
      using new AIR_SIZE_T (and some overdue clang-format)
      WEIRD: how was this working before? if the min number of parms was 1 instead of 0.  It needs to be zero
      use of new AIR_SIZE_T(_) == AIR_CAST(size_t, _), and some over-due clang-format-ing
      more use of existing AIR_INT(_) == AIR_CAST(int, _)
      syncing with source
      clarifying comment
      revisiting what to do for Teem v2
      about these files
      weird: ten does not depend on dye
      no, limn does not depend on gage
      removing errant slash
      fixing some warnings
      API CHANGE: adding another field to seekContext, to record the average (world-space) gradient magnitude, over the vertices in an isosurface (when there isn't a gageContext), with the hope that it is useful for some signed distance field computations. Also noting that Thomas Schultz commited some work to this file (other files in seek have a similar copyright attribution)
      API CHANGE: (oops didn't commit all files last time) adding another field to seekContext, to record the average (world-space) gradient magnitude, over the vertices in an isosurface (when there isn't a gageContext), with the hope that it is useful for some signed distance field computations. Also noting that Thomas Schultz commited some work to this file (other files in seek have a similar copyright attribution)
      synch with source
      bug fix in sctx->gradMagAvg computation, and improved descriptive comment in seek.h
      synching source
      sync with source
      smplr->verbPixel never initialized
      sync with source
      better wording of diagnostic message
      more handling of NaN
      fixing and improving description and usage info
      starting BUT NOT YET TESTED Jenkins Small Fast JSF RNG
      sync with sources
      finished BUT NOT TESTED double-precision versions
      sync with source
      variable rename to reflect what is described in the comment
      adding and using hestParmColumnsIoctl() to contain in a single function smarts for using ioctl() to get terminal width, for the sake of hest usage
      sync with sources
      tweaked handling of too-small ioctl-produced columns
      changing URL for where GLK learned this trick
      more explicitly disallowing block type
      synching with source
      nrrdTypeIsIntegral[nrrdTypeBlock] is no longer true; this was asserted in ~2002 but never made sense
      removing test on nrrdTypeIsIntegral[nrrdTypeBlock] from nrrdSanity()
      what the hell was that
      happy new year
      fixing typo in comment
      synching with source
      fixing writing fumble in comment
      refecting reality that Teem v2 is going to be next release
      finally re-started progress on limnCBF functions
      synching with source
      finally making some progress on cubic spline fitting; still very much in progress; committing work so far to facilitate testing on different platforms
      added warning about how AIR_MOD can give bad results if args differ in sign-ed-ness, and other formatting tweaks
      more progress; limnCBFFindTVT seems to work now
      may have limnCBFitSingle working; added --help support to test/lpu
      limnCBFitSingle seems to work on tests so far; more to come ...
      forgot to add this after having added the JSF code
      fixing memory leak
      code is all there, but TVT computations still need fixing, and all of this still needs debugging
      fctx->distMaxIdx is now set correctly, hopefully, and that and lots of other things still need to be tested more. Added documentation to reflect new term lifted indices, which is the right word for something GLK has been struggling to put into precise words
      data generation for for testing
      for testing limnCbfTVT
      one way to test limnCbfSingle
      testing in progress
      testing continues
      re-wrote idxLift and limnCbfTVT, and things may finally be working, but testing ongoing
      another script for debugging; may have found a bug (weird dependence on number of points in synthetic data)
      now lpu cbfit gets some defaults from limnCbfCtxNew
      this illustrates a situation for which single fit needs fixing
      typo in verbose output
      isolated a case where single fit is bad
      number of colummns set by terminal
      making more progress, but now debugging segfault
      fixing compilation/valgrind issues
      multi-fit may be working now
      another test script
      adding memory of recursion depth to limnCbfMulti
      segfault fixed, debugging continues
      renaming simple to punt (and removing incorrect statements of straight path), and some more refined debugging statements
      improved the nrp (Newton-based ReParameterization) so that it never takes bad steps; it did that previously
      refactored Newton-restep code to be less dumb and ugly
      clarifyig comments
      test script tweaks
      debugging scripts, maybe done?
      -roll options for debugging loops, and now path printing is uniform
      added wacky path handling for 3=spanlen, and maybe done
      some final comments
      synching with Teem source
      usefully acting on float-type data
      now actually accepting more that type double
      recognizing that having one corner in path is possible
      still debugging
      tweaks to new flexiblity in loi==hii, and in its testing
      tweaks to new flexiblity in loi==hii, and in its testing
      it may actually be working ...
      synching with source
      fixing use of AIR_STRLEN_SMALL
      fixing uses of AIR_STRLEN_x plus clang-format
      fixing uses of AIR_STRLEN_x plus clang-format
      fixing uses of AIR_STRLEN_x plus clang-format
      fixing uses of AIR_STRLEN_x plus clang-format
      fixing uses of AIR_STRLEN_x plus clang-format
      fixing uses of AIR_STRLEN_x plus clang-format
      fixing uses of AIR_STRLEN_x plus clang-format
      clarifying comment; trying to fix memory error
      biffMovef didnt free messages at source key -> memory leak
      clang format, and using nrrdHestNrrdNoTTY
      reformatting/clarifying comment
      clang format, and using nrrdHestNrrdNoTTY
      clang format, and using nrrdHestNrrdNoTTY
      more complete use of nrrdHestNrrdNoTTY instead of nrrdHestNrrd
      syncing with source
      fixing problem with nan generation from scale>0 vertex pos == orig pos
      syncing with source
      main change: now can use a callback function as part of determining which vertices count as a corner
      syncing with source
      limnCbfTVT now computes scale=0 TVT, and that is now passed back to fctx->cornerCB corner tester
      syncing with sources
      syncing with sources
      unfortunately a mix of (1) new formatting with a new version of blue, and (2) changing how #defines in header files are processed: from a list of strings defined, to: a dict mapping from name to value, and a modest effort to apply those substitutions prior to sending things to cffi.cdef()
      source sync
      added ability to recognize -= as the same stdin/stdout that - is recognized as
      now clang-format'ed
      API NEW: new field NrrdIoState->declineStdioOnTTY, which instructs nrrdLoad/nrrdSave to decline reading/writing to stdin/stdout if the given filename is - AND stdin/stdout is a terminal (as per isatty). Can be over-ridden by using filename -=. This is long-wanted functionality that was only half-addressed, on the command-line input side, via nrrdHestNrrdNoTTY
      syncing with source
      noted more realistic release year
      just blue formatting (maybe shorter line length?)
      synching Tenum with GLKs SciVis class python wrappers, adding TenumVal and TenumValParseAction from that
      synching Tenum with GLKs SciVis class python wrappers, adding TenumVal and TenumValParseAction from that
      adopting strategy that GLK used for his SciVis class code python wrappers, whereby an object instance becomes the module, and can thereby implement read-only module members
      re-ordering
      fixing where NULL comes from
      weird that this function prototype has been busted for so long
      tweaks as GLK revisits this and gets it working on new laptop
      tweaks2 as GLK revisits this and gets it working on new laptop
      tweaks3 as GLK revisits this and gets it working on new laptop
      now with 90 column lines
      adding airJSFRand to list of Teem types
      WHOA optarr_incr was missing static declaration
      oops forgot static qualifier on nfdsChar
      now with biff annotations
      now with biff annotations
      better notes to GLK on how to run teem/src/_util/scan-symbols.py
      resurrecting this on GLKs new laptop with latest greatest nm etc
      syncing with Teem sources
      happy new year(s)
      for reason latest clang-format refuses to format .c file with Language: Cpp option
      trying some C11-ification as procrastination
      trying some C11-ification as procrastination
```

</p>
</details> 