### PR TITLE
ENH: Add parameter node GUI connector for qMRMLSubjectHierarchyComboBox

### DIFF
--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
@@ -9,8 +9,8 @@ import qt
 import slicer
 
 from slicer import (
-    qMRMLSubjectHierarchyTreeView,
     qMRMLSubjectHierarchyComboBox,
+    qMRMLSubjectHierarchyTreeView,
     vtkMRMLModelNode,
     vtkMRMLScalarVolumeNode,
 )

--- a/Docs/developer_guide/parameter_nodes/gui_connection.md
+++ b/Docs/developer_guide/parameter_nodes/gui_connection.md
@@ -186,6 +186,7 @@ When connecting an `int` to a `QSpinBox`, if the `Minimum` annotation is used, i
 | ctkDirectoryButton | pathlib.\[Path, PosixPath, WindowsPath,<br/>&emsp;PurePath, PurePosixPath, PureWindowsPath] | Only directories can be represented |
 | qMRMLNodeComboBox | vtkMRMLNode<br/>&emsp;(including subclasses and a typing.Union of nodes) | To do a Union, need to do something like `typing.Union[vtkMRMLModelNode, vtkMRMLScalarVolumeNode, None]`.<br/>The `None` is necessary for the parameter node wrapper default node of None to work correctly. |
 | qMRMLSubjectHierarchyTreeView | vtkMRMLNode<br/>&emsp;(including subclasses and a typing.Union of nodes) | See notes for qMRMLNodeComboBox. |
