### PR TITLE
COMP: Remove obsolete Qt version checks related to Qt4

### DIFF
--- a/Modules/Loadable/Markups/qSlicerMarkupsModule.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModule.h
@@ -26,8 +26,6 @@
 
 #include "qSlicerMarkupsModuleExport.h"
 
-#include "vtkSlicerConfigure.h" // For Slicer_HAVE_QT5
-
 class qMRMLMarkupsToolBar;
 class vtkMRMLScene;
 class vtkMRMLMarkupsNode;

--- a/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qSlicerSequencesModuleWidgetsPlugin.h
+++ b/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qSlicerSequencesModuleWidgetsPlugin.h
@@ -22,12 +22,7 @@
 #define qSlicerSequencesModuleWidgetsPlugin_h
 
 // Qt includes
-#include "vtkSlicerConfigure.h" // For Slicer_HAVE_QT5
-#ifdef Slicer_HAVE_QT5
-# include <QtUiPlugin/QDesignerCustomWidgetCollectionInterface>
-#else
-# include <QDesignerCustomWidgetCollectionInterface>
-#endif
+#include <QtUiPlugin/QDesignerCustomWidgetCollectionInterface>
 
 // SequenceBrowser includes
 #include "qMRMLSequenceBrowserPlayWidgetPlugin.h"
@@ -41,9 +36,7 @@ class Q_SLICER_MODULE_SEQUENCES_WIDGETS_PLUGINS_EXPORT qSlicerSequenceBrowserMod
   , public QDesignerCustomWidgetCollectionInterface
 {
   Q_OBJECT
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
   Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QDesignerCustomWidgetInterface")
-#endif
   Q_INTERFACES(QDesignerCustomWidgetCollectionInterface);
 
 public:

--- a/Modules/Loadable/Sequences/qSlicerSequencesModule.h
+++ b/Modules/Loadable/Sequences/qSlicerSequencesModule.h
@@ -24,8 +24,6 @@
 // Slicer includes
 #include "qSlicerLoadableModule.h"
 
-#include "vtkSlicerConfigure.h" // For Slicer_HAVE_QT5
-
 #include "qSlicerSequencesModuleExport.h"
 
 class qMRMLSequenceBrowserToolBar;
@@ -39,9 +37,7 @@ class Q_SLICER_QTMODULES_SEQUENCES_EXPORT qSlicerSequencesModule : public qSlice
 {
   Q_OBJECT
   QVTK_OBJECT;
-#ifdef Slicer_HAVE_QT5
   Q_PLUGIN_METADATA(IID "org.slicer.modules.loadable.qSlicerLoadableModule/1.0");
-#endif
   Q_INTERFACES(qSlicerLoadableModule);
 
   /// Visibility of the sequence browser toolbar


### PR DESCRIPTION
Following c7fe93d44f ("COMP: Update build system removing support for C++98/Qt4/VTK7", 2019-03-08), support for Qt4 is obsolete.