### PR TITLE
COMP: Update CTK with PythonQt wrapping support for Qt 5.15

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "526988788cd1a3af8dc77ef117ebaa9670f81564"
+    "fcf31fc6d18ae7f8823060b2e8770a3a4f47ef65"
     QUIET
     )
 


### PR DESCRIPTION
This is a follow-up to previous Slicer PR #7475. 

The update CTK uses a branch of PythonQt that now includes Qt 5.15 wrappers unlike the older branch. Reviewing https://doc.qt.io/qt-5/newclasses515.html#new-enum-types, this now allows me to use https://doc.qt.io/qt-5/qtabbar.html#setTabVisible which was specifically introduced in Qt 5.15. This usage has currently been unavailable in latest Slicer.

![{36C6CB3B-A1C3-46A5-9BFB-391706B0680E}](https://github.com/user-attachments/assets/8bf648da-9995-48c7-9c2e-eaa268d52ad4)

```
CTK:
$ git shortlog 5269887..fcf31fc
Hans Johnson (1):
      COMP: Add conditional for VTK version in color assignment

Jean-Christophe Fillion-Robin (1):
      COMP: Update PythonQt to branch based off upstream v3.6.1
```