### PR TITLE
BUG: Fix incorrect QDir assignment introduced during refactoring

### DIFF
--- a/Base/QTCore/Testing/Cxx/qSlicerApplicationUpdateManagerTest.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerApplicationUpdateManagerTest.cxx
@@ -87,7 +87,7 @@ bool qSlicerApplicationUpdateManagerTester::resetTmp()
   ctk::removeDirRecursively(tmp.filePath(this->TemporaryDirName));
   tmp.mkdir(this->TemporaryDirName);
   tmp.cd(this->TemporaryDirName);
-  this->Tmp.setPath(tmp.dirName());
+  this->Tmp.setPath(tmp.path());
   return this->Tmp.exists();
 }
 

--- a/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
@@ -321,7 +321,7 @@ bool qSlicerExtensionsManagerModelTester::resetTmp()
   ctk::removeDirRecursively(tmp.filePath(this->TemporaryDirName));
   tmp.mkdir(this->TemporaryDirName);
   tmp.cd(this->TemporaryDirName);
-  this->Tmp.setPath(tmp.dirName());
+  this->Tmp.setPath(tmp.path());
   return this->Tmp.exists();
 }
 

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -870,7 +870,7 @@ QString qSlicerExtensionsManagerModelPrivate::extractArchive(const QDir& extensi
   QDir topLevelArchiveDir;
   while (extractDirOfFirstFile != extensionsDir)
   {
-    topLevelArchiveDir.setPath(extractDirOfFirstFile.dirName());
+    topLevelArchiveDir.setPath(extractDirOfFirstFile.path());
     extractDirOfFirstFile.cdUp();
   }
 

--- a/Base/QTGUI/Testing/Cxx/qSlicerScriptedLoadableModuleTest.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerScriptedLoadableModuleTest.cxx
@@ -70,7 +70,7 @@ bool qSlicerScriptedLoadableModuleTester::resetTmp()
   ctk::removeDirRecursively(tmp.filePath(this->TemporaryDirName));
   tmp.mkdir(this->TemporaryDirName);
   tmp.cd(this->TemporaryDirName);
-  this->Tmp.setPath(tmp.dirName());
+  this->Tmp.setPath(tmp.path());
   return this->Tmp.exists();
 }
 

--- a/Base/QTGUI/Testing/Cxx/qSlicerScriptedLoadableModuleWidgetTest.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerScriptedLoadableModuleWidgetTest.cxx
@@ -80,7 +80,7 @@ bool qSlicerScriptedLoadableModuleWidgetTester::resetTmp()
   ctk::removeDirRecursively(tmp.filePath(this->TemporaryDirName));
   tmp.mkdir(this->TemporaryDirName);
   tmp.cd(this->TemporaryDirName);
-  this->Tmp.setPath(tmp.dirName());
+  this->Tmp.setPath(tmp.path());
   return this->Tmp.exists();
 }
 


### PR DESCRIPTION
The regression introduced in commit d36781511c ("COMP: Refactor QDir assignment to use setPath for consistency", 2025-07-03) used `QDir::dirName()` instead of `QDir::path()` in several locations. Since `dirName()` returns only the last component of the directory path (e.g., the leaf), it resulted in incorrect paths being assigned to `QDir` instances.

This caused failures in both extension extraction and temporary directory setup during tests.

This commit restores the correct behavior by replacing `dirName()` with `path()` in the affected locations.

The following tests now pass:
- `qSlicerExtensionsManagerModelTest`
- `qSlicerApplicationUpdateManagerTest`
- `qSlicerScriptedLoadableModuleTest`
- `qSlicerScriptedLoadableModuleWidgetTest`

----

Follow-up if the following pull requests:
* https://github.com/Slicer/Slicer/pull/8558