### PR TITLE
COMP: Ensure correct handling of maximum representable double values

### DIFF
--- a/Libs/vtkITK/itkConstrainedValueMultiplicationImageFilter.h
+++ b/Libs/vtkITK/itkConstrainedValueMultiplicationImageFilter.h
@@ -65,7 +65,12 @@ public:
     const double dA = static_cast<double>(A);
     const double dB = static_cast<double>(B);
     const double add = dA * dB;
-    const double cadd1 = (add < NumericTraits<TOutput>::max()) ? add : NumericTraits<TOutput>::max();
+    // IEEE‑754 double can exactly represent all integers in the range [–2^53, 2^53], but beyond that,
+    // only some integer numbers are representable.
+    //  18446744073709551615 (2^64−1) must be rounded to the nearest representable double: 18446744073709551616
+    constexpr double max_closet_representable = static_cast<double>(NumericTraits<TOutput>::max());
+
+    const double cadd1 = (add < max_closet_representable) ? add : max_closet_representable;
     const double cadd2 = (cadd1 > NumericTraits<TOutput>::NonpositiveMin()) ? cadd1 : NumericTraits<TOutput>::NonpositiveMin();
     return static_cast<TOutput>(cadd2);
   }

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx
@@ -813,6 +813,10 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(vtkInformation* vtkNotU
       }
       else
       {
+        // IEEE‑754 double can exactly represent all integers in the range [–2^53, 2^53], but beyond that,
+        // only some integer numbers are representable.
+        //  18446744073709551615 (2^64−1) must be rounded to the nearest representable double: 18446744073709551616
+        constexpr double max_closest_representable = static_cast<double>(std::numeric_limits<uint64_t>::max());
         double min = 0, max = 0;
         for (unsigned int f = 0; f < this->FileNames.size(); f++)
         {
@@ -852,12 +856,12 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(vtkInformation* vtkNotU
           if (imageIO->GetComponentType() == itk::IOComponentEnum::ULONG)
           { // note that on windows ULONG is only 32 bit
             min = static_cast<double>(std::numeric_limits<uint64_t>::min() < min ? std::numeric_limits<uint64_t>::min() : min);
-            max = static_cast<double>(std::numeric_limits<uint64_t>::max() > max ? std::numeric_limits<uint64_t>::max() : max);
+            max = static_cast<double>(max_closest_representable > max ? max_closest_representable : max);
           }
           if (imageIO->GetComponentType() == itk::IOComponentEnum::LONG)
           { // note that on windows LONG is only 32 bit
             min = static_cast<double>(std::numeric_limits<int64_t>::min() < min ? std::numeric_limits<int64_t>::min() : min);
-            max = static_cast<double>(std::numeric_limits<int64_t>::max() > max ? std::numeric_limits<int64_t>::max() : max);
+            max = static_cast<double>(max_closest_representable > max ? max_closest_representable : max);
           }
           if (imageIO->GetComponentType() == itk::IOComponentEnum::FLOAT)
           {


### PR DESCRIPTION
- Introduced `max_closet_representable` constant for IEEE-754 double
  representation range.

- Adjusted comparisons in `vtkITKArchetypeImageSeriesReader.cxx` and
  `itkConstrainedValueMultiplicationImageFilter.h` to resolve rounding
  edge cases for large integer values.

IEEE‑754 double can exactly represent all integers in the range [–2⁵³,
  2⁵³], but beyond that, only some integer numbers are representable.

18446744073709551615 (2⁶⁴−1) must be rounded to the nearest representable double: 18446744073709551616

Libs/vtkITK/itkConstrainedValueMultiplicationImageFilter.h:68:32: warning: implicit conversion from 'slicer_itk::NumericTraits<long>::ValueType' (aka 'long') to 'double' changes value from 9223372036854775807 to 9223372036854775808
Libs/vtkITK/itkConstrainedValueMultiplicationImageFilter.h:68:71: warning: implicit conversion from 'slicer_itk::NumericTraits<long>::ValueType' (aka 'long') to 'double' changes value from 9223372036854775807 to 9223372036854775808
Libs/vtkITK/itkConstrainedValueMultiplicationImageFilter.h:77:32: warning: implicit conversion from 'slicer_itk::NumericTraits<long>::ValueType' (aka 'long') to 'double' changes value from 9223372036854775807 to 9223372036854775808
Libs/vtkITK/itkConstrainedValueMultiplicationImageFilter.h:77:71: warning: implicit conversion from 'slicer_itk::NumericTraits<long>::ValueType' (aka 'long') to 'double' changes value from 9223372036854775807 to 9223372036854775808
Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx:882:38: warning: implicit conversion from 'unsigned long' to 'double' changes value from 18446744073709551615 to 18446744073709551616
Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx:882:83: warning: implicit conversion from 'unsigned long' to 'double' changes value from 18446744073709551615 to 18446744073709551616
Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx:888:38: warning: implicit conversion from 'unsigned long' to 'double' changes value from 18446744073709551615 to 18446744073709551616
Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx:888:83: warning: implicit conversion from 'unsigned long' to 'double' changes value from 18446744073709551615 to 18446744073709551616
Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx:889:38: warning: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808
Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx:889:82: warning: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808
Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx:895:38: warning: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808
Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx:895:82: warning: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808
Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx:954:26: warning: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808
Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx:960:26: warning: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808
