### PR TITLE
COMP: Update JsonCpp to skip installation of object files

### DIFF
--- a/SuperBuild/External_JsonCpp.cmake
+++ b/SuperBuild/External_JsonCpp.cmake
@@ -25,7 +25,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "89e2973c754a9c02a49974d839779b151e95afd6" # slicer-v1.9.6-2024-09-09
+    "9000f7710f3d2b6817a2d35cf5feaabd47cb2c81" # slicer-v1.9.6-2024-09-09
     QUIET
     )
 


### PR DESCRIPTION
Update the JsonCpp external project to include a fix that disables the installation of `.o`/`.obj` files from shared library targets.

This fixes a regression introduced in 406beac7a25 ("ENH: Update JsonCpp from 0.10.6 to 1.9.6", 2025-06-19) and avoids unnecessary files in the install tree and prevents packaging issues in minimal environments such as the `slicer-base` Docker image.

List of JsonCpp changes:

```
$ git shortlog 89e2973..9000f77 --no-merges
Jean-Christophe Fillion-Robin (1):
      [Slicer] fix(cmake): Skip installation of object files
```

Related pull requests:
* https://github.com/Slicer/Slicer/pull/8492