### PR TITLE
BUG: Incorrect number of arguments given when weightAdjustment was desired.

### DIFF
--- a/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentsPlugin.cxx
+++ b/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentsPlugin.cxx
@@ -112,7 +112,10 @@ void qSlicerSubjectHierarchySegmentsPluginPrivate::init()
 
   // Clone segment action
   this->CloneSegmentAction = new QAction(qSlicerSubjectHierarchySegmentsPlugin::tr("Clone"), q);
-  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CloneSegmentAction, qSlicerSubjectHierarchyAbstractPlugin::SectionNode, 0.5); // put it right after "Rename" action
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CloneSegmentAction,                           //
+                                                           qSlicerSubjectHierarchyAbstractPlugin::SectionNode, //
+                                                           0,                                                  // "Rename" action's index
+                                                           1.0);                                               // put it right after
   QObject::connect(this->CloneSegmentAction, SIGNAL(triggered()), q, SLOT(cloneSegment()));
 
   this->OpacityMenu = new QMenu(qSlicerSubjectHierarchySegmentsPlugin::tr("Opacity"));

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyCloneNodePlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyCloneNodePlugin.cxx
@@ -73,7 +73,10 @@ void qSlicerSubjectHierarchyCloneNodePluginPrivate::init()
 
   this->CloneItemAction = new QAction(qSlicerSubjectHierarchyCloneNodePlugin::tr("Clone"), q);
   this->CloneItemAction->setToolTip(qSlicerSubjectHierarchyCloneNodePlugin::tr("Clone this item and its data node if any along with display and storage options"));
-  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CloneItemAction, qSlicerSubjectHierarchyAbstractPlugin::SectionNode, 0.5); // put it right after "Rename" action
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CloneItemAction,                              //
+                                                           qSlicerSubjectHierarchyAbstractPlugin::SectionNode, //
+                                                           0,                                                  // "Rename" action's index
+                                                           1.0);                                               // put it right after
   QObject::connect(this->CloneItemAction, SIGNAL(triggered()), q, SLOT(cloneCurrentItem()));
 }
 


### PR DESCRIPTION
Assume that the last "0.5" argument was supposed to be the
WeightAdjustment instead of weight.

```c++
setActionPosition(QAction* action, int section, int weight /*=0*/, double weightAdjustment /*=0.0*/)
```

Implicit conversion from 'double' to 'int' changes value from 0.5 to 0
