### PR TITLE
ENH: Update CTK to include PythonQt updates

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "ca28a23b93671114c419ab46930919c10756b1fc"
+    "526988788cd1a3af8dc77ef117ebaa9670f81564"
     QUIET
     )
 


### PR DESCRIPTION
This commit updates CTK to incorporate recent improvements to its internal PythonQt fork, continuing efforts to reduce divergence from the upstream MeVisLab/pythonqt project.

Fixes:

* Build warnings when using Qt 5.15+ (e.g., `QSet::unite`, `qrand()` deprecation).
* Regression in `setRedirectStdInCallbackEnabled`, introduced in previous backport.
* Compatibility issues with Python 3.13 and debug builds (`PYTHONQT_DEBUG`).
* Memory leaks and improved reference management.
* Improved usability in ScriptingConsole and PythonQt tests.

List of CTK changes:

```
$ git shortlog ca28a23b9..52698878 --no-merges
Jean-Christophe Fillion-Robin (1):
      BUG: Update PythonQt and fix warnings and regression
```