### PR TITLE
COMP: Fix OpenSSL 1.1.1w build on macOS with non-system zlib

### DIFF
--- a/SuperBuild/External_OpenSSL.cmake
+++ b/SuperBuild/External_OpenSSL.cmake
@@ -70,8 +70,10 @@ if(NOT DEFINED OPENSSL_LIBRARIES
     set(OpenSSL_1.1.1g_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/sources/openssl-1.1.1g-pr12238.tar.gz)
     set(OpenSSL_1.1.1g_MD5 4765dcd60bcbed784c59ad7c2ca2b841)
 
-    set(OpenSSL_1.1.1w_URL https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz)
-    set(OpenSSL_1.1.1w_MD5 3f76825f195e52d4b10c70040681a275)
+    # Workaround linking error when building against non-system zlib on macOS
+    # See https://github.com/openssl/openssl/pull/12238
+    set(OpenSSL_1.1.1w_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/sources/openssl-1.1.1w-pr12238.tar.gz)
+    set(OpenSSL_1.1.1w_MD5 6d9543e9fbfac5914a8597e3a14c4ece)
 
     if(NOT DEFINED OpenSSL_${OPENSSL_DOWNLOAD_VERSION}_URL)
       message(FATAL_ERROR "There is no source version of OpenSSL ${OPENSSL_DOWNLOAD_VERSION} available.


### PR DESCRIPTION
Follow-up to ebdd8127bbf ("COMP: OpenSSL 1.1.1w is needed to fix missing include", 2025-03-08) to resolve build issues on macOS when linking against a zlib library located in a non-system path.

While the upstream fix (openssl/openssl#12238) has been integrated into the OpenSSL 3.x series, this patch applies a backported fix by downloading `openssl-1.1.1w-pr12238.tar.gz`, which includes the necessary modifications for OpenSSL 1.1.1w.

Related pull requests:
* https://github.com/Slicer/Slicer/pull/8504
