### PR TITLE
COMP: Fix return type of extraPythonScriptProcessedArgumentsCount property

### DIFF
--- a/Base/QTCore/qSlicerCoreCommandOptions.h
+++ b/Base/QTCore/qSlicerCoreCommandOptions.h
@@ -37,7 +37,7 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerCoreCommandOptions : public ctkCommandL
   Q_PROPERTY(bool ignoreSlicerRC READ ignoreSlicerRC CONSTANT)
   Q_PROPERTY(QString pythonScript READ pythonScript CONSTANT)
   Q_PROPERTY(QString extraPythonScript READ extraPythonScript CONSTANT)
-  Q_PROPERTY(QString extraPythonScriptProcessedArgumentsCount READ extraPythonScriptProcessedArgumentsCount CONSTANT)
+  Q_PROPERTY(int extraPythonScriptProcessedArgumentsCount READ extraPythonScriptProcessedArgumentsCount CONSTANT)
   Q_PROPERTY(QString pythonCode READ pythonCode CONSTANT)
   Q_PROPERTY(bool runPythonAndExit READ runPythonAndExit WRITE setRunPythonAndExit)
   Q_PROPERTY(bool disableCLIModules READ disableCLIModules CONSTANT)


### PR DESCRIPTION
Update the `Q_PROPERTY` declaration for `extraPythonScriptProcessedArgumentsCount` to use int instead of `QString`.

This corrects the property type to match the actual return type of the associated getter. The mismatch was identified during the transition to Qt6.

Follow-up on 0cf480de872 ("BUG: Fix launching .py files using Slicer with -I argument", 2023-05-12)