### PR TITLE
COMP: Replace WIN32 with _WIN32 in VTK and ITK-related code

### DIFF
--- a/Base/CLI/vtkSlicerBaseCLIExport.h
+++ b/Base/CLI/vtkSlicerBaseCLIExport.h
@@ -17,7 +17,7 @@
 
 #include <vtkSlicerBaseCLIConfigure.h>
 
-#if defined(WIN32) && !defined(VTKSLICER_STATIC)
+#if defined(_WIN32) && !defined(VTKSLICER_STATIC)
 #if defined(SlicerBaseCLI_EXPORTS)
 #define VTK_SLICER_BASE_CLI_EXPORT __declspec( dllexport )
 #else

--- a/Base/Logic/vtkSlicerBaseLogicExport.h
+++ b/Base/Logic/vtkSlicerBaseLogicExport.h
@@ -17,7 +17,7 @@
 
 #include <vtkSlicerBaseLogicConfigure.h>
 
-#if defined(WIN32) && !defined(VTKSLICER_STATIC)
+#if defined(_WIN32) && !defined(VTKSLICER_STATIC)
 #if defined(SlicerBaseLogic_EXPORTS)
 #define VTK_SLICER_BASE_LOGIC_EXPORT __declspec( dllexport )
 #else

--- a/CMake/SlicerMacroConfigureModuleCxxTestDriver.cmake
+++ b/CMake/SlicerMacroConfigureModuleCxxTestDriver.cmake
@@ -66,7 +66,7 @@ macro(SlicerMacroConfigureModuleCxxTestDriver)
     else()
     set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN
       "${CMAKE_TESTDRIVER_BEFORE_TESTMAIN}\n// Direct VTK messages to standard output
-      #ifdef WIN32
+      #ifdef _WIN32
         vtkWin32OutputWindow* outputWindow =
           vtkWin32OutputWindow::SafeDownCast(vtkOutputWindow::GetInstance());
         if (outputWindow)

--- a/Extensions/Testing/CLIExtensionTemplate/CLIModuleTemplate/Testing/Cxx/CLIModuleTemplateTest.cxx
+++ b/Extensions/Testing/CLIExtensionTemplate/CLIModuleTemplate/Testing/Cxx/CLIModuleTemplateTest.cxx
@@ -11,7 +11,7 @@
 // STD includes
 #include <iostream>
 
-#ifdef WIN32
+#ifdef _WIN32
 # define MODULE_IMPORT __declspec(dllimport)
 #else
 # define MODULE_IMPORT

--- a/Extensions/Testing/SuperBuildExtensionTemplate/SuperCLIModuleTemplate/Testing/Cxx/SuperCLIModuleTemplateTest.cxx
+++ b/Extensions/Testing/SuperBuildExtensionTemplate/SuperCLIModuleTemplate/Testing/Cxx/SuperCLIModuleTemplateTest.cxx
@@ -11,7 +11,7 @@
 // STD includes
 #include <iostream>
 
-#ifdef WIN32
+#ifdef _WIN32
 # define MODULE_IMPORT __declspec(dllimport)
 #else
 # define MODULE_IMPORT

--- a/Libs/MRML/CLI/vtkMRMLCLIExport.h
+++ b/Libs/MRML/CLI/vtkMRMLCLIExport.h
@@ -17,7 +17,7 @@
 
 #include <vtkMRMLCLIConfigure.h>
 
-#if defined(WIN32) && !defined(VTKMRMLCLI_STATIC)
+#if defined(_WIN32) && !defined(VTKMRMLCLI_STATIC)
 #if defined(MRMLCLI_EXPORTS)
 #define VTK_MRML_CLI_EXPORT __declspec( dllexport )
 #else

--- a/Libs/MRML/Core/vtkMRMLExport.h
+++ b/Libs/MRML/Core/vtkMRMLExport.h
@@ -17,7 +17,7 @@
 
 #include <vtkMRMLConfigure.h>
 
-#if defined(WIN32) && !defined(VTKMRML_STATIC)
+#if defined(_WIN32) && !defined(VTKMRML_STATIC)
 #if defined(MRMLCore_EXPORTS)
 #define VTK_MRML_EXPORT __declspec( dllexport )
 #else

--- a/Libs/MRML/DisplayableManager/vtkMRMLDisplayableManagerExport.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLDisplayableManagerExport.h
@@ -16,7 +16,7 @@
 
 #include <vtkMRMLDisplayableManagerConfigure.h>
 
-#if defined(WIN32) && !defined(MRMLDisplayableManager_STATIC)
+#if defined(_WIN32) && !defined(MRMLDisplayableManager_STATIC)
 #if defined(MRMLDisplayableManager_EXPORTS)
 #define VTK_MRML_DISPLAYABLEMANAGER_EXPORT __declspec( dllexport )
 #else

