### PR TITLE
ENH: Enable relative import of Slicer Python-wrapped libraries

### DIFF
--- a/Base/Python/slicer/__init__.py
+++ b/Base/Python/slicer/__init__.py
@@ -194,7 +194,11 @@ for kit in available_kits:
     try:
         exec("from %s import *" % (kit))
     except ImportError as detail:
-        print(detail)
+        # Try kit relative import if installed in as a traditional package
+        try:
+            exec("from .%s import *" % (kit))
+        except ImportError:
+            print(detail)
 
     del kit
 


### PR DESCRIPTION
- Add slicer __init__ kit  relative import when using Slicer as a python library