+| qMRMLSubjectHierarchyComboBox | vtkMRMLNode<br/>&emsp;(including subclasses and a typing.Union of nodes) | See notes for qMRMLNodeComboBox. |
 
 For widgets that are not listed here see [Slicer Issue 7308](https://github.com/Slicer/Slicer/issues/7308) for discussion and progress.
 

--- a/Modules/Loadable/SubjectHierarchy/SubjectHierarchyLib/parameterNodeWrapper/guiConnectors.py
+++ b/Modules/Loadable/SubjectHierarchy/SubjectHierarchyLib/parameterNodeWrapper/guiConnectors.py
@@ -1,4 +1,4 @@
-from slicer import qMRMLSubjectHierarchyTreeView
+from slicer import qMRMLSubjectHierarchyTreeView, qMRMLSubjectHierarchyComboBox
 from slicer.parameterNodeWrapper import (
     isNodeOrUnionOfNodes,
     getNodeTypes,
@@ -34,12 +34,43 @@ class qMRMLSubjectHierarchyTreeViewToNodeConnector(GuiConnector):
         return self._widget
 
     def read(self):
-        itemId = self._widget.currentItem()
-        shNode = self._widget.subjectHierarchyNode()
-        if itemId == shNode.GetInvalidItemID():
-            return None
+        return self._widget.currentNode()
+
+    def write(self, value) -> None:
+        if value is not None:
+            self._widget.setCurrentNode(value)
         else:
-            return shNode.GetItemDataNode(itemId)
+            self._widget.clearSelection()
+
+
+@parameterNodeGuiConnector
+class qMRMLSubjectHierarchyComboBoxToNodeConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return type(widget) == qMRMLSubjectHierarchyComboBox and isNodeOrUnionOfNodes(datatype)
+
+    @staticmethod
+    def create(widget, datatype):
+        if qMRMLSubjectHierarchyComboBoxToNodeConnector.canRepresent(widget, datatype):
+            return qMRMLSubjectHierarchyComboBoxToNodeConnector(widget, datatype)
+        return None
+
+    def __init__(self, widget: qMRMLSubjectHierarchyComboBox, datatype):
+        super().__init__()
+        self._widget: qMRMLSubjectHierarchyComboBox = widget
+        self._widget.nodeTypes = getNodeTypes(datatype)
+
+    def _connect(self):
+        self._widget.currentItemChanged.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.currentItemChanged.disconnect(self.changed)
+
+    def widget(self) -> qMRMLSubjectHierarchyComboBox:
+        return self._widget
+
+    def read(self):
+        return self._widget.currentNode()
 
     def write(self, value) -> None:
         if value is not None:

--- a/Modules/Loadable/SubjectHierarchy/SubjectHierarchyLib/parameterNodeWrapper/guiConnectors.py
+++ b/Modules/Loadable/SubjectHierarchy/SubjectHierarchyLib/parameterNodeWrapper/guiConnectors.py
@@ -1,4 +1,4 @@
-from slicer import qMRMLSubjectHierarchyTreeView, qMRMLSubjectHierarchyComboBox
+from slicer import qMRMLSubjectHierarchyComboBox, qMRMLSubjectHierarchyTreeView
 from slicer.parameterNodeWrapper import (
     isNodeOrUnionOfNodes,
     getNodeTypes,

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -193,6 +193,20 @@ void qMRMLSubjectHierarchyComboBox::setCurrentItem(vtkIdType itemID)
   return d->TreeView->setCurrentItem(itemID);
 }
 
+//------------------------------------------------------------------------------
+vtkMRMLNode* qMRMLSubjectHierarchyComboBox::currentNode() const
+{
+  Q_D(const qMRMLSubjectHierarchyComboBox);
+  return d->TreeView->currentNode();
+}
+
+//------------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::setCurrentNode(vtkMRMLNode* node)
+{
+  Q_D(qMRMLSubjectHierarchyComboBox);
+  d->TreeView->setCurrentNode(node);
+}
+
 //--------------------------------------------------------------------------
 qMRMLSortFilterSubjectHierarchyProxyModel* qMRMLSubjectHierarchyComboBox::sortFilterProxyModel() const
 {
@@ -438,6 +452,13 @@ void qMRMLSubjectHierarchyComboBox::setNodeTypes(const QStringList& types)
 {
   Q_D(qMRMLSubjectHierarchyComboBox);
   d->TreeView->setNodeTypes(types);
+}
+
+//--------------------------------------------------------------------------
+QStringList qMRMLSubjectHierarchyComboBox::nodeTypes() const
+{
+  Q_D(const qMRMLSubjectHierarchyComboBox);
+  return d->TreeView->nodeTypes();
 }
 
 //--------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
@@ -95,6 +95,8 @@ class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qMRMLSubjectHierarchyCombo
   /// \deprecated Kept only for backwards compatibility. Use addItemAttributeFilter() or removeItemAttributeFilter() instead.
   Q_PROPERTY(QString attributeValueFilter READ attributeValueFilter WRITE setAttributeValueFilter)
 
+  Q_PROPERTY(QStringList nodeTypes READ nodeTypes WRITE setNodeTypes)
+
 public:
   typedef ctkComboBox Superclass;
   qMRMLSubjectHierarchyComboBox(QWidget* parent = nullptr);
@@ -107,6 +109,10 @@ public:
   Q_INVOKABLE void clearSelection();
   Q_INVOKABLE vtkIdType currentItem() const;
   Q_INVOKABLE vtkIdType rootItem() const;
+
+  /// Convenience method to set current item by associated data node.
+  Q_INVOKABLE virtual vtkMRMLNode* currentNode() const;
+  Q_INVOKABLE virtual void setCurrentNode(vtkMRMLNode*);
 
   void setShowRootItem(bool show);
   bool showRootItem() const;
@@ -168,6 +174,8 @@ public:
   Q_INVOKABLE void setLevelFilter(QStringList& levelFilter);
   /// Set node type filter that allows showing only data nodes of a certain type. Show all data nodes if empty
   Q_INVOKABLE void setNodeTypes(const QStringList& types);
+  QStringList nodeTypes() const;
+
   /// Set child node types filter that allows hiding certain data node subclasses that would otherwise be
   /// accepted by the data node type filter. Show all data nodes if empty
   Q_INVOKABLE void setHideChildNodeTypes(const QStringList& types);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
@@ -109,9 +109,10 @@ public:
   Q_INVOKABLE void clearSelection();
   Q_INVOKABLE vtkIdType currentItem() const;
   Q_INVOKABLE vtkIdType rootItem() const;
-
-  /// Convenience method to set current item by associated data node.
+  /// Convenience method to get the MRML data node corresponding to the selected item.
   Q_INVOKABLE virtual vtkMRMLNode* currentNode() const;
+
+  /// Convenience method to set the current item given a MRML data node.
   Q_INVOKABLE virtual void setCurrentNode(vtkMRMLNode*);
 
   void setShowRootItem(bool show);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
@@ -129,7 +129,7 @@ public:
   Q_INVOKABLE void currentItems(vtkIdList* selectedItems);
 
   /// Convenience method to set current item by associated data node.
-  virtual vtkMRMLNode* currentNode() const;
+  Q_INVOKABLE virtual vtkMRMLNode* currentNode() const;
 
   /// Get root item of the tree
   Q_INVOKABLE vtkIdType rootItem() const;


### PR DESCRIPTION
Parameter node wrapper GUI connector was not implemented for many widgets (#7308), including qMRMLSubjectHierarchyComboBox. This commit adds a connector that can read/write qMRMLSubjectHierarchyComboBox as a MRML node.

fixes #7905