### PR TITLE
COMP: Fix configuration on Windows by updating RapidJSON project installation

### DIFF
--- a/SuperBuild/External_RapidJSON.cmake
+++ b/SuperBuild/External_RapidJSON.cmake
@@ -72,6 +72,13 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       -DRAPIDJSON_ENABLE_INSTRUMENTATION_OPT:BOOL=OFF
       # Install directories
       -DCMAKE_INSTALL_PREFIX:PATH=${EP_INSTALL_DIR}
+
+      # Specify CMAKE_INSTALL_DIR to ensure CMake configuration files
+      # (RapidJSONConfig.cmake, RapidJSONConfigVersion.cmake, RapidJSON-targets.cmake)
+      # are generated in a consistent location across platforms (Linux, macOS, Windows).
+      # This variable is specific to RapidJSON's build system.
+      -DCMAKE_INSTALL_DIR:PATH=${EP_INSTALL_DIR}/lib/cmake/RapidJSON
+
       # Install the project to support importing the associated "header-only"
       # CMake target via find_package().
     DEPENDS


### PR DESCRIPTION
Set the `CMAKE_INSTALL_DIR` variable to ensure CMake configuration files (`RapidJSONConfig.cmake`, `RapidJSONConfigVersion.cmake`, `RapidJSON-targets.cmake`) are installed in a consistent location across platforms.

This fixes regression introduced in 0e905e91b ("COMP: Update RapidJSON to include optimization, compiler and build-system fixes", 2025-06-24) and resolves errors like the following on Windows when calling `find_package(RapidJSON REQUIRED)` in Slicer modules (e.g., Terminologies):

```
CMake Error at C:/path/to/S-0-build/RapidJSON-install/lib/cmake/RapidJSON/RapidJSONConfig.cmake:3 (include):
  include could not find requested file:

    C:/path/to/S-0-build/RapidJSON-install/lib/cmake/RapidJSON/RapidJSON-targets.cmake
Call Stack (most recent call first):
  Modules/Loadable/Terminologies/Logic/CMakeLists.txt:5 (find_package)
```

Related pull requests:
* https://github.com/Slicer/Slicer/pull/8502