### PR TITLE
ENH: Make JSON files in extensions translatable

### DIFF
--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -68,7 +68,7 @@
 namespace
 {
   const std::string VOLUME_DISPLAY_PRESETS_SCHEMA =
-    "https://raw.githubusercontent.com/Slicer/Slicer/main/Modules/Loadable/Volumes/Resources/Schema/volumes-display-presets-schema-v1.0.0.json#";
+    "https://raw.githubusercontent.com/Slicer/Slicer/main/Modules/Loadable/Volumes/Resources/Schema/volumes-display-presets-schema-v1.0.1.json#";
   const std::string ACCEPTED_VOLUME_DISPLAY_PRESETS_SCHEMA_REGEX =
     "^https://raw\\.githubusercontent\\.com/Slicer/Slicer/main/Modules/Loadable/Volumes/Resources/Schema/"
     "volumes-display-presets-schema-v1\\.[0-9]+\\.[0-9]+\\.json#";

--- a/Modules/Loadable/Volumes/Resources/Schema/volumes-display-presets-schema-v1.0.1.json
+++ b/Modules/Loadable/Volumes/Resources/Schema/volumes-display-presets-schema-v1.0.1.json
@@ -1,0 +1,90 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://raw.githubusercontent.com/Slicer/Slicer/main/Modules/Loadable/Volumes/Resources/Schema/volumes-display-presets-schema-v1.0.1.json#",
+    "type": "object",
+    "title": "Schema for storing presets for displaying image volumes",
+    "description": "Currently only window and level values are stored.",
+    "required": ["$schema", "volumeDisplayPresets"],
+    "additionalProperties": true,
+    "properties": {
+        "$schema": {
+            "$id": "#schema",
+            "type": "string",
+            "title": "Schema",
+            "description": "URL of versioned schema."
+        },
+        "volumeDisplayPresets": {
+            "$id": "#presets",
+            "type": "array",
+            "title": "Presets",
+            "description": "Stores a list of named display presets.",
+            "additionalItems": true,
+            "items": {
+                "$id": "#presetItems",
+                "anyOf": [
+                    {
+                        "$id": "#preset",
+                        "type": "object",
+                        "title": "Presets",
+                        "description": "Stores a single display preset.",
+                        "default": {},
+                        "required": ["id", "name", "window", "level", "color"],
+                        "additionalProperties": true,
+                        "properties": {
+                            "id": {
+                                "$id": "#preset/id",
+                                "type": "string",
+                                "title": "Id",
+                                "description": "Unique identifier of the preset. Must not start with underscore character (those are reserved for internal use).",
+                                "examples": ["CT_BONE", "CT_ABDOMEN"]
+                            },
+                            "name": {
+                                "$id": "#preset/name",
+                                "type": "string",
+                                "title": "Name",
+                                "description": "Human-readable name of the preset.",
+                                "examples": ["CT-Bone"],
+                                "translatable": true
+                            },
+                            "description": {
+                                "$id": "#preset/description",
+                                "type": "string",
+                                "title": "Description",
+                                "description": "Human-readable description of the preset.",
+                                "examples": ["Emphasize bone in a CT volume."],
+                                "translatable": true
+                            },
+                            "icon": {
+                                "$id": "#preset/icon",
+                                "type": "string",
+                                "title": "Icon",
+                                "description": "Illustrative image filename or resource path.",
+                                "examples": [":/Icons/WindowLevelPreset-CT-bone.png"]
+                            },
+                            "window": {
+                                "$id": "#preset/window",
+                                "type": "number",
+                                "title": "Window",
+                                "description": "Width of the voxel value range that will be mapped to the full dynamic range of the display. Negative value means inverse mapping (higher voxel values appear darker).",
+                                "examples": [1000.0, -50.0]
+                            },
+                            "level": {
+                                "$id": "#preset/level",
+                                "type": "number",
+                                "title": "Level",
+                                "description": "Center of the voxel value range that will be mapped to the full dynamic range of the display.",
+                                "examples": [426.0, -500.0]
+                            },
+                            "color": {
+                                "$id": "#preset/color",
+                                "type": "string",
+                                "title": "Color",
+                                "description": "Color node ID, specifying the lookup table that will be used to map voxel values to colors."
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/Modules/Loadable/Volumes/Resources/VolumeDisplayPresets.json
+++ b/Modules/Loadable/Volumes/Resources/VolumeDisplayPresets.json
@@ -1,5 +1,5 @@
 {
-    "@schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Modules/Loadable/Volumes/Resources/Schema/volumes-display-presets-schema-v1.0.0.json#",
+    "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Modules/Loadable/Volumes/Resources/Schema/volumes-display-presets-schema-v1.0.0.json#",
     "volumeDisplayPresets": [
         {
             "id": "CT_BONE",

--- a/Modules/Loadable/Volumes/Resources/VolumeDisplayPresets.json
+++ b/Modules/Loadable/Volumes/Resources/VolumeDisplayPresets.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Modules/Loadable/Volumes/Resources/Schema/volumes-display-presets-schema-v1.0.0.json#",
+    "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Modules/Loadable/Volumes/Resources/Schema/volumes-display-presets-schema-v1.0.1.json#",
     "volumeDisplayPresets": [
         {
             "id": "CT_BONE",


### PR DESCRIPTION
MONAIAuto3DSeg extension has a model description json file, which contains model title, description, etc., which is displayed on the GUI and therefore have to be translatable to different languages.

A general-purpose mechanism is implemented to detect if a json file is translatable (a filename-schema.json file is present in the same folder) and determine which properties are translatable (those that have their "transatable" custom property set to true).