### PR TITLE
STYLE: Explain static_cast use in Qt event handling

### DIFF
--- a/Base/QTGUI/qSlicerModuleFinderDialog.cxx
+++ b/Base/QTGUI/qSlicerModuleFinderDialog.cxx
@@ -306,6 +306,7 @@ bool qSlicerModuleFinderDialog::eventFilter(QObject* target, QEvent* event)
     // widget in the tab order)
     if (event->type() == QEvent::KeyPress)
     {
+      // type is already checked, so we can use static_cast instead of dynamic_cast for efficiency
       QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
       qSlicerModuleFactoryFilterModel* filterModel = d->ModuleListView->filterModel();
       if (keyEvent != nullptr && filterModel->rowCount() > 0)

--- a/Modules/Loadable/Colors/Widgets/qMRMLColorPickerWidget.cxx
+++ b/Modules/Loadable/Colors/Widgets/qMRMLColorPickerWidget.cxx
@@ -225,6 +225,7 @@ bool qMRMLColorPickerWidget::eventFilter(QObject* target, QEvent* event)
     }
     if (event->type() == QEvent::KeyPress)
     {
+      // type is already checked, so we can use static_cast instead of dynamic_cast for efficiency
       QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
       if (keyEvent->key() == Qt::Key_Up || //
           keyEvent->key() == Qt::Key_Down)

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
@@ -956,6 +956,7 @@ bool qMRMLSegmentsTableView::eventFilter(QObject* target, QEvent* event)
     // widget in the tab order)
     if (event->type() == QEvent::KeyPress)
     {
+      // type is already checked, so we can use static_cast instead of dynamic_cast for efficiency
       QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
       QAbstractItemModel* model = d->SegmentsTable->model();
       QModelIndex currentIndex = d->SegmentsTable->currentIndex();


### PR DESCRIPTION
Qt uses type ID check + static_cast for casting QEvent to more specific classes for performance reasons. Using dynamic_cast would be slower due to complexity of RTTI. qobject_cast does not use RTTI, so it is faster, but Qt event objects are not derived from QObject, so it cannot be used here.

See more discussion at https://github.com/Slicer/Slicer/pull/8555