### PR TITLE
COMP: Update teem to fix windows build

### DIFF
--- a/SuperBuild/External_teem.cmake
+++ b/SuperBuild/External_teem.cmake
@@ -46,7 +46,7 @@ if(NOT DEFINED Teem_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "bb7eebe62411f6a3dcb0bbf8471edad6b82ff5d9" # slicer-2025-05-18-r7265
+    "43395a690351cd98235de84775a8747d0bdae106" # slicer-2025-05-18-r7265
     QUIET
     )
 


### PR DESCRIPTION
Follow-up b0a7d2b68c2 ("ENH: Update teem from r6245 to r7265", 2025-06-23) to ensure compatibility with Windows.

This update enables Teem to build correctly on Windows by:
* Making `hestParmColumnsIoctl` cross-platform using `GetConsoleScreenBufferInfo()` for terminal width detection.
* Replacing POSIX-only `isatty()` usage with platform-specific macros based on `_isatty(_fileno(...))`.

List of changes:

```
$ git shortlog bb7eebe6..43395a69 --no-merges
Jean-Christophe Fillion-Robin (2):
      [Backport PATCH] COMP: Add cross-platform support for isatty on Windows
      [Backport PATCH] ENH: Make hestParmColumnsIoctl cross-platform by adding Windows console support
```

Related pull requests:
* https://github.com/Slicer/Slicer/pull/8500