### PR TITLE
COMP: Fix deprecated declarations related to vtkStdString

### DIFF
--- a/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
@@ -252,7 +252,7 @@ int vtkMRMLColorTableStorageNode::ReadCsvFile(std::string fullFileName, vtkMRMLC
       vtkErrorToMessageCollectionMacro(this->GetUserMessages(), "vtkMRMLColorTableStorageNode::ReadCsvFile",
         vtkMRMLI18N::Format(vtkMRMLTr("vtkMRMLColorTableStorageNode",
           "labelValue is not specified in color file in line %1. Skipping this line."),
-          std::to_string(fileRow).c_str()));
+          std::to_string(fileRow).c_str()).c_str());
       continue;
     }
     int labelValue = labelValueColumn->GetVariantValue(row).ToInt(&valid);
@@ -262,7 +262,7 @@ int vtkMRMLColorTableStorageNode::ReadCsvFile(std::string fullFileName, vtkMRMLC
         vtkMRMLI18N::Format(vtkMRMLTr("vtkMRMLColorTableStorageNode",
           "labelValue '%1' is invalid in color file in line %2. Skipping this line."),
           labelValueColumn->GetValue(row),
-          std::to_string(fileRow).c_str()));
+          std::to_string(fileRow).c_str()).c_str());
       continue;
     }
     if (labelValue < 0)
@@ -271,7 +271,7 @@ int vtkMRMLColorTableStorageNode::ReadCsvFile(std::string fullFileName, vtkMRMLC
         vtkMRMLI18N::Format(vtkMRMLTr("vtkMRMLColorTableStorageNode",
           "labelValue '%1' is invalid in color file in line %2: the value must be positive (>0). Skipping this line."),
           labelValueColumn->GetValue(row),
-          std::to_string(fileRow).c_str()));
+          std::to_string(fileRow).c_str()).c_str());
       continue;
     }
     validLabelValues[row] = labelValue;
@@ -287,7 +287,7 @@ int vtkMRMLColorTableStorageNode::ReadCsvFile(std::string fullFileName, vtkMRMLC
           labelValueColumn->GetValue(row),
           std::to_string(fileRow).c_str(),
           std::to_string(this->MaximumColorID).c_str()
-          ));
+          ).c_str());
       colorNode->SetNumberOfColors(0);
       return 0;
     }


### PR DESCRIPTION
Starting with VTK 9.3 relying on the `()` operator overload associated provided by `vtkStdString` is deprecated.

Fix warnings like the following:

```
/path/to/Slicer/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx:265:42: warning: ‘vtkStdString::operator const char*()’ is deprecated: Call `.c_str()` explicitly [-Wdeprecated-declarations]
  265 |           std::to_string(fileRow).c_str()).c_str());
      |                                          ^
```