### PR TITLE
DOC: Fix entry in "Script repository / Segmentations"

### DIFF
--- a/Docs/developer_guide/script_repository/segmentations.md
+++ b/Docs/developer_guide/script_repository/segmentations.md
@@ -436,7 +436,8 @@ seg=arrayFromSegment(segmentation_node, segmentId)
 mean_KjiCropped = [coords.mean() for coords in np.nonzero(seg)]
 
 # Get segmentation voxel coordinates
-segImage = segmentationNode.GetBinaryLabelmapRepresentation(segmentId)
+segImage = slicer.vtkOrientedImageData()
+segmentationNode.GetBinaryLabelmapRepresentation(segmentId, segImage)
 segImageExtent = segImage.GetExtent()
 # origin of the array in voxel coordinates is determined by the start extent
 mean_Ijk = [mean_KjiCropped[2], mean_KjiCropped[1], mean_KjiCropped[0]] + np.array([segImageExtent[0], segImageExtent[2], segImageExtent[4]])
@@ -445,7 +446,7 @@ mean_Ijk = [mean_KjiCropped[2], mean_KjiCropped[1], mean_KjiCropped[0]] + np.arr
 ijkToWorld = vtk.vtkMatrix4x4()
 segImage.GetImageToWorldMatrix(ijkToWorld)
 mean_World = [0, 0, 0, 1]
-ijkToRas.MultiplyPoint(np.append(mean_Ijk,1.0), mean_World)
+ijkToWorld.MultiplyPoint(np.append(mean_Ijk,1.0), mean_World)
 mean_World = mean_World[0:3]
 
 # If segmentation node is transformed, apply that transform to get RAS coordinates


### PR DESCRIPTION
Update "Get centroid of a segment in world (RAS) coordinates" entry to follow-up on API change introduced in fcb40b0 ("ENH: Add support for shared binary labelmap segmentations", 2019-10-08).

The signature of `GetBinaryLabelmapRepresentation` changed, and there was a typo in a variable name.