--- a/Libs/MRML/IDImageIO/itkMRMLIDIOExport.h
+++ b/Libs/MRML/IDImageIO/itkMRMLIDIOExport.h
@@ -17,7 +17,7 @@
 
 #include <itkMRMLIDImageIOConfigure.h>
 
-#if defined(WIN32) && !defined(MRMLIDIO_STATIC)
+#if defined(_WIN32) && !defined(MRMLIDIO_STATIC)
 #if defined(MRMLIDIO_EXPORTS)
 #define MRMLIDImageIO_EXPORT __declspec( dllexport )
 #else

--- a/Libs/MRML/IDImageIO/itkMRMLIDIOPlugin.h
+++ b/Libs/MRML/IDImageIO/itkMRMLIDIOPlugin.h
@@ -3,7 +3,7 @@
 
 #include "itkObjectFactoryBase.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #ifdef MRMLIDIOPlugin_EXPORTS
 #define MRMLIDIOPlugin_EXPORT __declspec(dllexport)
 #else

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -63,7 +63,7 @@
 #include <sstream>
 
 // For LoadDefaultParameterSets
-#ifdef WIN32
+#ifdef _WIN32
 # include <windows.h>
 #else
 # include <dirent.h>
@@ -690,7 +690,7 @@ int vtkMRMLApplicationLogic::LoadDefaultParameterSets(vtkMRMLScene* scene,
 //     {
 //     vtkDebugMacro("\nFindColorFiles: got user color file paths = " << this->UserColorFilePaths);
 //     // parse out the list, breaking at delimiter strings
-// #ifdef WIN32
+// #ifdef _WIN32
 //     const char *delim = ";";
 // #else
 //     const char *delim = ":";
@@ -716,7 +716,7 @@ int vtkMRMLApplicationLogic::LoadDefaultParameterSets(vtkMRMLScene* scene,
     filesVector.push_back(dirString);
     filesVector.emplace_back("/");
 
-#ifdef WIN32
+#ifdef _WIN32
     WIN32_FIND_DATA findData;
     HANDLE fileHandle;
     int flag = 1;
@@ -761,7 +761,7 @@ int vtkMRMLApplicationLogic::LoadDefaultParameterSets(vtkMRMLScene* scene,
         // take this file off so that can build the next file name
         filesVector.pop_back();
 
-#ifdef WIN32
+#ifdef _WIN32
         flag = FindNextFile(fileHandle, &findData);
       } // end of while flag
       FindClose(fileHandle);

--- a/Libs/MRML/Logic/vtkMRMLLogicExport.h
+++ b/Libs/MRML/Logic/vtkMRMLLogicExport.h
@@ -17,7 +17,7 @@
 
 #include <vtkMRMLLogicConfigure.h>
 
-#if defined(WIN32) && !defined(VTKMRMLLogic_STATIC)
+#if defined(_WIN32) && !defined(VTKMRMLLogic_STATIC)
 #if defined(MRMLLogic_EXPORTS)
 #define VTK_MRML_LOGIC_EXPORT __declspec( dllexport )
 #else

--- a/Libs/MRML/Widgets/qMRMLWidgetsExport.h
+++ b/Libs/MRML/Widgets/qMRMLWidgetsExport.h
@@ -2,7 +2,7 @@
 #ifndef __qMRMLWidgetsExport_h
 #define __qMRMLWidgetsExport_h
 
-#if defined(WIN32) && !defined(qMRMLWidgets_STATIC)
+#if defined(_WIN32) && !defined(qMRMLWidgets_STATIC)
  #if defined(qMRMLWidgets_EXPORTS)
   #define QMRML_WIDGETS_EXPORT __declspec( dllexport )
  #else

--- a/Libs/RemoteIO/vtkRemoteIOExport.h
+++ b/Libs/RemoteIO/vtkRemoteIOExport.h
@@ -3,7 +3,7 @@
 
 #include <vtkRemoteIOConfigure.h>
 
-#if defined(WIN32) && !defined(RemoteIO_STATIC)
+#if defined(_WIN32) && !defined(RemoteIO_STATIC)
 #if defined(RemoteIO_EXPORTS)
 #define VTK_RemoteIO_EXPORT __declspec( dllexport )
 #else

--- a/Libs/vtkITK/vtkITKExport.h
+++ b/Libs/vtkITK/vtkITKExport.h
@@ -17,7 +17,7 @@
 
 #include <vtkITKConfigure.h>
 
-#if defined(WIN32) && !defined(VTKITK_STATIC)
+#if defined(_WIN32) && !defined(VTKITK_STATIC)
 #if defined(vtkITK_EXPORTS)
 #define VTK_ITK_EXPORT __declspec( dllexport )
 #else

--- a/Modules/CLI/AddScalarVolumes/Testing/AddScalarVolumesTest.cxx
+++ b/Modules/CLI/AddScalarVolumes/Testing/AddScalarVolumesTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/CastScalarVolume/Testing/CastScalarVolumeTest.cxx
+++ b/Modules/CLI/CastScalarVolume/Testing/CastScalarVolumeTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/CheckerBoardFilter/Testing/CheckerBoardFilterTest.cxx
+++ b/Modules/CLI/CheckerBoardFilter/Testing/CheckerBoardFilterTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/CreateDICOMSeries/Testing/CreateDICOMSeriesTest.cxx
+++ b/Modules/CLI/CreateDICOMSeries/Testing/CreateDICOMSeriesTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/CurvatureAnisotropicDiffusion/Testing/CurvatureAnisotropicDiffusionTest.cxx
+++ b/Modules/CLI/CurvatureAnisotropicDiffusion/Testing/CurvatureAnisotropicDiffusionTest.cxx
@@ -1,7 +1,7 @@
 #include <iostream>
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/DiffusionTensorTest/Testing/DiffusionTensorTestTest.cxx
+++ b/Modules/CLI/DiffusionTensorTest/Testing/DiffusionTensorTestTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/ExecutionModelTour/Testing/ExecutionModelTourTest.cxx
+++ b/Modules/CLI/ExecutionModelTour/Testing/ExecutionModelTourTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/ExtractSkeleton/Testing/ExtractSkeletonTest.cxx
+++ b/Modules/CLI/ExtractSkeleton/Testing/ExtractSkeletonTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/FiducialRegistration/Testing/FiducialRegistrationTest.cxx
+++ b/Modules/CLI/FiducialRegistration/Testing/FiducialRegistrationTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/GaussianBlurImageFilter/Testing/GaussianBlurImageFilterTest.cxx
+++ b/Modules/CLI/GaussianBlurImageFilter/Testing/GaussianBlurImageFilterTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/GradientAnisotropicDiffusion/Testing/GradientAnisotropicDiffusionTest.cxx
+++ b/Modules/CLI/GradientAnisotropicDiffusion/Testing/GradientAnisotropicDiffusionTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/GrayscaleFillHoleImageFilter/Testing/GrayscaleFillHoleImageFilterTest.cxx
+++ b/Modules/CLI/GrayscaleFillHoleImageFilter/Testing/GrayscaleFillHoleImageFilterTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/GrayscaleGrindPeakImageFilter/Testing/GrayscaleGrindPeakImageFilterTest.cxx
+++ b/Modules/CLI/GrayscaleGrindPeakImageFilter/Testing/GrayscaleGrindPeakImageFilterTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/HistogramMatching/Testing/HistogramMatchingTest.cxx
+++ b/Modules/CLI/HistogramMatching/Testing/HistogramMatchingTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/ImageLabelCombine/Testing/ImageLabelCombineTest.cxx
+++ b/Modules/CLI/ImageLabelCombine/Testing/ImageLabelCombineTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/LabelMapSmoothing/Testing/LabelMapSmoothingTest.cxx
+++ b/Modules/CLI/LabelMapSmoothing/Testing/LabelMapSmoothingTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/MaskScalarVolume/Testing/MaskScalarVolumeTest.cxx
+++ b/Modules/CLI/MaskScalarVolume/Testing/MaskScalarVolumeTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/MedianImageFilter/Testing/MedianImageFilterTest.cxx
+++ b/Modules/CLI/MedianImageFilter/Testing/MedianImageFilterTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/MergeModels/Testing/MergeModelsTest.cxx
+++ b/Modules/CLI/MergeModels/Testing/MergeModelsTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/ModelMaker/Testing/ModelMakerTest.cxx
+++ b/Modules/CLI/ModelMaker/Testing/ModelMakerTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/ModelToLabelMap/Testing/ModelToLabelMapTest.cxx
+++ b/Modules/CLI/ModelToLabelMap/Testing/ModelToLabelMapTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/MultiplyScalarVolumes/Testing/MultiplyScalarVolumesTest.cxx
+++ b/Modules/CLI/MultiplyScalarVolumes/Testing/MultiplyScalarVolumesTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/N4ITKBiasFieldCorrection/Testing/N4ITKBiasFieldCorrectionTest.cxx
+++ b/Modules/CLI/N4ITKBiasFieldCorrection/Testing/N4ITKBiasFieldCorrectionTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/OrientScalarVolume/Testing/OrientScalarVolumeTest.cxx
+++ b/Modules/CLI/OrientScalarVolume/Testing/OrientScalarVolumeTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/ResampleDTIVolume/Testing/ResampleDTIVolumeTest.cxx
+++ b/Modules/CLI/ResampleDTIVolume/Testing/ResampleDTIVolumeTest.cxx
@@ -8,7 +8,7 @@
 =========================================================================*/
 #include "itkTestMainExtended.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/ResampleScalarVectorDWIVolume/Testing/ResampleScalarVectorDWIVolumeTest.cxx
+++ b/Modules/CLI/ResampleScalarVectorDWIVolume/Testing/ResampleScalarVectorDWIVolumeTest.cxx
@@ -1,7 +1,7 @@
 
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/ResampleScalarVolume/Testing/ResampleScalarVolumeTest.cxx
+++ b/Modules/CLI/ResampleScalarVolume/Testing/ResampleScalarVolumeTest.cxx
@@ -1,7 +1,7 @@
 
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/SimpleRegionGrowingSegmentation/Testing/SimpleRegionGrowingSegmentationTest.cxx
+++ b/Modules/CLI/SimpleRegionGrowingSegmentation/Testing/SimpleRegionGrowingSegmentationTest.cxx
@@ -1,6 +1,6 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/SubtractScalarVolumes/Testing/SubtractScalarVolumesTest.cxx
+++ b/Modules/CLI/SubtractScalarVolumes/Testing/SubtractScalarVolumesTest.cxx
@@ -1,7 +1,7 @@
 
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/TestGridTransformRegistration/Testing/TestGridTransformRegistrationTest.cxx
+++ b/Modules/CLI/TestGridTransformRegistration/Testing/TestGridTransformRegistrationTest.cxx
@@ -1,7 +1,7 @@
 
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/ThresholdScalarVolume/Testing/ThresholdScalarVolumeTest.cxx
+++ b/Modules/CLI/ThresholdScalarVolume/Testing/ThresholdScalarVolumeTest.cxx
@@ -1,7 +1,7 @@
 
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/CLI/VotingBinaryHoleFillingImageFilter/Testing/VotingBinaryHoleFillingImageFilterTest.cxx
+++ b/Modules/CLI/VotingBinaryHoleFillingImageFilter/Testing/VotingBinaryHoleFillingImageFilterTest.cxx
@@ -1,7 +1,7 @@
 
 #include "itkTestMain.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define MODULE_IMPORT __declspec(dllimport)
 #else
 #define MODULE_IMPORT

--- a/Modules/Loadable/Colors/Logic/vtkSlicerColorLogic.cxx
+++ b/Modules/Loadable/Colors/Logic/vtkSlicerColorLogic.cxx
@@ -27,7 +27,7 @@
 #include <vtkObjectFactory.h>
 #include <vtksys/SystemTools.hxx>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #else
 #include <dirent.h>
@@ -128,7 +128,7 @@ std::vector<std::string> vtkSlicerColorLogic::FindUserColorFiles()
   {
     vtkDebugMacro("FindColorFiles: got user color file paths = " << this->UserColorFilePaths);
     // parse out the list, breaking at delimiter strings
-#ifdef WIN32
+#ifdef _WIN32
     const char* delim = ";";
 #else
     const char* delim = ":";
@@ -165,7 +165,7 @@ std::vector<std::string> vtkSlicerColorLogic::FindColorFiles(const std::vector<s
     filesVector.push_back(dirString);
     filesVector.emplace_back("/");
 
-#ifdef WIN32
+#ifdef _WIN32
     WIN32_FIND_DATA findData;
     HANDLE fileHandle;
     int flag = 1;
@@ -225,7 +225,7 @@ std::vector<std::string> vtkSlicerColorLogic::FindColorFiles(const std::vector<s
         // take this file off so that can build the next file name
         filesVector.pop_back();
 
-#ifdef WIN32
+#ifdef _WIN32
         flag = FindNextFile(fileHandle, &findData);
       } // end of while flag
       FindClose(fileHandle);

--- a/Utilities/Templates/Modules/CLI/Testing/Cxx/TemplateKeyTest.cxx
+++ b/Utilities/Templates/Modules/CLI/Testing/Cxx/TemplateKeyTest.cxx
@@ -11,7 +11,7 @@
 // STD includes
 #include <iostream>
 
-#ifdef WIN32
+#ifdef _WIN32
 # define MODULE_IMPORT __declspec(dllimport)
 #else
 # define MODULE_IMPORT


### PR DESCRIPTION
Replaces usage of `WIN32` with `_WIN32` in VTK and ITK-related classes to ensure consistent and reliable Windows platform detection. The `WIN32` macro is not  guaranteed to be defined across compilers, while `_WIN32` is standard and universally defined when targeting Windows.

This change is limited to VTK and ITK logic, as Qt code relies on `Q_OS_WIN32` (or `Q_OS_WIN`) for platform-specific checks.