### PR TITLE
COMP: Update RapidJSON to latest revision

### DIFF
--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -107,7 +107,6 @@ set(include_dirs
   ${vtkITK_INCLUDE_DIRS}
   ${vtkSegmentationCore_INCLUDE_DIRS}
   ${LibArchive_INCLUDE_DIR}
-  ${RapidJSON_INCLUDE_DIR}
   )
 if(MRML_USE_vtkTeem)
   list(APPEND include_dirs ${vtkTeem_INCLUDE_DIRS})
@@ -358,6 +357,7 @@ set(libs
   ${VTK_LIBRARIES}
   VTK::IOInfovis
   ${LibArchive_LIBRARY}
+  RapidJSON
   )
 if(MRML_USE_vtkTeem)
   list(APPEND libs vtkTeem)

--- a/Modules/Loadable/Markups/MRML/CMakeLists.txt
+++ b/Modules/Loadable/Markups/MRML/CMakeLists.txt
@@ -7,7 +7,6 @@ set(KIT ${PROJECT_NAME})
 set(${KIT}_EXPORT_DIRECTIVE "VTK_SLICER_${MODULE_NAME_UPPER}_MODULE_MRML_EXPORT")
 
 set(${KIT}_INCLUDE_DIRECTORIES
-  ${RapidJSON_INCLUDE_DIR}
   ${vtkSlicer${MODULE_NAME}ModuleVTKWidgets_SOURCE_DIR}
   ${vtkSlicer${MODULE_NAME}ModuleVTKWidgets_BINARY_DIR}
   )
@@ -25,6 +24,7 @@ set(${KIT}_SRCS
 
 set(${KIT}_TARGET_LIBRARIES
   ${MRML_LIBRARIES}
+  RapidJSON
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Terminologies/Logic/CMakeLists.txt
+++ b/Modules/Loadable/Terminologies/Logic/CMakeLists.txt
@@ -7,7 +7,6 @@ find_package(RapidJSON REQUIRED)
 set(${KIT}_EXPORT_DIRECTIVE "VTK_SLICER_${MODULE_NAME_UPPER}_LOGIC_EXPORT")
 
 set(${KIT}_INCLUDE_DIRECTORIES
-  ${RapidJSON_INCLUDE_DIR}
   )
 
 set(${KIT}_SRCS
@@ -22,6 +21,7 @@ set(${KIT}_SRCS
   )
 
 set(${KIT}_TARGET_LIBRARIES
+  RapidJSON
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Volumes/Logic/CMakeLists.txt
+++ b/Modules/Loadable/Volumes/Logic/CMakeLists.txt
@@ -2,10 +2,11 @@ project(vtkSlicer${MODULE_NAME}ModuleLogic)
 
 set(KIT ${PROJECT_NAME})
 
+find_package(RapidJSON REQUIRED)
+
 set(${KIT}_EXPORT_DIRECTIVE "VTK_SLICER_${MODULE_NAME_UPPER}_MODULE_LOGIC_EXPORT")
 
 set(${KIT}_INCLUDE_DIRECTORIES
-  ${RapidJSON_INCLUDE_DIR}
   )
 
 set(${KIT}_SRCS
@@ -15,6 +16,7 @@ set(${KIT}_SRCS
 
 set(${KIT}_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
+  RapidJSON
   )
 
 #-----------------------------------------------------------------------------

--- a/SuperBuild/External_RapidJSON.cmake
+++ b/SuperBuild/External_RapidJSON.cmake
@@ -21,13 +21,13 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/miloyip/rapidjson.git"
+    "${EP_GIT_PROTOCOL}://github.com/slicer/rapidjson.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "973dc9c06dcd3d035ebd039cfb9ea457721ec213" # 2023.05.09
+    "973dc9c06dcd3d035ebd039cfb9ea457721ec213" # slicer-2023-05-09-973dc9c0
     QUIET
     )
 


### PR DESCRIPTION
This pull request updates the RapidJSON external project to update RapidJSON by integrating Slicer-specific patches and modernize the build process:

* Update RapidJSON external project to download source from Slicer fork

* Update the external project to install RapidJSON, as the generated config file cannot be imported via `find_package(RapidJSON)` when used from a build tree.

* Follow-up on d42156b1224 ("ENH: Use RapidJSON instead of JsonCPP in Terminologies module logic", 2017-01-20) removing the use of `RapidJSON_INCLUDE_DIR` variable and instead use the `RapidJSON` imported target.


### Backported Changes

The following upstream pull requests have been backported into the [slicer-2024-12-22-24b5e7a8](https://github.com/Slicer/rapidjson/tree/slicer-2024-12-22-24b5e7a8) branch:

* https://github.com/Tencent/rapidjson/pull/2343
* https://github.com/Tencent/rapidjson/pull/2344

> [!NOTE]
> Until the upstream build system is further improved to support importing targets directly from the build tree, this pull request ensures RapidJSON is installed explicitly to support `find_package()` integration.

### Additional Context

Ongoing improvements to the upstream CMake configuration can be tracked in:

* https://github.com/Tencent/rapidjson/pull/2340



