### PR TITLE
COMP: Replace `fabs` with `std::abs` for consistency in types

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScissorsEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScissorsEffect.cxx
@@ -420,8 +420,8 @@ void qSlicerSegmentEditorScissorsEffectPrivate::updateGlyphWithNewPosition(Sciss
 
         if (this->shapeDrawCentered())
         {
-          double halfWidth = fabs(eventPosition[0] - this->DragStartPosition[0]);
-          double halfHeight = fabs(eventPosition[1] - this->DragStartPosition[1]);
+          int halfWidth = std::abs(eventPosition[0] - this->DragStartPosition[0]);
+          int halfHeight = std::abs(eventPosition[1] - this->DragStartPosition[1]);
           points->SetPoint(0, this->DragStartPosition[0] - halfWidth, this->DragStartPosition[1] - halfHeight, 0.0);
           points->SetPoint(1, this->DragStartPosition[0] + halfWidth, this->DragStartPosition[1] - halfHeight, 0.0);
           points->SetPoint(2, this->DragStartPosition[0] + halfWidth, this->DragStartPosition[1] + halfHeight, 0.0);


### PR DESCRIPTION
All math can be performed as integers to avoid implicit type changes.

warning: using floating point absolute value function 'fabs' when
         argument is of integer type
