### PR TITLE
COMP: Use dynamic_cast for inheritance upcasting

### DIFF
--- a/Base/QTGUI/qSlicerModuleFinderDialog.cxx
+++ b/Base/QTGUI/qSlicerModuleFinderDialog.cxx
@@ -306,9 +306,9 @@ bool qSlicerModuleFinderDialog::eventFilter(QObject* target, QEvent* event)
     // widget in the tab order)
     if (event->type() == QEvent::KeyPress)
     {
-      QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
       qSlicerModuleFactoryFilterModel* filterModel = d->ModuleListView->filterModel();
-      if (keyEvent != nullptr && filterModel->rowCount() > 0)
+      QKeyEvent* keyEvent = dynamic_cast<QKeyEvent*>(event);
+      if (keyEvent && keyEvent != nullptr && filterModel->rowCount() > 0)
       {
         int currentRow = d->ModuleListView->currentIndex().row();
         int stepSize = 1;

--- a/Libs/MRML/Widgets/qMRMLTreeViewEventTranslator.cpp
+++ b/Libs/MRML/Widgets/qMRMLTreeViewEventTranslator.cpp
@@ -72,8 +72,8 @@ bool qMRMLTreeViewEventTranslator::translateEvent(QObject* Object, QEvent* Event
   {
     if (Event->type() == QEvent::KeyPress)
     {
-      QKeyEvent* e = static_cast<QKeyEvent*>(Event);
-      if (e->key() == Qt::Key_Enter)
+      QKeyEvent* e = dynamic_cast<QKeyEvent*>(Event);
+      if (e && (e->key() == Qt::Key_Enter))
       {
         QAction* action = menu->activeAction();
         if (action)
@@ -92,8 +92,8 @@ bool qMRMLTreeViewEventTranslator::translateEvent(QObject* Object, QEvent* Event
     }
     if (Event->type() == QEvent::MouseButtonRelease)
     {
-      QMouseEvent* e = static_cast<QMouseEvent*>(Event);
-      if (e->button() == Qt::LeftButton)
+      QMouseEvent* e = dynamic_cast<QMouseEvent*>(Event);
+      if (e && e->button() == Qt::LeftButton)
       {
         QAction* action = menu->actionAt(e->pos());
         if (action && !action->menu())

--- a/Modules/Loadable/Colors/Widgets/qMRMLColorPickerWidget.cxx
+++ b/Modules/Loadable/Colors/Widgets/qMRMLColorPickerWidget.cxx
@@ -225,9 +225,9 @@ bool qMRMLColorPickerWidget::eventFilter(QObject* target, QEvent* event)
     }
     if (event->type() == QEvent::KeyPress)
     {
-      QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
-      if (keyEvent->key() == Qt::Key_Up || //
-          keyEvent->key() == Qt::Key_Down)
+      QKeyEvent* keyEvent = dynamic_cast<QKeyEvent*>(event);
+      if (keyEvent && //
+          ((keyEvent->key() == Qt::Key_Up) || (keyEvent->key() == Qt::Key_Down)))
       {
         // give the Focus to MRMLColorListView
         d->MRMLColorListView->setFocus();

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
@@ -956,18 +956,17 @@ bool qMRMLSegmentsTableView::eventFilter(QObject* target, QEvent* event)
     // widget in the tab order)
     if (event->type() == QEvent::KeyPress)
     {
-      QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
       QAbstractItemModel* model = d->SegmentsTable->model();
       QModelIndex currentIndex = d->SegmentsTable->currentIndex();
-
-      if (model
-          && (                                                                                         //
-            (keyEvent->key() == Qt::Key_Left && currentIndex.column() == 0)                            //
-            || (keyEvent->key() == Qt::Key_Up && currentIndex.row() == 0)                              //
-            || (keyEvent->key() == Qt::Key_Right && currentIndex.column() == model->columnCount() - 1) //
-            || (keyEvent->key() == Qt::Key_Down && currentIndex.row() == model->rowCount() - 1)))
+      if (QKeyEvent* keyEvent = dynamic_cast<QKeyEvent*>(event))
       {
-        return true;
+        if (model
+            && ((keyEvent->key() == Qt::Key_Left && currentIndex.column() == 0) || (keyEvent->key() == Qt::Key_Up && currentIndex.row() == 0)
+                || (keyEvent->key() == Qt::Key_Right && currentIndex.column() == model->columnCount() - 1)
+                || (keyEvent->key() == Qt::Key_Down && currentIndex.row() == model->rowCount() - 1)))
+        {
+          return true;
+        }
       }
     }
   }


### PR DESCRIPTION
This is a followup on the previous isolated case to
apply the same fixes in the Slicer codebase widely.

Even though event is declared as a QEvent*, the compiler cannot
guarantee that it actually points to a QMouseEvent. The classes aren’t
related through inheritance in a static type-safe way.

Casting across siblings in the event class hierarchy is invalid.

Use dynamic_cast<> for casting between heirchies that do *not*
  derive from QObject (i.e. QEvents do not derive from QObjects)

Use qobject_cast<> for casting between QObjects.
  Qt provides qobject_cast<T*>(QObject*) as a safe way to cast between
  QObject-derived types using Qt’s meta-object system (requires Q_OBJECT
  in the class).  It is RTTI‑free, works across shared libraries, and
  is available in both Qt 5 and Qt 6  ￼ ￼.
    •   The function is declared in qobject.h, which is indirectly
        included by <QObject> in both Qt versions
