### PR TITLE
COMP: OpenSSL 1.1.1w is needed to fix missing include

### DIFF
--- a/SuperBuild/External_OpenSSL.cmake
+++ b/SuperBuild/External_OpenSSL.cmake
@@ -48,13 +48,13 @@ if(NOT DEFINED OPENSSL_LIBRARIES
     # Starting with Qt 5.12.4, official Qt binaries are build against OpenSSL 1.1.1
     # See https://www.qt.io/blog/2019/06/17/qt-5-12-4-released-support-openssl-1-1-1
     if("${Qt5_VERSION_MAJOR}.${Qt5_VERSION_MINOR}.${Qt5_VERSION_PATCH}" VERSION_GREATER_EQUAL "5.12.4")
-      set(_default_version "1.1.1g")
+      set(_default_version "1.1.1w")
     else()
       set(_default_version "1.0.2n")
     endif()
 
     set(OPENSSL_DOWNLOAD_VERSION "${_default_version}" CACHE STRING "Version of OpenSSL source package to download")
-    set_property(CACHE OPENSSL_DOWNLOAD_VERSION PROPERTY STRINGS "1.0.1e" "1.0.1l" "1.0.2n" "1.1.1g")
+    set_property(CACHE OPENSSL_DOWNLOAD_VERSION PROPERTY STRINGS "1.0.1e" "1.0.1l" "1.0.2n" "1.1.1g" "1.1.1w")
 
     set(OpenSSL_1.0.1e_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/sources/openssl-1.0.1e.tar.gz)
     set(OpenSSL_1.0.1e_MD5 66bf6f10f060d561929de96f9dfe5b8c)
@@ -69,6 +69,9 @@ if(NOT DEFINED OPENSSL_LIBRARIES
     # See https://github.com/openssl/openssl/pull/12238
     set(OpenSSL_1.1.1g_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/sources/openssl-1.1.1g-pr12238.tar.gz)
     set(OpenSSL_1.1.1g_MD5 4765dcd60bcbed784c59ad7c2ca2b841)
+
+    set(OpenSSL_1.1.1w_URL https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz)
+    set(OpenSSL_1.1.1w_MD5 3f76825f195e52d4b10c70040681a275)
 
     if(NOT DEFINED OpenSSL_${OPENSSL_DOWNLOAD_VERSION}_URL)
       message(FATAL_ERROR "There is no source version of OpenSSL ${OPENSSL_DOWNLOAD_VERSION} available.


### PR DESCRIPTION
Newer compilers require explicit inclusion of string.h for memcmp function usage.