### PR TITLE
slicer update python initialization 8460

### DIFF
--- a/Base/QTCore/qSlicerCorePythonManager.cxx
+++ b/Base/QTCore/qSlicerCorePythonManager.cxx
@@ -47,7 +47,17 @@ qSlicerCorePythonManager::qSlicerCorePythonManager(QObject* _parent)
 
   // If it applies, disable import of user site packages
   QString noUserSite = qgetenv("PYTHONNOUSERSITE");
-  Py_NoUserSiteDirectory = noUserSite.toInt();
+
+  PyConfig config;
+  PyConfig_InitPythonConfig(&config);
+
+  config.user_site_directory = noUserSite.toInt(); // disable user site packages
+
+  PyStatus status = Py_InitializeFromConfig(&config);
+  if (PyStatus_Exception(status))
+  {
+    Py_ExitStatusException(status);
+  }
 
   // Import site module to ensure the 'site-packages' directory
   // is added to the python path. (see site.addsitepackages function).


### PR DESCRIPTION
COMP: Resolve #8460

Update qSlicerCoreApplication.cxx to replace use of PySys_SetArgvEx
with PyConfig.argv as suggested in https://docs.python.org/3/c-api/init.html#c.PySys_SetArgvEx

- **ENH: Update Python initialization for compatibility with isolated mode**
- **ENH: Update Python initialization to use PyConfig API**
