### PR TITLE
COMP: Update SimpleITK to 2.5.2 and corresponding dependencies

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -33,7 +33,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "55c47b7a8ed6b80bc3be3ba9d304ebee02a8a71d" # slicer-v5.4.3-2025-03-19-0913f2a
+    "20d9dc0c6b9de7e65aeb69d1d2fe6674939c0954" # slicer-v5.4.4-2025-06-11-f98d5fa
     QUIET
     )
 

--- a/SuperBuild/External_PCRE2.cmake
+++ b/SuperBuild/External_PCRE2.cmake
@@ -1,5 +1,5 @@
 
-set(proj PCRE)
+set(proj PCRE2)
 
 # Set dependency list
 set(${proj}_DEPENDENCIES "")
@@ -12,8 +12,8 @@ if(Slicer_USE_SYSTEM_${proj})
 endif()
 
 # Sanity checks
-if(DEFINED PCRE_DIR AND NOT EXISTS ${PCRE_DIR})
-  message(FATAL_ERROR "PCRE_DIR variable is defined but corresponds to nonexistent directory")
+if(DEFINED PCRE2_DIR AND NOT EXISTS ${PCRE2_DIR})
+  message(FATAL_ERROR "PCRE2_DIR variable is defined but corresponds to nonexistent directory")
 endif()
 
 if(NOT Slicer_USE_SYSTEM_${proj})
@@ -21,9 +21,9 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   #  PCRE (Perl Compatible Regular Expressions)
   #
 
-  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/PCRE)
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/PCRE-build)
-  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/PCRE-install)
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/PCRE2)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/PCRE2-build)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/PCRE2-install)
 
   include(ExternalProjectForNonCMakeProject)
 
@@ -47,12 +47,12 @@ ExternalProject_Execute(${proj} \"configure\" sh ${EP_SOURCE_DIR}/configure
     --prefix=${EP_INSTALL_DIR} --disable-shared)
 ")
 
-  set(_version "8.44")
+  set(_version "10.44")
 
-  ExternalProject_add(PCRE
+  ExternalProject_add(PCRE2
     ${${proj}_EP_ARGS}
-    URL https://github.com/Slicer/SlicerBinaryDependencies/releases/download/PCRE/pcre-${_version}.tar.gz
-    URL_HASH SHA512=abac4c4f9df9e61d7d7761a9c50843882611752e1df0842a54318f358c28f5953025eba2d78997d21ee690756b56cc9f1c04a5ed591dd60654cc78ba16d9ecfb
+    URL https://github.com/Slicer/SlicerBinaryDependencies/releases/download/PCRE2/pcre2-${_version}.tar.gz
+    URL_HASH SHA512=c43bbe2235993cd703e887bc48cf76d6a6d2f8377accfee3620eff5a4681a36e1f9c147d9e99c6674d5648a54af1d5d174018d9a102abbea7e8d38337bbbd17e
     DOWNLOAD_DIR ${CMAKE_BINARY_DIR}
     SOURCE_DIR ${EP_SOURCE_DIR}
     BINARY_DIR ${EP_BINARY_DIR}
@@ -66,5 +66,5 @@ ExternalProject_Execute(${proj} \"configure\" sh ${EP_SOURCE_DIR}/configure
     VERSION ${_version}
     )
 
-  set(PCRE_DIR ${EP_INSTALL_DIR})
+  set(PCRE2_DIR ${EP_INSTALL_DIR})
 endif()

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -165,7 +165,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" \"-m\" \"pi
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "441c59aafaa179214d60b77f61d0aa12fd32bdfd"  # slicer-v2.3.1-2024-05-20-bc4449e
+    "a2adada325e7b6b88d9d66187694611844ed51e8"  # slicer-v2.5.2-2025-06-13-2018b6b
     QUIET
     )
 

--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -12,9 +12,9 @@ endif()
 
 if(NOT SWIG_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
-  set(SWIG_TARGET_VERSION 4.0.2)
-  set(SWIG_DOWNLOAD_SOURCE_HASH "05e7da70ce6d9a733b96c0bcfa3c1b82765bd859f48c74759bbf4bb1467acb1809caa310cba5e2b3280cd704fca249eaa0624821dffae1d2a75097c7f55d14ed")
-  set(SWIG_DOWNLOAD_WIN_HASH "b8f105f9b9db6acc1f6e3741990915b533cd1bc206eb9645fd6836457fd30789b7229d2e3219d8e35f2390605ade0fbca493ae162ec3b4bc4e428b57155db03d")
+  set(SWIG_TARGET_VERSION 4.3.1)
+  set(SWIG_DOWNLOAD_SOURCE_HASH "8958f7bc3345549a9bc4e00aa8d40a99f6c4bb92b95d627c8796cf8f8d1ba0041a89cab542f171778c2b26aa2a877767181ae9bd2c05fd055f373a32a463399c")
+  set(SWIG_DOWNLOAD_WIN_HASH "ca7210684b6ccb1b9bb186797bf1b67bbf3e76f6d0e702fee78edf7456992a4298eb5fa0b5f602a4240161fedd422920fe56e12cd60b8c8fd71c2f784f3d0f43")
 
   set(EXTERNAL_PROJECT_OPTIONAL_ARGS)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
@@ -46,7 +46,7 @@ if(NOT SWIG_DIR AND NOT Slicer_USE_SYSTEM_${proj})
     # not windows
 
     # Set dependency list
-    set(${proj}_DEPENDENCIES PCRE python)
+    set(${proj}_DEPENDENCIES PCRE2 python)
 
     # Include dependent projects if any
     ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
@@ -87,7 +87,7 @@ set(ENV{YFLAGS} \"${BISON_FLAGS}\")
 set(${proj}_WORKING_DIR \"${EP_BINARY_DIR}\")
 ExternalProject_Execute(${proj} \"configure\" sh ${EP_SOURCE_DIR}/configure
     --prefix=${EP_INSTALL_DIR}
-    --with-pcre-prefix=${PCRE_DIR}
+    --with-pcre2-prefix=${PCRE2_DIR}
     --without-octave
     --without-java
     --with-python=${PYTHON_EXECUTABLE})


### PR DESCRIPTION
I had come across this syntax warning when using the SimpleITK version in Slicer which was resolved by https://github.com/SimpleITK/SimpleITK/commit/3899a1314eb32f64af2231061d1e87ba5f75bcf4 as originally included in SimpleITK 2.5.0. This PR updates SimpleITK from a version based on 2.3.1 to a version based on 2.5.2. Other supporting dependencies related to SimpleITK have also been updated to the same versions that SimpleITK uses in its superbuild (such as SWIG 4.3.1).
```
..\Lib\site-packages\SimpleITK\extra.py:476: SyntaxWarning: invalid escape sequence '\s'
  \sa itk::simple::DiscreteGaussianImageFilter for the object oriented interface
```

A clean build on Windows was successful as well as packaging.

Follow-up of the following pull request:
* https://github.com/Slicer/Slicer/pull/8339