### PR TITLE
COMP: Prefer c++11 range for to Qt macros

### DIFF
--- a/Applications/SlicerApp/qSlicerAppMainWindow.cxx
+++ b/Applications/SlicerApp/qSlicerAppMainWindow.cxx
@@ -221,7 +221,7 @@ void qSlicerAppMainWindow::on_HelpKeyboardShortcutsAction_triggered()
   // scan the modules for their actions
   QList<QAction*> moduleActions;
   qSlicerModuleManager* moduleManager = qSlicerApplication::application()->moduleManager();
-  foreach (const QString& moduleName, moduleManager->modulesNames())
+  for (const QString& moduleName : moduleManager->modulesNames())
   {
     qSlicerAbstractModule* module = qobject_cast<qSlicerAbstractModule*>(moduleManager->module(moduleName));
     if (module)

--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -214,7 +214,7 @@ void qSlicerApplicationHelper::setupModuleFactoryManager(qSlicerModuleFactoryMan
   QStringList modulesToAlwaysIgnore = app->revisionUserSettings()->value("Modules/IgnoreModules").toStringList();
   QStringList modulesToTemporarlyIgnore = options->modulesToIgnore();
   // Discard modules already listed in the settings
-  foreach (const QString& moduleToAlwaysIgnore, modulesToAlwaysIgnore)
+  for (const QString& moduleToAlwaysIgnore : modulesToAlwaysIgnore)
   {
     modulesToTemporarlyIgnore.removeAll(moduleToAlwaysIgnore);
   }

--- a/Base/QTApp/qSlicerApplicationHelper.txx
+++ b/Base/QTApp/qSlicerApplicationHelper.txx
@@ -202,7 +202,7 @@ int qSlicerApplicationHelper::postInitializeApplication(qSlicerApplication& app,
   qSlicerModuleManager* moduleManager = app.moduleManager();
   qSlicerModuleFactoryManager* moduleFactoryManager = moduleManager->factoryManager();
   QStringList additionalModulePaths;
-  foreach (const QString& extensionOrModulePath, app.commandOptions()->additionalModulePaths())
+  for (const QString& extensionOrModulePath : app.commandOptions()->additionalModulePaths())
   {
     QStringList modulePaths = moduleFactoryManager->modulePaths(extensionOrModulePath);
     if (!modulePaths.empty())
@@ -218,7 +218,7 @@ int qSlicerApplicationHelper::postInitializeApplication(qSlicerApplication& app,
   qSlicerApplicationHelper::setupModuleFactoryManager(moduleFactoryManager);
 
   // Set list of modules to ignore
-  foreach (const QString& moduleToIgnore, app.commandOptions()->modulesToIgnore())
+  for (const QString& moduleToIgnore : app.commandOptions()->modulesToIgnore())
   {
     moduleFactoryManager->addModuleToIgnore(moduleToIgnore);
   }
@@ -256,7 +256,7 @@ int qSlicerApplicationHelper::postInitializeApplication(qSlicerApplication& app,
   if (!failedToBeInstantiatedModuleNames.isEmpty())
   {
     qCritical() << "The following modules failed to be instantiated:";
-    foreach (const QString& moduleName, failedToBeInstantiatedModuleNames)
+    for (const QString& moduleName : failedToBeInstantiatedModuleNames)
     {
       qCritical().noquote() << "  " << moduleName;
     }
@@ -289,7 +289,7 @@ int qSlicerApplicationHelper::postInitializeApplication(qSlicerApplication& app,
   }
 
   // Load all available modules
-  foreach (const QString& name, moduleFactoryManager->instantiatedModuleNames())
+  for (const QString& name : moduleFactoryManager->instantiatedModuleNames())
   {
     Q_ASSERT(!name.isNull());
     splashMessage(splashScreen, qSlicerApplication::tr("Loading module \"%1\"...").arg(name));

--- a/Base/QTApp/qSlicerErrorReportDialog.cxx
+++ b/Base/QTApp/qSlicerErrorReportDialog.cxx
@@ -70,7 +70,7 @@ qSlicerErrorReportDialog::qSlicerErrorReportDialog(QWidget* parentWidget)
   }
   QLocale locale = qSlicerCoreApplication::application()->applicationLocale();
   QStringList logFilePaths = qSlicerApplication::application()->recentLogFiles();
-  foreach (const QString& path, logFilePaths)
+  for (const QString& path : logFilePaths)
   {
     QTableWidgetItem* itemApp = new QTableWidgetItem(path);
     QTableWidgetItem* itemVersion = new QTableWidgetItem(path);

--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -750,7 +750,7 @@ void qSlicerMainWindowPrivate::addFavoriteModule(const QString& moduleName)
   // find the location of where to add the action.
   // Note: FavoriteModules is sorted
   QAction* beforeAction = nullptr; // 0 means insert at end
-  foreach (QAction* toolBarAction, this->ModuleToolBar->actions())
+  for (QAction* const toolBarAction : this->ModuleToolBar->actions())
   {
     bool isActionAFavoriteModule = (this->FavoriteModules.indexOf(toolBarAction->data().toString()) != -1);
     if (isActionAFavoriteModule && //
@@ -1540,7 +1540,7 @@ void qSlicerMainWindow::onModuleAboutToBeUnloaded(const QString& moduleName)
     d->ModuleSelectorToolBar->selectModule("");
   }
 
-  foreach (QAction* action, d->ModuleToolBar->actions())
+  for (QAction* const action : d->ModuleToolBar->actions())
   {
     if (action->data().toString() == moduleName)
     {
@@ -1571,7 +1571,7 @@ void qSlicerMainWindow::onLayoutActionTriggered(QAction* action)
   Q_D(qSlicerMainWindow);
   bool found = false;
   // std::cerr << "onLayoutActionTriggered: " << action->text().toStdString() << std::endl;
-  foreach (QAction* maction, d->LayoutMenu->actions())
+  for (QAction* const maction : d->LayoutMenu->actions())
   {
     if (action->text() == maction->text())
     {
@@ -1638,7 +1638,7 @@ void qSlicerMainWindow::onLayoutChanged(int layout)
   // data assigned, so they should never be triggered (they could be triggered
   // at startup, when layout is set to SlicerLayoutInitialView = 0).
 
-  foreach (QAction* action, d->LayoutMenu->actions())
+  for (QAction* const action : d->LayoutMenu->actions())
   {
     if (!action->menu() && action->data().toInt() == layout)
     {
@@ -1680,7 +1680,7 @@ void qSlicerMainWindow::restoreGUIState(bool force /*=false*/)
   settings.endGroup();
   d->FavoriteModules << settings.value("Modules/FavoriteModules").toStringList();
 
-  foreach (const qSlicerIO::IOProperties& fileProperty, qSlicerMainWindowPrivate::readRecentlyLoadedFiles())
+  for (const qSlicerIO::IOProperties& fileProperty : qSlicerMainWindowPrivate::readRecentlyLoadedFiles())
   {
     d->RecentlyLoadedFileProperties.enqueue(fileProperty);
   }
@@ -1799,7 +1799,7 @@ void qSlicerMainWindow::on_FavoriteModulesChanged()
 
   // Update favorite module toolbar
   d->ModuleToolBar->clear();
-  foreach (QString moduleName, d->FavoriteModules)
+  for (const QString& moduleName : d->FavoriteModules)
   {
     if (d->FavoriteModules.contains(moduleName))
     {

--- a/Base/QTCLI/Testing/qSlicerCLIExecutableModuleFactoryTest1.cxx
+++ b/Base/QTCLI/Testing/qSlicerCLIExecutableModuleFactoryTest1.cxx
@@ -35,7 +35,7 @@ int qSlicerCLIExecutableModuleFactoryTest1(int, char*[])
 
   QString expectedModuleName = "Threshold";
   qSlicerCLIExecutableModuleFactory factory;
-  foreach (const QString& executableName, executableNames)
+  for (const QString& executableName : executableNames)
   {
     QString moduleName = factory.fileNameToKey(executableName);
     if (moduleName != expectedModuleName)

--- a/Base/QTCLI/Testing/qSlicerCLILoadableModuleFactoryTest1.cxx
+++ b/Base/QTCLI/Testing/qSlicerCLILoadableModuleFactoryTest1.cxx
@@ -38,7 +38,7 @@ int qSlicerCLILoadableModuleFactoryTest1(int, char*[])
 
   QString expectedModuleName = "Threshold";
   qSlicerCLILoadableModuleFactory factory;
-  foreach (const QString& libraryName, libraryNames)
+  for (const QString& libraryName : libraryNames)
   {
     QString moduleName = factory.fileNameToKey(libraryName);
     if (moduleName != expectedModuleName)

--- a/Base/QTCLI/Testing/qSlicerCLIModuleTest1.cxx
+++ b/Base/QTCLI/Testing/qSlicerCLIModuleTest1.cxx
@@ -138,7 +138,7 @@ int qSlicerCLIModuleTest1(int argc, char* argv[])
     return EXIT_FAILURE;
   }
 
-  foreach (const QString& name, moduleNames)
+  for (const QString& name : moduleNames)
   {
     moduleFactoryManager->loadModule(name);
   }

--- a/Base/QTCLI/Testing/qSlicerPyCLIModuleTest1.cxx
+++ b/Base/QTCLI/Testing/qSlicerPyCLIModuleTest1.cxx
@@ -159,7 +159,7 @@ int qSlicerPyCLIModuleTest1(int argc, char* argv[])
     return EXIT_FAILURE;
   }
 
-  foreach (const QString& name, moduleNames)
+  for (const QString& name : moduleNames)
   {
     moduleFactoryManager->loadModule(name);
   }

--- a/Base/QTCLI/qSlicerCLILoadableModuleFactory.cxx
+++ b/Base/QTCLI/qSlicerCLILoadableModuleFactory.cxx
@@ -214,7 +214,7 @@ bool qSlicerCLILoadableModuleFactoryItem::updateLogo(qSlicerCLILoadableModuleFac
     expectedSymbols << "ModuleLogoWidth" << "ModuleLogoHeight"
                     << "ModuleLogoPixelSize" << "ModuleLogoLength";
     QList<SymbolAddressType> resolvedSymbols;
-    foreach (const QString& symbol, expectedSymbols)
+    for (const QString& symbol : expectedSymbols)
     {
       SymbolAddressType resolvedSymbol = item->symbolAddress(symbol);
       if (resolvedSymbol)

--- a/Base/QTCLI/qSlicerCLIModule.cxx
+++ b/Base/QTCLI/qSlicerCLIModule.cxx
@@ -131,11 +131,11 @@ QStringList qSlicerCLIModule::categories() const
   // "Registration.Specialized", we translate "Registration" and "Specialized").
   QStringList translatedCategoryList;
   QStringList categoryList = QString::fromStdString(d->Desc.GetCategory()).split(';');
-  foreach (const QString& category, categoryList)
+  for (const QString& category : categoryList)
   {
     QStringList translatedCategoryComponentList;
     QStringList categoryComponentList = category.split('.');
-    foreach (const QString& categoryComponent, categoryComponentList)
+    for (const QString& categoryComponent : categoryComponentList)
     {
       translatedCategoryComponentList << QCoreApplication::translate("qSlicerAbstractCoreModule", categoryComponent.toStdString().c_str());
     }

--- a/Base/QTCLI/qSlicerCLIModuleFactoryHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleFactoryHelper.cxx
@@ -61,7 +61,7 @@ const QStringList qSlicerCLIModuleFactoryHelper::modulePaths()
   QSettings* settings = app->revisionUserSettings();
   QStringList additionalModulePaths = app->toSlicerHomeAbsolutePaths(settings->value("Modules/AdditionalPaths").toStringList());
   QStringList cmdLineModulePaths = additionalModulePaths + defaultCmdLineModulePaths;
-  foreach (const QString& path, cmdLineModulePaths)
+  for (const QString& path : cmdLineModulePaths)
   {
     app->addLibraryPath(path);
   }

--- a/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
@@ -147,7 +147,7 @@ QString ButtonGroupWidgetWrapper::checkedValue()
 //-----------------------------------------------------------------------------
 void ButtonGroupWidgetWrapper::setCheckedValue(const QString& value)
 {
-  foreach (QAbstractButton* button, this->ButtonGroup->buttons())
+  for (QAbstractButton* const button : this->ButtonGroup->buttons())
   {
     if (button->property("EnumeratedValue").toString() == value)
     {
@@ -1125,7 +1125,7 @@ void qSlicerCLIModuleUIHelper::updateMRMLCommandLineModuleNode(vtkMRMLCommandLin
   // Block ModifyEvent to be fired, only fire 1 event at the end.
   int disabledModify = commandLineModuleNode->StartModify();
 
-  foreach (qSlicerWidgetValueWrapper* widgetValueWrapper, d->WidgetValueWrappers)
+  for (qSlicerWidgetValueWrapper* const widgetValueWrapper : d->WidgetValueWrappers)
   {
     this->setCommandLineModuleParameter(commandLineModuleNode, widgetValueWrapper->name(), widgetValueWrapper->value());
   }
@@ -1189,7 +1189,7 @@ void qSlicerCLIModuleUIHelper::updateUi(vtkMRMLCommandLineModuleNode* commandLin
   Q_D(qSlicerCLIModuleUIHelper);
 
   // Disable widgets if no module node is selected
-  foreach (qSlicerWidgetValueWrapper* valueWrapper, d->WidgetValueWrappers)
+  for (qSlicerWidgetValueWrapper* const valueWrapper : d->WidgetValueWrappers)
   {
     QWidget* widget = dynamic_cast<QWidget*>(valueWrapper->parent());
     if (!widget)
@@ -1204,7 +1204,7 @@ void qSlicerCLIModuleUIHelper::updateUi(vtkMRMLCommandLineModuleNode* commandLin
     return;
   }
 
-  foreach (qSlicerWidgetValueWrapper* valueWrapper, d->WidgetValueWrappers)
+  for (qSlicerWidgetValueWrapper* const valueWrapper : d->WidgetValueWrappers)
   {
     QString value = QString::fromStdString(commandLineModuleNode->GetParameterAsString(valueWrapper->name().toUtf8()));
     valueWrapper->setValue(value);
@@ -1215,7 +1215,7 @@ void qSlicerCLIModuleUIHelper::updateUi(vtkMRMLCommandLineModuleNode* commandLin
 void qSlicerCLIModuleUIHelper::setValue(const QString& name, const QVariant& value)
 {
   Q_D(qSlicerCLIModuleUIHelper);
-  foreach (qSlicerWidgetValueWrapper* valueWrapper, d->WidgetValueWrappers)
+  for (qSlicerWidgetValueWrapper* const valueWrapper : d->WidgetValueWrappers)
   {
     if (name == valueWrapper->name())
     {

--- a/Base/QTCore/Testing/Cxx/qSlicerCoreIOManagerTest1.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerCoreIOManagerTest1.cxx
@@ -100,7 +100,7 @@ int qSlicerCoreIOManagerTest1(int argc, char* argv[])
     return EXIT_FAILURE;
   }
   qDebug() << "All writable extensions = ";
-  foreach (QString ext, allWritableExtensions)
+  for (const QString& ext : allWritableExtensions)
   {
     qDebug() << ext;
   }
@@ -113,7 +113,7 @@ int qSlicerCoreIOManagerTest1(int argc, char* argv[])
     return EXIT_FAILURE;
   }
   qDebug() << "All readable extensions = ";
-  foreach (QString ext, allReadableExtensions)
+  for (const QString& ext : allReadableExtensions)
   {
     qDebug() << ext;
   }

--- a/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
@@ -329,7 +329,7 @@ bool qSlicerExtensionsManagerModelTester::resetTmp()
 void qSlicerExtensionsManagerModelTester::dumpExtensionMetatype(const char* varname, const ExtensionMetadataType& extensionMetadata)
 {
   std::cout << "[" << varname << "]" << std::endl;
-  foreach (const QString& key, extensionMetadata.keys())
+  for (const QString& key : extensionMetadata.keys())
   {
     std::cout << varname << ".insert(\"" << qPrintable(key) << "\", "
               << "\"" << qPrintable(extensionMetadata.value(key).toString()) << "\");" << std::endl;
@@ -379,7 +379,7 @@ qSlicerExtensionsManagerModelTester::ExtensionMetadataType qSlicerExtensionsMana
 
   QStringList keysToIgnore(qSlicerExtensionsManagerModel::serverKeysToIgnore(serverAPI));
   QVariantMap metadata;
-  foreach (const QString& key, allMetadata.keys())
+  for (const QString& key : allMetadata.keys())
   {
     if (filtered && keysToIgnore.contains(key))
     {
@@ -665,7 +665,7 @@ void qSlicerExtensionsManagerModelTester::testExtractExtensionArchive()
   }
 
   bool expectedFilesExist = true;
-  foreach (const QString& expectedFile, expectedFiles)
+  for (const QString& expectedFile : expectedFiles)
   {
     expectedFilesExist = expectedFilesExist && QFile::exists(this->Tmp.filePath(expectedFile));
     if (!expectedFilesExist)
@@ -909,9 +909,8 @@ void qSlicerExtensionsManagerModelTester::testUninstallExtension()
       this->installHelper(&model, operatingSystem, extensionId, this->Tmp.absolutePath());
     }
 
-    foreach (const QString& extensionName,
-             QStringList() //
-               << "MarkupsToModel")
+    for (const QString& extensionName : QStringList() //
+                                          << "MarkupsToModel")
     {
       QVERIFY(this->uninstallHelper(&model, extensionName));
       QVERIFY(!model.isExtensionInstalled(extensionName));
@@ -923,29 +922,26 @@ void qSlicerExtensionsManagerModelTester::testUninstallExtension()
     model.setSlicerRequirements(slicerRevision, operatingSystem, architecture);
     model.updateModel();
 
-    foreach (const QString& extensionName,
-             QStringList() //
-               << "ImageMaker"
-               << "CurveMaker")
+    for (const QString& extensionName : QStringList() //
+                                          << "ImageMaker"
+                                          << "CurveMaker")
     {
       QVERIFY(model.isExtensionInstalled(extensionName));
     }
 
-    foreach (const QString& extensionName,
-             QStringList() //
-               << "MarkupsToModel")
+    for (const QString& extensionName : QStringList() //
+                                          << "MarkupsToModel")
     {
       QVERIFY(!model.isExtensionInstalled(extensionName));
     }
 
-    foreach (const QString& extensionName,
-             QStringList() //
-               << "MarkupsToModel")
+    for (const QString& extensionName : QStringList() //
+                                          << "MarkupsToModel")
     {
       this->installHelper(&model, operatingSystem, this->expectedExtensionNames().indexOf(extensionName), this->Tmp.absolutePath());
     }
 
-    foreach (const QString& extensionName, this->expectedExtensionNames())
+    for (const QString& extensionName : this->expectedExtensionNames())
     {
       QVERIFY(model.isExtensionInstalled(extensionName));
     }
@@ -973,7 +969,7 @@ void qSlicerExtensionsManagerModelTester::testScheduleExtensionForUninstall()
     model.setExtensionsSettingsFilePath(QSettings().fileName());
     model.setSlicerRequirements(slicerRevision, operatingSystem, architecture);
     model.setSlicerVersion(slicerVersion);
-    foreach (int extensionIdToInstall, extensionIdsToInstall)
+    for (const int& extensionIdToInstall : extensionIdsToInstall)
     {
       this->installHelper(&model, operatingSystem, extensionIdToInstall, this->Tmp.absolutePath());
     }
@@ -989,7 +985,7 @@ void qSlicerExtensionsManagerModelTester::testScheduleExtensionForUninstall()
     model.setSlicerRequirements(slicerRevision, operatingSystem, architecture);
     model.setSlicerVersion(slicerVersion);
     model.updateModel();
-    foreach (const QString& extensionNameToScheduleForUninstall, extensionNamesToScheduleForUninstall)
+    for (const QString& extensionNameToScheduleForUninstall : extensionNamesToScheduleForUninstall)
     {
       model.scheduleExtensionForUninstall(extensionNameToScheduleForUninstall);
     }
@@ -1060,7 +1056,7 @@ void qSlicerExtensionsManagerModelTester::testCancelExtensionScheduledForUninsta
     model.setExtensionsSettingsFilePath(QSettings().fileName());
     model.setSlicerRequirements(slicerRevision, operatingSystem, architecture);
     model.setSlicerVersion(slicerVersion);
-    foreach (int extensionIdToInstall, extensionIdsToInstall)
+    for (const int& extensionIdToInstall : extensionIdsToInstall)
     {
       this->installHelper(&model, operatingSystem, extensionIdToInstall, this->Tmp.absolutePath());
     }
@@ -1073,7 +1069,7 @@ void qSlicerExtensionsManagerModelTester::testCancelExtensionScheduledForUninsta
     model.setSlicerRequirements(slicerRevision, operatingSystem, architecture);
     model.setSlicerVersion(slicerVersion);
     model.updateModel();
-    foreach (const QString& extensionNameToScheduleForUninstall, extensionNamesToScheduleForUninstall)
+    for (const QString& extensionNameToScheduleForUninstall : extensionNamesToScheduleForUninstall)
     {
       model.scheduleExtensionForUninstall(extensionNameToScheduleForUninstall);
     }
@@ -1088,7 +1084,7 @@ void qSlicerExtensionsManagerModelTester::testCancelExtensionScheduledForUninsta
     model.setSlicerRequirements(slicerRevision, operatingSystem, architecture);
     model.setSlicerVersion(slicerVersion);
     model.updateModel();
-    foreach (const QString& extensionNameToCancelScheduledForUninstall, extensionNamesToCancelScheduledForUninstall)
+    for (const QString& extensionNameToCancelScheduledForUninstall : extensionNamesToCancelScheduledForUninstall)
     {
       model.cancelExtensionScheduledForUninstall(extensionNameToCancelScheduledForUninstall);
     }
@@ -1227,9 +1223,8 @@ void qSlicerExtensionsManagerModelTester::testUpdateModel()
     QCOMPARE(spyExtensionEnabledChanged.count(), 1);
 
     QCOMPARE(model.isExtensionEnabled("ImageMaker"), false);
-    foreach (const QString& extensionName,
-             QStringList() << "MarkupsToModel"
-                           << "CurveMaker")
+    for (const QString& extensionName : QStringList() << "MarkupsToModel"
+                                                      << "CurveMaker")
     {
       QCOMPARE(model.isExtensionEnabled(extensionName), true);
     }
@@ -1237,9 +1232,8 @@ void qSlicerExtensionsManagerModelTester::testUpdateModel()
     model.updateModel();
 
     QCOMPARE(model.isExtensionEnabled("ImageMaker"), false);
-    foreach (const QString& extensionName,
-             QStringList() << "MarkupsToModel"
-                           << "CurveMaker")
+    for (const QString& extensionName : QStringList() << "MarkupsToModel"
+                                                      << "CurveMaker")
     {
       QCOMPARE(model.isExtensionEnabled(extensionName), true);
     }
@@ -1348,7 +1342,7 @@ void qSlicerExtensionsManagerModelTester::testInstalledExtensionsCount()
     qSlicerExtensionsManagerModel model;
     model.setExtensionsSettingsFilePath(QSettings().fileName());
     model.setSlicerRequirements(slicerRevision, operatingSystem, architecture);
-    foreach (int extensionIdToInstall, extensionIdsToInstall)
+    for (const int& extensionIdToInstall : extensionIdsToInstall)
     {
       this->installHelper(&model, operatingSystem, extensionIdToInstall, this->Tmp.absolutePath());
     }
@@ -1413,7 +1407,7 @@ void qSlicerExtensionsManagerModelTester::testInstalledExtensions()
     qSlicerExtensionsManagerModel model;
     model.setExtensionsSettingsFilePath(QSettings().fileName());
     model.setSlicerRequirements(slicerRevision, operatingSystem, architecture);
-    foreach (int extensionIdToInstall, extensionIdsToInstall)
+    for (const int& extensionIdToInstall : extensionIdsToInstall)
     {
       this->installHelper(&model, operatingSystem, extensionIdToInstall, this->Tmp.absolutePath());
     }
@@ -1490,25 +1484,25 @@ void qSlicerExtensionsManagerModelTester::testIsExtensionEnabled()
     qSlicerExtensionsManagerModel model;
     model.setExtensionsSettingsFilePath(QSettings().fileName());
     model.setSlicerRequirements(slicerRevision, operatingSystem, architecture);
-    foreach (int extensionIdToInstall, extensionIdsToInstall)
+    for (const int& extensionIdToInstall : extensionIdsToInstall)
     {
       this->installHelper(&model, operatingSystem, extensionIdToInstall, this->Tmp.absolutePath());
     }
     QCOMPARE(model.enabledExtensions(), expectedEnabledExtensionNames);
 
-    foreach (const QString& extensionName, expectedEnabledExtensionNames)
+    for (const QString& extensionName : expectedEnabledExtensionNames)
     {
       additionalModulePathsPerExtension.insert(extensionName, model.extensionModulePaths(extensionName));
     }
 
-    foreach (const QString& extensionName, extensionNamesToDisable)
+    for (const QString& extensionName : extensionNamesToDisable)
     {
       model.setExtensionEnabled(extensionName, false);
     }
     QCOMPARE(model.enabledExtensions(), expectedEnabledExtensionNamesAfterDisable);
 
     QStringList expectedAdditionalPaths;
-    foreach (const QString& extensionName, expectedEnabledExtensionNamesAfterDisable)
+    for (const QString& extensionName : expectedEnabledExtensionNamesAfterDisable)
     {
       expectedAdditionalPaths << additionalModulePathsPerExtension.value(extensionName);
     }
@@ -1524,7 +1518,7 @@ void qSlicerExtensionsManagerModelTester::testIsExtensionEnabled()
     QCOMPARE(model.enabledExtensions(), expectedEnabledExtensionNamesAfterDisable);
 
     QStringList expectedAdditionalPaths;
-    foreach (const QString& extensionName, expectedEnabledExtensionNamesAfterDisable)
+    for (const QString& extensionName : expectedEnabledExtensionNamesAfterDisable)
     {
       expectedAdditionalPaths << additionalModulePathsPerExtension.value(extensionName);
     }
@@ -1930,7 +1924,7 @@ void testRequirementsHelper(qSlicerExtensionsManagerModel* model, QStringSetter 
 
   QSignalSpy spySlicerRequirementsChanged(model, SIGNAL(slicerRequirementsChanged(QString, QString, QString)));
   QSignalSpy spySlicerPropertyChanged(model, changedPropertySignal);
-  foreach (const QString& valuetoSet, valuesToSet)
+  for (const QString& valuetoSet : valuesToSet)
   {
     (model->*qStringSetterFuncPtr)(valuetoSet);
   }

--- a/Base/QTCore/Testing/Cxx/qSlicerLoadableModuleFactoryTest1.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerLoadableModuleFactoryTest1.cxx
@@ -38,7 +38,7 @@ int qSlicerLoadableModuleFactoryTest1(int, char*[])
 
   QString expectedModuleName = "Threshold";
 
-  foreach (const QString& libraryName, libraryNames)
+  for (const QString& libraryName : libraryNames)
   {
     QString moduleName = qSlicerLoadableModuleFactory::extractModuleName(libraryName);
     if (moduleName != expectedModuleName)

--- a/Base/QTCore/Testing/Cxx/qSlicerSslTest.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerSslTest.cxx
@@ -45,7 +45,7 @@ public slots:
   void onSslErrors(QNetworkReply* reply, const QList<QSslError>& sslErrors)
   {
     Q_UNUSED(reply);
-    foreach (const QSslError& sslError, sslErrors)
+    for (const QSslError& sslError : sslErrors)
     {
       this->SslErrors << sslError.error();
       this->SslErrorStrings << sslError.errorString();

--- a/Base/QTCore/Testing/Cxx/qSlicerUtilsTest1.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerUtilsTest1.cxx
@@ -101,14 +101,14 @@ int isExecutableNameTest()
                   << "Threshold.py" << "Threshold.tcl"
                   << "Threshold.m" << "Threshold.exe";
 
-  foreach (const QString& executableName, executableNames)
+  for (const QString& executableName : executableNames)
   {
     CHECK_BOOL(qSlicerUtils::isExecutableName(executableName), true);
   }
 
   QStringList notExecutableNames;
   notExecutableNames << "Threshold.ini" << "Threshold.txt" << "Threshold";
-  foreach (const QString& notExecutableName, notExecutableNames)
+  for (const QString& notExecutableName : notExecutableNames)
   {
     CHECK_BOOL(qSlicerUtils::isExecutableName(notExecutableName), false);
   }
@@ -125,7 +125,7 @@ int isCLILoadableModuleTest()
                  << "ThresholdLib.DLL"
                  << "libThresholdLib.dylib"
                  << "libThresholdLib.so";
-  foreach (const QString& filePath, validFilePaths)
+  for (const QString& filePath : validFilePaths)
   {
     CHECK_BOOL(qSlicerUtils::isCLILoadableModule(filePath), true);
   }
@@ -138,7 +138,7 @@ int isCLILoadableModuleTest()
                    << "Lib.dll"
                    << "libThresholdlib.so"
                    << "Thresholdlib.so";
-  foreach (const QString& filePath, invalidFilePaths)
+  for (const QString& filePath : invalidFilePaths)
   {
     CHECK_BOOL(qSlicerUtils::isCLILoadableModule(filePath), false);
   }
@@ -155,7 +155,7 @@ int isLoadableModuleTest()
                  << "qSlicerThresholdModule.DLL"
                  << "libqSlicerThresholdModule.dylib"
                  << "libqSlicerThresholdModule.so";
-  foreach (const QString& filePath, validFilePaths)
+  for (const QString& filePath : validFilePaths)
   {
     CHECK_BOOL(qSlicerUtils::isLoadableModule(filePath), true);
   }
@@ -167,7 +167,7 @@ int isLoadableModuleTest()
                    << "qSlicerModule.dll"
                    << "libQSlicerThresholdmodule.so"
                    << "QSlicerThresholdmodule.so";
-  foreach (const QString& filePath, invalidFilePaths)
+  for (const QString& filePath : invalidFilePaths)
   {
     CHECK_BOOL(qSlicerUtils::isLoadableModule(filePath), false);
   }
@@ -200,7 +200,7 @@ int executableExtensionTest()
 
   QString expectedModuleName = "VR";
 
-  foreach (const QString& libraryName, libraryNames)
+  for (const QString& libraryName : libraryNames)
   {
     QString moduleName = qSlicerUtils::extractModuleNameFromLibraryName(libraryName);
     CHECK_QSTRING(moduleName, expectedModuleName);
@@ -247,8 +247,7 @@ int isPluginInstalledBuiltinTest()
 
   createFile(__LINE__, tmp1, ".", "CMakeCache.txt");
 
-  foreach (const QString& relativePath,
-           QStringList() << debug << release << relWithDebInfo << minSizeRel << foo << fooDebug << fooRelease << fooBar << fooBarDebug << fooBarRelease)
+  for (const QString& relativePath : QStringList() << debug << release << relWithDebInfo << minSizeRel << foo << fooDebug << fooRelease << fooBar << fooBarDebug << fooBarRelease)
   {
     createFile(__LINE__, tmp1, relativePath, "plugin.txt");
   }
@@ -328,7 +327,7 @@ int isPluginInstalledBuiltinTest()
   tmp3.mkdir(temporaryDirName);
   tmp3.cd(temporaryDirName);
 
-  foreach (const QString& relativePath, QStringList() << foo << fooBar)
+  for (const QString& relativePath : QStringList() << foo << fooBar)
   {
     createFile(__LINE__, tmp1, relativePath, "plugin.txt");
   }
@@ -414,7 +413,7 @@ int isPluginInstalledBuiltinTest()
 #endif
 
   // Clean temporary directories
-  foreach (const QString& dir, directoriesToRemove)
+  for (const QString& dir : directoriesToRemove)
   {
     ctk::removeDirRecursively(dir);
   }
@@ -702,9 +701,8 @@ int setPermissionsRecursivelyTest()
   createFile(__LINE__, tmp, path2, "sol.txt");
 
   // Let's confirm that created file are readable
-  foreach (const QString& relativeFilepath,
-           QStringList() //
-             << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
+  for (const QString& relativeFilepath : QStringList() //
+                                           << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
   {
     CHECK_BOOL((QFile::permissions(tmp.filePath(relativeFilepath)) & QFile::ReadOwner) != 0, true);
   }
@@ -718,9 +716,8 @@ int setPermissionsRecursivelyTest()
   //  https://qt.gitorious.org/qt/qt/blobs/092cd760d5fddf9640a310214fe01929f0fff3a8/src/corelib/io/qfsfileengine_win.cpp#line1781
 
   // Since directory are *NOT* executable, files should *NOT* be readable
-  foreach (const QString& relativeFilepath,
-           QStringList() //
-             << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
+  for (const QString& relativeFilepath : QStringList() //
+                                           << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
   {
     CHECK_BOOL((QFile::permissions(tmp.filePath(relativeFilepath)) & QFile::ReadOwner) != 0, false);
   }
@@ -728,9 +725,8 @@ int setPermissionsRecursivelyTest()
   CHECK_BOOL(qSlicerUtils::setPermissionsRecursively(tmp.path(), QFile::ReadOwner | QFile::ExeOwner, QFile::ReadOwner), true);
 
   // Since directory are executable, files should be readable
-  foreach (const QString& relativeFilepath,
-           QStringList() //
-             << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
+  for (const QString& relativeFilepath : QStringList() //
+                                           << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
   {
     CHECK_BOOL((QFile::permissions(tmp.filePath(relativeFilepath)) & QFile::ReadOwner) != 0, true);
   }
@@ -739,9 +735,8 @@ int setPermissionsRecursivelyTest()
   CHECK_BOOL(ctk::removeDirRecursively(tmp.path()), false);
 #endif
 
-  foreach (const QString& relativeFilepath,
-           QStringList() //
-             << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
+  for (const QString& relativeFilepath : QStringList() //
+                                           << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
   {
     // Since files are read-only, they should *NOT* be writable
     CHECK_BOOL((QFile::permissions(tmp.filePath(relativeFilepath)) & QFile::WriteOwner) != 0, false);
@@ -750,9 +745,8 @@ int setPermissionsRecursivelyTest()
   CHECK_BOOL(qSlicerUtils::setPermissionsRecursively(tmp.path(), QFile::ReadOwner | QFile::ExeOwner | QFile::WriteOwner, QFile::ReadOwner | QFile::WriteOwner), true);
 
   // Make sure files are readable and writable
-  foreach (const QString& relativeFilepath,
-           QStringList() //
-             << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
+  for (const QString& relativeFilepath : QStringList() //
+                                           << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
   {
     CHECK_BOOL((QFile::permissions(tmp.filePath(relativeFilepath)) & QFile::WriteOwner) != 0, true);
   }

--- a/Base/QTCore/qSlicerAbstractModuleFactoryManager.cxx
+++ b/Base/QTCore/qSlicerAbstractModuleFactoryManager.cxx
@@ -76,7 +76,7 @@ void qSlicerAbstractModuleFactoryManagerPrivate::printAdditionalInfo()
 {
   Q_Q(qSlicerAbstractModuleFactoryManager);
   qDebug() << "Factories:";
-  foreach (qSlicerAbstractModuleFactoryManager::qSlicerModuleFactory* factory, this->Factories.keys())
+  for (qSlicerAbstractModuleFactoryManager::qSlicerModuleFactory* const factory : this->Factories.keys())
   {
     // todo: qSlicerModuleFactory should derive from QObject.
     qDebug() << "\t" << typeid(factory).name() << ": ";
@@ -92,7 +92,7 @@ void qSlicerAbstractModuleFactoryManagerPrivate::printAdditionalInfo()
 QVector<qSlicerAbstractModuleFactoryManagerPrivate::qSlicerFileBasedModuleFactory*> qSlicerAbstractModuleFactoryManagerPrivate::fileBasedFactories() const
 {
   QVector<qSlicerFileBasedModuleFactory*> factories;
-  foreach (qSlicerModuleFactory* factory, this->Factories.keys())
+  for (qSlicerModuleFactory* const factory : this->Factories.keys())
   {
     if (dynamic_cast<qSlicerFileBasedModuleFactory*>(factory) != nullptr)
     {
@@ -116,7 +116,7 @@ qSlicerAbstractModuleFactoryManagerPrivate::qSlicerModuleFactory* qSlicerAbstrac
 QVector<qSlicerAbstractModuleFactoryManagerPrivate::qSlicerModuleFactory*> qSlicerAbstractModuleFactoryManagerPrivate::notFileBasedFactories() const
 {
   QVector<qSlicerModuleFactory*> factories;
-  foreach (qSlicerModuleFactory* factory, this->Factories.keys())
+  for (qSlicerModuleFactory* const factory : this->Factories.keys())
   {
     if (dynamic_cast<qSlicerFileBasedModuleFactory*>(factory) == nullptr)
     {
@@ -246,10 +246,10 @@ void qSlicerAbstractModuleFactoryManager::registerModules()
   Q_D(qSlicerAbstractModuleFactoryManager);
   // Register "regular" factories first
   // \todo: don't support factories other than filebased factories
-  foreach (qSlicerModuleFactory* factory, d->notFileBasedFactories())
+  for (qSlicerModuleFactory* const factory : d->notFileBasedFactories())
   {
     factory->registerItems();
-    foreach (const QString& moduleName, factory->itemKeys())
+    for (const QString& moduleName : factory->itemKeys())
     {
       if (d->Verbose)
       {
@@ -260,7 +260,7 @@ void qSlicerAbstractModuleFactoryManager::registerModules()
     }
   }
   // then register file based factories
-  foreach (const QString& path, d->SearchPaths)
+  for (const QString& path : d->SearchPaths)
   {
     if (d->Verbose)
     {
@@ -276,7 +276,7 @@ void qSlicerAbstractModuleFactoryManager::registerModules(const QString& path)
 {
   QDir directory(path);
   /// \tbd recursive search ?
-  foreach (const QFileInfo& file, directory.entryInfoList(QDir::Files))
+  for (const QFileInfo& file : directory.entryInfoList(QDir::Files))
   {
     this->registerModule(file);
   }
@@ -288,7 +288,7 @@ void qSlicerAbstractModuleFactoryManager::registerModule(const QFileInfo& file)
   Q_D(qSlicerAbstractModuleFactoryManager);
 
   qSlicerFileBasedModuleFactory* moduleFactory = nullptr;
-  foreach (qSlicerFileBasedModuleFactory* factory, d->fileBasedFactories())
+  for (qSlicerFileBasedModuleFactory* const factory : d->fileBasedFactories())
   {
     if (d->Verbose)
     {
@@ -363,7 +363,7 @@ void qSlicerAbstractModuleFactoryManager::registerModule(const QFileInfo& file)
 void qSlicerAbstractModuleFactoryManager::instantiateModules()
 {
   Q_D(qSlicerAbstractModuleFactoryManager);
-  foreach (const QString& moduleName, d->RegisteredModules.keys())
+  for (const QString& moduleName : d->RegisteredModules.keys())
   {
     emit moduleAboutToBeInstantiated(moduleName);
     this->instantiateModule(moduleName);
@@ -400,11 +400,11 @@ qSlicerAbstractCoreModule* qSlicerAbstractModuleFactoryManager::instantiateModul
   }
   module->setName(moduleName);
   module->setObjectName(QString("%1Module").arg(moduleName));
-  foreach (const QString& associatedNodeType, module->associatedNodeTypes())
+  for (const QString& associatedNodeType : module->associatedNodeTypes())
   {
     qSlicerCoreApplication::application()->addModuleAssociatedNodeType(associatedNodeType, moduleName);
   }
-  foreach (const QString& dependency, module->dependencies())
+  for (const QString& dependency : module->dependencies())
   {
     QStringList dependees = d->ModuleDependees.value(dependency);
     if (!dependees.contains(moduleName))
@@ -428,7 +428,7 @@ QStringList qSlicerAbstractModuleFactoryManager::instantiatedModuleNames() const
 {
   Q_D(const qSlicerAbstractModuleFactoryManager);
   QStringList instantiatedModules;
-  foreach (const QString& moduleName, d->RegisteredModules.keys())
+  for (const QString& moduleName : d->RegisteredModules.keys())
   {
     qSlicerModuleFactory* factory = d->registeredModuleFactory(moduleName);
     if (!factory)
@@ -448,7 +448,7 @@ void qSlicerAbstractModuleFactoryManager::uninstantiateModules()
 {
   QStringList modulesToUninstantiate = this->instantiatedModuleNames();
   emit modulesAboutToBeUninstantiated(modulesToUninstantiate);
-  foreach (const QString& name, modulesToUninstantiate)
+  for (const QString& name : modulesToUninstantiate)
   {
     this->uninstantiateModule(name);
   }
@@ -502,7 +502,7 @@ bool qSlicerAbstractModuleFactoryManager::isInstantiated(const QString& moduleNa
 void qSlicerAbstractModuleFactoryManager::setVerboseModuleDiscovery(bool verbose)
 {
   Q_D(qSlicerAbstractModuleFactoryManager);
-  foreach (qSlicerModuleFactory* factory, d->Factories.keys())
+  for (qSlicerModuleFactory* const factory : d->Factories.keys())
   {
     factory->setVerbose(verbose);
   }
@@ -513,7 +513,7 @@ void qSlicerAbstractModuleFactoryManager::setVerboseModuleDiscovery(bool verbose
 QStringList qSlicerAbstractModuleFactoryManager::dependentModules(const QString& dependency) const
 {
   QStringList dependents;
-  foreach (const QString& moduleName, this->instantiatedModuleNames())
+  for (const QString& moduleName : this->instantiatedModuleNames())
   {
     qSlicerAbstractCoreModule* coreModule = this->moduleInstance(moduleName);
     if (coreModule && coreModule->dependencies().contains(dependency))

--- a/Base/QTCore/qSlicerAbstractModuleFactoryManager.h
+++ b/Base/QTCore/qSlicerAbstractModuleFactoryManager.h
@@ -254,7 +254,7 @@ void qSlicerAbstractModuleFactoryManager::addSearchPath(const QString& path)
 //-----------------------------------------------------------------------------
 void qSlicerAbstractModuleFactoryManager::removeSearchPaths(const QStringList& paths)
 {
-  foreach (const QString& path, paths)
+  for (const QString& path : paths)
   {
     this->removeSearchPath(path);
   }

--- a/Base/QTCore/qSlicerApplicationUpdateManager.cxx
+++ b/Base/QTCore/qSlicerApplicationUpdateManager.cxx
@@ -164,7 +164,7 @@ bool qSlicerApplicationUpdateManagerPrivate::validateReleaseInfo(const QVariantM
                        << "product_name"
                        << "revision"
                        << "version";
-  foreach (const QString& key, requiredNonEmptyKeys)
+  for (const QString& key : requiredNonEmptyKeys)
   {
     if (releaseInfo.value(key).toString().isEmpty())
     {

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -302,7 +302,7 @@ void qSlicerCoreApplicationPrivate::init()
   {
     QProcessEnvironment updatedEnv;
     ctkAppLauncherEnvironment::saveEnvironment(this->Environment, this->Environment.keys(), updatedEnv);
-    foreach (const QString& varname, updatedEnv.keys())
+    for (const QString& varname : updatedEnv.keys())
     {
       q->setEnvironmentVariable(varname, updatedEnv.value(varname));
     }
@@ -320,13 +320,13 @@ void qSlicerCoreApplicationPrivate::init()
 
   // Regular environment variables
   QHash<QString, QString> envVars = appLauncherSettings.envVars();
-  foreach (const QString& key, envVars.keys())
+  for (const QString& key : envVars.keys())
   {
     q->setEnvironmentVariable(key, envVars.value(key));
   }
   // Path environment variables (includes PATH, (DY)LD_LIBRARY_PATH and variables like PYTHONPATH)
   QHash<QString, QStringList> pathsEnvVars = appLauncherSettings.pathsEnvVars();
-  foreach (const QString& key, pathsEnvVars.keys())
+  for (const QString& key : pathsEnvVars.keys())
   {
     QString value;
     if (this->Environment.contains(key))
@@ -361,7 +361,7 @@ void qSlicerCoreApplicationPrivate::init()
   // Load default settings if any.
   if (q->defaultSettings())
   {
-    foreach (const QString& key, q->defaultSettings()->allKeys())
+    for (const QString& key : q->defaultSettings()->allKeys())
     {
       if (!q->userSettings()->contains(key))
       {
@@ -523,14 +523,14 @@ void qSlicerCoreApplicationPrivate::init()
 
   QStringList updatedExtensions;
   model->updateScheduledExtensions(updatedExtensions);
-  foreach (const QString& extensionName, updatedExtensions)
+  for (const QString& extensionName : updatedExtensions)
   {
     qDebug() << "Successfully updated extension" << extensionName;
   }
 
   QStringList uninstalledExtensions;
   model->uninstallScheduledExtensions(uninstalledExtensions);
-  foreach (const QString& extensionName, uninstalledExtensions)
+  for (const QString& extensionName : uninstalledExtensions)
   {
     qDebug() << "Successfully uninstalled extension" << extensionName;
   }
@@ -720,7 +720,7 @@ QString qSlicerCoreApplicationPrivate::discoverSlicerHomeDirectory()
   Q_Q(qSlicerCoreApplication);
   if (!this->isInstalled(slicerHome))
   {
-    foreach (const QString& subDir, QStringList() << Slicer_BIN_DIR << Slicer_CLIMODULES_BIN_DIR << "Cxx")
+    for (const QString& subDir : QStringList() << Slicer_BIN_DIR << Slicer_CLIMODULES_BIN_DIR << "Cxx")
     {
       qSlicerUtils::pathWithoutIntDir(q->applicationDirPath(), subDir, this->IntDir);
       if (!this->IntDir.isEmpty())
@@ -1134,7 +1134,7 @@ void qSlicerCoreApplication::handleURIArguments(const QStringList& fileNames)
 {
   QStringList filesToLoad;
 
-  foreach (QString fileName, fileNames)
+  for (const QString& fileName : fileNames)
   {
     QUrl url = QUrl(fileName);
     if (url.scheme().toLower() == this->applicationName().toLower()) // Scheme is case insensitive
@@ -2084,7 +2084,7 @@ void qSlicerCoreApplication::loadTranslations(const QString& dir)
 
   QStringList qmFiles = qSlicerCoreApplicationPrivate::findTranslationFiles(dir, app->applicationLocaleName());
 
-  foreach (QString qmFile, qmFiles)
+  for (const QString& qmFile : qmFiles)
   {
     QTranslator* translator = new QTranslator();
     QString qmFilePath = QString(dir + QString("/") + qmFile);
@@ -2136,7 +2136,7 @@ void qSlicerCoreApplication::loadLanguage()
     return;
   }
   QStringList qmDirs = qSlicerCoreApplication::translationFolders();
-  foreach (QString qmDir, qmDirs)
+  for (const QString& qmDir : qmDirs)
   {
     app->loadTranslations(qmDir);
   }
@@ -2264,7 +2264,7 @@ QStringList qSlicerCoreApplication::toSlicerHomeAbsolutePaths(const QStringList&
 {
   Q_D(const qSlicerCoreApplication);
   QStringList absolutePaths;
-  foreach (QString path, paths)
+  for (const QString& path : paths)
   {
     absolutePaths << this->toSlicerHomeAbsolutePath(path);
   }
@@ -2276,7 +2276,7 @@ QStringList qSlicerCoreApplication::toSlicerHomeRelativePaths(const QStringList&
 {
   Q_D(const qSlicerCoreApplication);
   QStringList relativePaths;
-  foreach (QString path, paths)
+  for (const QString& path : paths)
   {
     relativePaths << this->toSlicerHomeRelativePath(path);
   }
@@ -2368,7 +2368,7 @@ QString qSlicerCoreApplication::moduleDocumentationUrl(const QString& moduleName
 bool qSlicerCoreApplication::loadFiles(const QStringList& filePaths, vtkMRMLMessageCollection* userMessages /*=nullptr*/)
 {
   bool success = true;
-  foreach (QString filePath, filePaths)
+  for (const QString& filePath : filePaths)
   {
     QFileInfo file(filePath);
     qSlicerCoreIOManager* ioManager = this->coreIOManager();

--- a/Base/QTCore/qSlicerCoreIOManager.cxx
+++ b/Base/QTCore/qSlicerCoreIOManager.cxx
@@ -103,7 +103,7 @@ QList<qSlicerFileReader*> qSlicerCoreIOManagerPrivate::readers(const QString& fi
 {
   // Use a map so that we can access readers sorted by confidence.
   QMultiMap<double, qSlicerFileReader*> matchingReadersSortedByConfidence;
-  foreach (qSlicerFileReader* reader, this->Readers)
+  for (qSlicerFileReader* const reader : this->Readers)
   {
     double confidence = reader->canLoadFileConfidence(fileName);
     if (confidence > 0.0)
@@ -152,16 +152,16 @@ QList<qSlicerFileWriter*> qSlicerCoreIOManagerPrivate::writers(const qSlicerIO::
   // that writers associated with specific file extension are
   // considered first.
   QList<qSlicerFileWriter*> genericWriters;
-  foreach (qSlicerFileWriter* writer, this->Writers)
+  for (qSlicerFileWriter* const writer : this->Writers)
   {
     if (writer->fileType() != fileType)
     {
       continue;
     }
     QStringList matchingNameFilters;
-    foreach (const QString& nameFilter, writer->extensions(object))
+    for (const QString& nameFilter : writer->extensions(object))
     {
-      foreach (const QString& extension, ctk::nameFilterToExtensions(nameFilter))
+      for (const QString& extension : ctk::nameFilterToExtensions(nameFilter))
       {
         // HACK - See https://github.com/Slicer/Slicer/issues/3322
         QString extensionWithStar(extension);
@@ -182,7 +182,7 @@ QList<qSlicerFileWriter*> qSlicerCoreIOManagerPrivate::writers(const qSlicerIO::
       continue;
     }
     // Generic readers must be added to the end
-    foreach (const QString& nameFilter, matchingNameFilters)
+    for (const QString& nameFilter : matchingNameFilters)
     {
       if (nameFilter.contains("*.*") || nameFilter.contains("(*)"))
       {
@@ -195,7 +195,7 @@ QList<qSlicerFileWriter*> qSlicerCoreIOManagerPrivate::writers(const qSlicerIO::
       }
     }
   }
-  foreach (qSlicerFileWriter* writer, genericWriters)
+  for (qSlicerFileWriter* const writer : genericWriters)
   {
     if (!matchingWriters.contains(writer))
     {
@@ -248,7 +248,7 @@ qSlicerFileWriter* qSlicerCoreIOManager::writer(vtkObject* object, const QString
   qSlicerFileWriter* closestMatch = nullptr;
   double closestMatchConfidence = 0.0;
 
-  foreach (qSlicerFileWriter* writer, d->Writers)
+  for (qSlicerFileWriter* const writer : d->Writers)
   {
     double confidence = writer->canWriteObjectConfidence(object);
     if (confidence > 0.0)
@@ -302,7 +302,7 @@ QList<qSlicerIO::IOFileType> qSlicerCoreIOManager::fileTypes(const QString& file
 {
   Q_D(const qSlicerCoreIOManager);
   QList<qSlicerIO::IOFileType> matchingFileTypes;
-  foreach (const qSlicerIO* matchingReader, d->readers(fileName))
+  for (const qSlicerIO* matchingReader : d->readers(fileName))
   {
     matchingFileTypes << matchingReader->fileType();
   }
@@ -314,7 +314,7 @@ QStringList qSlicerCoreIOManager::fileDescriptions(const QString& fileName) cons
 {
   Q_D(const qSlicerCoreIOManager);
   QStringList matchingDescriptions;
-  foreach (qSlicerFileReader* reader, d->readers(fileName))
+  for (qSlicerFileReader* const reader : d->readers(fileName))
   {
     matchingDescriptions << reader->description();
   }
@@ -325,7 +325,7 @@ QStringList qSlicerCoreIOManager::fileDescriptions(const QString& fileName) cons
 QStringList qSlicerCoreIOManager::fileDescriptionsByType(const qSlicerIO::IOFileType fileType) const
 {
   QStringList matchingDescriptions;
-  foreach (qSlicerFileReader* reader, this->readers())
+  for (qSlicerFileReader* const reader : this->readers())
   {
     if (reader->fileType() == fileType)
     {
@@ -339,7 +339,7 @@ QStringList qSlicerCoreIOManager::fileDescriptionsByType(const qSlicerIO::IOFile
 QStringList qSlicerCoreIOManager::fileWriterDescriptions(const qSlicerIO::IOFileType& fileType) const
 {
   QStringList matchingDescriptions;
-  foreach (qSlicerFileWriter* writer, this->writers(fileType))
+  for (qSlicerFileWriter* const writer : this->writers(fileType))
   {
     matchingDescriptions << writer->description();
   }
@@ -352,7 +352,7 @@ QStringList qSlicerCoreIOManager::fileWriterExtensions(vtkObject* object) const
   Q_D(const qSlicerCoreIOManager);
   // Use a map so that we can access writers sorted by confidence.
   QMultiMap<double, qSlicerFileWriter*> matchingWritersSortedByConfidence;
-  foreach (qSlicerFileWriter* writer, d->Writers)
+  for (qSlicerFileWriter* const writer : d->Writers)
   {
     double confidence = writer->canWriteObjectConfidence(object);
     if (confidence > 0.0)
@@ -492,7 +492,7 @@ QString qSlicerCoreIOManager::forceFileNameMaxLength(const QString& filename, in
 QString qSlicerCoreIOManager::extractKnownExtension(const QString& fileName, vtkObject* object)
 {
   QString longestMatchedExtension;
-  foreach (const QString& nameFilter, this->fileWriterExtensions(object))
+  for (const QString& nameFilter : this->fileWriterExtensions(object))
   {
     QString extension = QString::fromStdString(vtkDataFileFormatHelper::GetFileExtensionFromFormatString(nameFilter.toUtf8()));
     if (!extension.isEmpty() && fileName.endsWith(extension))
@@ -604,7 +604,7 @@ bool qSlicerCoreIOManager::loadNodes(const qSlicerIO::IOFileType& fileType,
     QStringList fileNames = parameters["fileName"].toStringList();
     QStringList names = parameters["name"].toStringList();
     int nameId = 0;
-    foreach (const QString& fileName, fileNames)
+    for (const QString& fileName : fileNames)
     {
       qSlicerIO::IOProperties fileParameters = parameters;
       fileParameters["fileName"] = fileName;
@@ -631,7 +631,7 @@ bool qSlicerCoreIOManager::loadNodes(const qSlicerIO::IOFileType& fileType,
   QString userMessagePrefix = tr("Loading %1").arg(parameters["fileName"].toString()) + " - ";
 
   QStringList nodes;
-  foreach (qSlicerFileReader* reader, readers)
+  for (qSlicerFileReader* const reader : readers)
   {
     QElapsedTimer timeProbe;
     timeProbe.start();
@@ -671,7 +671,7 @@ bool qSlicerCoreIOManager::loadNodes(const qSlicerIO::IOFileType& fileType,
 
   if (loadedNodes)
   {
-    foreach (const QString& node, nodes)
+    for (const QString& node : nodes)
     {
       vtkMRMLNode* loadedNode = d->currentScene()->GetNodeByID(node.toUtf8());
       if (!loadedNode)
@@ -690,7 +690,7 @@ bool qSlicerCoreIOManager::loadNodes(const qSlicerIO::IOFileType& fileType,
 bool qSlicerCoreIOManager::loadNodes(const QList<qSlicerIO::IOProperties>& files, vtkCollection* loadedNodes, vtkMRMLMessageCollection* userMessages /*=nullptr*/)
 {
   bool success = true;
-  foreach (qSlicerIO::IOProperties fileProperties, files)
+  for (qSlicerIO::IOProperties fileProperties : files)
   {
     int numberOfUserMessagesBefore = userMessages ? userMessages->GetNumberOfMessages() : 0;
     success = this->loadNodes(                                                             //
@@ -853,7 +853,7 @@ bool qSlicerCoreIOManager::saveNodes(qSlicerIO::IOFileType fileType,
 
   QStringList nodes;
   bool writeSuccess = false;
-  foreach (qSlicerFileWriter* writer, writers)
+  for (qSlicerFileWriter* const writer : writers)
   {
     writer->setMRMLScene(scene);
     writer->userMessages()->ClearMessages();
@@ -1097,7 +1097,7 @@ QList<qSlicerFileReader*> qSlicerCoreIOManager::readers(const qSlicerIO::IOFileT
 {
   Q_D(const qSlicerCoreIOManager);
   QList<qSlicerFileReader*> res;
-  foreach (qSlicerFileReader* io, d->Readers)
+  for (qSlicerFileReader* const io : d->Readers)
   {
     if (io->fileType() == fileType)
     {
@@ -1112,7 +1112,7 @@ QList<qSlicerFileWriter*> qSlicerCoreIOManager::writers(const qSlicerIO::IOFileT
 {
   Q_D(const qSlicerCoreIOManager);
   QList<qSlicerFileWriter*> res;
-  foreach (qSlicerFileWriter* io, d->Writers)
+  for (qSlicerFileWriter* const io : d->Writers)
   {
     if (io->fileType() == fileType)
     {
@@ -1127,7 +1127,7 @@ qSlicerFileReader* qSlicerCoreIOManager::reader(const QString& ioDescription) co
 {
   Q_D(const qSlicerCoreIOManager);
   QList<qSlicerFileReader*> res;
-  foreach (qSlicerFileReader* io, d->Readers)
+  for (qSlicerFileReader* const io : d->Readers)
   {
     if (io->description() == ioDescription)
     {
@@ -1192,7 +1192,7 @@ bool qSlicerCoreIOManager::examineFileInfoList(QFileInfoList& fileInfoList, QFil
 {
   Q_D(const qSlicerCoreIOManager);
   QList<qSlicerFileReader*> res;
-  foreach (qSlicerFileReader* reader, d->Readers)
+  for (qSlicerFileReader* const reader : d->Readers)
   {
     // TODO: currently the first reader that accepts the list will be used, but nothing
     // guarantees that the first reader is the most suitable choice (e.g., volume reader

--- a/Base/QTCore/qSlicerCorePythonManager.cxx
+++ b/Base/QTCore/qSlicerCorePythonManager.cxx
@@ -133,7 +133,7 @@ void qSlicerCorePythonManager::appendPythonPath(const QString& path)
 //-----------------------------------------------------------------------------
 void qSlicerCorePythonManager::appendPythonPaths(const QStringList& paths)
 {
-  foreach (const QString& path, paths)
+  for (const QString& path : paths)
   {
     this->appendPythonPath(path);
   }

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -312,7 +312,7 @@ void qSlicerExtensionsManagerModelPrivate::init()
   // See https://www.developer.nokia.com/Community/Wiki/Using_QStandardItemModel_in_QML
   QHash<int, QByteArray> roleNames;
   int columnIdx = 0;
-  foreach (const QString& columnName, this->columnNames())
+  for (const QString& columnName : this->columnNames())
   {
     roleNames[Qt::UserRole + 1 + columnIdx] = columnName.toUtf8();
     ++columnIdx;
@@ -407,7 +407,7 @@ void qSlicerExtensionsManagerModelPrivate::saveExtensionsMetadataFromServerToCac
 
   // Convert to json to allow writing to settings TODO: use filename instead?
   QJsonObject jsonExtensionsMetadata;
-  foreach (const QString& extensionName, this->ExtensionsMetadataFromServer.keys())
+  for (const QString& extensionName : this->ExtensionsMetadataFromServer.keys())
   {
     QJsonObject metadata = QJsonObject::fromVariantMap(this->ExtensionsMetadataFromServer[extensionName]);
     jsonExtensionsMetadata.insert(extensionName, metadata);
@@ -456,7 +456,7 @@ void qSlicerExtensionsManagerModelPrivate::loadCachedExtensionsMetadataFromServe
   QJsonObject jsonExtensionsMetadata = jsonDoc.object();
 
   // Convert from json to string->QVariantMap map
-  foreach (const QString& extensionName, jsonExtensionsMetadata.keys())
+  for (const QString& extensionName : jsonExtensionsMetadata.keys())
   {
     QJsonObject jsonMetadata = jsonExtensionsMetadata[extensionName].toObject();
     QVariantMap metadata = jsonMetadata.toVariantMap();
@@ -527,7 +527,7 @@ void qSlicerExtensionsManagerModelPrivate::addExtensionModelRow(const ExtensionM
     // Extension is in the model already, update items
     int row = foundItems.at(0)->row();
     int column = 0;
-    foreach (const QString& key, this->columnNames())
+    for (const QString& key : this->columnNames())
     {
       QString value = metadata.value(key).toString();
       QStandardItem* item = this->Model.item(row, column);
@@ -540,7 +540,7 @@ void qSlicerExtensionsManagerModelPrivate::addExtensionModelRow(const ExtensionM
   {
     // Extension is not in the model yet, create new row
     QList<QStandardItem*> itemList;
-    foreach (const QString& key, this->columnNames())
+    for (const QString& key : this->columnNames())
     {
       QString value = metadata.value(key).toString();
       QStandardItem* item = new QStandardItem(value);
@@ -578,7 +578,7 @@ namespace
 bool hasPath(const QStringList& paths, const QString& pathToCheck)
 {
   QString dirToCheck = QDir::cleanPath(pathToCheck);
-  foreach (const QString& path, paths)
+  for (const QString& path : paths)
   {
     if (dirToCheck == QDir::cleanPath(path))
     {
@@ -592,7 +592,7 @@ bool hasPath(const QStringList& paths, const QString& pathToCheck)
 QStringList appendToPathList(const QStringList& paths, const QStringList& pathsToAppend, bool shouldExist = true)
 {
   QStringList updatedPaths(paths);
-  foreach (const QString& pathToAppend, pathsToAppend)
+  for (const QString& pathToAppend : pathsToAppend)
   {
     if (hasPath(updatedPaths, pathToAppend))
     {
@@ -613,7 +613,7 @@ QStringList appendToPathList(const QStringList& paths, const QStringList& pathsT
 QStringList removeFromPathList(QStringList& paths, const QString& pathToRemove)
 {
   QDir extensionDir(pathToRemove);
-  foreach (const QString& path, paths)
+  for (const QString& path : paths)
   {
     if (extensionDir == QDir(path))
     {
@@ -628,7 +628,7 @@ QStringList removeFromPathList(QStringList& paths, const QString& pathToRemove)
 QStringList removeFromPathList(const QStringList& paths, const QStringList& pathsToRemove)
 {
   QStringList updatedPaths(paths);
-  foreach (const QString& pathToRemove, pathsToRemove)
+  for (const QString& pathToRemove : pathsToRemove)
   {
     removeFromPathList(updatedPaths, pathToRemove);
   }
@@ -979,7 +979,7 @@ bool qSlicerExtensionsManagerModelPrivate::validateExtensionMetadata(const Exten
     return false;
   }
   // Check required keys (error if missing)
-  foreach (const QString& key, requiredNonEmptyKeys)
+  for (const QString& key : requiredNonEmptyKeys)
   {
     if (extensionMetadata.value(key).toString().isEmpty())
     {
@@ -988,7 +988,7 @@ bool qSlicerExtensionsManagerModelPrivate::validateExtensionMetadata(const Exten
     }
   }
   // Check expected keys (warning if missing)
-  foreach (const QString& key, expectedNonEmptyKeys)
+  for (const QString& key : expectedNonEmptyKeys)
   {
     if (extensionMetadata.value(key).toString().isEmpty())
     {
@@ -1274,7 +1274,7 @@ qSlicerExtensionsManagerModel::ExtensionMetadataType qSlicerExtensionsManagerMod
     if (item)
     {
       int row = item->row();
-      foreach (const QString& columnName, d->columnNames())
+      for (const QString& columnName : d->columnNames())
       {
         metadata.insert(columnName, d->Model.data(d->Model.index(row, d->columnNames().indexOf(columnName)), Qt::DisplayRole).toString());
       }
@@ -1641,7 +1641,7 @@ bool qSlicerExtensionsManagerModel::downloadAndInstallExtension(const QString& e
   }
 
   // Find extension name by ID
-  foreach (const QString& extensionName, d->ExtensionsMetadataFromServer.keys())
+  for (const QString& extensionName : d->ExtensionsMetadataFromServer.keys())
   {
     if (d->ExtensionsMetadataFromServer[extensionName].value("extension_id") == extensionId)
     {
@@ -1706,7 +1706,7 @@ bool qSlicerExtensionsManagerModel::installExtensionFromServer(const QString& ex
       {
         return false;
       }
-      foreach (const QString& extensionName, updatedExtensions)
+      for (const QString& extensionName : updatedExtensions)
       {
         qDebug() << "Successfully updated extension" << extensionName;
       }
@@ -1922,7 +1922,7 @@ bool qSlicerExtensionsManagerModel::installExtension(const QString& extensionNam
                  << /*no tr*/ "status" << /*no tr*/ "updated";
 
     const ExtensionMetadataType::const_iterator notFound = extensionIndexMetadata.constEnd();
-    foreach (const QString& key, expectedKeys)
+    for (const QString& key : expectedKeys)
     {
       const ExtensionMetadataType::const_iterator iter = extensionIndexMetadata.constFind(key);
       if (iter != notFound)
@@ -1961,7 +1961,7 @@ bool qSlicerExtensionsManagerModel::installExtension(const QString& extensionNam
       if (d->Interactive && !d->AutoInstallDependencies)
       {
         QString msg = QString("<p>%1 depends on the following extensions:</p><ul>").arg(extensionName);
-        foreach (const QString& dependencyName, dependenciesToInstall)
+        for (const QString& dependencyName : dependenciesToInstall)
         {
           msg += QString("<li>%1</li>").arg(dependencyName);
         }
@@ -1979,7 +1979,7 @@ bool qSlicerExtensionsManagerModel::installExtension(const QString& extensionNam
       {
         // Install dependencies
         QString msg;
-        foreach (const QString& dependency, dependenciesToInstall)
+        for (const QString& dependency : dependenciesToInstall)
         {
           bool res = this->downloadAndInstallExtensionByName(dependency, false /*installation of dependencies already confirmed*/);
           if (!res)
@@ -2010,7 +2010,7 @@ bool qSlicerExtensionsManagerModel::installExtension(const QString& extensionNam
       {
         //: %1 is the extension name
         QString msg = QString("<p>%1</p><ul>").arg(tr("%1 depends on the following extensions, which could not be found:").arg(extensionName));
-        foreach (const QString& dependencyName, unresolvedDependencies)
+        for (const QString& dependencyName : unresolvedDependencies)
         {
           msg += QString("<li>%1</li>").arg(dependencyName);
         }
@@ -2177,7 +2177,7 @@ bool qSlicerExtensionsManagerModel::onExtensionsMetadataFromServerQueryFinished(
   d->ExtensionsMetadataFromServer.clear();
 
   // Process response
-  foreach (const QVariantMap& result, restResult->results())
+  for (const QVariantMap& result : restResult->results())
   {
     // Get extension information from server response
     ExtensionMetadataType serverExtensionMetadata = qRestAPI::qVariantMapFlattened(result);
@@ -2207,7 +2207,7 @@ void qSlicerExtensionsManagerModel::checkForExtensionsUpdates()
   bool updatedExtensionsFound = false;
 
   QSettings settings;
-  foreach (const QString& extensionName, d->ExtensionsMetadataFromServer.keys())
+  for (const QString& extensionName : d->ExtensionsMetadataFromServer.keys())
   {
     ExtensionMetadataType metadata = d->ExtensionsMetadataFromServer[extensionName];
     // Check for updates
@@ -2654,7 +2654,7 @@ bool qSlicerExtensionsManagerModelPrivate::removeExtensionDescriptionFile(const 
   // Remove icon file
   const QDir installDir(q->extensionsInstallPath());
   const QFileInfoList& iconEntries = installDir.entryInfoList(QStringList() << extensionName + "-icon.*");
-  foreach (const QFileInfo& iconEntry, iconEntries)
+  for (const QFileInfo& iconEntry : iconEntries)
   {
     success = success && QFile::remove(iconEntry.absoluteFilePath());
   }
@@ -2711,7 +2711,7 @@ bool qSlicerExtensionsManagerModel::uninstallScheduledExtensions()
 bool qSlicerExtensionsManagerModel::uninstallScheduledExtensions(QStringList& uninstalledExtensions)
 {
   bool result = true;
-  foreach (const QString& extensionName, this->scheduledForUninstallExtensions())
+  for (const QString& extensionName : this->scheduledForUninstallExtensions())
   {
     const bool success = this->uninstallExtension(extensionName);
     if (success)
@@ -2738,7 +2738,7 @@ void qSlicerExtensionsManagerModel::updateModel()
   // First just gather extensions, we'll sort and group them before adding to the model
   QStringList installedExtensions;
   QMap<QString, ExtensionMetadataType> extensionsMetadataFromDescriptionFiles;
-  foreach (const QFileInfo& fileInfo, d->extensionDescriptionFileInfos(extensionDescriptionPath))
+  for (const QFileInfo& fileInfo : d->extensionDescriptionFileInfos(extensionDescriptionPath))
   {
     ExtensionMetadataType metadata = Self::parseExtensionDescriptionFile(fileInfo.absoluteFilePath());
     QString extensionName = metadata["extensionname"].toString();
@@ -2767,7 +2767,7 @@ void qSlicerExtensionsManagerModel::updateModel()
   managedExtensions << installedExtensions;
   managedExtensions.removeDuplicates();
   managedExtensions.sort(Qt::CaseInsensitive);
-  foreach (const QString& extensionName, managedExtensions)
+  for (const QString& extensionName : managedExtensions)
   {
     if (extensionsMetadataFromDescriptionFiles.contains(extensionName))
     {
@@ -2868,7 +2868,7 @@ void qSlicerExtensionsManagerModel::setSlicerRequirements(const QString& revisio
 void qSlicerExtensionsManagerModel::identifyIncompatibleExtensions()
 {
   Q_D(const qSlicerExtensionsManagerModel);
-  foreach (const QString& extensionName, this->installedExtensions())
+  for (const QString& extensionName : this->installedExtensions())
   {
     QStringList reasons = this->isExtensionCompatible(extensionName, d->SlicerRevision, d->SlicerOs, d->SlicerArch);
     if (!reasons.isEmpty())
@@ -3002,7 +3002,7 @@ qSlicerExtensionsManagerModel::ExtensionMetadataType qSlicerExtensionsManagerMod
 {
   ExtensionMetadataType updatedExtensionMetadata;
   QHash<QString, QString> serverToExtensionDescriptionKey = Self::serverToExtensionDescriptionKey(serverAPI);
-  foreach (const QString& key, extensionMetadata.keys())
+  for (const QString& key : extensionMetadata.keys())
   {
     updatedExtensionMetadata.insert(serverToExtensionDescriptionKey.value(key, key), extensionMetadata.value(key));
   }
@@ -3039,7 +3039,7 @@ qSlicerExtensionsManagerModel::ExtensionMetadataType qSlicerExtensionsManagerMod
   QStringList extensionMetadataKeys = serverToExtensionDescriptionKey(serverAPI).values();
 
   ExtensionMetadataType filteredExtensionMetadata = extensionMetadata;
-  foreach (const QString& key, Self::serverKeysToIgnore(serverAPI))
+  for (const QString& key : Self::serverKeysToIgnore(serverAPI))
   {
     // Do not remove entry if the corresponding key may be returned
     // by "convertExtensionMetadata()".
@@ -3178,7 +3178,7 @@ bool qSlicerExtensionsManagerModel::writeExtensionDescriptionFile(const QString&
     return false;
   }
   QTextStream outputStream(&outputFile);
-  foreach (const QString& key, metadata.keys())
+  for (const QString& key : metadata.keys())
   {
     if (key == "extensionname" // name is defined by the s4ext filename
         || key == "bookmarked" // bookmarked extensions are stored in application settings
@@ -3257,7 +3257,7 @@ bool qSlicerExtensionsManagerModel::exportExtensionList(QString& exportFilePath)
   }
   QTextStream exportStream(&exportFile);
 
-  foreach (const QFileInfo& fileInfo, d->extensionDescriptionFileInfos(extensionDescriptionPath))
+  for (const QFileInfo& fileInfo : d->extensionDescriptionFileInfos(extensionDescriptionPath))
   {
     QFile inputFile(fileInfo.absoluteFilePath());
     if (!inputFile.open(QFile::ReadOnly))

--- a/Base/QTCore/qSlicerFileReader.cxx
+++ b/Base/QTCore/qSlicerFileReader.cxx
@@ -88,9 +88,9 @@ QStringList qSlicerFileReader::supportedNameFilters(const QString& fileName, int
   {
     return matchingNameFilters;
   }
-  foreach (const QString& nameFilter, this->extensions())
+  for (const QString& nameFilter : this->extensions())
   {
-    foreach (QString extension, ctk::nameFilterToExtensions(nameFilter))
+    for (QString extension : ctk::nameFilterToExtensions(nameFilter))
     {
       QRegExp regExp(extension, Qt::CaseInsensitive, QRegExp::Wildcard);
       Q_ASSERT(regExp.isValid());

--- a/Base/QTCore/qSlicerModuleFactoryManager.cxx
+++ b/Base/QTCore/qSlicerModuleFactoryManager.cxx
@@ -81,7 +81,7 @@ void qSlicerModuleFactoryManager::printAdditionalInfo()
 //-----------------------------------------------------------------------------
 int qSlicerModuleFactoryManager::loadModules()
 {
-  foreach (const QString& name, this->instantiatedModuleNames())
+  for (const QString& name : this->instantiatedModuleNames())
   {
     this->loadModule(name);
   }
@@ -93,13 +93,13 @@ int qSlicerModuleFactoryManager::loadModules()
 bool qSlicerModuleFactoryManager::loadModules(const QStringList& modules)
 {
   // Ensure requested modules are instantiated
-  foreach (const QString& moduleKey, modules)
+  for (const QString& moduleKey : modules)
   {
     this->instantiateModule(moduleKey);
   }
 
   // Load requested modules
-  foreach (const QString& moduleKey, modules)
+  for (const QString& moduleKey : modules)
   {
     if (!this->loadModule(moduleKey))
     {
@@ -163,7 +163,7 @@ bool qSlicerModuleFactoryManager::loadModule(const QString& name, const QString&
 
   // Load the modules the module depends on.
   // There is no cycle check, so be careful
-  foreach (const QString& dependency, instance->dependencies())
+  for (const QString& dependency : instance->dependencies())
   {
     // no-op if the module is already loaded
     bool dependencyLoaded = this->loadModule(dependency, name);
@@ -226,7 +226,7 @@ void qSlicerModuleFactoryManager::unloadModules()
   std::reverse(modulesToUnload.begin(), modulesToUnload.end());
   emit this->modulesAboutToBeUnloaded(modulesToUnload);
   emit this->modulesAboutToBeUninstantiated(modulesToUnload);
-  foreach (const QString& name, modulesToUnload)
+  for (const QString& name : modulesToUnload)
   {
     this->unloadModule(name);
   }
@@ -332,7 +332,7 @@ QStringList qSlicerModuleFactoryManager::modulePaths(const QString& basePath)
 #endif
   subPaths << Slicer_QTLOADABLEMODULES_LIB_DIR;
 
-  foreach (const QString& subPath, subPaths)
+  for (const QString& subPath : subPaths)
   {
     QString candidatePath = QDir(basePath).filePath(subPath);
     if (QDir(candidatePath).exists())

--- a/Base/QTCore/qSlicerPersistentCookieJar.cxx
+++ b/Base/QTCore/qSlicerPersistentCookieJar.cxx
@@ -99,7 +99,7 @@ QList<QNetworkCookie> qSlicerPersistentCookieJar::cookiesForUrl(const QUrl& url)
   QList<QNetworkCookie> cookieList;
   settings.beginGroup(url.host());
   QStringList keys = settings.childKeys();
-  foreach (const QString& key, keys)
+  for (const QString& key : keys)
   {
     cookieList << QNetworkCookie(key.toUtf8(), settings.value(key).toString().toUtf8());
   }
@@ -112,7 +112,7 @@ bool qSlicerPersistentCookieJar::setCookiesFromUrl(const QList<QNetworkCookie>& 
   Q_D(qSlicerPersistentCookieJar);
   QSettings settings(d->FilePath, QSettings::IniFormat);
   settings.beginGroup(url.host());
-  foreach (const QNetworkCookie& cookie, cookieList)
+  for (const QNetworkCookie& cookie : cookieList)
   {
     settings.setValue(cookie.name(), cookie.value());
   }

--- a/Base/QTCore/qSlicerScriptedUtils.cxx
+++ b/Base/QTCore/qSlicerScriptedUtils.cxx
@@ -203,7 +203,7 @@ PyObject* qSlicerPythonCppAPI::instantiateClass(QObject* cpp, const QString& cla
     return nullptr;
   }
 
-  foreach (int methodId, this->APIMethods.keys())
+  for (const int& methodId : this->APIMethods.keys())
   {
     QString methodName = this->APIMethods.value(methodId);
     if (!PyObject_HasAttrString(self.object(), methodName.toUtf8()))

--- a/Base/QTCore/qSlicerUtils.cxx
+++ b/Base/QTCore/qSlicerUtils.cxx
@@ -40,7 +40,7 @@ bool qSlicerUtils::isExecutableName(const QString& name)
   extensions << ".bat" << ".com" << ".sh" << ".csh" << ".tcsh"
              << ".pl" << ".py" << ".tcl" << ".m" << ".exe";
 
-  foreach (const QString& extension, extensions)
+  for (const QString& extension : extensions)
   {
     if (name.endsWith(extension, Qt::CaseInsensitive))
     {
@@ -103,7 +103,7 @@ bool qSlicerUtils::isLoadableModule(const QString& filePath)
 bool qSlicerUtils::isTestingModule(qSlicerAbstractCoreModule* module)
 {
   const QStringList& categories = module->categories();
-  foreach (const QString& category, categories)
+  for (const QString& category : categories)
   {
     if (category.split('.').takeFirst() != "Testing")
     {
@@ -120,7 +120,7 @@ QString qSlicerUtils::searchTargetInIntDir(const QString& directory, const QStri
   QStringList intDirs;
   intDirs << "." << "Debug" << "RelWithDebInfo" << "Release" << "MinSizeRel";
   QString intDir = directory + "/%2/" + target;
-  foreach (const QString& subdir, intDirs)
+  for (const QString& subdir : intDirs)
   {
     if (QFile::exists(intDir.arg(subdir)))
     {
@@ -256,7 +256,7 @@ bool qSlicerUtils::setPermissionsRecursively(const QString& path, QFile::Permiss
     return false;
   }
 
-  foreach (const QFileInfo& info, QDir(path).entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot))
+  for (const QFileInfo& info : QDir(path).entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot))
   {
     if (info.isDir())
     {

--- a/Base/QTGUI/Testing/Cxx/qSlicerModuleGenericTest.cxx.in
+++ b/Base/QTGUI/Testing/Cxx/qSlicerModuleGenericTest.cxx.in
@@ -81,7 +81,7 @@ int qSlicer@MODULENAME@ModuleGenericTest(int argc, char* argv[])
              << moduleFactoryManager->instantiatedModuleNames().count();
 
     // Load all available modules
-    foreach (const QString& name, moduleFactoryManager->instantiatedModuleNames())
+    for (const QString& name: moduleFactoryManager->instantiatedModuleNames())
     {
       Q_ASSERT(!name.isNull());
       moduleFactoryManager->loadModule(name);

--- a/Base/QTGUI/Testing/Cxx/qSlicerModuleWidgetGenericTest.cxx.in
+++ b/Base/QTGUI/Testing/Cxx/qSlicerModuleWidgetGenericTest.cxx.in
@@ -89,7 +89,7 @@ int qSlicer@MODULENAME@ModuleWidgetGenericTest(int argc, char* argv[])
              << moduleFactoryManager->instantiatedModuleNames().count();
 
     // Load all available modules
-    foreach (const QString& name, moduleFactoryManager->instantiatedModuleNames())
+    for (const QString& name: moduleFactoryManager->instantiatedModuleNames())
     {
       Q_ASSERT(!name.isNull());
       moduleFactoryManager->loadModule(name);

--- a/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
@@ -35,7 +35,7 @@
 
 QString activePlaceActionText(qSlicerMouseModeToolBar& mouseModeToolBar)
 {
-  foreach (QAction* action, mouseModeToolBar.actions())
+  for (QAction* const action : mouseModeToolBar.actions())
   {
     if (action->objectName() == QString("PlaceWidgetAction"))
     {
@@ -47,7 +47,7 @@ QString activePlaceActionText(qSlicerMouseModeToolBar& mouseModeToolBar)
 
 QString getActiveActionText(qSlicerMouseModeToolBar& mouseModeToolBar)
 {
-  foreach (QAction* action, mouseModeToolBar.actions())
+  for (QAction* const action : mouseModeToolBar.actions())
   {
     std::cout << "action name: " << qPrintable(action->objectName()) << std::endl;
     ;

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -343,7 +343,7 @@ void qSlicerApplicationPrivate::init()
                                << "slicer.mrmlScene"
                                << "qt.QPushButton";
     q->pythonConsole()->completer()->setAutocompletePreferenceList(autocompletePreferenceList);
-    foreach (QAction* action, q->pythonConsole()->actions())
+    for (QAction* const action : q->pythonConsole()->actions())
     {
       if (action->shortcut() == QKeySequence("Ctrl+H"))
       {
@@ -690,7 +690,7 @@ qSlicerLayoutManager* qSlicerApplication::layoutManager() const
 //-----------------------------------------------------------------------------
 QMainWindow* qSlicerApplication::mainWindow() const
 {
-  foreach (QWidget* widget, this->topLevelWidgets())
+  for (QWidget* const widget : this->topLevelWidgets())
   {
     QMainWindow* window = qobject_cast<QMainWindow*>(widget);
     if (window)
@@ -799,7 +799,7 @@ QString qSlicerApplication::nodeModule(vtkMRMLNode* node, double* confidence /*=
 
   // Modules that support a parent class of the node
   QStringList classNames = this->allModuleAssociatedNodeTypes();
-  foreach (const QString& className, classNames)
+  for (const QString& className : classNames)
   {
     if (node->IsA(className.toUtf8()))
     {
@@ -807,7 +807,7 @@ QString qSlicerApplication::nodeModule(vtkMRMLNode* node, double* confidence /*=
     }
   }
 
-  foreach (const QString& moduleName, moduleNames)
+  for (const QString& moduleName : moduleNames)
   {
     qSlicerAbstractCoreModule* module = this->moduleManager()->module(moduleName);
     if (!module)
@@ -1075,7 +1075,7 @@ void qSlicerApplication::setupFileLogging()
   userSettings->beginGroup("LogFiles");
   userSettings->setValue("NumberOfFilesToKeep", numberOfFilesToKeep);
 
-  foreach (QString filePath, logFilePaths)
+  for (const QString& filePath : logFilePaths)
   {
     // If the file is to keep then save it in the settings
     if (fileNumber < numberOfFilesToKeep)
@@ -1126,7 +1126,7 @@ void qSlicerApplication::logApplicationInformation() const
          << "Additional module paths ";
 
   int titleWidth = 0;
-  foreach (const QString& title, titles)
+  for (const QString& title : titles)
   {
     if (title.length() > titleWidth)
     {
@@ -1301,7 +1301,7 @@ void qSlicerApplication::logApplicationInformation() const
   QStringList additionalModulePaths = this->revisionUserSettings()->value("Modules/AdditionalPaths").toStringList();
 
   qSlicerModuleFactoryManager* moduleFactoryManager = this->moduleManager()->factoryManager();
-  foreach (const QString& extensionOrModulePath, this->commandOptions()->additionalModulePaths())
+  for (const QString& extensionOrModulePath : this->commandOptions()->additionalModulePaths())
   {
     QStringList modulePaths = moduleFactoryManager->modulePaths(extensionOrModulePath);
     if (!modulePaths.empty())
@@ -1472,7 +1472,7 @@ void qSlicerApplication::logToPythonConsole(const QDateTime& currentDateTime,
   }
   QString prefixedText;
   QStringList lines = text.split('\n');
-  foreach (const QString& line, lines)
+  for (const QString& line : lines)
   {
     if (line.isEmpty())
     {

--- a/Base/QTGUI/qSlicerDataDialog.cxx
+++ b/Base/QTGUI/qSlicerDataDialog.cxx
@@ -141,7 +141,7 @@ void qSlicerDataDialogPrivate::addFiles()
   qSlicerStandardFileDialog fileDialog;
   QStringList files = fileDialog.getOpenFileName();
 
-  foreach (QString file, files)
+  for (const QString& file : files)
   {
     this->addFile(file);
   }
@@ -172,7 +172,7 @@ void qSlicerDataDialogPrivate::addDirectory(const QDir& directory)
   // now add any files and directories that weren't filtered
   // out by the ioManager
   //
-  foreach (QFileInfo entry, fileInfoList)
+  for (const QFileInfo& entry : fileInfoList)
   {
     if (entry.isFile())
     {
@@ -238,7 +238,7 @@ void qSlicerDataDialogPrivate::addFile(const QFileInfo& file, const QString& rea
   this->FileWidget->setItem(row, FileColumn, fileItem);
   // Description
   QComboBox* descriptionComboBox = new QComboBox(this->FileWidget);
-  foreach (const QString& fileDescription, fileDescriptions)
+  for (const QString& fileDescription : fileDescriptions)
   {
     descriptionComboBox->addItem(fileDescription, QVariant(coreIOManager->fileTypeFromDescription(fileDescription)));
   }
@@ -578,7 +578,7 @@ void qSlicerDataDialog::dropEvent(QDropEvent* event)
 {
   Q_D(qSlicerDataDialog);
   bool pathAdded = false;
-  foreach (QUrl url, event->mimeData()->urls())
+  for (const QUrl& url : event->mimeData()->urls())
   {
     if (!url.isValid() || url.isEmpty())
     {
@@ -614,7 +614,7 @@ bool qSlicerDataDialog::exec(const qSlicerIO::IOProperties& readerProperties)
   if (readerProperties.contains("fileNames"))
   {
     QStringList fileNames = readerProperties["fileNames"].toStringList();
-    foreach (QString fileName, fileNames)
+    for (const QString& fileName : fileNames)
     {
       d->addFile(QFileInfo(fileName));
     }

--- a/Base/QTGUI/qSlicerDirectoryListView.cxx
+++ b/Base/QTGUI/qSlicerDirectoryListView.cxx
@@ -143,7 +143,7 @@ QStringList qSlicerDirectoryListView::selectedDirectoryList(bool absolutePath) c
     role = qSlicerDirectoryListViewPrivate::AbsolutePathRole;
   }
   QModelIndexList selectedIndexes = d->ListView->selectionModel()->selectedRows();
-  foreach (const QModelIndex& index, selectedIndexes)
+  for (const QModelIndex& index : selectedIndexes)
   {
     directoryList << d->DirectoryListModel.data(index, role).toString();
   }
@@ -222,7 +222,7 @@ void qSlicerDirectoryListView::setDirectoryList(const QStringList& paths)
   if (paths.count() == this->directoryList().count())
   {
     int found = 0;
-    foreach (const QString& path, paths)
+    for (const QString& path : paths)
     {
       if (this->hasDirectory(path))
       {
@@ -237,7 +237,7 @@ void qSlicerDirectoryListView::setDirectoryList(const QStringList& paths)
 
   d->DirectoryListModel.removeRows(0, d->DirectoryListModel.rowCount());
 
-  foreach (const QString& path, paths)
+  for (const QString& path : paths)
   {
     d->addDirectory(path);
   }
@@ -256,7 +256,7 @@ void qSlicerDirectoryListView::dragEnterEvent(QDragEnterEvent* event)
 //-----------------------------------------------------------------------------
 void qSlicerDirectoryListView::dropEvent(QDropEvent* event)
 {
-  foreach (QUrl url, event->mimeData()->urls())
+  for (const QUrl& url : event->mimeData()->urls())
   {
     if (!url.isValid() || url.isEmpty())
     {

--- a/Base/QTGUI/qSlicerExportNodeDialog.cxx
+++ b/Base/QTGUI/qSlicerExportNodeDialog.cxx
@@ -88,7 +88,7 @@ NodeTypeWidgetSet::NodeTypeWidgetSet(QWidget* parent, vtkMRMLStorableNode* stora
   // (Checking that storageNode is not null allows us to dodge a warning from completeSlicerWritableFileNameSuffix)
   QString currentExtension = storageNode ? coreIOManager->completeSlicerWritableFileNameSuffix(storableNode) : QString(".");
   int suggestedFormatIndex = -1; // will be index corresponding to format corresponding to currentExtension
-  foreach (QString nameFilter, coreIOManager->fileWriterExtensions(storableNode))
+  for (const QString& nameFilter : coreIOManager->fileWriterExtensions(storableNode))
   {
     // extract extension (e.g. ".ext") from format description string (e.g. "Blahblahblah (.ext)")
     QString extension = QString::fromStdString(vtkDataFileFormatHelper::GetFileExtensionFromFormatString(nameFilter.toUtf8()));

--- a/Base/QTGUI/qSlicerExtensionsLocalWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsLocalWidget.cxx
@@ -1146,14 +1146,14 @@ void qSlicerExtensionsLocalWidget::onModelUpdated()
   // Show extensions with available update at the top
   QStringList availableUpdateExtensions = d->ExtensionsManagerModel->availableUpdateExtensions();
   availableUpdateExtensions.sort();
-  foreach (const QString& extensionName, availableUpdateExtensions)
+  for (const QString& extensionName : availableUpdateExtensions)
   {
     d->updateExtensionItem(extensionName);
   }
   // Show all other extensions
   QStringList managedExtensions = d->ExtensionsManagerModel->managedExtensions();
   managedExtensions.sort();
-  foreach (const QString& extensionName, managedExtensions)
+  for (const QString& extensionName : managedExtensions)
   {
     if (availableUpdateExtensions.contains(extensionName))
     {

--- a/Base/QTGUI/qSlicerExtensionsManagerWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsManagerWidget.cxx
@@ -391,7 +391,7 @@ void qSlicerExtensionsManagerWidget::onModelUpdated()
   // Get the list of extensions that have update available but not updated yet
   QStringList extensionsToUpdate = this->extensionsManagerModel()->availableUpdateExtensions();
   const QStringList& extensionsAlreadyScheduledForUpdate = this->extensionsManagerModel()->scheduledForUpdateExtensions();
-  foreach (const QString& extensionName, extensionsAlreadyScheduledForUpdate)
+  for (const QString& extensionName : extensionsAlreadyScheduledForUpdate)
   {
     extensionsToUpdate.removeAll(extensionName);
   }
@@ -411,7 +411,7 @@ void qSlicerExtensionsManagerWidget::onModelUpdated()
 
   int foundNonInstalledBookmarkedExtension = 0;
   QStringList bookmarkedExtensions = this->extensionsManagerModel()->bookmarkedExtensions();
-  foreach (const QString& extensionName, bookmarkedExtensions)
+  for (const QString& extensionName : bookmarkedExtensions)
   {
     if (this->extensionsManagerModel()->isExtensionInstalled(extensionName))
     {
@@ -653,7 +653,7 @@ void qSlicerExtensionsManagerWidget::onInstallUpdatesTriggered()
   // Save last update check time
   bool wasBatchProcessing = d->setBatchProcessing(true);
   QStringList extensionNames = this->extensionsManagerModel()->availableUpdateExtensions();
-  foreach (const QString& extensionName, extensionNames)
+  for (const QString& extensionName : extensionNames)
   {
     this->extensionsManagerModel()->scheduleExtensionForUpdate(extensionName);
   }
@@ -667,7 +667,7 @@ void qSlicerExtensionsManagerWidget::onInstallBookmarkedTriggered()
   bool wasBatchProcessing = d->setBatchProcessing(true);
   // Save last update check time
   QStringList extensionNames = this->extensionsManagerModel()->bookmarkedExtensions();
-  foreach (const QString& extensionName, extensionNames)
+  for (const QString& extensionName : extensionNames)
   {
     if (this->extensionsManagerModel()->isExtensionInstalled(extensionName))
     {
@@ -703,7 +703,7 @@ void qSlicerExtensionsManagerWidget::onInstallFromFileTriggered()
 
   bool wasBatchProcessing = d->setBatchProcessing(true);
   qSlicerExtensionsManagerModel* const model = this->extensionsManagerModel();
-  foreach (const QString& archiveName, archiveNames)
+  for (const QString& archiveName : archiveNames)
   {
     model->installExtension(archiveName);
   }

--- a/Base/QTGUI/qSlicerExtensionsServerWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsServerWidget.cxx
@@ -131,7 +131,7 @@ void qSlicerExtensionsServerWidgetPrivate::setFailurePage(const QStringList& err
       "</div>";
 
   QStringList htmlErrors;
-  foreach (const QString& error, errors)
+  for (const QString& error : errors)
   {
     htmlErrors << QString("<li>%1</li>").arg(error);
   }

--- a/Base/QTGUI/qSlicerFileDialog.cxx
+++ b/Base/QTGUI/qSlicerFileDialog.cxx
@@ -64,9 +64,9 @@ QStringList qSlicerFileDialog::nameFilters(qSlicerIO::IOFileType fileType)
   QStringList filters;
   QStringList extensions;
   QList<qSlicerFileReader*> readers = qSlicerApplication::application()->ioManager()->readers(fileType);
-  foreach (const qSlicerFileReader* reader, readers)
+  for (const qSlicerFileReader* reader : readers)
   {
-    foreach (const QString& filter, reader->extensions())
+    for (const QString& filter : reader->extensions())
     {
       QString nameFilter = filter.contains('(') ? filter : reader->description() + " (" + filter + ")";
       filters << nameFilter;

--- a/Base/QTGUI/qSlicerIOManager.cxx
+++ b/Base/QTGUI/qSlicerIOManager.cxx
@@ -133,7 +133,7 @@ void qSlicerIOManagerPrivate::readSettings()
   if (!settings.value("favoritesPaths").toList().isEmpty())
   {
     QStringList paths = qSlicerCoreApplication::application()->toSlicerHomeAbsolutePaths(settings.value("favoritesPaths").toStringList());
-    foreach (const QString& varUrl, paths)
+    for (const QString& varUrl : paths)
     {
       this->Favorites << QUrl(varUrl);
     }
@@ -153,7 +153,7 @@ void qSlicerIOManagerPrivate::writeSettings()
   QSettings settings;
   settings.beginGroup("ioManager");
   QStringList list;
-  foreach (const QUrl& url, q->favorites())
+  for (const QUrl& url : q->favorites())
   {
     list << url.toString();
   }
@@ -179,7 +179,7 @@ QString qSlicerIOManagerPrivate::createUniqueDialogName(qSlicerIO::IOFileType fi
 qSlicerFileDialog* qSlicerIOManagerPrivate::findDialog(qSlicerIO::IOFileType fileType, qSlicerFileDialog::IOAction action) const
 {
   const QList<qSlicerFileDialog*>& dialogs = (action == qSlicerFileDialog::Read) ? this->ReadDialogs : this->WriteDialogs;
-  foreach (qSlicerFileDialog* dialog, dialogs)
+  for (qSlicerFileDialog* const dialog : dialogs)
   {
     if (dialog->fileType() == fileType)
     {
@@ -246,7 +246,7 @@ bool qSlicerIOManager::openDialog(qSlicerIO::IOFileType fileType, qSlicerFileDia
   bool res = dialog->exec(properties);
   if (loadedNodes)
   {
-    foreach (const QString& nodeID, dialog->loadedNodes())
+    for (const QString& nodeID : dialog->loadedNodes())
     {
       vtkMRMLNode* node = d->currentScene()->GetNodeByID(nodeID.toUtf8());
       if (node)
@@ -266,7 +266,7 @@ bool qSlicerIOManager::openDialog(qSlicerIO::IOFileType fileType, qSlicerFileDia
 void qSlicerIOManager::dragEnterEvent(QDragEnterEvent* event)
 {
   Q_D(qSlicerIOManager);
-  foreach (qSlicerFileDialog* dialog, d->ReadDialogs)
+  for (qSlicerFileDialog* const dialog : d->ReadDialogs)
   {
     if (dialog->isMimeDataAccepted(event->mimeData()))
     {
@@ -282,7 +282,7 @@ void qSlicerIOManager::dropEvent(QDropEvent* event)
   Q_D(qSlicerIOManager);
   QStringList supportedReaders;
   QStringList genericReaders; // those must be last in the choice menu
-  foreach (qSlicerFileDialog* dialog, d->ReadDialogs)
+  for (qSlicerFileDialog* const dialog : d->ReadDialogs)
   {
     if (dialog->isMimeDataAccepted(event->mimeData()))
     {
@@ -322,7 +322,7 @@ void qSlicerIOManager::dropEvent(QDropEvent* event)
   {
     return;
   }
-  foreach (qSlicerFileDialog* dialog, d->ReadDialogs)
+  for (qSlicerFileDialog* const dialog : d->ReadDialogs)
   {
     if (dialog->description() == selectedReader)
     {
@@ -369,7 +369,7 @@ void qSlicerIOManager::setFavorites(const QList<QUrl>& urls)
 {
   Q_D(qSlicerIOManager);
   QList<QUrl> newFavorites;
-  foreach (const QUrl& url, urls)
+  for (const QUrl& url : urls)
   {
     newFavorites << url;
   }
@@ -453,7 +453,7 @@ bool qSlicerIOManager::loadNodes(const QList<qSlicerIO::IOProperties>& files, vt
   SlicerRenderBlocker renderBlocker;
   bool needStop = d->startProgressDialog(files.count());
   bool success = true;
-  foreach (qSlicerIO::IOProperties fileProperties, files)
+  for (const qSlicerIO::IOProperties& fileProperties : files)
   {
     int numberOfUserMessagesBefore = userMessages ? userMessages->GetNumberOfMessages() : 0;
     success = this->loadNodes(static_cast<qSlicerIO::IOFileType>(fileProperties["fileType"].toString()), fileProperties, loadedNodes, userMessages) && success;

--- a/Base/QTGUI/qSlicerModelsDialog.cxx
+++ b/Base/QTGUI/qSlicerModelsDialog.cxx
@@ -126,7 +126,7 @@ bool qSlicerModelsDialog::exec(const qSlicerIO::IOProperties& readerProperties)
     return res;
   }
   QStringList files = d->SelectedFiles;
-  foreach (QString file, files)
+  for (const QString& file : files)
   {
     qSlicerIO::IOProperties properties = readerProperties;
     properties["fileName"] = file;

--- a/Base/QTGUI/qSlicerModuleFactoryFilterModel.cxx
+++ b/Base/QTGUI/qSlicerModuleFactoryFilterModel.cxx
@@ -411,7 +411,7 @@ bool qSlicerModuleFactoryFilterModel::dropMimeData(const QMimeData* data, Qt::Dr
   }
 
   // Insert new items
-  foreach (QStandardItem* item, items)
+  for (QStandardItem* const item : items)
   {
     QString moduleName = item->data(Qt::UserRole).toString();
     newShowModules.removeAll(moduleName);

--- a/Base/QTGUI/qSlicerModuleFinderDialog.cxx
+++ b/Base/QTGUI/qSlicerModuleFinderDialog.cxx
@@ -186,7 +186,7 @@ void qSlicerModuleFinderDialog::onSelectionChanged(const QItemSelection& selecte
     // Categories
     QStringList categories = module->categories();
     QStringList filteredCategories;
-    foreach (QString category, categories)
+    for (QString category : categories)
     {
       if (category.isEmpty())
       {

--- a/Base/QTGUI/qSlicerModuleSelectorToolBar.cxx
+++ b/Base/QTGUI/qSlicerModuleSelectorToolBar.cxx
@@ -115,11 +115,11 @@ void qSlicerModuleSelectorToolBarPrivate::init()
   ViewFindModuleAction->setShortcut(QKeySequence(Qt::ControlModifier + Qt::Key_F));
   QObject::connect(ViewFindModuleAction, SIGNAL(triggered()), q, SLOT(showModuleFinder()));
   QMainWindow* mainWindow = qSlicerApplication::application()->mainWindow();
-  foreach (QMenu* toolBarMenu, mainWindow->findChildren<QMenu*>())
+  for (QMenu* const toolBarMenu : mainWindow->findChildren<QMenu*>())
   {
     if (toolBarMenu->objectName() == QString("ViewMenu"))
     {
-      foreach (QAction* action, toolBarMenu->actions())
+      for (QAction* const action : toolBarMenu->actions())
       {
         if (action->objectName() == QString("ViewExtensionsManagerAction"))
         {

--- a/Base/QTGUI/qSlicerModulesListView.cxx
+++ b/Base/QTGUI/qSlicerModulesListView.cxx
@@ -237,7 +237,7 @@ QStandardItem* qSlicerModulesListViewPrivate::moduleItem(const QString& moduleNa
 QStringList qSlicerModulesListViewPrivate::indexListToModules(const QModelIndexList& indexes) const
 {
   QStringList modules;
-  foreach (const QModelIndex& index, indexes)
+  for (const QModelIndex& index : indexes)
   {
     modules << index.data(qSlicerModuleFactoryFilterModel::ModuleNameRole).toString();
   }
@@ -248,7 +248,7 @@ QStringList qSlicerModulesListViewPrivate::indexListToModules(const QModelIndexL
 void qSlicerModulesListViewPrivate::setModulesCheckState(const QStringList& moduleNames, Qt::CheckState checkState)
 {
   Q_Q(qSlicerModulesListView);
-  foreach (const QString& moduleName, q->modules())
+  for (const QString& moduleName : q->modules())
   {
     QStandardItem* moduleItem = this->moduleItem(moduleName);
     if (moduleItem == nullptr)
@@ -389,7 +389,7 @@ void qSlicerModulesListView::hideSelectedModules()
   Q_D(qSlicerModulesListView);
   QStringList newShowModules = d->FilterModel->showModules();
   QStringList modulesToHide = d->indexListToModules(this->selectionModel()->selectedIndexes());
-  foreach (const QString& moduleToHide, modulesToHide)
+  for (const QString& moduleToHide : modulesToHide)
   {
     newShowModules.removeAll(moduleToHide);
   }
@@ -414,7 +414,7 @@ void qSlicerModulesListView::moveSelectedModules(int offset)
   Q_D(qSlicerModulesListView);
   QStringList newShowModules = d->FilterModel->showModules();
   QStringList modulesToMove = d->indexListToModules(this->selectionModel()->selectedIndexes());
-  foreach (const QString& moduleToMove, modulesToMove)
+  for (const QString& moduleToMove : modulesToMove)
   {
     int moduleIndex = newShowModules.indexOf(moduleToMove);
     if (moduleIndex != -1)
@@ -438,7 +438,7 @@ void qSlicerModulesListView::scrollToSelectedModules()
 // --------------------------------------------------------------------------
 void qSlicerModulesListView::addModules(const QStringList& moduleNames)
 {
-  foreach (const QString& moduleName, moduleNames)
+  for (const QString& moduleName : moduleNames)
   {
     this->addModule(moduleName);
   }
@@ -465,7 +465,7 @@ void qSlicerModulesListView::updateModules()
 // --------------------------------------------------------------------------
 void qSlicerModulesListView::updateModules(const QStringList& moduleNames)
 {
-  foreach (const QString& moduleName, moduleNames)
+  for (const QString& moduleName : moduleNames)
   {
     this->updateModule(moduleName);
   }
@@ -502,7 +502,7 @@ void qSlicerModulesListView::onItemChanged(QStandardItem* item)
     // ensure dependencies are checked
     if (module)
     {
-      foreach (const QString& dependency, module->dependencies())
+      for (const QString& dependency : module->dependencies())
       {
         d->FactoryManager->removeModuleToIgnore(dependency);
       }
@@ -514,7 +514,7 @@ void qSlicerModulesListView::onItemChanged(QStandardItem* item)
     // ensure dependent modules are unchecked
     if (module)
     {
-      foreach (const QString& dependentModule, d->FactoryManager->dependentModules(moduleName))
+      for (const QString& dependentModule : d->FactoryManager->dependentModules(moduleName))
       {
         d->FactoryManager->addModuleToIgnore(dependentModule);
       }

--- a/Base/QTGUI/qSlicerModulesMenu.cxx
+++ b/Base/QTGUI/qSlicerModulesMenu.cxx
@@ -123,7 +123,7 @@ QAction* qSlicerModulesMenuPrivate::action(const QVariant& actionData, const QMe
   {
     parentMenu = q;
   }
-  foreach (QAction* action, parentMenu->actions())
+  for (QAction* const action : parentMenu->actions())
   {
     if (action->data() == actionData)
     {
@@ -149,7 +149,7 @@ QAction* qSlicerModulesMenuPrivate::action(const QString& text, const QMenu* par
   {
     parentMenu = q;
   }
-  foreach (QAction* action, parentMenu->actions())
+  for (QAction* const action : parentMenu->actions())
   {
     if (action->text() == text)
     {
@@ -190,7 +190,7 @@ void qSlicerModulesMenuPrivate::addModuleAction(QMenu* menu, QAction* moduleActi
     index = 65535; // big enough
   }
   // Search where moduleAction should be inserted. Before what action.
-  foreach (QAction* action, actions)
+  for (QAction* const action : actions)
   {
     Q_ASSERT(action);
     int actionIndex = action->property("index").toInt(&ok);
@@ -247,7 +247,7 @@ void qSlicerModulesMenuPrivate::addModuleAction(QMenu* menu, QAction* moduleActi
   {
     // look for third separator (second, as the first one was removed above)
     int separatorCount = 0;
-    foreach (QAction* action, actions)
+    for (QAction* const action : actions)
     {
       Q_ASSERT(action);
       if (action->isSeparator())
@@ -300,7 +300,7 @@ QList<QMenu*> qSlicerModulesMenuPrivate::categoryMenus(QMenu* topLevelMenu, QStr
   {
     return QList<QMenu*>();
   }
-  foreach (QAction* action, topLevelMenu->actions())
+  for (QAction* const action : topLevelMenu->actions())
   {
     if (action->text() == category)
     {
@@ -327,7 +327,7 @@ QMenu* qSlicerModulesMenuPrivate::menu(QMenu* menu, QStringList subCategories, b
     return menu;
   }
   // The actions are inserted alphabetically
-  foreach (QAction* action, menu->actions())
+  for (QAction* const action : menu->actions())
   {
     if (action->text() == category)
     {
@@ -360,7 +360,7 @@ QMenu* qSlicerModulesMenuPrivate::actionMenu(QAction* action, QMenu* parentMenu)
   {
     actions.removeFirst(); // remove All Modules menu
   }
-  foreach (QAction* subAction, actions)
+  for (QAction* const subAction : actions)
   {
     if (subAction->menu())
     {
@@ -553,7 +553,7 @@ void qSlicerModulesMenu::addModule(qSlicerAbstractCoreModule* moduleToAdd)
   }
   QObject::connect(moduleAction, SIGNAL(triggered(bool)), this, SLOT(onActionTriggered()));
 
-  foreach (const QString& category, module->categories())
+  for (const QString& category : module->categories())
   {
     QMenu* menu = d->menu(this, category.split('.'), module->isBuiltIn());
     if (!menu)

--- a/Base/QTGUI/qSlicerModulesMenu.h
+++ b/Base/QTGUI/qSlicerModulesMenu.h
@@ -162,7 +162,7 @@ private:
 //---------------------------------------------------------------------------
 void qSlicerModulesMenu::addModules(const QStringList& moduleNames)
 {
-  foreach (const QString& moduleName, moduleNames)
+  for (const QString& moduleName : moduleNames)
   {
     this->addModule(moduleName);
   }
@@ -171,7 +171,7 @@ void qSlicerModulesMenu::addModules(const QStringList& moduleNames)
 //---------------------------------------------------------------------------
 void qSlicerModulesMenu::removeModules(const QStringList& moduleNames)
 {
-  foreach (const QString& moduleName, moduleNames)
+  for (const QString& moduleName : moduleNames)
   {
     this->removeModule(moduleName);
   }

--- a/Base/QTGUI/qSlicerMouseModeToolBar.cxx
+++ b/Base/QTGUI/qSlicerMouseModeToolBar.cxx
@@ -240,7 +240,7 @@ void qSlicerMouseModeToolBarPrivate::updateWidgetFromMRML()
   // Find action corresponding to current interaction mode
   int currentInteractionMode = interactionNode->GetCurrentInteractionMode();
   QAction* currentAction = nullptr;
-  foreach (QAction* action, this->InteractionModesActionGroup->actions())
+  for (QAction* const action : this->InteractionModesActionGroup->actions())
   {
     if (action->data().toInt() == currentInteractionMode)
     {
@@ -394,7 +394,7 @@ void qSlicerMouseModeToolBarPrivate::updateCursor()
     else
     {
       // Find action corresponding to current interaction mode
-      foreach (QAction* action, this->InteractionModesActionGroup->actions())
+      for (QAction* const action : this->InteractionModesActionGroup->actions())
       {
         if (action->data().toInt() == currentInteractionMode)
         {
@@ -552,7 +552,7 @@ void qSlicerMouseModeToolBar::changeCursorTo(QCursor cursor)
   }
 
   // Updated all mapped slicer viewers
-  foreach (const QString& viewerName, layoutManager->sliceViewNames())
+  for (const QString& viewerName : layoutManager->sliceViewNames())
   {
     qMRMLSliceView* sliceView = layoutManager->sliceWidget(viewerName)->sliceView();
 
@@ -587,7 +587,7 @@ void qSlicerMouseModeToolBar::switchPlaceMode()
 //---------------------------------------------------------------------------
 QAction* qSlicerMouseModeToolBar::actionFromPlaceNodeClassName(QString placeNodeClassName, QMenu* menu)
 {
-  foreach (QAction* action, menu->actions())
+  for (QAction* const action : menu->actions())
   {
     if (action->objectName() == placeNodeClassName)
     {
@@ -709,7 +709,7 @@ void qSlicerMouseModeToolBar::toggleMarkupsToolBar()
     qDebug("qSlicerMouseModeToolBar::toggleMarkupsToolBar: no main window is available, toolbar is not added");
     return;
   }
-  foreach (QToolBar* toolBar, mainWindow->findChildren<QToolBar*>())
+  for (QToolBar* const toolBar : mainWindow->findChildren<QToolBar*>())
   {
     if (toolBar->objectName() == QString("MarkupsToolBar"))
     {

--- a/Base/QTGUI/qSlicerNodeWriter.cxx
+++ b/Base/QTGUI/qSlicerNodeWriter.cxx
@@ -92,7 +92,7 @@ bool qSlicerNodeWriter::canWriteObject(vtkObject* object) const
   vtkMRMLStorableNode* node = vtkMRMLStorableNode::SafeDownCast(object);
   if (node)
   {
-    foreach (QString className, d->NodeClassNames)
+    for (const QString& className : d->NodeClassNames)
     {
       if (node->IsA(className.toUtf8()))
       {

--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -311,7 +311,7 @@ void qSlicerSaveDataDialogPrivate::populateScene()
   QComboBox* sceneComboBoxWidget = new QComboBox(this->FileWidget);
   int currentFormat = -1;
   QString currentExtension = coreIOManager->extractKnownExtension(sceneFileInfo.fileName(), this->MRMLScene);
-  foreach (const QString& nameFilter, coreIOManager->fileWriterExtensions(this->MRMLScene))
+  for (const QString& nameFilter : coreIOManager->fileWriterExtensions(this->MRMLScene))
   {
     QString extension = QString::fromStdString(vtkDataFileFormatHelper::GetFileExtensionFromFormatString(nameFilter.toUtf8()));
     sceneComboBoxWidget->addItem(nameFilter, extension);
@@ -565,7 +565,7 @@ QWidget* qSlicerSaveDataDialogPrivate::createFileFormatsWidget(vtkMRMLStorableNo
   qSlicerCoreIOManager* coreIOManager = qSlicerCoreApplication::application()->coreIOManager();
   int currentFormat = -1;
   QString currentExtension = coreIOManager->completeSlicerWritableFileNameSuffix(node);
-  foreach (QString nameFilter, coreIOManager->fileWriterExtensions(node))
+  for (const QString& nameFilter : coreIOManager->fileWriterExtensions(node))
   {
     QString extension = QString::fromStdString(vtkDataFileFormatHelper::GetFileExtensionFromFormatString(nameFilter.toUtf8()));
     fileFormats->addItem(nameFilter, extension);

--- a/Base/QTGUI/qSlicerSettingsModulesPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsModulesPanel.cxx
@@ -125,7 +125,7 @@ void qSlicerSettingsModulesPanelPrivate::init()
 #endif
   // The separator commas have been removed, but we also need need to remove leading and trailing spaces from the retrieved names.
   QStringList favorites;
-  foreach (QString s, favoritesRaw)
+  for (const QString& s : favoritesRaw)
   {
     favorites << s.trimmed();
   }
@@ -245,7 +245,7 @@ void qSlicerSettingsModulesPanel::setModulesToAlwaysIgnore(const QStringList& mo
   // Update the list of modules to ignore removing the one
   // specified from the command line.
   QStringList updatedModulesToAlwaysIgnore;
-  foreach (const QString& moduleName, moduleNames)
+  for (const QString& moduleName : moduleNames)
   {
     if (!coreApp->coreCommandOptions()->modulesToIgnore().contains(moduleName))
     {
@@ -290,7 +290,7 @@ void qSlicerSettingsModulesPanel::onTemporaryPathChanged(const QString& path)
 void qSlicerSettingsModulesPanel::onShowHiddenModulesChanged(bool show)
 {
   QMainWindow* mainWindow = qSlicerApplication::application()->mainWindow();
-  foreach (qSlicerModuleSelectorToolBar* toolBar, mainWindow->findChildren<qSlicerModuleSelectorToolBar*>())
+  for (qSlicerModuleSelectorToolBar* const toolBar : mainWindow->findChildren<qSlicerModuleSelectorToolBar*>())
   {
     toolBar->modulesMenu()->setShowHiddenModules(show);
     // refresh the list

--- a/Base/QTGUI/qSlicerSettingsStylesPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsStylesPanel.cxx
@@ -156,7 +156,7 @@ void qSlicerSettingsStylesPanelPrivate::populateStyles()
   bool wasBlocking = this->StyleComboBox->blockSignals(true);
   // Re-populate styles
   this->StyleComboBox->clear();
-  foreach (const QString& style, q->availableSlicerStyles())
+  for (const QString& style : q->availableSlicerStyles())
   {
     this->StyleComboBox->addItem(toCamelCase(style));
   }
@@ -214,14 +214,14 @@ void qSlicerSettingsStylesPanel::onAdditionalStylePathsChanged()
   Q_D(qSlicerSettingsStylesPanel);
 
   // Remove old paths
-  foreach (const QString& path, d->AdditionalPaths)
+  for (const QString& path : d->AdditionalPaths)
   {
     QCoreApplication::removeLibraryPath(path);
   }
 
   // Add new ones
   d->AdditionalPaths = d->AdditionalStylePathsView->directoryList(true);
-  foreach (const QString& path, d->AdditionalPaths)
+  for (const QString& path : d->AdditionalPaths)
   {
     QCoreApplication::addLibraryPath(path);
   }
@@ -256,7 +256,7 @@ void qSlicerSettingsStylesPanel::onRemoveStyleAdditionalPathClicked()
 QStringList qSlicerSettingsStylesPanel::availableSlicerStyles()
 {
   QStringList styles;
-  foreach (const QString& style, QStyleFactory::keys())
+  for (const QString& style : QStyleFactory::keys())
   {
     if (qSlicerSettingsStylesPanelPrivate::isQtStyle(style))
     {

--- a/Base/QTGUI/qSlicerWebWidget.cxx
+++ b/Base/QTGUI/qSlicerWebWidget.cxx
@@ -471,7 +471,7 @@ void qSlicerWebWidget::handleSslErrors(QNetworkReply* reply, const QList<QSslErr
   Q_UNUSED(reply);
   Q_UNUSED(errors);
 #else
-  foreach (QSslError e, errors)
+  for (const QSslError& e : errors)
   {
     qDebug() << "[SSL] [" << qPrintable(reply->url().host().trimmed()) << "]" << qPrintable(e.errorString());
   }

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerVisibilityTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerVisibilityTest.cxx
@@ -93,7 +93,7 @@ bool checkNodeVisibleInLayout(int line, vtkMRMLAbstractViewNode* viewNode, bool 
 // --------------------------------------------------------------------------
 bool checkViews(int line, qMRMLLayoutManager* layoutManager, QHash<vtkMRMLAbstractViewNode*, QList<bool>> viewNodesToExpectedVisibility)
 {
-  foreach (vtkMRMLAbstractViewNode* viewNode, viewNodesToExpectedVisibility.keys())
+  for (vtkMRMLAbstractViewNode* const viewNode : viewNodesToExpectedVisibility.keys())
   {
 
     bool expectedNodeVisibility = viewNodesToExpectedVisibility[viewNode].at(0);

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeAttributeTableViewTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeAttributeTableViewTest.cxx
@@ -111,7 +111,7 @@ void qMRMLNodeAttributeTableViewTester::testPopulate()
   vtkNew<vtkMRMLModelNode> node;
 
   QFETCH(QList<AttributeType>, attributes);
-  foreach (const AttributeType& attribute, attributes)
+  for (const AttributeType& attribute : attributes)
   {
     node->SetAttribute(attribute.first.toUtf8(), attribute.second.toUtf8());
   }
@@ -124,7 +124,7 @@ void qMRMLNodeAttributeTableViewTester::testPopulate()
 
   QStringList resultAttributes = this->NodeAttributeTableView->attributes();
   int i = 0;
-  foreach (QString attribute, resultAttributes)
+  for (const QString& attribute : resultAttributes)
   {
     QCOMPARE(attribute, expectedAttributes[i].first);
     QCOMPARE(this->NodeAttributeTableView->attributeValue(attribute), expectedAttributes[i].second);
@@ -243,7 +243,7 @@ void qMRMLNodeAttributeTableViewTester::testSelect()
     QFETCH(QList<AttributeType>, attributes);
     vtkNew<vtkMRMLModelNode> node;
 
-    foreach (const AttributeType& attribute, attributes)
+    for (const AttributeType& attribute : attributes)
     {
       node->SetAttribute(attribute.first.toUtf8(), attribute.second.toUtf8());
     }
@@ -294,7 +294,7 @@ void qMRMLNodeAttributeTableViewTester::testAdd()
   vtkNew<vtkMRMLModelNode> node;
 
   QFETCH(QList<AttributeType>, attributes);
-  foreach (const AttributeType& attribute, attributes)
+  for (const AttributeType& attribute : attributes)
   {
     node->SetAttribute(attribute.first.toUtf8(), attribute.second.toUtf8());
   }
@@ -307,7 +307,7 @@ void qMRMLNodeAttributeTableViewTester::testAdd()
 
   QStringList resultAttributes = this->NodeAttributeTableView->attributes();
   int i = 0;
-  foreach (QString attribute, resultAttributes)
+  for (const QString& attribute : resultAttributes)
   {
     QCOMPARE(attribute, expectedAttributes[i].first);
     QCOMPARE(this->NodeAttributeTableView->attributeValue(attribute), expectedAttributes[i].second);
@@ -387,7 +387,7 @@ void qMRMLNodeAttributeTableViewTester::testRemove()
 
   vtkNew<vtkMRMLModelNode> node;
 
-  foreach (const AttributeType& attribute, attributesToAdd)
+  for (const AttributeType& attribute : attributesToAdd)
   {
     node->SetAttribute(attribute.first.toUtf8(), attribute.second.toUtf8());
   }
@@ -399,7 +399,7 @@ void qMRMLNodeAttributeTableViewTester::testRemove()
   this->NodeAttributeTableView->removeSelectedAttributes();
   QCOMPARE(this->NodeAttributeTableView->attributeCount(), expectedAttributeCountAfterRemove);
 
-  foreach (const AttributeEmptyType& attributeExist, expectedExistingAttributesAfterRemove)
+  for (const AttributeEmptyType& attributeExist : expectedExistingAttributesAfterRemove)
   {
     bool isEmpty = attributeExist.second;
     QCOMPARE(this->NodeAttributeTableView->attributeValue(attributeExist.first).isEmpty(), isEmpty);
@@ -443,7 +443,7 @@ void qMRMLNodeAttributeTableViewTester::testSelectAndAdd()
   QFETCH(QList<AttributeType>, attributes);
   vtkNew<vtkMRMLModelNode> node;
 
-  foreach (const AttributeType& attribute, attributes)
+  for (const AttributeType& attribute : attributes)
   {
     node->SetAttribute(attribute.first.toUtf8(), attribute.second.toUtf8());
   }
@@ -460,7 +460,7 @@ void qMRMLNodeAttributeTableViewTester::testSelectAndAdd()
   QFETCH(QList<AttributeType>, expectedAttributes);
   QStringList resultAttributes = this->NodeAttributeTableView->attributes();
   int i = 0;
-  foreach (QString attribute, resultAttributes)
+  for (const QString& attribute : resultAttributes)
   {
     QCOMPARE(attribute, expectedAttributes[i].first);
     QCOMPARE(this->NodeAttributeTableView->attributeValue(attribute), expectedAttributes[i].second);

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest8.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest8.cxx
@@ -230,11 +230,10 @@ int qMRMLNodeComboBoxTest8(int argc, char* argv[])
   //  * "Edit current "
   //  * "Rename current "
   //  * "Create and rename "
-  foreach (const QString& actionPrefix,
-           QStringList() << "Create new "
-                         << "Delete current "
-                         << "Edit current "
-                         << "Rename current ")
+  for (const QString& actionPrefix : QStringList() << "Create new "
+                                                   << "Delete current "
+                                                   << "Edit current "
+                                                   << "Rename current ")
   {
     startingActions = sceneModel->postItems(sceneModel->mrmlSceneItem()).size();
 

--- a/Libs/MRML/Widgets/qMRMLCheckableNodeComboBox.cxx
+++ b/Libs/MRML/Widgets/qMRMLCheckableNodeComboBox.cxx
@@ -104,7 +104,7 @@ QList<vtkMRMLNode*> qMRMLCheckableNodeComboBox::checkedNodes() const
   Q_D(const qMRMLCheckableNodeComboBox);
   QList<vtkMRMLNode*> res;
   const ctkCheckableComboBox* checkableComboBox = qobject_cast<const ctkCheckableComboBox*>(d->ComboBox);
-  foreach (const QModelIndex& checkedIndex, checkableComboBox->checkedIndexes())
+  for (const QModelIndex& checkedIndex : checkableComboBox->checkedIndexes())
   {
     vtkMRMLNode* checkedNode = d->mrmlNodeFromIndex(checkedIndex);
     // MRMLScene or extra items could be checked, we don't want them
@@ -120,7 +120,7 @@ QList<vtkMRMLNode*> qMRMLCheckableNodeComboBox::checkedNodes() const
 QList<vtkMRMLNode*> qMRMLCheckableNodeComboBox::uncheckedNodes() const
 {
   QList<vtkMRMLNode*> res = this->nodes();
-  foreach (vtkMRMLNode* checkedNode, this->checkedNodes())
+  for (vtkMRMLNode* const checkedNode : this->checkedNodes())
   {
     res.removeAll(checkedNode);
   }

--- a/Libs/MRML/Widgets/qMRMLCheckableNodeComboBoxEventPlayer.cpp
+++ b/Libs/MRML/Widgets/qMRMLCheckableNodeComboBoxEventPlayer.cpp
@@ -58,7 +58,7 @@ bool qMRMLCheckableNodeComboBoxEventPlayer::playEvent(QObject* Object, const QSt
     if (Command == "check_indexes")
     {
       QStringList Args = Arguments.split(" ");
-      foreach (QString Arg, Args)
+      for (const QString& Arg : Args)
       {
         const int value = Arg.toInt();
         vtkMRMLNode* node = parent->nodeFromIndex(value);
@@ -70,7 +70,7 @@ bool qMRMLCheckableNodeComboBoxEventPlayer::playEvent(QObject* Object, const QSt
     if (Command == "uncheck_indexes")
     {
       QStringList Args = Arguments.split(" ");
-      foreach (QString Arg, Args)
+      for (const QString& Arg : Args)
       {
         const int value = Arg.toInt();
         vtkMRMLNode* node = parent->nodeFromIndex(value);

--- a/Libs/MRML/Widgets/qMRMLDisplayNodeViewComboBox.cxx
+++ b/Libs/MRML/Widgets/qMRMLDisplayNodeViewComboBox.cxx
@@ -174,11 +174,11 @@ void qMRMLDisplayNodeViewComboBox::updateMRMLFromWidget()
   }
   else
   {
-    foreach (vtkMRMLAbstractViewNode* viewNode, this->checkedViewNodes())
+    for (vtkMRMLAbstractViewNode* const viewNode : this->checkedViewNodes())
     {
       d->MRMLDisplayNode->AddViewNodeID(viewNode ? viewNode->GetID() : nullptr);
     }
-    foreach (vtkMRMLAbstractViewNode* viewNode, this->uncheckedViewNodes())
+    for (vtkMRMLAbstractViewNode* const viewNode : this->uncheckedViewNodes())
     {
       d->MRMLDisplayNode->RemoveViewNodeID(viewNode ? viewNode->GetID() : nullptr);
     }
@@ -191,7 +191,7 @@ void qMRMLDisplayNodeViewComboBox::updateMRMLFromWidget()
 QList<vtkMRMLAbstractViewNode*> qMRMLDisplayNodeViewComboBox::checkedViewNodes() const
 {
   QList<vtkMRMLAbstractViewNode*> res;
-  foreach (vtkMRMLNode* checkedNode, this->checkedNodes())
+  for (vtkMRMLNode* const checkedNode : this->checkedNodes())
   {
     res << vtkMRMLAbstractViewNode::SafeDownCast(checkedNode);
   }
@@ -202,7 +202,7 @@ QList<vtkMRMLAbstractViewNode*> qMRMLDisplayNodeViewComboBox::checkedViewNodes()
 QList<vtkMRMLAbstractViewNode*> qMRMLDisplayNodeViewComboBox::uncheckedViewNodes() const
 {
   QList<vtkMRMLAbstractViewNode*> res;
-  foreach (vtkMRMLNode* uncheckedNode, this->uncheckedNodes())
+  for (vtkMRMLNode* const uncheckedNode : this->uncheckedNodes())
   {
     res << vtkMRMLAbstractViewNode::SafeDownCast(uncheckedNode);
   }

--- a/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
@@ -180,7 +180,7 @@ void qMRMLLayoutPlotViewFactory::setColorLogic(vtkMRMLColorLogic* colorLogic)
 {
   this->ColorLogic = colorLogic;
   /*
-  foreach (QWidget* view, this->registeredViews())
+  for (QWidget* const view: this->registeredViews())
     {
     qMRMLPlotWidget* plotWidget = qobject_cast<qMRMLPlotWidget*>(view);
     plotWidget->setColorLogic(this->colorLogic());
@@ -505,7 +505,7 @@ void qMRMLLayoutManagerPrivate::onNodeAddedEvent(vtkObject* scene, vtkObject* no
     // No explicit parent layout node means that view is handled by the main Slicer layout
     if (!viewNode->GetParentLayoutNode())
     {
-      foreach (qMRMLLayoutViewFactory* mrmlViewFactory, q->mrmlViewFactories())
+      for (qMRMLLayoutViewFactory* const mrmlViewFactory : q->mrmlViewFactories())
       {
         mrmlViewFactory->onViewNodeAdded(viewNode);
       }
@@ -537,7 +537,7 @@ void qMRMLLayoutManagerPrivate::onNodeRemovedEvent(vtkObject* scene, vtkObject* 
   vtkMRMLAbstractViewNode* viewNode = vtkMRMLAbstractViewNode::SafeDownCast(node);
   if (viewNode)
   {
-    foreach (qMRMLLayoutViewFactory* mrmlViewFactory, q->mrmlViewFactories())
+    for (qMRMLLayoutViewFactory* const mrmlViewFactory : q->mrmlViewFactories())
     {
       mrmlViewFactory->onViewNodeRemoved(viewNode);
     }
@@ -606,7 +606,7 @@ void qMRMLLayoutManagerPrivate::onLayoutNodeModifiedEvent(vtkObject* vtkNotUsed(
 void qMRMLLayoutManagerPrivate::updateLayoutFromMRMLScene()
 {
   Q_Q(qMRMLLayoutManager);
-  foreach (qMRMLLayoutViewFactory* viewFactory, q->mrmlViewFactories())
+  for (qMRMLLayoutViewFactory* const viewFactory : q->mrmlViewFactories())
   {
     viewFactory->onSceneModified();
   }
@@ -712,7 +712,7 @@ void qMRMLLayoutManagerPrivate::updateSegmentationControls()
 {
   Q_Q(qMRMLLayoutManager);
 
-  foreach (const QString& viewName, q->sliceViewNames())
+  for (const QString& viewName : q->sliceViewNames())
   {
     q->sliceWidget(viewName)->sliceController()->updateSegmentationControlsVisibility();
   }
@@ -754,7 +754,7 @@ qMRMLLayoutManager::~qMRMLLayoutManager()
   Q_D(qMRMLLayoutManager);
 
   // Erase all views (must happen before deleting viewports)
-  foreach (ctkLayoutViewFactory* viewFactory, this->registeredViewFactories())
+  for (ctkLayoutViewFactory* const viewFactory : this->registeredViewFactories())
   {
     qMRMLLayoutViewFactory* mrmlViewFactory = qobject_cast<qMRMLLayoutViewFactory*>(viewFactory);
     if (mrmlViewFactory)
@@ -764,7 +764,7 @@ qMRMLLayoutManager::~qMRMLLayoutManager()
   }
 
   // Delete detached viewports if they are not owned by the application mainWindow
-  foreach (qMRMLLayoutManagerPrivate::ViewportInfo viewport, d->DetachedViewports)
+  for (qMRMLLayoutManagerPrivate::ViewportInfo viewport : d->DetachedViewports)
   {
     if (viewport.Window && !viewport.Window->parent())
     {
@@ -792,7 +792,7 @@ void qMRMLLayoutManager::setEnabled(bool enable)
 QList<qMRMLLayoutViewFactory*> qMRMLLayoutManager::mrmlViewFactories() const
 {
   QList<qMRMLLayoutViewFactory*> res;
-  foreach (ctkLayoutViewFactory* viewFactory, this->registeredViewFactories())
+  for (ctkLayoutViewFactory* const viewFactory : this->registeredViewFactories())
   {
     qMRMLLayoutViewFactory* mrmlViewFactory = qobject_cast<qMRMLLayoutViewFactory*>(viewFactory);
     if (mrmlViewFactory)
@@ -806,7 +806,7 @@ QList<qMRMLLayoutViewFactory*> qMRMLLayoutManager::mrmlViewFactories() const
 // --------------------------------------------------------------------------
 qMRMLLayoutViewFactory* qMRMLLayoutManager::mrmlViewFactory(const QString& viewClassName) const
 {
-  foreach (qMRMLLayoutViewFactory* viewFactory, this->mrmlViewFactories())
+  for (qMRMLLayoutViewFactory* const viewFactory : this->mrmlViewFactories())
   {
     if (viewFactory->viewClassName() == viewClassName)
     {
@@ -1019,7 +1019,7 @@ void qMRMLLayoutManager::setMRMLScene(vtkMRMLScene* scene)
 
   d->qvtkReconnect(oldScene, scene, vtkMRMLScene::EndCloseEvent, d, SLOT(onSceneClosedEvent()));
 
-  foreach (qMRMLLayoutViewFactory* viewFactory, this->mrmlViewFactories())
+  for (qMRMLLayoutViewFactory* const viewFactory : this->mrmlViewFactories())
   {
     viewFactory->setMRMLScene(d->MRMLScene);
   }
@@ -1159,7 +1159,7 @@ void qMRMLLayoutManager::resetThreeDViews()
 //------------------------------------------------------------------------------
 void qMRMLLayoutManager::resetSliceViews()
 {
-  foreach (const QString& viewName, this->sliceViewNames())
+  for (const QString& viewName : this->sliceViewNames())
   {
     this->sliceWidget(viewName)->sliceController()->fitSliceToBackground();
   }
@@ -1287,7 +1287,7 @@ QWidget* qMRMLLayoutManager::createViewport(const QDomElement& layoutElement, co
 
     // Get application mainwindow
     QMainWindow* mainWindow = nullptr;
-    foreach (QWidget* widget, qApp->topLevelWidgets())
+    for (QWidget* const widget : qApp->topLevelWidgets())
     {
       mainWindow = qobject_cast<QMainWindow*>(widget);
       if (mainWindow)

--- a/Libs/MRML/Widgets/qMRMLLayoutViewFactory.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutViewFactory.cxx
@@ -93,7 +93,7 @@ void qMRMLLayoutViewFactoryPrivate::init()
 //------------------------------------------------------------------------------
 vtkMRMLAbstractViewNode* qMRMLLayoutViewFactoryPrivate::viewNodeByName(const QString& viewName) const
 {
-  foreach (vtkMRMLAbstractViewNode* viewNode, this->Views.keys())
+  for (vtkMRMLAbstractViewNode* const viewNode : this->Views.keys())
   {
     if (viewName == QString(viewNode->GetName()))
     {
@@ -106,7 +106,7 @@ vtkMRMLAbstractViewNode* qMRMLLayoutViewFactoryPrivate::viewNodeByName(const QSt
 //------------------------------------------------------------------------------
 vtkMRMLAbstractViewNode* qMRMLLayoutViewFactoryPrivate::viewNodeByLayoutLabel(const QString& layoutLabel) const
 {
-  foreach (vtkMRMLAbstractViewNode* viewNode, this->Views.keys())
+  for (vtkMRMLAbstractViewNode* const viewNode : this->Views.keys())
   {
     if (layoutLabel == QString(viewNode->GetLayoutLabel()))
     {
@@ -160,7 +160,7 @@ vtkMRMLLayoutLogic::ViewProperty qMRMLLayoutViewFactoryPrivate::propertyFromXML(
 QList<qMRMLWidget*> qMRMLLayoutViewFactoryPrivate::mrmlWidgets() const
 {
   QList<qMRMLWidget*> res;
-  foreach (QWidget* viewWidget, this->Views.values())
+  for (QWidget* const viewWidget : this->Views.values())
   {
     qMRMLWidget* mrmlWidget = qobject_cast<qMRMLWidget*>(viewWidget);
     if (mrmlWidget)
@@ -308,7 +308,7 @@ QStringList qMRMLLayoutViewFactory::viewNodeNames() const
   Q_D(const qMRMLLayoutViewFactory);
 
   QStringList res;
-  foreach (vtkMRMLAbstractViewNode* viewNode, d->Views.keys())
+  for (vtkMRMLAbstractViewNode* const viewNode : d->Views.keys())
   {
     res << viewNode->GetName();
   }
@@ -328,7 +328,7 @@ void qMRMLLayoutViewFactory::beginSetupLayout()
 {
   Q_D(qMRMLLayoutViewFactory);
   this->Superclass::beginSetupLayout();
-  foreach (vtkMRMLAbstractViewNode* viewNode, d->Views.keys())
+  for (vtkMRMLAbstractViewNode* const viewNode : d->Views.keys())
   {
     viewNode->SetMappedInLayout(false);
   }
@@ -577,7 +577,7 @@ QList<QWidget*> qMRMLLayoutViewFactory::createViewsFromXML(QDomElement viewEleme
   QList<vtkMRMLAbstractViewNode*> viewNodes = this->viewNodesFromXML(viewElement);
 
   QList<QWidget*> res;
-  foreach (vtkMRMLAbstractViewNode* viewNode, viewNodes)
+  for (vtkMRMLAbstractViewNode* const viewNode : viewNodes)
   {
     res << this->viewWidget(viewNode);
     vtkMRMLLayoutLogic::ViewProperties properties = d->propertiesFromXML(viewElement);

--- a/Libs/MRML/Widgets/qMRMLNodeAttributeTableView.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeAttributeTableView.cxx
@@ -281,7 +281,7 @@ void qMRMLNodeAttributeTableView::removeSelectedAttributes()
   // (there may be more items selected in a row)
   QList<QTableWidgetItem*> selectedItems = d->NodeAttributesTable->selectedItems();
   QSet<int> affectedRowNumbers;
-  foreach (QTableWidgetItem* item, selectedItems)
+  for (QTableWidgetItem* const item : selectedItems)
   {
     affectedRowNumbers.insert(item->row());
   }
@@ -328,7 +328,7 @@ QTableWidgetItem* qMRMLNodeAttributeTableView::findAttributeNameItem(const QStri
   QTableWidgetItem* item = nullptr;
   int numberOfAttributesFound = 0;
   QList<QTableWidgetItem*> itemList = d->NodeAttributesTable->findItems(attributeName, Qt::MatchFixedString);
-  foreach (QTableWidgetItem* currentItem, itemList)
+  for (QTableWidgetItem* const currentItem : itemList)
   {
     // Check if found item is in the name column (there may be values containing the same text)
     if (currentItem != nullptr && currentItem->column() == 0)

--- a/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
@@ -305,7 +305,7 @@ void qMRMLNodeComboBoxPrivate::updateActionItems(bool resetRootIndex)
     }
     if (this->AddEnabled)
     {
-      foreach (QString nodeType, q->nodeTypes())
+      for (const QString& nodeType : q->nodeTypes())
       {
         QString label = q->nodeTypeLabel(nodeType);
         extraItems.append(createNew + label);
@@ -319,7 +319,7 @@ void qMRMLNodeComboBoxPrivate::updateActionItems(bool resetRootIndex)
     {
       extraItems.append(qMRMLNodeComboBox::tr("Delete current ") + label);
     }
-    foreach (QAction* action, this->UserMenuActions)
+    for (QAction* const action : this->UserMenuActions)
     {
       extraItems.append(action->text());
     }
@@ -371,7 +371,7 @@ void qMRMLNodeComboBoxPrivate::updateDelegate(bool force)
 // --------------------------------------------------------------------------
 bool qMRMLNodeComboBoxPrivate::hasPostItem(const QString& name) const
 {
-  foreach (const QString& item, this->MRMLSceneModel->postItems(this->MRMLSceneModel->mrmlSceneItem()))
+  for (const QString& item : this->MRMLSceneModel->postItems(this->MRMLSceneModel->mrmlSceneItem()))
   {
     if (item.startsWith(name))
     {
@@ -475,7 +475,7 @@ void qMRMLNodeComboBox::activateExtraItem(const QModelIndex& index)
   else
   {
     // check for user added items
-    foreach (QAction* action, d->UserMenuActions)
+    for (QAction* const action : d->UserMenuActions)
     {
       if (data.startsWith(action->text()))
       {
@@ -520,7 +520,7 @@ void qMRMLNodeComboBox::setBaseName(const QString& baseName, const QString& node
     qWarning("qMRMLNodeComboBox::setBaseName failed: no node types have been set yet");
     return;
   }
-  foreach (QString aNodeType, nodeTypes)
+  for (const QString& aNodeType : nodeTypes)
   {
     d->MRMLNodeFactory->setBaseName(aNodeType, baseName);
   }
@@ -1286,7 +1286,7 @@ void qMRMLNodeComboBox::addMenuAction(QAction* newAction)
   Q_D(qMRMLNodeComboBox);
 
   // is an action with the same text already in the user list?
-  foreach (QAction* action, d->UserMenuActions)
+  for (QAction* const action : d->UserMenuActions)
   {
     if (action->text() == newAction->text())
     {

--- a/Libs/MRML/Widgets/qMRMLNodeFactory.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeFactory.cxx
@@ -94,7 +94,7 @@ vtkMRMLNode* qMRMLNodeFactory::createNode(const QString& className)
   // Ideally the qMRMLSortFilterProxyModel should listen the all the nodes and
   // when the attribute property is changed, make sure that it doesn't change
   // it's visibility
-  foreach (const QString& attributeName, d->Attributes.keys())
+  for (const QString& attributeName : d->Attributes.keys())
   {
     node->SetAttribute(attributeName.toUtf8(), d->Attributes[attributeName].toUtf8());
   }
@@ -124,7 +124,7 @@ vtkMRMLNode* qMRMLNodeFactory::createNode(vtkMRMLScene* scene, const QString& cl
   QScopedPointer<qMRMLNodeFactory> factory(new qMRMLNodeFactory());
   factory->setMRMLScene(scene);
   // Loop over attribute map and update the factory
-  foreach (const QString& key, attributes.keys())
+  for (const QString& key : attributes.keys())
   {
     factory->addAttribute(key, attributes.value(key));
   }

--- a/Libs/MRML/Widgets/qMRMLScalarsDisplayWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLScalarsDisplayWidget.cxx
@@ -94,7 +94,7 @@ void qMRMLScalarsDisplayWidgetPrivate::init()
 QList<vtkMRMLModelDisplayNode*> qMRMLScalarsDisplayWidgetPrivate::currentModelDisplayNodes() const
 {
   QList<vtkMRMLModelDisplayNode*> modelDisplayNodes;
-  foreach (vtkMRMLDisplayNode* displayNode, this->CurrentDisplayNodes)
+  for (vtkMRMLDisplayNode* const displayNode : this->CurrentDisplayNodes)
   {
     vtkMRMLModelDisplayNode* modelDisplayNode = vtkMRMLModelDisplayNode::SafeDownCast(displayNode);
     if (modelDisplayNode)
@@ -194,7 +194,7 @@ void qMRMLScalarsDisplayWidget::setScalarsVisibility(bool visible)
 {
   Q_D(qMRMLScalarsDisplayWidget);
 
-  foreach (vtkMRMLDisplayNode* displayNode, d->CurrentDisplayNodes)
+  for (vtkMRMLDisplayNode* const displayNode : d->CurrentDisplayNodes)
   {
     displayNode->SetScalarVisibility(visible);
     displayNode->UpdateAssignedAttribute();
@@ -220,7 +220,7 @@ void qMRMLScalarsDisplayWidget::setActiveScalarName(const QString& arrayName)
 {
   Q_D(qMRMLScalarsDisplayWidget);
 
-  foreach (vtkMRMLDisplayNode* displayNode, d->CurrentDisplayNodes)
+  for (vtkMRMLDisplayNode* const displayNode : d->CurrentDisplayNodes)
   {
     int wasModified = displayNode->StartModify();
 
@@ -256,7 +256,7 @@ void qMRMLScalarsDisplayWidget::setScalarsColorNode(vtkMRMLColorNode* colorNode)
 {
   Q_D(qMRMLScalarsDisplayWidget);
 
-  foreach (vtkMRMLDisplayNode* displayNode, d->CurrentDisplayNodes)
+  for (vtkMRMLDisplayNode* const displayNode : d->CurrentDisplayNodes)
   {
     if (displayNode)
     {
@@ -278,7 +278,7 @@ void qMRMLScalarsDisplayWidget::setScalarRangeMode(vtkMRMLDisplayNode::ScalarRan
   Q_D(qMRMLScalarsDisplayWidget);
 
   bool modified = false;
-  foreach (vtkMRMLDisplayNode* displayNode, d->CurrentDisplayNodes)
+  for (vtkMRMLDisplayNode* const displayNode : d->CurrentDisplayNodes)
   {
     int currentScalarRangeMode = displayNode->GetScalarRangeFlag();
     if (currentScalarRangeMode != mode)
@@ -311,7 +311,7 @@ void qMRMLScalarsDisplayWidget::setScalarsDisplayRange(double min, double max)
 {
   Q_D(qMRMLScalarsDisplayWidget);
 
-  foreach (vtkMRMLDisplayNode* displayNode, d->CurrentDisplayNodes)
+  for (vtkMRMLDisplayNode* const displayNode : d->CurrentDisplayNodes)
   {
     double* range = displayNode->GetScalarRange();
     if (range[0] == min && range[1] == max)
@@ -328,7 +328,7 @@ void qMRMLScalarsDisplayWidget::setTresholdEnabled(bool b)
   Q_D(qMRMLScalarsDisplayWidget);
 
   QList<vtkMRMLModelDisplayNode*> currentModelDisplayNodes = d->currentModelDisplayNodes();
-  foreach (vtkMRMLModelDisplayNode* modelDisplayNode, currentModelDisplayNodes)
+  for (vtkMRMLModelDisplayNode* const modelDisplayNode : currentModelDisplayNodes)
   {
     modelDisplayNode->SetThresholdEnabled(b);
   }
@@ -340,7 +340,7 @@ void qMRMLScalarsDisplayWidget::setThresholdRange(double min, double max)
   Q_D(qMRMLScalarsDisplayWidget);
 
   QList<vtkMRMLModelDisplayNode*> currentModelDisplayNodes = d->currentModelDisplayNodes();
-  foreach (vtkMRMLModelDisplayNode* modelDisplayNode, currentModelDisplayNodes)
+  for (vtkMRMLModelDisplayNode* const modelDisplayNode : currentModelDisplayNodes)
   {
     double oldMin = modelDisplayNode->GetThresholdMin();
     double oldMax = modelDisplayNode->GetThresholdMax();

--- a/Libs/MRML/Widgets/qMRMLSceneModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSceneModel.cxx
@@ -288,7 +288,7 @@ void qMRMLSceneModel::setPreItems(const QStringList& extraItems, QStandardItem* 
   d->removeAllExtraItems(parent, "preItem");
 
   int row = 0;
-  foreach (QString extraItem, extraItems)
+  for (const QString& extraItem : extraItems)
   {
     d->insertExtraItem(row++, parent, extraItem, "preItem", Qt::ItemIsEnabled | Qt::ItemIsSelectable);
   }
@@ -319,7 +319,7 @@ void qMRMLSceneModel::setPostItems(const QStringList& extraItems, QStandardItem*
   }
 
   d->removeAllExtraItems(parent, "postItem");
-  foreach (QString extraItem, extraItems)
+  for (const QString& extraItem : extraItems)
   {
     d->insertExtraItem(parent->rowCount(), parent, extraItem, "postItem", Qt::ItemIsEnabled);
   }
@@ -655,7 +655,7 @@ QMimeData* qMRMLSceneModel::mimeData(const QModelIndexList& indexes) const
     return nullptr;
   }
   QModelIndexList allColumnsIndexes;
-  foreach (const QModelIndex& index, indexes)
+  for (const QModelIndex& index : indexes)
   {
     QModelIndex parent = index.parent();
     for (int column = 0; column < this->columnCount(parent); ++column)
@@ -773,7 +773,7 @@ void qMRMLSceneModel::populateScene()
     index++;
     d->insertNode(node, index);
   }
-  foreach (vtkMRMLNode* misplacedNode, d->MisplacedNodes)
+  for (vtkMRMLNode* const misplacedNode : d->MisplacedNodes)
   {
     this->onMRMLNodeModified(misplacedNode);
   }
@@ -1200,7 +1200,7 @@ void qMRMLSceneModel::onMRMLSceneNodeAboutToBeRemoved(vtkMRMLScene* scene, vtkMR
     }
     // Remove the item from any orphan list if it exist as we don't want to
     // add it back later in onMRMLSceneNodeRemoved
-    foreach (QList<QStandardItem*> orphans, d->Orphans)
+    for (QList<QStandardItem*> orphans : d->Orphans)
     {
       if (orphans.contains(item))
       {
@@ -1224,7 +1224,7 @@ void qMRMLSceneModel::onMRMLSceneNodeRemoved(vtkMRMLScene* scene, vtkMRMLNode* n
   // The removed node may had children, if they haven't been updated, they
   // are likely to be lost (not reachable when browsing the model), we need
   // to reparent them.
-  foreach (QList<QStandardItem*> orphans, d->Orphans)
+  for (QList<QStandardItem*> orphans : d->Orphans)
   {
     QStandardItem* orphan = orphans[0];
     // Make sure that the orphans have not already been reparented.

--- a/Libs/MRML/Widgets/qMRMLSegmentSelectorWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSegmentSelectorWidget.cxx
@@ -310,7 +310,7 @@ void qMRMLSegmentSelectorWidget::onSegmentMultiSelectionChanged()
   }
 
   d->SelectedSegmentIDs.clear();
-  foreach (QModelIndex index, d->CheckableComboBox_Segment->checkedIndexes())
+  for (const QModelIndex& index : d->CheckableComboBox_Segment->checkedIndexes())
   {
     d->SelectedSegmentIDs << d->CheckableComboBox_Segment->itemData(index.row()).toString();
   }
@@ -401,7 +401,7 @@ void qMRMLSegmentSelectorWidget::setSelectedSegmentIDs(QStringList segmentIDList
 
   // Make sure all the IDs in the list are valid
   QStringList invalidSegmentIDs;
-  foreach (QString segmentID, segmentIDList)
+  for (const QString& segmentID : segmentIDList)
   {
     if (!d->SegmentationNode->GetSegmentation()->GetSegment(segmentID.toUtf8().constData()))
     {
@@ -409,7 +409,7 @@ void qMRMLSegmentSelectorWidget::setSelectedSegmentIDs(QStringList segmentIDList
       invalidSegmentIDs << segmentID;
     }
   }
-  foreach (QString invalidID, invalidSegmentIDs)
+  for (const QString& invalidID : invalidSegmentIDs)
   {
     segmentIDList.removeAll(invalidID);
   }

--- a/Libs/MRML/Widgets/qMRMLSliceView.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceView.cxx
@@ -196,7 +196,7 @@ void qMRMLSliceViewPrivate::initDisplayableManagers()
   displayableManagers << "vtkMRMLOrientationMarkerDisplayableManager";
   displayableManagers << "vtkMRMLRulerDisplayableManager";
   displayableManagers << "vtkMRMLScalarBarDisplayableManager";
-  foreach (const QString& displayableManager, displayableManagers)
+  for (const QString& displayableManager : displayableManagers)
   {
     if (!factory->IsDisplayableManagerRegistered(displayableManager.toUtf8()))
     {

--- a/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
@@ -360,7 +360,7 @@ void qMRMLSliceWidget::showEvent(QShowEvent* event)
   // Reset slice view size when screen changes to account for a possible change
   // in the device pixel ratio.
   QWindow* window = nullptr;
-  foreach (QWidget* widget, qApp->topLevelWidgets())
+  for (QWidget* const widget : qApp->topLevelWidgets())
   {
     QMainWindow* mainWindow = qobject_cast<QMainWindow*>(widget);
     if (mainWindow)

--- a/Libs/MRML/Widgets/qMRMLSortFilterProxyModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSortFilterProxyModel.cxx
@@ -230,7 +230,7 @@ qMRMLSortFilterProxyModel::AcceptType qMRMLSortFilterProxyModel::filterAcceptsNo
   if (!d->ShowHidden && node->GetHideFromEditors())
   {
     bool hide = true;
-    foreach (const QString& nodeType, d->ShowHiddenForTypes)
+    for (const QString& nodeType : d->ShowHiddenForTypes)
     {
       if (node->IsA(nodeType.toUtf8()))
       {
@@ -260,7 +260,7 @@ qMRMLSortFilterProxyModel::AcceptType qMRMLSortFilterProxyModel::filterAcceptsNo
     // Apply filter if any
     return AcceptButPotentiallyRejectable;
   }
-  foreach (const QString& nodeType, d->NodeTypes)
+  for (const QString& nodeType : d->NodeTypes)
   {
     // filter by node type
     if (!node->IsA(nodeType.toUtf8().data()))
@@ -277,7 +277,7 @@ qMRMLSortFilterProxyModel::AcceptType qMRMLSortFilterProxyModel::filterAcceptsNo
     // filter by HideChildNodeType
     if (d->ShowChildNodeTypes)
     {
-      foreach (const QString& hideChildNodeType, d->HideChildNodeTypes)
+      for (const QString& hideChildNodeType : d->HideChildNodeTypes)
       {
         if (node->IsA(hideChildNodeType.toUtf8().data()))
         {

--- a/Libs/MRML/Widgets/qMRMLTableModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLTableModel.cxx
@@ -681,9 +681,8 @@ int qMRMLTableModel::removeSelectionFromMRML(QModelIndexList selection, bool rem
   }
   bool removeMRMLRows = d->Transposed ? !removeModelRow : removeModelRow;
 
-  QModelIndex index;
   QList<int> mrmlIndexList; // list of MRML table columns or rows that will be removed
-  foreach (index, selection)
+  for (const QModelIndex index : selection)
   {
     int mrmlIndex = removeMRMLRows ? mrmlTableRowIndex(index) : mrmlTableColumnIndex(index);
     if (!mrmlIndexList.contains(mrmlIndex))
@@ -697,7 +696,7 @@ int qMRMLTableModel::removeSelectionFromMRML(QModelIndexList selection, bool rem
 
   // block modified events to prevent updating of the table during processing
   int wasModified = d->MRMLTableNode->StartModify();
-  foreach (int mrmlIndex, mrmlIndexList)
+  for (const int& mrmlIndex : mrmlIndexList)
   {
     if (removeMRMLRows)
     {

--- a/Libs/MRML/Widgets/qMRMLTableView.cxx
+++ b/Libs/MRML/Widgets/qMRMLTableView.cxx
@@ -404,11 +404,11 @@ void qMRMLTableView::pasteSelection()
   }
   mrmlModel->updateModelFromMRML();
 
-  foreach (QString line, lines)
+  for (const QString& line : lines)
   {
     int columnIndex = startColumnIndex;
     QStringList cells = line.split('\t');
-    foreach (QString cell, cells)
+    for (const QString& cell : cells)
     {
       // Pre-allocate new columns (enough for at least for storing all the items in the current row)
       if (columnIndex >= mrmlModel->columnCount())
@@ -833,8 +833,7 @@ QList<int> qMRMLTableView::selectedMRMLTableColumnIndices() const
   QList<int> mrmlColumnIndexList;
   QModelIndexList selection = selectionModel()->selectedIndexes();
   qMRMLTableModel* tableModel = this->tableModel();
-  QModelIndex index;
-  foreach (index, selection)
+  for (const QModelIndex index : selection)
   {
     int mrmlColumnIndex = tableModel->mrmlTableColumnIndex(index);
     if (!mrmlColumnIndexList.contains(mrmlColumnIndex))

--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -133,7 +133,7 @@ void qMRMLThreeDViewPrivate::initDisplayableManagers()
                       << "vtkMRMLCrosshairDisplayableManager3D"
                       << "vtkMRMLOrientationMarkerDisplayableManager"
                       << "vtkMRMLRulerDisplayableManager";
-  foreach (const QString& displayableManager, displayableManagers)
+  for (const QString& displayableManager : displayableManagers)
   {
     if (!factory->IsDisplayableManagerRegistered(displayableManager.toUtf8()))
     {

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -497,7 +497,7 @@ void qMRMLThreeDViewControllerWidget::updateWidgetFromMRMLView()
   QList<QWidget*> widgets;
   widgets << d->AxesWidget << d->CenterButton << d->OrthoButton << d->VisibilityButton << d->ZoomInButton << d->ZoomOutButton << d->ShadowsButton << d->RockButton << d->SpinButton
           << d->MoreToolButton << d->OrientationMarkerButton; // RulerButton enable state is not set here (it depends on render mode)
-  foreach (QWidget* w, widgets)
+  for (QWidget* const w : widgets)
   {
     w->setEnabled(viewNode != nullptr);
   }

--- a/Libs/MRML/Widgets/qMRMLTreeView.cxx
+++ b/Libs/MRML/Widgets/qMRMLTreeView.cxx
@@ -924,7 +924,7 @@ bool qMRMLTreeView::isAncestor(const QModelIndex& index, const QModelIndex& pote
 //------------------------------------------------------------------------------
 QModelIndex qMRMLTreeView::findAncestor(const QModelIndex& index, const QModelIndexList& potentialAncestors)
 {
-  foreach (const QModelIndex& potentialAncestor, potentialAncestors)
+  for (const QModelIndex& potentialAncestor : potentialAncestors)
   {
     if (qMRMLTreeView::isAncestor(index, potentialAncestor))
     {
@@ -938,7 +938,7 @@ QModelIndex qMRMLTreeView::findAncestor(const QModelIndex& index, const QModelIn
 QModelIndexList qMRMLTreeView::removeChildren(const QModelIndexList& indexes)
 {
   QModelIndexList noAncestorIndexList;
-  foreach (QModelIndex index, indexes)
+  for (const QModelIndex& index : indexes)
   {
     if (!qMRMLTreeView::findAncestor(index, indexes).isValid())
     {

--- a/Libs/MRML/Widgets/qMRMLUtils.cxx
+++ b/Libs/MRML/Widgets/qMRMLUtils.cxx
@@ -194,7 +194,7 @@ void qMRMLUtils::mimeDataToSubjectHierarchyItemIDs(const QMimeData* mimeData, vt
     return;
   }
   idList->Reset();
-  foreach (QUrl url, mimeData->urls())
+  for (const QUrl& url : mimeData->urls())
   {
     if (!url.isValid() || url.isEmpty())
     {

--- a/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.cxx
+++ b/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.cxx
@@ -275,7 +275,7 @@ void qSlicerCropVolumeModuleWidget::enter()
     qSlicerApplication* app = qSlicerApplication::application();
     if (app && app->layoutManager())
     {
-      foreach (QString sliceViewName, app->layoutManager()->sliceViewNames())
+      for (const QString& sliceViewName : app->layoutManager()->sliceViewNames())
       {
         qMRMLSliceWidget* sliceWidget = app->layoutManager()->sliceWidget(sliceViewName);
         const char* backgroundVolumeNodeID = sliceWidget->sliceLogic()->GetSliceCompositeNode()->GetBackgroundVolumeID();

--- a/Modules/Loadable/Data/qSlicerDataModuleWidget.cxx
+++ b/Modules/Loadable/Data/qSlicerDataModuleWidget.cxx
@@ -175,7 +175,7 @@ void qSlicerDataModuleWidget::setup()
   QString aggregatedHelpText("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">"
                              "<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\"> p, li { white-space: pre-wrap; }"
                              "</style></head><body style=\" font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;\">");
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, qSlicerSubjectHierarchyPluginHandler::instance()->allPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : qSlicerSubjectHierarchyPluginHandler::instance()->allPlugins())
   {
     // Add help text from each plugin
     QString pluginHelpText = plugin->helpText();

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
@@ -780,7 +780,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::removeNodesToBeDeleted()
     return;
   }
 
-  foreach (vtkWeakPointer<vtkMRMLMarkupsNode> markupsNode, d->NodesToDelete)
+  for (const vtkWeakPointer<vtkMRMLMarkupsNode>& markupsNode : d->NodesToDelete)
   {
     if (!markupsNode)
     {

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsOptionsWidgetsFactory.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsOptionsWidgetsFactory.cxx
@@ -184,7 +184,7 @@ qMRMLMarkupsAbstractOptionsWidget* qMRMLMarkupsOptionsWidgetsFactory::createWidg
 //-----------------------------------------------------------------------------
 void qMRMLMarkupsOptionsWidgetsFactory::unregisterAll()
 {
-  foreach (auto widget, this->RegisteredWidgets)
+  for (const auto& widget : this->RegisteredWidgets)
   {
     if (widget)
     {

--- a/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
@@ -745,7 +745,7 @@ QToolButton* qSlicerMarkupsPlaceWidget::deleteButton() const
 bool qSlicerMarkupsPlaceWidget::buttonsVisible() const
 {
   Q_D(const qSlicerMarkupsPlaceWidget);
-  foreach (QWidget* w, d->OptionsWidgets)
+  for (QWidget* const w : d->OptionsWidgets)
   {
     if (!w->isVisible())
     {
@@ -759,7 +759,7 @@ bool qSlicerMarkupsPlaceWidget::buttonsVisible() const
 void qSlicerMarkupsPlaceWidget::setButtonsVisible(bool visible)
 {
   Q_D(qSlicerMarkupsPlaceWidget);
-  foreach (QWidget* w, d->OptionsWidgets)
+  for (QWidget* const w : d->OptionsWidgets)
   {
     w->setVisible(visible);
   }

--- a/Modules/Loadable/Markups/qSlicerAnnotationsIOOptionsWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerAnnotationsIOOptionsWidget.cxx
@@ -108,7 +108,7 @@ void qSlicerAnnotationsIOOptionsWidget::setFileNames(const QStringList& fileName
 {
   Q_D(qSlicerAnnotationsIOOptionsWidget);
   QStringList names;
-  foreach (const QString& fileName, fileNames)
+  for (const QString& fileName : fileNames)
   {
     QFileInfo fileInfo(fileName);
     if (fileInfo.isFile())

--- a/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
@@ -148,7 +148,7 @@ void qSlicerMarkupsModulePrivate::addToolBar()
   mainWindow->addToolBarBreak();
   mainWindow->addToolBar(this->ToolBar);
   this->MarkupsModuleOwnsToolBar = false;
-  foreach (QMenu* toolBarMenu, mainWindow->findChildren<QMenu*>())
+  for (QMenu* const toolBarMenu : mainWindow->findChildren<QMenu*>())
   {
     if (toolBarMenu->objectName() == QString("WindowToolBarsMenu"))
     {

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -683,7 +683,7 @@ bool qSlicerMarkupsModuleWidgetPrivate::getPersistanceModeEnabled()
 //-----------------------------------------------------------
 void qSlicerMarkupsModuleWidgetPrivate::updateMarkupsOptionsWidgets()
 {
-  foreach (auto widget, this->MarkupsOptionsWidgets)
+  for (const auto& widget : this->MarkupsOptionsWidgets)
   {
     widget->setParent(nullptr);
   }
@@ -692,7 +692,7 @@ void qSlicerMarkupsModuleWidgetPrivate::updateMarkupsOptionsWidgets()
 
   // Create the markups options widgets registered in qMRMLMarkupsOptionsWidgetsFactory.
   auto factory = qMRMLMarkupsOptionsWidgetsFactory::instance();
-  foreach (const auto& widgetClassName, factory->registeredOptionsWidgetsClassNames())
+  for (const auto& widgetClassName : factory->registeredOptionsWidgetsClassNames())
   {
     this->MarkupsOptionsWidgets.append(factory->createWidget(widgetClassName));
   }
@@ -704,7 +704,7 @@ void qSlicerMarkupsModuleWidgetPrivate::placeMarkupsOptionsWidgets()
   Q_Q(qSlicerMarkupsModuleWidget);
 
   // Add the options widgets
-  foreach (const auto& widget, this->MarkupsOptionsWidgets)
+  for (const auto& widget : this->MarkupsOptionsWidgets)
   {
     // If the parent is different from the qSlicerMarkupsModule widget, then add the widget.
     if (widget->parentWidget() != q)
@@ -968,7 +968,7 @@ void qSlicerMarkupsModuleWidget::updateWidgetFromMRML()
     this->updateRows();
   }
   // Update options widgets
-  foreach (const auto& widget, d->MarkupsOptionsWidgets)
+  for (const auto& widget : d->MarkupsOptionsWidgets)
   {
     widget->updateWidgetFromMRML();
   }
@@ -2560,7 +2560,7 @@ void qSlicerMarkupsModuleWidget::pasteSelectedFromClipboard()
   // SetPointFromString calls various events reporting the id of the point modified.
   // However, already for > 200 points, it gets bad performance. Therefore, we call a simply modified call at the end.
   MRMLNodeModifyBlocker blocker(d->MarkupsNode);
-  foreach (QString line, lines)
+  for (QString line : lines)
   {
     line = line.trimmed();
     if (line.isEmpty() || line.startsWith('#'))
@@ -2622,7 +2622,7 @@ void qSlicerMarkupsModuleWidget::setMRMLMarkupsNode(vtkMRMLMarkupsNode* markupsN
   // Setting the internal Markups node
   d->MarkupsNode = markupsNode;
 
-  foreach (const auto& widget, d->MarkupsOptionsWidgets)
+  for (const auto& widget : d->MarkupsOptionsWidgets)
   {
     widget->setMRMLMarkupsNode(markupsNode);
     widget->setVisible(widget->canManageMRMLMarkupsNode(markupsNode));
@@ -3033,7 +3033,7 @@ void qSlicerMarkupsModuleWidget::onMeasurementModified(vtkObject* caller)
     else
     {
       QList<QTableWidgetItem*> nameItemsFound = d->measurementSettingsTableWidget->findItems(measurementName, Qt::MatchExactly);
-      foreach (QTableWidgetItem* nameItem, nameItemsFound)
+      for (QTableWidgetItem* const nameItem : nameItemsFound)
       {
         QCheckBox* checkbox = qobject_cast<QCheckBox*>(d->measurementSettingsTableWidget->cellWidget(nameItem->row(), 1));
         checkbox->setChecked(measurement->GetEnabled());

--- a/Modules/Loadable/Models/Widgets/qMRMLModelDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Models/Widgets/qMRMLModelDisplayNodeWidget.cxx
@@ -153,7 +153,7 @@ QList<vtkMRMLModelDisplayNode*> qMRMLModelDisplayNodeWidgetPrivate::modelDisplay
     return modelDisplayNodes;
   }
 
-  foreach (vtkIdType itemID, this->CurrentSubjectHierarchyItemIDs)
+  for (const vtkIdType& itemID : this->CurrentSubjectHierarchyItemIDs)
   {
     // Can be set from model or folder
     vtkMRMLModelNode* modelNode = vtkMRMLModelNode::SafeDownCast(shNode->GetItemDataNode(itemID));
@@ -185,7 +185,7 @@ QList<vtkMRMLDisplayNode*> qMRMLModelDisplayNodeWidgetPrivate::displayNodesFromS
     return displayNodes;
   }
 
-  foreach (vtkIdType itemID, this->CurrentSubjectHierarchyItemIDs)
+  for (const vtkIdType& itemID : this->CurrentSubjectHierarchyItemIDs)
   {
     // Can be set from model or folder
     vtkMRMLDisplayableNode* displayableNode = vtkMRMLDisplayableNode::SafeDownCast(shNode->GetItemDataNode(itemID));
@@ -508,7 +508,7 @@ void qMRMLModelDisplayNodeWidget::setVisibility(bool visible)
   Q_D(qMRMLModelDisplayNodeWidget);
 
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     displayNode->SetVisibility(visible);
   }
@@ -527,7 +527,7 @@ void qMRMLModelDisplayNodeWidget::setClipping(bool clip)
   Q_D(qMRMLModelDisplayNodeWidget);
 
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     displayNode->SetClipping(clip);
   }
@@ -547,7 +547,7 @@ void qMRMLModelDisplayNodeWidget::setSliceIntersectionVisible(bool visible)
   Q_D(qMRMLModelDisplayNodeWidget);
 
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     displayNode->SetVisibility2D(visible);
   }
@@ -566,7 +566,7 @@ void qMRMLModelDisplayNodeWidget::setSliceIntersectionThickness(int thickness)
   Q_D(qMRMLModelDisplayNodeWidget);
 
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     displayNode->SetSliceIntersectionThickness(thickness);
   }
@@ -585,7 +585,7 @@ void qMRMLModelDisplayNodeWidget::setSliceIntersectionOpacity(double opacity)
   Q_D(qMRMLModelDisplayNodeWidget);
 
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     displayNode->SetSliceIntersectionOpacity(opacity);
   }
@@ -609,7 +609,7 @@ void qMRMLModelDisplayNodeWidget::updateDisplayNodesFromProperty()
   }
 
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     int wasModifying = displayNode->StartModify();
     // Lighting
@@ -633,7 +633,7 @@ void qMRMLModelDisplayNodeWidget::setRepresentation(int newRepresentation)
   Q_D(qMRMLModelDisplayNodeWidget);
 
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     switch (newRepresentation)
     {
@@ -662,7 +662,7 @@ void qMRMLModelDisplayNodeWidget::setSliceDisplayMode(int newMode)
   Q_D(qMRMLModelDisplayNodeWidget);
 
   QList<vtkMRMLModelDisplayNode*> modelDisplayNodesInSelection = d->modelDisplayNodesFromSelection();
-  foreach (vtkMRMLModelDisplayNode* modelDisplayNode, modelDisplayNodesInSelection)
+  for (vtkMRMLModelDisplayNode* const modelDisplayNode : modelDisplayNodesInSelection)
   {
     int wasModified = modelDisplayNode->StartModify();
     // Select a color node if none is selected yet
@@ -683,7 +683,7 @@ void qMRMLModelDisplayNodeWidget::setPointSize(double newPointSize)
   Q_D(qMRMLModelDisplayNodeWidget);
 
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     displayNode->SetPointSize(newPointSize);
   }
@@ -695,7 +695,7 @@ void qMRMLModelDisplayNodeWidget::setLineWidth(double newLineWidth)
   Q_D(qMRMLModelDisplayNodeWidget);
 
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     displayNode->SetLineWidth(newLineWidth);
   }
@@ -706,7 +706,7 @@ void qMRMLModelDisplayNodeWidget::setBackfaceHueOffset(double newOffset)
 {
   Q_D(qMRMLModelDisplayNodeWidget);
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     vtkMRMLModelDisplayNode* modelDisplayNode = vtkMRMLModelDisplayNode::SafeDownCast(displayNode);
     if (!modelDisplayNode)
@@ -724,7 +724,7 @@ void qMRMLModelDisplayNodeWidget::setBackfaceSaturationOffset(double newOffset)
 {
   Q_D(qMRMLModelDisplayNodeWidget);
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     vtkMRMLModelDisplayNode* modelDisplayNode = vtkMRMLModelDisplayNode::SafeDownCast(displayNode);
     if (!modelDisplayNode)
@@ -742,7 +742,7 @@ void qMRMLModelDisplayNodeWidget::setBackfaceBrightnessOffset(double newOffset)
 {
   Q_D(qMRMLModelDisplayNodeWidget);
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     vtkMRMLModelDisplayNode* modelDisplayNode = vtkMRMLModelDisplayNode::SafeDownCast(displayNode);
     if (!modelDisplayNode)
@@ -761,7 +761,7 @@ void qMRMLModelDisplayNodeWidget::setShowFaces(int newShowFaces)
   Q_D(qMRMLModelDisplayNodeWidget);
 
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     int wasModified = displayNode->StartModify();
     switch (newShowFaces)
@@ -789,7 +789,7 @@ void qMRMLModelDisplayNodeWidget::setColor(const QColor& newColor)
   Q_D(qMRMLModelDisplayNodeWidget);
 
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     double* oldColorArray = displayNode->GetColor();
     QColor oldColor = QColor::fromRgbF(oldColorArray[0], oldColorArray[1], oldColorArray[2]);
@@ -809,7 +809,7 @@ void qMRMLModelDisplayNodeWidget::setOpacity(double newOpacity)
   Q_D(qMRMLModelDisplayNodeWidget);
 
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     displayNode->SetOpacity(newOpacity);
   }
@@ -832,7 +832,7 @@ void qMRMLModelDisplayNodeWidget::setEdgeColor(const QColor& newColor)
   Q_D(qMRMLModelDisplayNodeWidget);
 
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
-  foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
+  for (vtkMRMLDisplayNode* const displayNode : displayNodesInSelection)
   {
     displayNode->SetEdgeColor(newColor.redF(), newColor.greenF(), newColor.blueF());
   }

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorEffectFactory.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorEffectFactory.cxx
@@ -78,7 +78,7 @@ qSlicerSegmentEditorEffectFactory::qSlicerSegmentEditorEffectFactory(QObject* pa
 //-----------------------------------------------------------------------------
 qSlicerSegmentEditorEffectFactory::~qSlicerSegmentEditorEffectFactory()
 {
-  foreach (qSlicerSegmentEditorAbstractEffect* effect, m_RegisteredEffects)
+  for (qSlicerSegmentEditorAbstractEffect* const effect : m_RegisteredEffects)
   {
     delete effect;
   }
@@ -100,8 +100,7 @@ bool qSlicerSegmentEditorEffectFactory::registerEffect(qSlicerSegmentEditorAbstr
   }
 
   // Check if the same effect has already been registered
-  qSlicerSegmentEditorAbstractEffect* currentEffect = nullptr;
-  foreach (currentEffect, this->m_RegisteredEffects)
+  for (const qSlicerSegmentEditorAbstractEffect* const currentEffect : this->m_RegisteredEffects)
   {
     if (effectToRegister->name().compare(currentEffect->name()) == 0)
     {
@@ -119,11 +118,11 @@ bool qSlicerSegmentEditorEffectFactory::registerEffect(qSlicerSegmentEditorAbstr
 QList<qSlicerSegmentEditorAbstractEffect*> qSlicerSegmentEditorEffectFactory::copyEffects(QList<qSlicerSegmentEditorAbstractEffect*>& effects)
 {
   QList<qSlicerSegmentEditorAbstractEffect*> copiedEffects;
-  foreach (qSlicerSegmentEditorAbstractEffect* effect, m_RegisteredEffects)
+  for (qSlicerSegmentEditorAbstractEffect* const effect : m_RegisteredEffects)
   {
     // If effect is added already then skip it
     bool effectAlreadyAdded = false;
-    foreach (qSlicerSegmentEditorAbstractEffect* existingEffect, effects)
+    for (qSlicerSegmentEditorAbstractEffect* const existingEffect : effects)
     {
       if (existingEffect->name() == effect->name())
       {

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
@@ -771,7 +771,7 @@ void qSlicerSegmentEditorPaintEffectPrivate::updateBrushes()
   // unusedWidgetPipelines will contain those widget pointers that are not in the layout anymore
   QList<qMRMLWidget*> unusedWidgetPipelines = this->BrushPipelines.keys();
   qSlicerLayoutManager* layoutManager = qSlicerApplication::application()->layoutManager();
-  foreach (QString sliceViewName, layoutManager->sliceViewNames())
+  for (const QString& sliceViewName : layoutManager->sliceViewNames())
   {
     qMRMLSliceWidget* sliceWidget = layoutManager->sliceWidget(sliceViewName);
     if (!q->segmentationDisplayableInView(sliceWidget->mrmlSliceNode()))
@@ -798,7 +798,7 @@ void qSlicerSegmentEditorPaintEffectPrivate::updateBrushes()
     qSlicerSegmentEditorAbstractEffect::scheduleRender(threeDWidget);
   }
 
-  foreach (qMRMLWidget* viewWidget, unusedWidgetPipelines)
+  for (qMRMLWidget* const viewWidget : unusedWidgetPipelines)
   {
     BrushPipeline* pipeline = this->BrushPipelines[viewWidget];
     BrushPipeline2D* pipeline2D = dynamic_cast<BrushPipeline2D*>(pipeline);
@@ -1201,7 +1201,7 @@ bool qSlicerSegmentEditorPaintEffect::processInteractionEvents(vtkRenderWindowIn
     {
       return false;
     }
-    foreach (qMRMLWidget* viewWidget, viewWidgets)
+    for (qMRMLWidget* const viewWidget : viewWidgets)
     {
       d->BrushPipelines[viewWidget]->SetFeedbackVisibility(d->DelayedPaint);
     }
@@ -1228,7 +1228,7 @@ bool qSlicerSegmentEditorPaintEffect::processInteractionEvents(vtkRenderWindowIn
       // Cleaning up pipelines schedules re-rendering as well, but on some Intel video cards, and especially in debug mode,
       // this additional rendering request is necessary for showing the filled segment after paint stroke is completed.
       QList<qMRMLWidget*> viewWidgets = d->BrushPipelines.keys();
-      foreach (qMRMLWidget* aViewWidget, viewWidgets)
+      for (qMRMLWidget* const aViewWidget : viewWidgets)
       {
         d->BrushPipelines[aViewWidget]->SetFeedbackVisibility(false);
         d->BrushPipelines[aViewWidget]->SetBrushVisibility(worldPositionValid);
@@ -1279,7 +1279,7 @@ bool qSlicerSegmentEditorPaintEffect::processInteractionEvents(vtkRenderWindowIn
     {
       // no valid world position (nothing can be picked), hide the brush
       QList<qMRMLWidget*> viewWidgets = d->BrushPipelines.keys();
-      foreach (qMRMLWidget* aViewWidget, viewWidgets)
+      for (qMRMLWidget* const aViewWidget : viewWidgets)
       {
         bool brushVisibilityChanged = (d->BrushPipelines[aViewWidget]->GetBrushVisibility() != worldPositionValid);
         if (brushVisibilityChanged)

--- a/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentsPlugin.cxx
+++ b/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentsPlugin.cxx
@@ -956,7 +956,7 @@ void qSlicerSubjectHierarchySegmentsPlugin::jumpSlices()
     // Application is closing
     return;
   }
-  foreach (QString sliceViewName, layoutManager->sliceViewNames())
+  for (const QString& sliceViewName : layoutManager->sliceViewNames())
   {
     // Check if segmentation is visible in this view
     qMRMLSliceWidget* sliceWidget = layoutManager->sliceWidget(sliceViewName);

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -361,7 +361,7 @@ qMRMLSegmentEditorWidgetPrivate::~qMRMLSegmentEditorWidgetPrivate()
   Q_Q(qMRMLSegmentEditorWidget);
   q->removeViewObservations();
 
-  foreach (qSlicerSegmentEditorAbstractEffect* effect, this->RegisteredEffects)
+  for (qSlicerSegmentEditorAbstractEffect* const effect : this->RegisteredEffects)
   {
     effect->cleanup();
     delete effect;
@@ -499,7 +499,7 @@ void qMRMLSegmentEditorWidgetPrivate::init()
 QToolButton* qMRMLSegmentEditorWidgetPrivate::toolButton(qSlicerSegmentEditorAbstractEffect* effect)
 {
   QList<QAbstractButton*> effectButtons = this->EffectButtonGroup.buttons();
-  foreach (QAbstractButton* effectButton, effectButtons)
+  for (QAbstractButton* const effectButton : effectButtons)
   {
     qSlicerSegmentEditorAbstractEffect* foundEffect = qobject_cast<qSlicerSegmentEditorAbstractEffect*>(effectButton->property("Effect").value<QObject*>());
     if (effect == foundEffect)
@@ -521,7 +521,7 @@ void qMRMLSegmentEditorWidgetPrivate::notifyEffectsOfReferenceGeometryChange(con
   }
   this->LastNotifiedReferenceImageGeometry = geometry;
 
-  foreach (qSlicerSegmentEditorAbstractEffect* effect, this->RegisteredEffects)
+  for (qSlicerSegmentEditorAbstractEffect* const effect : this->RegisteredEffects)
   {
     effect->referenceGeometryChanged();
   }
@@ -530,7 +530,7 @@ void qMRMLSegmentEditorWidgetPrivate::notifyEffectsOfReferenceGeometryChange(con
 //-----------------------------------------------------------------------------
 void qMRMLSegmentEditorWidgetPrivate::notifyEffectsOfSourceVolumeNodeChange()
 {
-  foreach (qSlicerSegmentEditorAbstractEffect* effect, this->RegisteredEffects)
+  for (qSlicerSegmentEditorAbstractEffect* const effect : this->RegisteredEffects)
   {
     effect->sourceVolumeNodeChanged();
     effect->masterVolumeNodeChanged(); // for backward compatibility
@@ -540,7 +540,7 @@ void qMRMLSegmentEditorWidgetPrivate::notifyEffectsOfSourceVolumeNodeChange()
 //-----------------------------------------------------------------------------
 void qMRMLSegmentEditorWidgetPrivate::notifyEffectsOfLayoutChange()
 {
-  foreach (qSlicerSegmentEditorAbstractEffect* effect, this->RegisteredEffects)
+  for (qSlicerSegmentEditorAbstractEffect* const effect : this->RegisteredEffects)
   {
     effect->layoutChanged();
   }
@@ -816,7 +816,7 @@ void qMRMLSegmentEditorWidgetPrivate::setEffectCursor(qSlicerSegmentEditorAbstra
   // We update the default cursor as well so that if the user hovers the mouse over
   // a markup, the cursor shape is then restored to the effect cursor.
 
-  foreach (QString sliceViewName, layoutManager->sliceViewNames())
+  for (const QString& sliceViewName : layoutManager->sliceViewNames())
   {
     qMRMLSliceWidget* sliceWidget = layoutManager->sliceWidget(sliceViewName);
     QString viewNodeID = QString::fromStdString(sliceWidget->mrmlSliceNode()->GetID());
@@ -1066,7 +1066,7 @@ void qMRMLSegmentEditorWidget::updateEffectList()
   QList<qSlicerSegmentEditorAbstractEffect*> addedEffects = qSlicerSegmentEditorEffectFactory::instance()->copyEffects(d->RegisteredEffects);
 
   // Set up effect connections and options frame for all newly added effects
-  foreach (qSlicerSegmentEditorAbstractEffect* effect, addedEffects)
+  for (qSlicerSegmentEditorAbstractEffect* const effect : addedEffects)
   {
     // Connect callbacks that allow effects to send requests to the editor widget without
     // introducing a direct dependency of the effect on the widget.
@@ -1107,7 +1107,7 @@ void qMRMLSegmentEditorWidget::updateEffectList()
   // a different button order) and hide all buttons (to only show buttons
   // that are requested to be displayed).
   QList<QAbstractButton*> effectButtons = d->EffectButtonGroup.buttons();
-  foreach (QAbstractButton* button, effectButtons)
+  for (QAbstractButton* const button : effectButtons)
   {
     button->hide();
     QLayoutItem* child;
@@ -1122,7 +1122,7 @@ void qMRMLSegmentEditorWidget::updateEffectList()
   displayedEffects << nullptr;
 
   // Add effects in the requested order
-  foreach (QString effectName, d->EffectNameOrder)
+  for (const QString& effectName : d->EffectNameOrder)
   {
     qSlicerSegmentEditorAbstractEffect* effect = this->effectByName(effectName);
     if (effect)
@@ -1140,7 +1140,7 @@ void qMRMLSegmentEditorWidget::updateEffectList()
   // Add buttons of displayed effect to layout
   int rowIndex = 0;
   int columnIndex = 0;
-  foreach (qSlicerSegmentEditorAbstractEffect* effect, displayedEffects)
+  for (qSlicerSegmentEditorAbstractEffect* const effect : displayedEffects)
   {
     QToolButton* effectButton = d->toolButton(effect);
     if (!effectButton)
@@ -1166,7 +1166,7 @@ void qMRMLSegmentEditorWidget::updateEffectList()
   rowIndex = 0;
   columnIndex = 0;
   QList<QAbstractButton*> undoRedoButtons = d->UndoRedoButtonGroup.buttons();
-  foreach (QAbstractButton* button, undoRedoButtons)
+  for (QAbstractButton* const button : undoRedoButtons)
   {
     auto undoRedoGridLayout = dynamic_cast<QGridLayout*>(d->UndoRedoGroupBox->layout());
     undoRedoGridLayout->addWidget(button, rowIndex, columnIndex);
@@ -1642,7 +1642,7 @@ void qMRMLSegmentEditorWidget::updateEffectsSectionFromMRML()
     QString selectedSegmentID(d->ParameterSetNode->GetSelectedSegmentID());
     bool segmentSelected = !selectedSegmentID.isEmpty();
     QList<QAbstractButton*> effectButtons = d->EffectButtonGroup.buttons();
-    foreach (QAbstractButton* effectButton, effectButtons)
+    for (QAbstractButton* const effectButton : effectButtons)
     {
       qSlicerSegmentEditorAbstractEffect* effect = qobject_cast<qSlicerSegmentEditorAbstractEffect*>(effectButton->property("Effect").value<QObject*>());
       if (!effect)
@@ -1711,7 +1711,7 @@ void qMRMLSegmentEditorWidget::updateEffectsSectionFromMRML()
     effectName = activeEffect->name();
   }
   QList<QAbstractButton*> effectButtons = d->EffectButtonGroup.buttons();
-  foreach (QAbstractButton* effectButton, effectButtons)
+  for (QAbstractButton* const effectButton : effectButtons)
   {
     bool checked = effectButton->isChecked();
     bool needToBeChecked = (effectButton->objectName().compare(effectName) == 0);
@@ -1893,7 +1893,7 @@ void qMRMLSegmentEditorWidget::initializeParameterSetNode()
   MRMLNodeModifyBlocker blocker(d->ParameterSetNode);
 
   // Set parameter set node to all effects
-  foreach (qSlicerSegmentEditorAbstractEffect* effect, d->RegisteredEffects)
+  for (qSlicerSegmentEditorAbstractEffect* const effect : d->RegisteredEffects)
   {
     effect->setParameterSetNode(d->ParameterSetNode);
     effect->setMRMLDefaults();
@@ -2492,8 +2492,7 @@ qSlicerSegmentEditorAbstractEffect* qMRMLSegmentEditorWidget::effectByName(QStri
   }
 
   // Find effect with name
-  qSlicerSegmentEditorAbstractEffect* currentEffect = nullptr;
-  foreach (currentEffect, d->RegisteredEffects)
+  for (qSlicerSegmentEditorAbstractEffect* const currentEffect : d->RegisteredEffects)
   {
     if (currentEffect->name().compare(name) == 0)
     {
@@ -2564,7 +2563,7 @@ QStringList qMRMLSegmentEditorWidget::availableEffectNames()
 {
   Q_D(qMRMLSegmentEditorWidget);
   QStringList availableEffectNames;
-  foreach (qSlicerSegmentEditorAbstractEffect* effect, d->RegisteredEffects)
+  for (qSlicerSegmentEditorAbstractEffect* const effect : d->RegisteredEffects)
   {
     availableEffectNames << effect->name();
   }
@@ -2615,7 +2614,7 @@ void qMRMLSegmentEditorWidget::setupViewObservations()
   }
 
   // Slice views
-  foreach (QString sliceViewName, layoutManager->sliceViewNames())
+  for (const QString& sliceViewName : layoutManager->sliceViewNames())
   {
     // Create command for slice view
     qMRMLSliceWidget* sliceWidget = layoutManager->sliceWidget(sliceViewName);
@@ -2742,11 +2741,11 @@ void qMRMLSegmentEditorWidget::setupViewObservations()
 void qMRMLSegmentEditorWidget::removeViewObservations()
 {
   Q_D(qMRMLSegmentEditorWidget);
-  foreach (SegmentEditorEventObservation eventObservation, d->EventObservations)
+  for (const SegmentEditorEventObservation& eventObservation : d->EventObservations)
   {
     if (eventObservation.ObservedObject)
     {
-      foreach (int observationTag, eventObservation.ObservationTags)
+      for (const int& observationTag : eventObservation.ObservationTags)
       {
         eventObservation.ObservedObject->RemoveObserver(observationTag);
       }
@@ -3212,7 +3211,7 @@ void qMRMLSegmentEditorWidget::installKeyboardShortcuts(QWidget* parent /*=nullp
 void qMRMLSegmentEditorWidget::uninstallKeyboardShortcuts()
 {
   Q_D(qMRMLSegmentEditorWidget);
-  foreach (QShortcut* shortcut, d->KeyboardShortcuts)
+  for (QShortcut* const shortcut : d->KeyboardShortcuts)
   {
     shortcut->disconnect(SIGNAL(activated()));
     shortcut->setParent(nullptr);
@@ -3362,13 +3361,13 @@ void qMRMLSegmentEditorWidget::setEffectButtonStyle(Qt::ToolButtonStyle toolButt
   }
   d->EffectButtonStyle = toolButtonStyle;
   QList<QAbstractButton*> effectButtons = d->EffectButtonGroup.buttons();
-  foreach (QAbstractButton* button, effectButtons)
+  for (QAbstractButton* const button : effectButtons)
   {
     QToolButton* toolButton = dynamic_cast<QToolButton*>(button);
     toolButton->setToolButtonStyle(d->EffectButtonStyle);
   }
   QList<QAbstractButton*> undoRedoButtons = d->UndoRedoButtonGroup.buttons();
-  foreach (QAbstractButton* button, undoRedoButtons)
+  for (QAbstractButton* const button : undoRedoButtons)
   {
     QToolButton* toolButton = qobject_cast<QToolButton*>(button);
     if (toolButton)
@@ -3604,7 +3603,7 @@ void qMRMLSegmentEditorWidget::updateSliceRotateWarningButtonVisibility()
   }
 
   // Check if any of the slices are rotated
-  foreach (QString sliceViewName, layoutManager->sliceViewNames())
+  for (const QString& sliceViewName : layoutManager->sliceViewNames())
   {
     qMRMLSliceWidget* sliceWidget = layoutManager->sliceWidget(sliceViewName);
     if (!d->segmentationDisplayableInView(sliceWidget->mrmlSliceNode()))
@@ -3665,7 +3664,7 @@ void qMRMLSegmentEditorWidget::rotateSliceViewsToSegmentation()
     d->SliceRotateWarningButton->hide();
     return;
   }
-  foreach (QString sliceViewName, layoutManager->sliceViewNames())
+  for (const QString& sliceViewName : layoutManager->sliceViewNames())
   {
     qMRMLSliceWidget* sliceWidget = layoutManager->sliceWidget(sliceViewName);
     if (!d->segmentationDisplayableInView(sliceWidget->mrmlSliceNode()))

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
@@ -1496,7 +1496,7 @@ void qMRMLSegmentsTableView::jumpSlices()
     // application is closing
     return;
   }
-  foreach (QString sliceViewName, layoutManager->sliceViewNames())
+  for (const QString& sliceViewName : layoutManager->sliceViewNames())
   {
     // Check if segmentation is visible in this view
     qMRMLSliceWidget* sliceWidget = layoutManager->sliceWidget(sliceViewName);
@@ -1554,7 +1554,7 @@ void qMRMLSegmentsTableView::moveSelectedSegmentsUp()
 
   QModelIndexList segmentModelIndices;
   QList<int> selectedRows;
-  foreach (QString segmentID, selectedSegmentIDs)
+  for (const QString& segmentID : selectedSegmentIDs)
   {
     QModelIndex index = d->SortFilterModel->indexFromSegmentID(segmentID);
     segmentModelIndices << index;
@@ -1598,7 +1598,7 @@ void qMRMLSegmentsTableView::moveSelectedSegmentsDown()
 
   QModelIndexList segmentModelIndices;
   QList<int> selectedRows;
-  foreach (QString segmentID, selectedSegmentIDs)
+  for (const QString& segmentID : selectedSegmentIDs)
   {
     QModelIndex index = d->SortFilterModel->indexFromSegmentID(segmentID);
     segmentModelIndices << index;

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
@@ -523,7 +523,7 @@ void qSlicerSegmentationsModuleWidget::onRemoveSelectedSegments()
   }
 
   QStringList selectedSegmentIds = d->SegmentsTableView->selectedSegmentIDs();
-  foreach (QString segmentId, selectedSegmentIds)
+  for (const QString& segmentId : selectedSegmentIds)
   {
     currentSegmentationNode->GetSegmentation()->RemoveSegment(segmentId.toUtf8().constData());
   }
@@ -830,7 +830,7 @@ bool qSlicerSegmentationsModuleWidget::copySegmentsBetweenSegmentations(bool cop
 
   // Copy/move segments
   bool success = true;
-  foreach (QString segmentId, selectedSegmentIds)
+  for (const QString& segmentId : selectedSegmentIds)
   {
     success = success && this->copySegmentBetweenSegmentations(sourceSegmentation, targetSegmentation, segmentId, removeFromSource);
   }

--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.cxx
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.cxx
@@ -159,7 +159,7 @@ void qMRMLSequenceBrowserPlayWidget::updateWidgetFromMRML()
   d->pushButton_Snapshot->setVisible(recordingAllowed && d->RecordingControlsVisible);
   d->pushButton_Snapshot->setEnabled(!playbackActive && !recordingActive);
 
-  foreach (QObject* w, vcrPlaybackControls)
+  for (QObject* const w : vcrPlaybackControls)
   {
     w->setProperty("enabled", vcrControlsEnabled);
   }

--- a/Modules/Loadable/Sequences/qSlicerSequencesModule.cxx
+++ b/Modules/Loadable/Sequences/qSlicerSequencesModule.cxx
@@ -109,7 +109,7 @@ void qSlicerSequencesModulePrivate::addToolBar()
   mainWindow->addToolBarBreak();
   mainWindow->addToolBar(this->ToolBar);
   this->SequencesModuleOwnsToolBar = false;
-  foreach (QMenu* toolBarMenu, mainWindow->findChildren<QMenu*>())
+  for (QMenu* const toolBarMenu : mainWindow->findChildren<QMenu*>())
   {
     if (toolBarMenu->objectName() == QString("WindowToolBarsMenu"))
     {

--- a/Modules/Loadable/SlicerWelcome/qSlicerWelcomeModuleWidget.cxx
+++ b/Modules/Loadable/SlicerWelcome/qSlicerWelcomeModuleWidget.cxx
@@ -113,16 +113,15 @@ void qSlicerWelcomeModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
 
   // Add all collabsibleWidgetButton to a button group
   QList<ctkCollapsibleButton*> collapsibles = widget->findChildren<ctkCollapsibleButton*>();
-  foreach (ctkCollapsibleButton* collapsible, collapsibles)
+  for (ctkCollapsibleButton* const collapsible : collapsibles)
   {
     group->addButton(collapsible);
   }
 
   // Update occurrences of documentation URLs
   qSlicerCoreApplication* app = qSlicerCoreApplication::application();
-  foreach (QWidget* widget,
-           QWidgetList() << this->FeedbackCollapsibleWidget << this->WelcomeAndAboutCollapsibleWidget << this->OtherUsefulHintsCollapsibleWidget
-                         << this->AcknowledgmentCollapsibleWidget)
+  for (QWidget* const widget : QWidgetList() << this->FeedbackCollapsibleWidget << this->WelcomeAndAboutCollapsibleWidget << this->OtherUsefulHintsCollapsibleWidget
+                                             << this->AcknowledgmentCollapsibleWidget)
   {
     QTextBrowser* textBrowser = widget->findChild<QTextBrowser*>();
     if (!textBrowser)

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSortFilterSubjectHierarchyProxyModel.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSortFilterSubjectHierarchyProxyModel.cxx
@@ -153,7 +153,7 @@ int qMRMLSortFilterSubjectHierarchyProxyModelPrivate::findAttributeFilter(QList<
                                                                           QString className)
 {
   int index = 0;
-  foreach (AttributeFilter filter, filterList)
+  for (const AttributeFilter& filter : filterList)
   {
     if (filter.AttributeName == attributeName && filter.AttributeValue == attributeValue //
         && filter.Include == include && filter.ClassName == className)
@@ -170,7 +170,7 @@ QList<int> qMRMLSortFilterSubjectHierarchyProxyModelPrivate::findAttributeFilter
 {
   QList<int> foundIndices;
   int index = 0;
-  foreach (AttributeFilter filter, filterList)
+  for (const AttributeFilter& filter : filterList)
   {
     if ((attributeName.isEmpty() || filter.AttributeName == attributeName) && filter.Include == include)
     {
@@ -365,7 +365,7 @@ void qMRMLSortFilterSubjectHierarchyProxyModel::setIncludeItemAttributeNamesFilt
   Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
 
   d->removeFiltersByIncludeFlag(d->ItemAttributeFilters, true);
-  foreach (QString filter, filterList)
+  for (const QString& filter : filterList)
   {
     this->addItemAttributeFilter(filter);
   }
@@ -395,7 +395,7 @@ void qMRMLSortFilterSubjectHierarchyProxyModel::setIncludeNodeAttributeNamesFilt
   Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
 
   d->removeFiltersByIncludeFlag(d->NodeAttributeFilters, true);
-  foreach (QString filter, filterList)
+  for (const QString& filter : filterList)
   {
     this->addNodeAttributeFilter(filter);
   }
@@ -425,7 +425,7 @@ void qMRMLSortFilterSubjectHierarchyProxyModel::setExcludeItemAttributeNamesFilt
   Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
 
   d->removeFiltersByIncludeFlag(d->ItemAttributeFilters, false);
-  foreach (QString filter, filterList)
+  for (const QString& filter : filterList)
   {
     this->addItemAttributeFilter(filter, QString(), false);
   }
@@ -455,7 +455,7 @@ void qMRMLSortFilterSubjectHierarchyProxyModel::setExcludeNodeAttributeNamesFilt
   Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
 
   d->removeFiltersByIncludeFlag(d->NodeAttributeFilters, false);
-  foreach (QString filter, filterList)
+  for (const QString& filter : filterList)
   {
     this->addNodeAttributeFilter(filter, QString(), false);
   }
@@ -749,7 +749,7 @@ qMRMLSortFilterSubjectHierarchyProxyModel::AcceptType qMRMLSortFilterSubjectHier
     bool nodeTypeAccepted = false;
     if (!d->NodeTypes.isEmpty())
     {
-      foreach (const QString& nodeType, d->NodeTypes)
+      for (const QString& nodeType : d->NodeTypes)
       {
         if (dataNode->IsA(nodeType.toUtf8().data()))
         {
@@ -764,7 +764,7 @@ qMRMLSortFilterSubjectHierarchyProxyModel::AcceptType qMRMLSortFilterSubjectHier
     }
     if (nodeTypeAccepted)
     {
-      foreach (const QString& hideChildNodeType, d->HideChildNodeTypes)
+      for (const QString& hideChildNodeType : d->HideChildNodeTypes)
       {
         if (dataNode->IsA(hideChildNodeType.toUtf8().data()))
         {
@@ -887,7 +887,7 @@ qMRMLSortFilterSubjectHierarchyProxyModel::AcceptType qMRMLSortFilterSubjectHier
   if (!d->LevelFilter.isEmpty())
   {
     QString itemLevel(shNode->GetItemLevel(itemID).c_str());
-    foreach (const QString& levelFilter, d->LevelFilter)
+    for (const QString& levelFilter : d->LevelFilter)
     {
       if (itemLevel == levelFilter)
       {

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
@@ -724,7 +724,7 @@ QMimeData* qMRMLSubjectHierarchyModel::mimeData(const QModelIndexList& indexes) 
   }
   QList<QUrl> selectedShItemUrls;
   QModelIndexList allColumnsIndexes;
-  foreach (const QModelIndex& index, indexes)
+  for (const QModelIndex& index : indexes)
   {
     QModelIndex parent = index.parent();
     for (int column = 0; column < this->columnCount(parent); ++column)
@@ -1576,7 +1576,7 @@ void qMRMLSubjectHierarchyModel::onSubjectHierarchyItemAboutToBeRemoved(vtkIdTyp
       d->Orphans.push_back(item->takeRow(0));
     }
     // Remove the item from any orphan list if it exist as we don't want to add it back later in onSubjectHierarchyItemRemoved
-    foreach (QList<QStandardItem*> orphans, d->Orphans)
+    for (QList<QStandardItem*> orphans : d->Orphans)
     {
       if (orphans.contains(item))
       {
@@ -1598,7 +1598,7 @@ void qMRMLSubjectHierarchyModel::onSubjectHierarchyItemRemoved(vtkIdType removed
   }
   // The removed item may have had children, if they haven't been updated, they are likely to be lost
   // (not reachable when browsing the model), we need to reparent them.
-  foreach (QList<QStandardItem*> orphans, d->Orphans)
+  for (QList<QStandardItem*> orphans : d->Orphans)
   {
     QStandardItem* orphan = orphans[0];
     // Make sure that the orphans have not already been reparented.
@@ -1776,7 +1776,7 @@ void qMRMLSubjectHierarchyModel::delayedItemChanged()
 
   // Get parents of all dragged items
   std::vector<QStandardItem*> draggedParentShItems;
-  foreach (vtkIdType draggedShItemID, d->DraggedSubjectHierarchyItems)
+  for (const vtkIdType& draggedShItemID : d->DraggedSubjectHierarchyItems)
   {
     QStandardItem* draggedShItem = this->itemFromSubjectHierarchyItem(draggedShItemID);
     if (!draggedShItem)

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -314,7 +314,7 @@ void qMRMLSubjectHierarchyTreeViewPrivate::updateMenuActions()
   this->updateTransformMenuActions();
 
   // Connect plugin events to be handled by the tree view
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, this->enabledPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : this->enabledPlugins())
   {
     QObject::connect(plugin, SIGNAL(requestExpandItem(vtkIdType)), q, SLOT(expandItem(vtkIdType)), Qt::UniqueConnection);
     QObject::connect(plugin, SIGNAL(requestInvalidateFilter()), q->model(), SIGNAL(invalidateFilter()), Qt::UniqueConnection);
@@ -329,9 +329,9 @@ void qMRMLSubjectHierarchyTreeViewPrivate::updateSceneMenuActions()
 {
   Q_Q(qMRMLSubjectHierarchyTreeView);
   QList<QAction*> sceneMenuActions;
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, this->enabledPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : this->enabledPlugins())
   {
-    foreach (QAction* action, plugin->sceneContextMenuActions())
+    for (QAction* const action : plugin->sceneContextMenuActions())
     {
       sceneMenuActions.append(action);
     }
@@ -339,7 +339,7 @@ void qMRMLSubjectHierarchyTreeViewPrivate::updateSceneMenuActions()
 
   this->AddNodeActions.clear();
   QStringList nodeTypes = q->nodeTypes();
-  foreach (QString nodeType, q->nodeTypes())
+  for (const QString& nodeType : q->nodeTypes())
   {
     QString label = q->nodeTypeLabel(nodeType);
     QAction* addNodeAction = new QAction(qMRMLSubjectHierarchyTreeView::tr("Create new %1").arg(label), nullptr);
@@ -358,10 +358,10 @@ void qMRMLSubjectHierarchyTreeViewPrivate::updateVisibilityMenuActions()
 {
   Q_Q(qMRMLSubjectHierarchyTreeView);
   QList<QAction*> visibilityMenuActions;
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, this->enabledPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : this->enabledPlugins())
   {
     // Add visibility context menu actions
-    foreach (QAction* action, plugin->visibilityContextMenuActions())
+    for (QAction* const action : plugin->visibilityContextMenuActions())
     {
       visibilityMenuActions.append(action);
     }
@@ -382,9 +382,9 @@ void qMRMLSubjectHierarchyTreeViewPrivate::updateNodeMenuActions()
   nodeMenuActions.append(this->HideAction);
   nodeMenuActions.append(this->ShowAction);
   nodeMenuActions.append(this->ToggleVisibilityAction);
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, this->enabledPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : this->enabledPlugins())
   {
-    foreach (QAction* action, plugin->itemContextMenuActions())
+    for (QAction* const action : plugin->itemContextMenuActions())
     {
       nodeMenuActions.append(action);
     }
@@ -398,7 +398,7 @@ void qMRMLSubjectHierarchyTreeViewPrivate::updateNodeMenuActions()
   this->SelectPluginSubMenu = new QMenu();
   this->SelectPluginAction->setMenu(this->SelectPluginSubMenu);
   this->SelectPluginActionGroup = new QActionGroup(q);
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, this->enabledPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : this->enabledPlugins())
   {
     QAction* selectPluginAction = new QAction(plugin->name(), q);
     selectPluginAction->setCheckable(true);
@@ -421,9 +421,9 @@ void qMRMLSubjectHierarchyTreeViewPrivate::updateTransformMenuActions()
 {
   Q_Q(qMRMLSubjectHierarchyTreeView);
   QList<QAction*> transformMenuActions;
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, this->enabledPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : this->enabledPlugins())
   {
-    foreach (QAction* action, plugin->transformContextMenuActions())
+    for (QAction* const action : plugin->transformContextMenuActions())
     {
       transformMenuActions.append(action);
     }
@@ -437,7 +437,7 @@ QList<qSlicerSubjectHierarchyAbstractPlugin*> qMRMLSubjectHierarchyTreeViewPriva
 {
   QList<qSlicerSubjectHierarchyAbstractPlugin*> enabledPluginList;
 
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, qSlicerSubjectHierarchyPluginHandler::instance()->allPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : qSlicerSubjectHierarchyPluginHandler::instance()->allPlugins())
   {
     QString pluginName = plugin->name();
     bool allowlisted = (this->PluginAllowList.isEmpty() || this->PluginAllowList.contains(pluginName));
@@ -486,7 +486,7 @@ void qMRMLSubjectHierarchyTreeViewPrivate::setVisibilityOfSelectedItems(Visibili
   // Remove items from the list whose ancestor item is also contained
   // to prevent toggling visibility multiple times on the same item
   QList<vtkIdType> consolidatedItemIDs(this->SelectedItems);
-  foreach (vtkIdType itemID, this->SelectedItems)
+  for (const vtkIdType& itemID : this->SelectedItems)
   {
     // Get children recursively for current item
     std::vector<vtkIdType> childItemIDs;
@@ -506,7 +506,7 @@ void qMRMLSubjectHierarchyTreeViewPrivate::setVisibilityOfSelectedItems(Visibili
   }
 
   // Toggle visibility on the remaining items
-  foreach (vtkIdType itemID, consolidatedItemIDs)
+  for (const vtkIdType& itemID : consolidatedItemIDs)
   {
     this->setSubjectHierarchyItemVisibility(itemID, visibilityAction);
   }
@@ -694,7 +694,7 @@ void qMRMLSubjectHierarchyTreeView::currentItems(vtkIdList* selectedItems)
     return;
   }
 
-  foreach (vtkIdType item, d->SelectedItems)
+  for (const vtkIdType& item : d->SelectedItems)
   {
     selectedItems->InsertNextId(item);
   }
@@ -712,7 +712,7 @@ void qMRMLSubjectHierarchyTreeView::setCurrentItems(QList<vtkIdType> items)
 
   // Get requested selection
   QSet<QModelIndex> requestedSelectedItems;
-  foreach (vtkIdType itemID, items)
+  for (const vtkIdType& itemID : items)
   {
     QModelIndex itemIndex = d->SortFilterModel->indexFromSubjectHierarchyItem(itemID);
     if (itemIndex.isValid())
@@ -726,7 +726,7 @@ void qMRMLSubjectHierarchyTreeView::setCurrentItems(QList<vtkIdType> items)
   QSet<QModelIndex> previouslySelectedItems(previouslySelectedItemsList.begin(), previouslySelectedItemsList.end());
 
   // Deselect items that were previously selected but not requested anymore
-  foreach (QModelIndex itemIndex, previouslySelectedItems)
+  for (const QModelIndex& itemIndex : previouslySelectedItems)
   {
     if (itemIndex.isValid() && !requestedSelectedItems.contains(itemIndex))
     {
@@ -735,7 +735,7 @@ void qMRMLSubjectHierarchyTreeView::setCurrentItems(QList<vtkIdType> items)
   }
 
   // Select items that are requested but have not been previously selected
-  foreach (QModelIndex itemIndex, requestedSelectedItems)
+  for (const QModelIndex& itemIndex : requestedSelectedItems)
   {
     if (!previouslySelectedItems.contains(itemIndex))
     {
@@ -1400,7 +1400,7 @@ void qMRMLSubjectHierarchyTreeView::keyPressEvent(QKeyEvent* e)
   {
     // Show/hide current item(s) using space
     QList<vtkIdType> currentItemIDs = d->SelectedItems;
-    foreach (vtkIdType itemID, currentItemIDs)
+    for (const vtkIdType& itemID : currentItemIDs)
     {
       d->setSubjectHierarchyItemVisibility(itemID, qMRMLSubjectHierarchyTreeViewPrivate::ToggleVisibility);
     }
@@ -1423,7 +1423,7 @@ void qMRMLSubjectHierarchyTreeView::onSelectionChanged(const QItemSelection& sel
   // Collect selected subject hierarchy items
   QList<vtkIdType> selectedShItems;
   QList<QModelIndex> selectedIndices = this->selectedIndexes();
-  foreach (QModelIndex index, selectedIndices)
+  for (const QModelIndex& index : selectedIndices)
   {
     // Only consider the first column to avoid duplicates
     if (index.column() != 0)
@@ -1516,7 +1516,7 @@ void qMRMLSubjectHierarchyTreeView::populateContextMenuForItem(vtkIdType itemID)
   }
 
   // Have all plugins hide all context menu actions
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, qSlicerSubjectHierarchyPluginHandler::instance()->allPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : qSlicerSubjectHierarchyPluginHandler::instance()->allPlugins())
   {
     plugin->hideAllContextMenuActions();
   }
@@ -1546,7 +1546,7 @@ void qMRMLSubjectHierarchyTreeView::populateContextMenuForItem(vtkIdType itemID)
 
   // "Add new ..." node actions
   bool addNodeActionsVisible = d->AddNodeMenuActionVisible && (!currentItemID || currentItemID == d->SubjectHierarchyNode->GetSceneItemID());
-  foreach (QAction* addNodeAction, d->AddNodeActions)
+  for (QAction* const addNodeAction : d->AddNodeActions)
   {
     addNodeAction->setVisible(addNodeActionsVisible);
   }
@@ -1587,7 +1587,7 @@ void qMRMLSubjectHierarchyTreeView::populateContextMenuForItem(vtkIdType itemID)
   }
 
   // Have all enabled plugins show context menu actions for current item
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, d->enabledPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : d->enabledPlugins())
   {
     plugin->showContextMenuActionsForItem(currentItemID);
   }
@@ -1610,12 +1610,12 @@ void qMRMLSubjectHierarchyTreeView::populateVisibilityContextMenuForItem(vtkIdTy
   }
 
   // Have all plugins hide all visibility context menu actions
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, qSlicerSubjectHierarchyPluginHandler::instance()->allPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : qSlicerSubjectHierarchyPluginHandler::instance()->allPlugins())
   {
     plugin->hideAllContextMenuActions();
   }
   // Have all enabled plugins show visibility context menu actions for current item
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, d->enabledPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : d->enabledPlugins())
   {
     plugin->showVisibilityContextMenuActionsForItem(itemID);
   }
@@ -1641,12 +1641,12 @@ void qMRMLSubjectHierarchyTreeView::populateTransformContextMenuForItem(vtkIdTyp
   d->updateTransformMenuActions();
 
   // Have all plugins hide all transform context menu actions
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, qSlicerSubjectHierarchyPluginHandler::instance()->allPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : qSlicerSubjectHierarchyPluginHandler::instance()->allPlugins())
   {
     plugin->hideAllContextMenuActions();
   }
   // Have all enabled plugins show transform context menu actions for current item
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, d->enabledPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : d->enabledPlugins())
   {
     plugin->showTransformContextMenuActionsForItem(itemID);
   }
@@ -1730,7 +1730,7 @@ void qMRMLSubjectHierarchyTreeView::updateSelectPluginActions()
 
   QList<qSlicerSubjectHierarchyAbstractPlugin*> enabledPluginsList = d->enabledPlugins();
 
-  foreach (QAction* currentSelectPluginAction, d->SelectPluginActions)
+  for (QAction* const currentSelectPluginAction : d->SelectPluginActions)
   {
     // Check select plugin action if it's the owner
     bool isOwner = !(currentSelectPluginAction->data().toString().compare(ownerPluginName));
@@ -1826,7 +1826,7 @@ void qMRMLSubjectHierarchyTreeView::deleteSelectedItems()
 
   // Remove each selected item
   QList<vtkIdType> currentItemIDs = d->SelectedItems;
-  foreach (vtkIdType itemID, currentItemIDs)
+  for (const vtkIdType& itemID : currentItemIDs)
   {
     if (itemID == d->SubjectHierarchyNode->GetSceneItemID())
     {
@@ -1914,7 +1914,7 @@ void qMRMLSubjectHierarchyTreeView::applyReferenceHighlightForItems(QList<vtkIdT
   int nameColumn = sceneModel->nameColumn();
 
   // Clear highlight for previously highlighted items
-  foreach (vtkIdType highlightedItemID, d->HighlightedItems)
+  for (const vtkIdType& highlightedItemID : d->HighlightedItems)
   {
     QStandardItem* item = sceneModel->itemFromSubjectHierarchyItem(highlightedItemID, nameColumn);
     if (item && this->sortFilterProxyModel()->filterAcceptsItem(highlightedItemID))
@@ -1925,7 +1925,7 @@ void qMRMLSubjectHierarchyTreeView::applyReferenceHighlightForItems(QList<vtkIdT
   d->HighlightedItems.clear();
 
   // Go through all given items
-  foreach (vtkIdType itemID, itemIDs)
+  for (const vtkIdType& itemID : itemIDs)
   {
     if (itemID == d->SubjectHierarchyNode->GetSceneItemID() || !itemID)
     {
@@ -2159,7 +2159,7 @@ void qMRMLSubjectHierarchyTreeView::onSubjectHierarchyItemTransformModified(vtkO
       }
     }
 
-    foreach (vtkIdType itemID, d->SelectedItems)
+    for (const vtkIdType& itemID : d->SelectedItems)
     {
       vtkMRMLTransformableNode* node = vtkMRMLTransformableNode::SafeDownCast(shNode->GetItemDataNode(itemID));
       if (node == nullptr)
@@ -2468,7 +2468,7 @@ void qMRMLSubjectHierarchyTreeView::setBaseName(const QString& baseName, const Q
     qWarning("qMRMLSubjectHierarchyTreeView::setBaseName failed: no node types have been set yet");
     return;
   }
-  foreach (QString aNodeType, nodeTypes)
+  for (const QString& aNodeType : nodeTypes)
   {
     d->MRMLNodeFactory->setBaseName(aNodeType, baseName);
   }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.cxx
@@ -529,7 +529,7 @@ void qSlicerSubjectHierarchyAbstractPlugin::hideAllContextMenuActions() const
   allActions << this->visibilityContextMenuActions();
   allActions << this->viewContextMenuActions();
 
-  foreach (QAction* action, allActions)
+  for (QAction* const action : allActions)
   {
     action->setVisible(false);
   }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyParseLocalDataPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyParseLocalDataPlugin.cxx
@@ -208,7 +208,7 @@ void qSlicerSubjectHierarchyParseLocalDataPlugin::createHierarchyFromLoadedDirec
   do
   {
     QString firstComponent;
-    foreach (QStringList filePath, loadedFilePaths)
+    for (const QStringList& filePath : loadedFilePaths)
     {
       if (filePath.count() == 0)
       {
@@ -274,7 +274,7 @@ void qSlicerSubjectHierarchyParseLocalDataPlugin::createHierarchyFromLoadedDirec
   }
 
   // Expand generated branches
-  foreach (vtkIdType createdItemID, createdItemIDs)
+  for (const vtkIdType& createdItemID : createdItemIDs)
   {
     emit requestExpandItem(createdItemID);
   }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
@@ -131,8 +131,7 @@ bool qSlicerSubjectHierarchyPluginHandler::registerPlugin(qSlicerSubjectHierarch
   }
 
   // Check if the same plugin has already been registered
-  qSlicerSubjectHierarchyAbstractPlugin* currentPlugin = nullptr;
-  foreach (currentPlugin, this->m_RegisteredPlugins)
+  for (const qSlicerSubjectHierarchyAbstractPlugin* const currentPlugin : this->m_RegisteredPlugins)
   {
     if (pluginToRegister->name().compare(currentPlugin->name()) == 0)
     {
@@ -144,7 +143,7 @@ bool qSlicerSubjectHierarchyPluginHandler::registerPlugin(qSlicerSubjectHierarch
   // Add view menu actions from plugin to plugin logic
   if (this->m_PluginLogic)
   {
-    foreach (QAction* action, pluginToRegister->viewContextMenuActions())
+    for (QAction* const action : pluginToRegister->viewContextMenuActions())
     {
       if (action != nullptr && action->objectName().isEmpty())
       {
@@ -191,8 +190,7 @@ qSlicerSubjectHierarchyAbstractPlugin* qSlicerSubjectHierarchyPluginHandler::plu
   }
 
   // Find plugin with name
-  qSlicerSubjectHierarchyAbstractPlugin* currentPlugin = nullptr;
-  foreach (currentPlugin, this->m_RegisteredPlugins)
+  for (qSlicerSubjectHierarchyAbstractPlugin* const currentPlugin : this->m_RegisteredPlugins)
   {
     if (currentPlugin->name().compare(name) == 0)
     {
@@ -211,8 +209,7 @@ QList<qSlicerSubjectHierarchyAbstractPlugin*> qSlicerSubjectHierarchyPluginHandl
 {
   QList<qSlicerSubjectHierarchyAbstractPlugin*> mostSuitablePlugins;
   double bestConfidence = 0.0;
-  qSlicerSubjectHierarchyAbstractPlugin* currentPlugin = nullptr;
-  foreach (currentPlugin, this->m_RegisteredPlugins)
+  for (qSlicerSubjectHierarchyAbstractPlugin* const currentPlugin : this->m_RegisteredPlugins)
   {
     double currentConfidence = currentPlugin->canAddNodeToSubjectHierarchy(node, parentItemID);
     if (currentConfidence > bestConfidence)
@@ -238,8 +235,7 @@ QList<qSlicerSubjectHierarchyAbstractPlugin*> qSlicerSubjectHierarchyPluginHandl
 {
   QList<qSlicerSubjectHierarchyAbstractPlugin*> mostSuitablePlugins;
   double bestConfidence = 0.0;
-  qSlicerSubjectHierarchyAbstractPlugin* currentPlugin = nullptr;
-  foreach (currentPlugin, this->m_RegisteredPlugins)
+  for (qSlicerSubjectHierarchyAbstractPlugin* const currentPlugin : this->m_RegisteredPlugins)
   {
     double currentConfidence = currentPlugin->canReparentItemInsideSubjectHierarchy(itemID, parentItemID);
     if (currentConfidence > bestConfidence)
@@ -271,8 +267,7 @@ qSlicerSubjectHierarchyAbstractPlugin* qSlicerSubjectHierarchyPluginHandler::fin
 
   QList<qSlicerSubjectHierarchyAbstractPlugin*> mostSuitablePlugins;
   double bestConfidence = 0.0;
-  qSlicerSubjectHierarchyAbstractPlugin* currentPlugin = nullptr;
-  foreach (currentPlugin, this->m_RegisteredPlugins)
+  for (qSlicerSubjectHierarchyAbstractPlugin* const currentPlugin : this->m_RegisteredPlugins)
   {
     double currentConfidence = currentPlugin->canOwnSubjectHierarchyItem(itemID);
     if (currentConfidence > bestConfidence)
@@ -364,7 +359,7 @@ qSlicerSubjectHierarchyAbstractPlugin* qSlicerSubjectHierarchyPluginHandler::sel
 
   // Convert list of plugin objects to string list for the dialog
   QStringList candidatePluginNames;
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, candidatePlugins)
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : candidatePlugins)
   {
     candidatePluginNames << plugin->name();
   }
@@ -375,7 +370,7 @@ qSlicerSubjectHierarchyAbstractPlugin* qSlicerSubjectHierarchyPluginHandler::sel
   if (ok && !selectedPluginName.isEmpty())
   {
     // The user pressed OK, find the object for the selected plugin [1]
-    foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, candidatePlugins)
+    for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : candidatePlugins)
     {
       if (!selectedPluginName.compare(plugin->name()))
       {
@@ -461,9 +456,9 @@ void qSlicerSubjectHierarchyPluginHandler::setPluginLogic(qSlicerSubjectHierarch
   // Register view menu actions of those plugins that were registered before the PluginLogic was set.
   if (this->m_PluginLogic)
   {
-    foreach (qSlicerSubjectHierarchyAbstractPlugin* pluginToRegister, this->m_RegisteredPlugins)
+    for (qSlicerSubjectHierarchyAbstractPlugin* const pluginToRegister : this->m_RegisteredPlugins)
     {
-      foreach (QAction* action, pluginToRegister->viewContextMenuActions())
+      for (QAction* const action : pluginToRegister->viewContextMenuActions())
       {
         if (action != nullptr && action->objectName().isEmpty())
         {
@@ -513,7 +508,7 @@ void qSlicerSubjectHierarchyPluginHandler::currentItems(vtkIdList* selectedItems
     return;
   }
 
-  foreach (vtkIdType item, this->m_CurrentItems)
+  for (const vtkIdType& item : this->m_CurrentItems)
   {
     selectedItems->InsertNextId(item);
   }
@@ -717,7 +712,7 @@ void qSlicerSubjectHierarchyPluginHandler::showItemsInView(vtkIdList* itemIDsToS
     }
   }
   vtkNew<vtkIdList> allItemIDsToShow;
-  foreach (vtkIdType itemID, allItemIDsSet)
+  for (const vtkIdType& itemID : allItemIDsSet)
   {
     allItemIDsToShow->InsertNextId(itemID);
   }
@@ -742,7 +737,7 @@ QString qSlicerSubjectHierarchyPluginHandler::dumpContextMenuActions()
 
   info.append("=== Item context menu ===\n");
   actions.clear();
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, this->m_RegisteredPlugins)
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : this->m_RegisteredPlugins)
   {
     actions << plugin->itemContextMenuActions();
   }
@@ -750,7 +745,7 @@ QString qSlicerSubjectHierarchyPluginHandler::dumpContextMenuActions()
 
   info.append("\n=== Scene context menu ===\n");
   actions.clear();
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, this->m_RegisteredPlugins)
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : this->m_RegisteredPlugins)
   {
     actions << plugin->sceneContextMenuActions();
   }
@@ -758,7 +753,7 @@ QString qSlicerSubjectHierarchyPluginHandler::dumpContextMenuActions()
 
   info.append("\n=== Visibility context menu ===\n");
   actions.clear();
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, this->m_RegisteredPlugins)
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : this->m_RegisteredPlugins)
   {
     actions << plugin->visibilityContextMenuActions();
   }
@@ -766,7 +761,7 @@ QString qSlicerSubjectHierarchyPluginHandler::dumpContextMenuActions()
 
   info.append("\n=== View context menu ===\n");
   actions.clear();
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, this->m_RegisteredPlugins)
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : this->m_RegisteredPlugins)
   {
     actions << plugin->viewContextMenuActions();
   }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
@@ -571,7 +571,7 @@ void qSlicerSubjectHierarchyPluginLogic::onDisplayMenuEvent(vtkObject* displayNo
   }
 
   // Have all plugins show context view menu actions for current item
-  foreach (qSlicerSubjectHierarchyAbstractPlugin* plugin, qSlicerSubjectHierarchyPluginHandler::instance()->allPlugins())
+  for (qSlicerSubjectHierarchyAbstractPlugin* const plugin : qSlicerSubjectHierarchyPluginHandler::instance()->allPlugins())
   {
     plugin->hideAllContextMenuActions();
     plugin->showViewContextMenuActionsForItem(itemID, eventDataMap);
@@ -714,7 +714,7 @@ QStringList qSlicerSubjectHierarchyPluginLogic::registeredViewContextMenuActionN
   Q_D(qSlicerSubjectHierarchyPluginLogic);
 
   QStringList registeredActionNames;
-  foreach (QAction* action, d->ViewContextMenuActions)
+  for (QAction* const action : d->ViewContextMenuActions)
   {
     registeredActionNames << action->objectName();
   }
@@ -753,7 +753,7 @@ QString qSlicerSubjectHierarchyPluginLogic::buildMenuFromActions(QMenu* menu, QL
   std::sort(actions.begin(), actions.end(), [](const QAction* a, const QAction* b) -> bool { return a->property("section").toDouble() < b->property("section").toDouble(); });
 
   int lastSection = static_cast<int>(actions.front()->property("section").toDouble() + 0.5);
-  foreach (QAction* action, actions)
+  for (QAction* const action : actions)
   {
     if (!allowedActions.isEmpty() && !allowedActions.contains(action->objectName()))
     {

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyRegisterPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyRegisterPlugin.cxx
@@ -421,7 +421,7 @@ void qSlicerSubjectHierarchyRegisterPlugin::registerInteractiveLandmark()
       QList<qMRMLNodeComboBox*> comboboxes = volumeSelectorDialog->findChildren<qMRMLNodeComboBox*>();
 
       // Set fixed and moving image. Unfortunately currently only the tooltip refers to the role
-      foreach (qMRMLNodeComboBox* combobox, comboboxes)
+      for (qMRMLNodeComboBox* const combobox : comboboxes)
       {
         if (combobox->toolTip().contains("moving", Qt::CaseInsensitive))
         {

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.cxx
@@ -378,7 +378,7 @@ QList<QAction*> qSlicerSubjectHierarchyScriptedPlugin::itemContextMenuActions() 
   }
   QList<QVariant> resultVariantList = resultVariant.toList();
   QList<QAction*> actionList;
-  foreach (QVariant actionVariant, resultVariantList)
+  for (const QVariant& actionVariant : resultVariantList)
   {
     QAction* action = qobject_cast<QAction*>(actionVariant.value<QObject*>());
     actionList << action;
@@ -405,7 +405,7 @@ QList<QAction*> qSlicerSubjectHierarchyScriptedPlugin::viewContextMenuActions() 
   }
   QList<QVariant> resultVariantList = resultVariant.toList();
   QList<QAction*> actionList;
-  foreach (QVariant actionVariant, resultVariantList)
+  for (const QVariant& actionVariant : resultVariantList)
   {
     QAction* action = qobject_cast<QAction*>(actionVariant.value<QObject*>());
     actionList << action;
@@ -432,7 +432,7 @@ QList<QAction*> qSlicerSubjectHierarchyScriptedPlugin::sceneContextMenuActions()
   }
   QList<QVariant> resultVariantList = resultVariant.toList();
   QList<QAction*> actionList;
-  foreach (QVariant actionVariant, resultVariantList)
+  for (const QVariant& actionVariant : resultVariantList)
   {
     QAction* action = qobject_cast<QAction*>(actionVariant.value<QObject*>());
     actionList << action;

--- a/Modules/Loadable/Tables/Widgets/qSlicerTableColumnPropertiesWidget.cxx
+++ b/Modules/Loadable/Tables/Widgets/qSlicerTableColumnPropertiesWidget.cxx
@@ -126,7 +126,7 @@ void qSlicerTableColumnPropertiesWidget::setup()
   d->PropertyEditWidgets << d->ComponentNamesLineEdit;
 
   connect(d->DataTypeComboBox, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(onDataTypeChanged(const QString&)));
-  foreach (QLineEdit* widget, d->PropertyEditWidgets)
+  for (QLineEdit* const widget : d->PropertyEditWidgets)
   {
     connect(widget, SIGNAL(textEdited(const QString&)), this, SLOT(onPropertyChanged(const QString&)));
   }
@@ -178,7 +178,7 @@ void qSlicerTableColumnPropertiesWidget::setColumnProperty(QString propertyName,
     qWarning() << Q_FUNC_INFO << " failed: table column names are not specified";
     return;
   }
-  foreach (const QString& columnName, d->ColumnNames)
+  for (const QString& columnName : d->ColumnNames)
   {
     d->CurrentTableNode->SetColumnProperty(columnName.toUtf8().constData(), propertyName.toUtf8().constData(), propertyValue.toUtf8().constData());
   }
@@ -198,7 +198,7 @@ QString qSlicerTableColumnPropertiesWidget::columnProperty(QString propertyName)
     return "";
   }
   std::string commonPropertyValue = d->CurrentTableNode->GetColumnProperty(d->ColumnNames[0].toUtf8().constData(), propertyName.toUtf8().constData());
-  foreach (const QString& columnName, d->ColumnNames)
+  for (const QString& columnName : d->ColumnNames)
   {
     std::string currentPropertyValue = d->CurrentTableNode->GetColumnProperty(columnName.toUtf8().constData(), propertyName.toUtf8().constData());
     if (currentPropertyValue != commonPropertyValue)
@@ -236,7 +236,7 @@ void qSlicerTableColumnPropertiesWidget::updateWidget()
   int columnTypeIndex = d->DataTypeComboBox->findText(columnType);
   d->DataTypeComboBox->setCurrentIndex(columnTypeIndex);
 
-  foreach (QLineEdit* widget, d->PropertyEditWidgets)
+  for (QLineEdit* const widget : d->PropertyEditWidgets)
   {
     widget->setText(this->columnProperty(widget->property(SCHEMA_PROPERTY_NAME).toString()));
   }
@@ -303,7 +303,7 @@ void qSlicerTableColumnPropertiesWidget::tableViewSelectionChanged()
   {
     vtkMRMLTableNode* tableNode = d->TableViewForSelection->mrmlTableNode();
     QList<int> selectedColumns = d->TableViewForSelection->selectedMRMLTableColumnIndices();
-    foreach (int columnIndex, selectedColumns)
+    for (const int& columnIndex : selectedColumns)
     {
       selectedColumnNames << tableNode->GetColumnName(columnIndex).c_str();
     }

--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
@@ -517,7 +517,7 @@ QTableWidgetItem* qSlicerTerminologyNavigatorWidgetPrivate::findTableWidgetItemF
     return nullptr;
   }
 
-  foreach (QTableWidgetItem* item, items)
+  for (QTableWidgetItem* const item : items)
   {
     QString codingSchemeDesignator = item->data(qSlicerTerminologyNavigatorWidget::CodingSchemeDesignatorRole).toString();
     QString codeValue = item->data(qSlicerTerminologyNavigatorWidget::CodeValueRole).toString();
@@ -547,7 +547,7 @@ QTableWidgetItem* qSlicerTerminologyNavigatorWidgetPrivate::findTableWidgetItemF
     return nullptr;
   }
 
-  foreach (QTableWidgetItem* item, items)
+  for (QTableWidgetItem* const item : items)
   {
     QString codingSchemeDesignator = item->data(qSlicerTerminologyNavigatorWidget::CodingSchemeDesignatorRole).toString();
     QString codeValue = item->data(qSlicerTerminologyNavigatorWidget::CodeValueRole).toString();
@@ -687,7 +687,7 @@ void qSlicerTerminologyNavigatorWidgetPrivate::populateTypeTable()
   // Collect selected categories. Use current category if selected list is empty and current is valid
   // (selection happens from UI, current is set when setting from outside using setTerminologyEntry)
   QList<vtkSlicerTerminologyCategory*> selectedCategories;
-  foreach (vtkSmartPointer<vtkSlicerTerminologyCategory> category, this->SelectedCategoryObjects)
+  for (const vtkSmartPointer<vtkSlicerTerminologyCategory>& category : this->SelectedCategoryObjects)
   {
     selectedCategories << category.GetPointer();
   }
@@ -724,7 +724,7 @@ void qSlicerTerminologyNavigatorWidgetPrivate::populateTypeTable()
   std::string searchTerm(this->SearchBox_Type->text().toUtf8().constData());
   std::vector<vtkSmartPointer<vtkSlicerTerminologyType>>::iterator typeObjIt;
   std::set<std::string> existingTypesSchemeValue;
-  foreach (vtkSlicerTerminologyCategory* category, selectedCategories)
+  for (vtkSlicerTerminologyCategory* const category : selectedCategories)
   {
     std::vector<vtkSlicerTerminologiesModuleLogic::CodeIdentifier> typesInCategory;
     std::vector<vtkSmartPointer<vtkSlicerTerminologyType>> typesObjectsInCategory;
@@ -2049,7 +2049,7 @@ void qSlicerTerminologyNavigatorWidget::onCategorySelectionChanged()
   bool showAnatomyOnInAnyCategories = false;
 
   d->SelectedCategoryObjects.clear();
-  foreach (QTableWidgetItem* currentItem, selectedItems)
+  for (QTableWidgetItem* const currentItem : selectedItems)
   {
     vtkSlicerTerminologiesModuleLogic::CodeIdentifier categoryId(currentItem->data(CodingSchemeDesignatorRole).toString().toUtf8().constData(),
                                                                  currentItem->data(CodeValueRole).toString().toUtf8().constData(),

--- a/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.cxx
+++ b/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.cxx
@@ -409,7 +409,7 @@ void qSlicerSubjectHierarchyTransformsPluginPrivate::showResetCenterOfTransforma
 void qSlicerSubjectHierarchyTransformsPluginPrivate::removeResetCenterOfTransformationForTransformedNodesActions()
 {
   QList<QAction*> transformActions = this->ResetCenterOfTransformationNodeGroup->actions();
-  foreach (QAction* transformAction, transformActions)
+  for (QAction* const transformAction : transformActions)
   {
     this->ResetCenterOfTransformationNodeGroup->removeAction(transformAction);
     this->ResetCenterOfTransformationMenu->removeAction(transformAction);
@@ -506,7 +506,7 @@ vtkMRMLTransformNode* qSlicerSubjectHierarchyTransformsPluginPrivate::firstAppli
   QList<vtkIdType> currentItemIDs;
   currentItemIDs = qSlicerSubjectHierarchyPluginHandler::instance()->currentItems();
 
-  foreach (vtkIdType itemID, currentItemIDs)
+  for (const vtkIdType& itemID : currentItemIDs)
   {
     std::vector<vtkIdType> childItemIDs;
     shNode->GetItemChildren(itemID, childItemIDs, true);
@@ -1192,7 +1192,7 @@ void qSlicerSubjectHierarchyTransformsPlugin::showTransformContextMenuActionsFor
   }
 
   QList<QAction*> transformActions = d->TransformActionGroup->actions();
-  foreach (QAction* transformAction, transformActions)
+  for (QAction* const transformAction : transformActions)
   {
     std::string actionTransformNodeID = transformAction->data().toString().toStdString();
     bool checked = allTransformsAreTheSame && currentTransformNodeID == actionTransformNodeID;
@@ -1278,7 +1278,7 @@ QList<QAction*> qSlicerSubjectHierarchyTransformsPlugin::transformContextMenuAct
     }
 
     QAction* transformAction = nullptr;
-    foreach (QAction* foundTransformAction, originalTransformActions)
+    for (QAction* const foundTransformAction : originalTransformActions)
     {
       if (foundTransformAction->data().toString().toStdString() == transformNode->GetID())
       {
@@ -1310,7 +1310,7 @@ QList<QAction*> qSlicerSubjectHierarchyTransformsPlugin::transformContextMenuAct
   }
 
   // Remove actions that belong to deleted transform nodes
-  foreach (QAction* transformAction, originalTransformActions)
+  for (QAction* const transformAction : originalTransformActions)
   {
     QString actionTransformNodeID = transformAction->data().toString();
     if (actionTransformNodeID.isEmpty())
@@ -1339,7 +1339,7 @@ void qSlicerSubjectHierarchyTransformsPlugin::onTransformActionSelected()
   std::string selectedTransformNodeID = action->data().toString().toStdString();
   QList<vtkIdType> currentItemIDs;
   currentItemIDs = qSlicerSubjectHierarchyPluginHandler::instance()->currentItems();
-  foreach (vtkIdType itemID, currentItemIDs)
+  for (const vtkIdType& itemID : currentItemIDs)
   {
     d->applyTransformToItem(itemID, selectedTransformNodeID.c_str());
   }
@@ -1431,7 +1431,7 @@ void qSlicerSubjectHierarchyTransformsPlugin::onCreateNewTransform()
   }
   QList<vtkIdType> currentItemIDs;
   currentItemIDs = qSlicerSubjectHierarchyPluginHandler::instance()->currentItems();
-  foreach (vtkIdType itemID, currentItemIDs)
+  for (const vtkIdType& itemID : currentItemIDs)
   {
     d->applyTransformToItem(itemID, newTransformNode->GetID());
   }

--- a/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.cxx
+++ b/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.cxx
@@ -98,7 +98,7 @@ QList<vtkSmartPointer<vtkMRMLTransformableNode>> qSlicerTransformsModuleWidgetPr
 
   // Return the list of nodes
   QList<vtkSmartPointer<vtkMRMLTransformableNode>> selectedNodes;
-  foreach (QModelIndex selectedIndex, selectedIndexes)
+  for (const QModelIndex& selectedIndex : selectedIndexes)
   {
     vtkMRMLTransformableNode* node = vtkMRMLTransformableNode::SafeDownCast(tree->sortFilterProxyModel()->mrmlNodeFromIndex(selectedIndex));
     Q_ASSERT(node);
@@ -620,7 +620,7 @@ void qSlicerTransformsModuleWidget::transformSelectedNodes()
 {
   Q_D(qSlicerTransformsModuleWidget);
   QList<vtkSmartPointer<vtkMRMLTransformableNode>> nodesToTransform = qSlicerTransformsModuleWidgetPrivate::getSelectedNodes(d->TransformableTreeView);
-  foreach (vtkSmartPointer<vtkMRMLTransformableNode> node, nodesToTransform)
+  for (const vtkSmartPointer<vtkMRMLTransformableNode>& node : nodesToTransform)
   {
     node->SetAndObserveTransformNodeID(d->MRMLTransformNode->GetID());
   }
@@ -631,7 +631,7 @@ void qSlicerTransformsModuleWidget::untransformSelectedNodes()
 {
   Q_D(qSlicerTransformsModuleWidget);
   QList<vtkSmartPointer<vtkMRMLTransformableNode>> nodesToTransform = qSlicerTransformsModuleWidgetPrivate::getSelectedNodes(d->TransformedTreeView);
-  foreach (vtkSmartPointer<vtkMRMLTransformableNode> node, nodesToTransform)
+  for (const vtkSmartPointer<vtkMRMLTransformableNode>& node : nodesToTransform)
   {
     node->SetAndObserveTransformNodeID(nullptr);
   }
@@ -643,7 +643,7 @@ void qSlicerTransformsModuleWidget::hardenSelectedNodes()
   Q_D(qSlicerTransformsModuleWidget);
   QList<vtkSmartPointer<vtkMRMLTransformableNode>> nodesToTransform = qSlicerTransformsModuleWidgetPrivate::getSelectedNodes(d->TransformedTreeView);
   QApplication::setOverrideCursor(QCursor(Qt::BusyCursor));
-  foreach (vtkSmartPointer<vtkMRMLTransformableNode> node, nodesToTransform)
+  for (const vtkSmartPointer<vtkMRMLTransformableNode>& node : nodesToTransform)
   {
     d->logic()->hardenTransform(vtkMRMLTransformableNode::SafeDownCast(node));
   }

--- a/Modules/Loadable/Units/qSlicerUnitsSettingsPanel.cxx
+++ b/Modules/Loadable/Units/qSlicerUnitsSettingsPanel.cxx
@@ -168,7 +168,7 @@ void qSlicerUnitsSettingsPanelPrivate::addQuantity(const QString& quantity)
 // ---------------------------------------------------------------------------
 void qSlicerUnitsSettingsPanelPrivate::clearQuantities()
 {
-  foreach (QObject* obj, this->GridLayout->children())
+  for (QObject* const obj : this->GridLayout->children())
   {
     delete obj;
   }
@@ -192,7 +192,7 @@ void qSlicerUnitsSettingsPanelPrivate::setMRMLScene(vtkMRMLScene* scene)
   quantities << "length" << "time" << "frequency" << "velocity" << "intensity";
   q->setQuantities(quantities);
 
-  foreach (qMRMLSettingsUnitWidget* widget, this->Quantities.values())
+  for (qMRMLSettingsUnitWidget* const widget : this->Quantities.values())
   {
     widget->unitComboBox()->setMRMLScene(this->MRMLScene);
   }
@@ -256,7 +256,7 @@ void qSlicerUnitsSettingsPanel::setUnitsLogic(vtkSlicerUnitsLogic* logic)
   qvtkReconnect(d->Logic, logic, vtkCommand::ModifiedEvent, this, SLOT(onUnitsLogicModified()));
   d->Logic = logic;
 
-  foreach (qMRMLSettingsUnitWidget* widget, d->Quantities.values())
+  for (qMRMLSettingsUnitWidget* const widget : d->Quantities.values())
   {
     widget->setUnitsLogic(d->Logic);
   }
@@ -289,7 +289,7 @@ void qSlicerUnitsSettingsPanel::setQuantities(const QStringList& newQuantities)
 {
   Q_D(qSlicerUnitsSettingsPanel);
 
-  foreach (QString newQuantity, newQuantities)
+  for (const QString& newQuantity : newQuantities)
   {
     if (!d->Quantities.contains(newQuantity))
     {
@@ -333,7 +333,7 @@ void qSlicerUnitsSettingsPanel::showAll(bool showAll)
 
   d->resize(showAll);
 
-  foreach (qMRMLSettingsUnitWidget* widget, d->Quantities.values())
+  for (qMRMLSettingsUnitWidget* const widget : d->Quantities.values())
   {
     // clang-format off
     qMRMLUnitWidget::UnitProperties allButNameAndQuantity =

--- a/Modules/Loadable/VolumeRendering/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumeRenderingPlugin.cxx
+++ b/Modules/Loadable/VolumeRendering/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumeRenderingPlugin.cxx
@@ -253,7 +253,7 @@ void qSlicerSubjectHierarchyVolumeRenderingPlugin::resetFieldOfView(vtkMRMLDispl
     qCritical() << Q_FUNC_INFO << " failed: cannot get application logic";
     return;
   }
-  foreach (vtkMRMLViewNode* currentViewNode, viewNodes)
+  for (vtkMRMLViewNode* const currentViewNode : viewNodes)
   {
     // Show the volume in slice view
     vtkMRMLViewLogic* viewLogic = appLogic->GetViewLogic(currentViewNode);

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.cxx
@@ -239,7 +239,7 @@ vtkMRMLVolumeRenderingDisplayNode* qSlicerVolumeRenderingModuleWidgetPrivate::cr
   // Do not show newly selected volume (because it would be triggered by simply selecting it in the combobox,
   // and it would not adhere to the customary Slicer behavior)
   // Set selected views to the display node
-  foreach (vtkMRMLAbstractViewNode* viewNode, this->ViewCheckableNodeComboBox->checkedViewNodes())
+  for (vtkMRMLAbstractViewNode* const viewNode : this->ViewCheckableNodeComboBox->checkedViewNodes())
   {
     displayNode->AddViewNodeID(viewNode ? viewNode->GetID() : nullptr);
   }

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
@@ -252,7 +252,7 @@ qMRMLSliceWidget* qSlicerSubjectHierarchyVolumesPluginPrivate::sliceWidgetForSli
   }
 
   QStringList sliceViewNames = layoutManager->sliceViewNames();
-  foreach (QString sliceName, sliceViewNames)
+  for (const QString& sliceName : sliceViewNames)
   {
     qMRMLSliceWidget* sliceWidget = layoutManager->sliceWidget(sliceName);
     if (sliceWidget->mrmlSliceCompositeNode() == compositeNode)

--- a/Modules/Loadable/Volumes/qSlicerVolumesIOOptionsWidget.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesIOOptionsWidget.cxx
@@ -128,7 +128,7 @@ void qSlicerVolumesIOOptionsWidget::setFileNames(const QStringList& fileNames)
     qWarning("qSlicerVolumesIOOptionsWidget::setFileNames: mrmlScene is invalid, node name may not be determined accurately");
     snode = vtkSmartPointer<vtkMRMLVolumeArchetypeStorageNode>::New();
   }
-  foreach (const QString& fileName, fileNames)
+  for (const QString& fileName : fileNames)
   {
     QFileInfo fileInfo(fileName);
     QString fileBaseName = fileInfo.baseName();

--- a/Modules/Loadable/Volumes/qSlicerVolumesReader.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesReader.cxx
@@ -209,7 +209,7 @@ bool qSlicerVolumesReader::load(const IOProperties& properties)
   if (properties.contains("fileNames"))
   {
     fileList = vtkSmartPointer<vtkStringArray>::New();
-    foreach (QString file, properties["fileNames"].toStringList())
+    for (const QString& file : properties["fileNames"].toStringList())
     {
       fileList->InsertNextValue(file.toUtf8());
     }
@@ -266,7 +266,7 @@ bool qSlicerVolumesReader::examineFileInfoList(QFileInfoList& fileInfoList, QFil
   // Check each file to see if it's recognized as part of a series.  If so,
   // keep it as the archetype and remove all the others from the list
   //
-  foreach (QFileInfo fileInfo, fileInfoList)
+  for (const QFileInfo& fileInfo : fileInfoList)
   {
     itk::ArchetypeSeriesFileNames::Pointer seriesNames = itk::ArchetypeSeriesFileNames::New();
     std::vector<std::string> candidateFiles;

--- a/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMExportDialog.cxx
+++ b/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMExportDialog.cxx
@@ -255,7 +255,7 @@ void qSlicerDICOMExportDialog::examineSelectedItem()
 
   // Get exportables from DICOM plugins for selection
   QMultiMap<QString, qSlicerDICOMExportable*> exportablesByPlugin;
-  foreach (vtkIdType selectedSeriesItemID, selectedSeriesItemIDs)
+  for (const vtkIdType& selectedSeriesItemID : selectedSeriesItemIDs)
   {
     PythonQt::init();
     PythonQtObjectPtr context = PythonQt::self()->getMainModule();
@@ -276,7 +276,7 @@ void qSlicerDICOMExportDialog::examineSelectedItem()
     QVariantList exportablesVariantList = context.getVariable("exportables").toList();
 
     // Group exportables by provider plugin
-    foreach (QVariant exportableVariant, exportablesVariantList)
+    for (const QVariant& exportableVariant : exportablesVariantList)
     {
       qSlicerDICOMExportable* exportable = qobject_cast<qSlicerDICOMExportable*>(exportableVariant.value<QObject*>());
       if (!exportable)
@@ -291,12 +291,12 @@ void qSlicerDICOMExportDialog::examineSelectedItem()
   }
   // Map the grouped exportables by confidence values so that the highest confidence is on top
   QMultiMap<double, QList<qSlicerDICOMExportable*>> exportablesByConfidence;
-  foreach (const QString& plugin, exportablesByPlugin.uniqueKeys())
+  for (const QString& plugin : exportablesByPlugin.uniqueKeys())
   {
     // Geometric mean to emphasize larger values
     double meanConfidenceForPlugin = 0.0;
     QList<qSlicerDICOMExportable*> exportablesForPlugin = exportablesByPlugin.values(plugin);
-    foreach (qSlicerDICOMExportable* exportable, exportablesForPlugin)
+    for (qSlicerDICOMExportable* const exportable : exportablesForPlugin)
     {
       meanConfidenceForPlugin += exportable->confidence();
     }
@@ -308,11 +308,11 @@ void qSlicerDICOMExportDialog::examineSelectedItem()
   }
 
   // Populate the exportables list widget
-  foreach (double inverseConfidence, exportablesByConfidence.uniqueKeys())
+  for (const double& inverseConfidence : exportablesByConfidence.uniqueKeys())
   {
     // Get exportable lists for the confidence number (there might be equality!)
     QList<QList<qSlicerDICOMExportable*>> exportableLists = exportablesByConfidence.values(inverseConfidence);
-    foreach (QList<qSlicerDICOMExportable*> exportables, exportableLists)
+    for (const QList<qSlicerDICOMExportable*>& exportables : exportableLists)
     {
       // Set exportable name as the first one in the list, giving also the
       // confidence number and plugin name in parentheses
@@ -325,7 +325,7 @@ void qSlicerDICOMExportDialog::examineSelectedItem()
       exportableItem->setToolTip(exportables[0]->tooltip());
       // Construct data variant object
       QList<QVariant> itemData;
-      foreach (qSlicerDICOMExportable* exportable, exportables)
+      for (qSlicerDICOMExportable* const exportable : exportables)
       {
         itemData.append(QVariant::fromValue<QObject*>(exportable));
       }
@@ -355,7 +355,7 @@ void qSlicerDICOMExportDialog::onExportableSelectedAtRow(int row)
   // Get exportable object from list item
   QList<qSlicerDICOMExportable*> exportableList;
   QList<QVariant> itemData = exportableItem->data(Qt::UserRole).toList();
-  foreach (QVariant exportableVariant, itemData)
+  for (const QVariant& exportableVariant : itemData)
   {
     qSlicerDICOMExportable* exportable = qobject_cast<qSlicerDICOMExportable*>(exportableVariant.value<QObject*>());
     if (!exportable)
@@ -444,7 +444,7 @@ void qSlicerDICOMExportDialog::onExport()
       indexer.addDirectory(outputFolder.absolutePath(), true);
     }
     // Remove temporary DICOM folder if exported to the DICOM database folder
-    foreach (QString file, outputFolder.entryList())
+    for (const QString& file : outputFolder.entryList())
     {
       outputFolder.remove(file);
     }
@@ -539,7 +539,7 @@ bool qSlicerDICOMExportDialog::exportSeries(const QDir& outputFolder)
   // a composite export where the series are referenced from each other, or if the
   // file naming is static (to avoid overwrite)
   QList<QVariant> exportableList;
-  foreach (qSlicerDICOMExportable* exportable, d->DICOMTagEditorWidget->exportables())
+  for (qSlicerDICOMExportable* const exportable : d->DICOMTagEditorWidget->exportables())
   {
     // Set output directory
     exportable->setDirectory(outputFolder.absolutePath());

--- a/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMLoadable.cxx
+++ b/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMLoadable.cxx
@@ -138,12 +138,12 @@ void qSlicerDICOMLoadable::copyToVtkLoadable(vtkSlicerDICOMLoadable* vtkLoadable
   vtkLoadable->SetConfidence(d->Confidence);
   vtkLoadable->SetLoadSuccess(d->LoadSuccess);
 
-  foreach (QString file, d->Files)
+  for (const QString& file : d->Files)
   {
     vtkLoadable->AddFile(file.toUtf8().constData());
   }
 
-  foreach (QString referencedInstanceUID, d->ReferencedInstanceUIDs)
+  for (const QString& referencedInstanceUID : d->ReferencedInstanceUIDs)
   {
     vtkLoadable->AddReferencedInstanceUID(referencedInstanceUID.toUtf8().constData());
   }

--- a/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMTagEditorWidget.cxx
+++ b/Modules/Scripted/DICOMLib/Widgets/qSlicerDICOMTagEditorWidget.cxx
@@ -248,7 +248,7 @@ void qSlicerDICOMTagEditorWidgetPrivate::insertTagsTableRow(unsigned int row)
 
   // Update those series header row indices above which the row is inserted
   QMap<unsigned int, qSlicerDICOMExportable*> updatedSeriesTagsHeaderRows;
-  foreach (unsigned int seriesHeaderRow, this->SeriesTagsHeaderRows.keys())
+  for (unsigned int seriesHeaderRow : this->SeriesTagsHeaderRows.keys())
   {
     // If inserted above the series header then increase it
     if (row <= seriesHeaderRow)
@@ -330,7 +330,7 @@ QString qSlicerDICOMTagEditorWidget::setExportables(QList<qSlicerDICOMExportable
   d->StudyItemID = vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID;
 
   // Check if the exportables are in the same study
-  foreach (qSlicerDICOMExportable* exportable, d->Exportables)
+  for (qSlicerDICOMExportable* const exportable : d->Exportables)
   {
     vtkIdType seriesItemID = exportable->subjectHierarchyItemID();
     if (seriesItemID == vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID)
@@ -416,7 +416,7 @@ QString qSlicerDICOMTagEditorWidget::setExportables(QList<qSlicerDICOMExportable
       d->TagsTable->item(row, 0)->setFlags(Qt::ItemIsEnabled);
 
       // Also add it to the exportables (needed there for export)
-      foreach (qSlicerDICOMExportable* exportable, d->Exportables)
+      for (qSlicerDICOMExportable* const exportable : d->Exportables)
       {
         exportable->setTag(tagName, tagValue);
       }
@@ -465,7 +465,7 @@ QString qSlicerDICOMTagEditorWidget::setExportables(QList<qSlicerDICOMExportable
       d->TagsTable->item(row, 0)->setFlags(Qt::ItemIsEnabled);
 
       // Also add it to the exportables (needed there for export)
-      foreach (qSlicerDICOMExportable* exportable, d->Exportables)
+      for (qSlicerDICOMExportable* const exportable : d->Exportables)
       {
         exportable->setTag(tagName, tagValue);
       }
@@ -473,7 +473,7 @@ QString qSlicerDICOMTagEditorWidget::setExportables(QList<qSlicerDICOMExportable
   }
 
   // Create series sections for each exportable
-  foreach (qSlicerDICOMExportable* exportable, d->Exportables)
+  for (qSlicerDICOMExportable* const exportable : d->Exportables)
   {
     // Get exportable series item
     vtkIdType seriesItemID = exportable->subjectHierarchyItemID();
@@ -497,7 +497,7 @@ QString qSlicerDICOMTagEditorWidget::setExportables(QList<qSlicerDICOMExportable
 
     // Get series tags from exportable and populate table with them
     QMap<QString, QString> exportableTagsMap = exportable->tags();
-    foreach (QString tagName, exportableTagsMap.keys())
+    for (const QString& tagName : exportableTagsMap.keys())
     {
       // Only use series tags
       if (vtkSlicerSubjectHierarchyModuleLogic::IsPatientTag(tagName.toUtf8().constData()) //
@@ -628,7 +628,7 @@ void qSlicerDICOMTagEditorWidget::tagsTableCellChanged(int row, int column)
   if (row < (int)d->topSeriesHeaderRow())
   {
     // Set new tag value in each exportable
-    foreach (qSlicerDICOMExportable* exportable, d->Exportables)
+    for (qSlicerDICOMExportable* const exportable : d->Exportables)
     {
       exportable->setTag(d->TagsTable->item(row, 0)->text(), d->TagsTable->item(row, 1)->text());
     }


### PR DESCRIPTION
As of Qt 5.7, `foreach` and `Q_FOREACH` are deprecated, and you should use
C++11 range-based for loops.

Prefer `const` references where possible.
