### PR TITLE
COMP: Ensure `isPythonDisabled` is defined regardless of Python support

### DIFF
--- a/Base/QTCore/qSlicerCoreCommandOptions.cxx
+++ b/Base/QTCore/qSlicerCoreCommandOptions.cxx
@@ -384,14 +384,16 @@ bool qSlicerCoreCommandOptions::isTestingEnabled() const
   return d->ParsedArgs.value(/*no tr*/ "testing").toBool();
 }
 
-#ifdef Slicer_USE_PYTHONQT
 //-----------------------------------------------------------------------------
 bool qSlicerCoreCommandOptions::isPythonDisabled() const
 {
+#ifdef Slicer_USE_PYTHONQT
   Q_D(const qSlicerCoreCommandOptions);
   return d->ParsedArgs.value("disable-python").toBool();
-}
+#else
+  return true;
 #endif
+}
 
 //-----------------------------------------------------------------------------
 void qSlicerCoreCommandOptions::addArguments()

--- a/Base/QTCore/qSlicerCoreCommandOptions.h
+++ b/Base/QTCore/qSlicerCoreCommandOptions.h
@@ -56,9 +56,7 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerCoreCommandOptions : public ctkCommandL
   Q_PROPERTY(bool verboseModuleDiscovery READ verboseModuleDiscovery CONSTANT)
   Q_PROPERTY(bool disableMessageHandlers READ disableMessageHandlers CONSTANT)
   Q_PROPERTY(bool testingEnabled READ isTestingEnabled CONSTANT)
-#ifdef Slicer_USE_PYTHONQT
   Q_PROPERTY(bool pythonDisabled READ isPythonDisabled CONSTANT)
-#endif
   Q_PROPERTY(QStringList additionalModulePaths READ additionalModulePaths CONSTANT)
   Q_PROPERTY(QStringList modulesToIgnore READ modulesToIgnore CONSTANT)
 public:
@@ -198,12 +196,12 @@ public:
   /// \sa settingsDisabled()
   bool isTestingEnabled() const;
 
-#ifdef Slicer_USE_PYTHONQT
   /// Return True if slicer has no python infrastructure initialized.
-  /// Python is still compiled with the app, but not enabled at run-time.
+  /// This can happen either if the application is started with
+  /// the "--disable-python" argument, or if Slicer was built with
+  /// Slicer_USE_PYTHONQT set to OFF.
   /// \sa settingsDisabled()
   bool isPythonDisabled() const;
-#endif
 
 protected:
   /// Add arguments - Called from parse() method


### PR DESCRIPTION
When Slicer is built with `Slicer_USE_PYTHONQT` set to `OFF`, the method `qSlicerCoreCommandOptions::isPythonDisabled()` should still be available and consistently return `true`, indicating that Python support is not enabled.

This change ensures the method is always defined by moving the `#ifdef` inside the function body. It also updates the `Q_PROPERTY` to be unconditionally available.

