### PR TITLE
DRAFT:  DO NOT MERGE Maintenance Scripts

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -72,13 +72,15 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/commontk/CTK.git"
+    #"${EP_GIT_PROTOCOL}://github.com/commontk/CTK.git"
+    "${EP_GIT_PROTOCOL}://github.com/BRAINSia/CTK.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "3b3f9eff550b5b8d2a207a575b0f40f54e850169"
+    #"db2cfae9ed46b48b43d291ee9758a219c87f89f2"
+    "update-Q_OBJECT-clazy"
     QUIET
     )
 

--- a/Utilities/Maintenance/apply_one_clazy_yaml_dir.sh
+++ b/Utilities/Maintenance/apply_one_clazy_yaml_dir.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# A script to assist with applying found fixes
+# NOTE: This is a good starting point, but is almost certainly not complete!
+#       compiler errors may be present, check manually with care.
+#
+
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+export SRC_DIR="$(dirname $(dirname ${SCRIPT_DIR}))"
+export BLD_DIR=$(dirname ${SRC_DIR})/Qt5clazySlicer-build
+export INNER_BLD_DIR=${BLD_DIR}/Slicer-build
+
+echo "
+SRC_DIR=${SRC_DIR}
+BLD_DIR=${BLD_DIR}
+INNER_BLD_DIR=${INNER_BLD_DIR}
+CLAZY_CHECKS=${CLAZY_CHECKS}
+CLAZY_EXPORT_FIXES=${CLAZY_EXPORT_FIXES}
+CMAKE_EXPORT_COMPILE_COMMANDS=${CMAKE_EXPORT_COMPILE_COMMANDS}
+CMAKE_GENERATOR=${CMAKE_GENERATOR}
+"
+
+usage() {
+  echo "USAGE: $0 # no arguments can be provided."
+  echo ""
+  exit -1
+}
+
+
+cd ${INNER_BLD_DIR}
+if [ $# -ne 0 ];then
+  usage
+fi
+
+precommit_bin=$(which pre-commit)
+if [ ! -f ${precommit_bin} ];then
+  echo "required pre-commit not found:  consider a possible solution like the following"
+  echo "python3 -m venv /tmp/venv"
+  echo "source /tmp/venv"
+  echo "pip install pre-commit"
+  usage
+fi
+
+# Convert the yaml files to standard gcc errfmt files for
+# easier corrections via `vim -q /tmp/errmt.err`
+error_file=/tmp/errfmt.err
+message_file=/tmp/commit_msg_clazy_$(date +%Y%m%d.%H%M%S)
+cat > ${message_file} << EOF
+ENH: Update to support Qt6 using clazy auto-fixes
+
+
+EOF
+
+for clazy_yaml_file in $(find ${SRC_DIR} ${INNER_BLD_DIR} -name "*.clazy.yaml"); do
+  # Only include errors/warnings from this source tree in them
+  set +e
+  ${SCRIPT_DIR}/yaml_to_gcc_fmt.py ${clazy_yaml_file} | grep --no-messages ${SRC_DIR} >> ${error_file}
+  set -e
+  clang-apply-replacements-19 \
+    --format                  \
+    --style=file              \
+    $(dirname ${clazy_yaml_file})
+  mv ${clazy_yaml_file} ${clazy_yaml_file//.yaml/.doneyaml}
+done
+sort -u ${error_file} > ${error_file}.tmp
+mv ${error_file}.tmp ${error_file}
+cat ${error_file} >> ${message_file}
+
+cd ${SRC_DIR}
+for changed_file in $(git diff --name-only); do
+  git add ${changed_file}
+done
+
+pre-commit run -a
+
+if cmake --build ${INNER_BLD_DIR}; then
+  git commit -e -F ${message_file}
+else
+  echo "============================================================="
+  echo "Fix compiler errors, then run git commit -e -F ${message_file}"
+fi
+echo "=Useful commands============================================================"
+echo vim -q ${error_file}
+echo "find ${SRC_DIR} ${INNER_BLD_DIR} -name \"*.clazy.yaml\""
+echo "find ${SRC_DIR} ${INNER_BLD_DIR} \"*.clazy.doneyaml\" -delete"

--- a/Utilities/Maintenance/apply_one_clazy_yaml_dir_CTK.sh
+++ b/Utilities/Maintenance/apply_one_clazy_yaml_dir_CTK.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# A script to assist with applying found fixes
+# NOTE: This is a good starting point, but is almost certainly not complete!
+#       compiler errors may be present, check manually with care.
+#
+
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+export SRC_DIR="$(dirname $(dirname $(dirname ${SCRIPT_DIR})))/Qt5clazySlicer-build/CTK"
+export BLD_DIR=$(dirname ${SRC_DIR})/CTK-build
+export INNER_BLD_DIR=${BLD_DIR}/CTK-build
+
+echo "
+SRC_DIR=${SRC_DIR}
+BLD_DIR=${BLD_DIR}
+INNER_BLD_DIR=${INNER_BLD_DIR}
+CLAZY_CHECKS=${CLAZY_CHECKS}
+CLAZY_EXPORT_FIXES=${CLAZY_EXPORT_FIXES}
+CMAKE_EXPORT_COMPILE_COMMANDS=${CMAKE_EXPORT_COMPILE_COMMANDS}
+CMAKE_GENERATOR=${CMAKE_GENERATOR}
+"
+
+usage() {
+  echo "USAGE: $0 # no arguments can be provided."
+  echo ""
+  exit -1
+}
+
+
+cd ${INNER_BLD_DIR}
+if [ $# -ne 0 ];then
+  usage
+fi
+
+precommit_bin=$(which pre-commit)
+if [ ! -f ${precommit_bin} ];then
+  echo "required pre-commit not found:  consider a possible solution like the following"
+  echo "python3 -m venv /tmp/venv"
+  echo "source /tmp/venv"
+  echo "pip install pre-commit"
+  usage
+fi
+
+# Convert the yaml files to standard gcc errfmt files for
+# easier corrections via `vim -q /tmp/errmt.err`
+error_file=/tmp/errfmt.err
+message_file=/tmp/commit_msg_clazy_$(date +%Y%m%d.%H%M%S)
+cat > ${message_file} << EOF
+ENH: Update to support Qt6 using clazy auto-fixes
+
+
+EOF
+
+for clazy_yaml_file in $(find ${SRC_DIR} ${INNER_BLD_DIR} -name "*.clazy.yaml"); do
+  # Only include errors/warnings from this source tree in them
+  set +e
+  ${SCRIPT_DIR}/yaml_to_gcc_fmt.py ${clazy_yaml_file} | grep --no-messages ${SRC_DIR} >> ${error_file}
+  set -e
+  clang-apply-replacements-19 \
+    --format                  \
+    --style=file              \
+    $(dirname ${clazy_yaml_file})
+  mv ${clazy_yaml_file} ${clazy_yaml_file//.yaml/.doneyaml}
+done
+sort -u ${error_file} > ${error_file}.tmp
+mv ${error_file}.tmp ${error_file}
+cat ${error_file} >> ${message_file}
+
+cd ${SRC_DIR}
+for changed_file in $(git diff --name-only); do
+  git add ${changed_file}
+done
+
+pre-commit run -a
+
+if cmake --build ${INNER_BLD_DIR}; then
+  git commit -e -F ${message_file}
+else
+  echo "============================================================="
+  echo "Fix compiler errors, then run git commit -e -F ${message_file}"
+fi
+echo "=Useful commands============================================================"
+echo vim -q ${error_file}
+echo "find ${SRC_DIR} ${INNER_BLD_DIR} -name \"*.clazy.yaml\""
+echo "find ${SRC_DIR} ${INNER_BLD_DIR} \"*.clazy.doneyaml\" -delete"

--- a/Utilities/Maintenance/build_with_clazy_compiler.sh
+++ b/Utilities/Maintenance/build_with_clazy_compiler.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Clazy can automatically fix many Qt5-to-Qt6 porting issues using Fix‑It style
+# rewrites—but with some important caveats. Here’s how it works:
+#
+# Clazy includes several Qt6‑porting checks that provide automatic fix-it suggestions, including:
+#   •  qt6-deprecated-api-fixes
+#   •  qt6-header-fixes
+#   •  qt6-qhash-signature
+#   •  qt6-fwd-fixes
+#   •  missing-qobject-macro
+# ￼
+# These checks can identify deprecated APIs and even offer automatic replacements.
+#   Clazy generates .clazy.yaml files alongside your source files, containing replacement instructions.
+#  •  Use clang-apply-replacements <path> to apply changes in bulk.
+#  •  Conflicts or ambiguous fix‑its are reported and halted.
+#
+# ⚠️ Limitations and Notes
+#  •  Not all Qt6 migration issues can be auto-fixed. Some require manual review.
+#  •  Fix‑its may conflict if multiple rules apply to the same code line. Handle with caution.
+#  •  After applying fixes, your code may only compile under Qt6, not with Qt5.  Use git diff tools
+#     to add pre-processor alternate compilations paths to support both Qt5 and Qt6
+#     #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#       menuOption.tabWidth = 0;
+#     #endif
+
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+export SRC_DIR="$(dirname $(dirname ${SCRIPT_DIR}))"
+export BLD_DIR=$(dirname ${SRC_DIR})/Qt5clazySlicer-build
+export INNER_BLD_DIR=${BLD_DIR}/Slicer-build
+
+
+usage() {
+  echo "Usage:  $0 <checks_to_run> <cleanbuild|build>"
+  echo "  where can be one of qt6-deprecated-api-fixes,qt6-header-fixes,qt6-qhash-signature,qt6-fwd-fixes,missing-qobject-macro"
+  echo "For example:"
+  echo "  $0 \"qt6-deprecated-api-fixes,qt6-header-fixes,qt6-qhash-signature,qt6-fwd-fixes,missing-qobject-macro\" cleanbuild"
+  echo "  $0 \"qt6-deprecated-api-fixes\" cleanbuild"
+  echo "  $0 \"qt6-header-fixes\" cleanbuild"
+  echo "  $0 \"qt6-qhash-signature\" cleanbuild"
+  echo "  $0 \"qt6-fwd-fixes\" cleanbuild"
+  echo "  $0 \"missing-qobject-macro\" cleanbuild"
+
+  exit -1
+}
+
+
+if [ $# -ne 2 ];then
+  usage
+fi
+export CLAZY_CHECKS="$1"
+export CLAZY_EXPORT_FIXES=ON
+export CMAKE_EXPORT_COMPILE_COMMANDS=ON
+export CMAKE_GENERATOR=Ninja
+
+echo "
+SRC_DIR=${SRC_DIR}
+BLD_DIR=${BLD_DIR}
+INNER_BLD_DIR=${INNER_BLD_DIR}
+CLAZY_CHECKS=${CLAZY_CHECKS}
+CLAZY_EXPORT_FIXES=${CLAZY_EXPORT_FIXES}
+CMAKE_EXPORT_COMPILE_COMMANDS=${CMAKE_EXPORT_COMPILE_COMMANDS}
+CMAKE_GENERATOR=${CMAKE_GENERATOR}
+"
+
+
+# use clazy as your compiler
+#
+if [ ! -f ${BLD_DIR}/CMakeCache.txt ] ;then
+  cmake -GNinja \
+        -S ${SRC_DIR} \
+        -B ${BLD_DIR} \
+        -DCMAKE_BUILD_TYPE:BOOL=Release \
+        -DCMAKE_CXX_COMPILER=clazy
+   cmake --build ${BLD_DIR}
+fi
+cd ${INNER_BLD_DIR}
+buildmode="$2"
+case "$buildmode" in
+  "cleanbuild")
+    echo "Starting clean build in ${INNER_BLD_DIR} ..."
+    cmake --build ${INNER_BLD_DIR} --target clean
+    cmake .
+    cmake --build ${INNER_BLD_DIR}
+    ;;
+  "build")
+    echo "Starting re-build in ${INNER_BLD_DIR} ..."
+    cmake .
+    cmake --build ${INNER_BLD_DIR}
+    ;;
+  *)
+    echo "Unknown command: '$buildmode'"
+    usage
+    ;;
+esac
+
+
+echo "Now consider applying all found clazy regresssions"
+echo "for clazy_yaml in \$(find ${INNER_BLD_DIR} -name \"*.clazy.yaml\"); do"
+echo "  ${SCRIPT_DIR}/apply_one_clazy_yaml_dir.sh \${clazy_yaml}"
+echo "done"

--- a/Utilities/Maintenance/build_with_clazy_compiler_CTK.sh
+++ b/Utilities/Maintenance/build_with_clazy_compiler_CTK.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Clazy can automatically fix many Qt5-to-Qt6 porting issues using Fix‑It style
+# rewrites—but with some important caveats. Here’s how it works:
+#
+# Clazy includes several Qt6‑porting checks that provide automatic fix-it suggestions, including:
+#   •  qt6-deprecated-api-fixes
+#   •  qt6-header-fixes
+#   •  qt6-qhash-signature
+#   •  qt6-fwd-fixes
+#   •  missing-qobject-macro
+# ￼
+# These checks can identify deprecated APIs and even offer automatic replacements.
+#   Clazy generates .clazy.yaml files alongside your source files, containing replacement instructions.
+#  •  Use clang-apply-replacements <path> to apply changes in bulk.
+#  •  Conflicts or ambiguous fix‑its are reported and halted.
+#
+# ⚠️ Limitations and Notes
+#  •  Not all Qt6 migration issues can be auto-fixed. Some require manual review.
+#  •  Fix‑its may conflict if multiple rules apply to the same code line. Handle with caution.
+#  •  After applying fixes, your code may only compile under Qt6, not with Qt5.  Use git diff tools
+#     to add pre-processor alternate compilations paths to support both Qt5 and Qt6
+#     #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#       menuOption.tabWidth = 0;
+#     #endif
+
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+export SRC_DIR="$(dirname $(dirname $(dirname ${SCRIPT_DIR})))/Qt5clazySlicer-build/CTK"
+export BLD_DIR=$(dirname ${SRC_DIR})/CTK-build
+export INNER_BLD_DIR=${BLD_DIR}/CTK-build
+
+find ${INNER_BLD_DIR} -name "*.clazy*yaml*" -delete
+
+usage() {
+  echo "Usage:  $0 <checks_to_run> <cleanbuild|build>"
+  echo "  where can be one of qt6-deprecated-api-fixes,qt6-header-fixes,qt6-qhash-signature,qt6-fwd-fixes,missing-qobject-macro"
+  echo "For example:"
+  echo "  $0 \"qt6-deprecated-api-fixes,qt6-header-fixes,qt6-qhash-signature,qt6-fwd-fixes,missing-qobject-macro\" cleanbuild"
+  echo "  $0 \"qt6-deprecated-api-fixes\" cleanbuild"
+  echo "  $0 \"qt6-header-fixes\" cleanbuild"
+  echo "  $0 \"qt6-qhash-signature\" cleanbuild"
+  echo "  $0 \"qt6-fwd-fixes\" cleanbuild"
+  echo "  $0 \"missing-qobject-macro\" cleanbuild"
+
+  exit -1
+}
+
+
+if [ $# -ne 2 ];then
+  usage
+fi
+export CLAZY_CHECKS="$1"
+export CLAZY_EXPORT_FIXES=ON
+export CMAKE_EXPORT_COMPILE_COMMANDS=ON
+export CMAKE_GENERATOR=Ninja
+
+echo "
+SRC_DIR=${SRC_DIR}
+BLD_DIR=${BLD_DIR}
+INNER_BLD_DIR=${INNER_BLD_DIR}
+CLAZY_CHECKS=${CLAZY_CHECKS}
+CLAZY_EXPORT_FIXES=${CLAZY_EXPORT_FIXES}
+CMAKE_EXPORT_COMPILE_COMMANDS=${CMAKE_EXPORT_COMPILE_COMMANDS}
+CMAKE_GENERATOR=${CMAKE_GENERATOR}
+"
+
+
+# use clazy as your compiler
+#
+if [ ! -f ${BLD_DIR}/CMakeCache.txt ] ;then
+  cmake -GNinja \
+        -S ${SRC_DIR} \
+        -B ${BLD_DIR} \
+        -DCMAKE_BUILD_TYPE:BOOL=Release \
+        -DCMAKE_CXX_COMPILER=clazy
+   cmake --build ${BLD_DIR}
+fi
+cd ${INNER_BLD_DIR}
+buildmode="$2"
+case "$buildmode" in
+  "cleanbuild")
+    echo "Starting clean build in ${INNER_BLD_DIR} ..."
+    cmake --build ${INNER_BLD_DIR} --target clean
+    cmake .
+    cmake --build ${INNER_BLD_DIR}
+    ;;
+  "build")
+    echo "Starting re-build in ${INNER_BLD_DIR} ..."
+    cmake .
+    cmake --build ${INNER_BLD_DIR}
+    ;;
+  *)
+    echo "Unknown command: '$buildmode'"
+    usage
+    ;;
+esac
+
+
+echo "Now consider applying all found clazy regresssions"
+echo "for clazy_yaml in \$(find ${INNER_BLD_DIR} -name \"*.clazy.yaml\"); do"
+echo "  ${SCRIPT_DIR}/apply_one_clazy_yaml_dir.sh \${clazy_yaml}"
+echo "done"

--- a/Utilities/Maintenance/clang-tidy-modernize.sh
+++ b/Utilities/Maintenance/clang-tidy-modernize.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+#
+#
+SLICER_SRC=/localcache/Users/johnsonhj/src/Slicer
+CHECK=misc-const-correctness
+cd $SLICER_SRC
+find ${SLICER_SRC}  ${SLICER_SRC}-clang19/Slicer-build -name '*.cpp' -o -name "*.cxx" \
+  | xargs -P 42 -n1 /usr/bin/clang-tidy-19 \
+                            -p=${SLICER_SRC}-clang19/Slicer-build \
+                            --fix \
+                            --checks=${CHECK}  \
+                            -header-filter=".*" \
+                            --header-filter=".*"
+
+
+cat > /tmp/${CHECK}.msg << EOF
+COMP: Prefer explicit const designation
+
+Add const to variables that do not change.
+
+Detect local variables which could be declared as const but are not. Declaring
+variables as const is recommended by many coding guidelines, such
+as: ES.25 from the C++ Core Guidelines.
+
+EOF

--- a/Utilities/Maintenance/fix_Qt6_clazy_missing_notify.py
+++ b/Utilities/Maintenance/fix_Qt6_clazy_missing_notify.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+import re
+import sys
+
+prop_pattern = re.compile(
+    r"^(?P<indent>\s*)Q_PROPERTY\([\s\n]*"
+    r"(?P<type>[\w:<>]+)[\s\n]+"
+    r"(?P<prop>[A-Za-z_]\w*)[\s\n]+"
+    r"READ[\s\n]+(?P<readfunction>[A-Za-z_]\w*)[\s\n]+"
+    r"WRITE[\s\n]+(?P<writefunction>\w+)[\s\n]*\)[\s\n]*;*[\s\n]*$",
+)
+
+signal_pattern = re.compile(
+    r"[\s\n]*void[\s\n]+"
+    r"(?P<prop>[A-Za-z_]\w*)Changed[\s\n]*\([\s\n]*[\w:<>]+[\s\n]*\)[\s\n]*;",
+)
+
+def process_lines(lines):
+    out = []
+    existing_signals = set()
+    # First pass: collect existing signal names
+    for line in lines:
+        m = signal_pattern.match(line)
+        if m:
+            existing_signals.add(m.group("prop"))
+
+    # Second pass: transform properties and insert signal declaration
+    q_signals_block = ["Q_SIGNALS:\n"]
+    for line in lines:
+        pm = prop_pattern.match(line)
+        if pm:
+            indent = pm.group("indent")
+            type_ = pm.group("type")
+            prop = pm.group("prop")
+            readfunction = pm.group("readfunction")
+            writefunction = pm.group("writefunction")
+            #notify = f' NOTIFY {prop}Changed'
+            #new_prop_line = re.sub(r'\)[\s\n]*;', notify + ');', line)
+            new_prop_line = f"{indent}Q_PROPERTY({type_} {prop} READ {readfunction} WRITE {writefunction} NOTIFY {prop}Changed);\n"
+            out.append(new_prop_line)
+            if prop not in existing_signals:
+                # insert signal declaration
+                q_signals_block.append(f"{indent}    void {prop}Changed({type_});\n")
+                existing_signals.add(prop)
+        else:
+           out.append(line)
+    if len(q_signals_block) > 1:
+        for signal_function_prototypes in q_signals_block:
+            out.append(signal_function_prototypes)
+    return out
+
+def convert_file(src_path, dst_path=None):
+    with open(src_path) as f:
+        lines = f.readlines()
+    transformed = process_lines(lines)
+    out = open(dst_path, "w") if dst_path else sys.stdout
+    out.writelines(transformed)
+    if dst_path:
+        out.close()
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <input-file> [<output-file>]")
+        sys.exit(1)
+    convert_file(sys.argv[1], sys.argv[2] if len(sys.argv) > 2 else None)

--- a/Utilities/Maintenance/fix_Qt6_q_signal_function_prototypes_pass_by_const_reference.py
+++ b/Utilities/Maintenance/fix_Qt6_q_signal_function_prototypes_pass_by_const_reference.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+import re
+import sys
+
+PRIMITIVE = {
+    "bool","char","signed char","unsigned char",
+    "short","unsigned short","int","unsigned int",
+    "long","unsigned long","long long","unsigned long long",
+    "float","double","long double",
+    "char16_t","char32_t","wchar_t",
+}
+
+signal_proto = re.compile(
+    r"^(?P<indent>\s*)void\s+(?P<function_name>[\w:<>]+)\s*\(\s*(?P<variable_type>[\w:<>]+)\s*(?P<variable_name>[\w:<>]*)\)\s*;\s*$",
+)
+
+def is_primitive(typ: str) -> bool:
+    t = typ.strip()
+    # ignore parameter names
+    t = re.sub(r"\b\w+\s*$", "", t).strip()
+    return t in PRIMITIVE
+
+def process(lines):
+    out = []
+    in_signals = False
+    for line in lines:
+        if re.match(r"^\s*Q_SIGNALS\s*:", line): # Q_SIGNALS indicates the start of a block
+            in_signals = True
+            out.append(line)
+            continue
+        if re.match(r"^\s*.*:\s*$", line):
+            in_signals = False
+            out.append(line)
+            continue
+        if in_signals:
+            pm = signal_proto.match(line)
+            if not pm:
+                out.append(line)
+                continue
+            indent = pm.group("indent")
+            function_name = pm.group("function_name")
+            variable_type = pm.group("variable_type").strip()
+            variable_name = pm.group("variable_name").strip()
+            if len(variable_name) > 1:
+              variable_name = f" {variable_name}" # insert space before name
+            if variable_type.strip() in PRIMITIVE:
+              out.append(line)
+              continue
+            if "*" in variable_type: # Skip pointers
+              out.append(line)
+              continue
+            if "&" in variable_type: # Skip references
+              out.append(line)
+              continue
+            if pm:
+              new = f"{indent}void {function_name}(const {variable_type} &{variable_name});\n"
+              out.append(new)
+              continue
+        out.append(line)
+    return out
+
+def convert(src, dst=None):
+    with open(src) as f:
+        lines = f.readlines()
+    transformed = process(lines)
+    out = open(dst, "w") if dst else sys.stdout
+    out.writelines(transformed)
+    if dst:
+        out.close()
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <header.h> [<out.h>]")
+        sys.exit(1)
+    convert(sys.argv[1], sys.argv[2] if len(sys.argv) > 2 else None)

--- a/Utilities/Maintenance/replace_qt_foreach_with_c++11.py
+++ b/Utilities/Maintenance/replace_qt_foreach_with_c++11.py
@@ -1,0 +1,71 @@
+import re
+import sys
+import os
+
+def convert_foreach_to_range_for(line):
+    # Match: foreach (Type var, container)
+    pattern = r"\b(?:foreach|Q_FOREACH)\s*\(\s*([\w]+)\s*([\w]+),\s*(.+?)\s*\)"
+    match = re.search(pattern, line)
+    if match:
+        type_name = match.group(1).strip()
+        var = match.group(2).strip()
+        container = match.group(3).strip()
+        line=re.sub(pattern, f"for (const {type_name} & {var}: {container})", line)
+    # Match: foreach (const Type &var, container)
+    pattern = r"\b(?:foreach|Q_FOREACH)\s*\(\s*(const)+\s*([\w]+\s*&)\s*([\w]+)\s*,\s*(.+?)\s*\)"
+    match = re.search(pattern, line)
+    if match:
+        const = match.group(1).strip()
+        type_name = match.group(2).strip()
+        var = match.group(3).strip()
+        container = match.group(4).strip()
+        line=re.sub(pattern, f"for ({const} {type_name} {var}: {container})", line)
+    # Match: foreach (Type* var, container)
+    pattern = r"\b(?:foreach|Q_FOREACH)\s*\(\s*([\w]+\s*\*)\s*([\w]+)\s*,\s*(.+?)\s*\)"
+    match = re.search(pattern, line)
+    if match:
+        type_name = match.group(1).strip()
+        var = match.group(2).strip()
+        container = match.group(3).strip()
+        line=re.sub(pattern, f"for ({type_name} const {var}: {container})", line)
+
+    return line
+
+def process_file(filename):
+    with open(filename) as f:
+        lines = f.readlines()
+
+    modified = False
+    new_lines = []
+
+    for line in lines:
+        new_line = convert_foreach_to_range_for(line)
+        if new_line != line:
+            modified = True
+        new_lines.append(new_line)
+
+    if modified:
+        with open(filename, "w") as f:
+            f.writelines(new_lines)
+        print(f"Updated: {filename}")
+    else:
+        print(f"No changes: {filename}")
+
+def process_directory(root_dir):
+    for dirpath, _, filenames in os.walk(root_dir):
+        for file in filenames:
+            if file.endswith((".cpp", ".h", ".cxx", ".hpp", ".txx")):
+                process_file(os.path.join(dirpath, file))
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python convert_foreach.py <file-or-directory>")
+        sys.exit(1)
+
+    target = sys.argv[1]
+    if os.path.isdir(target):
+        process_directory(target)
+    elif os.path.isfile(target):
+        process_file(target)
+    else:
+        print(f"Invalid path: {target}")

--- a/Utilities/Maintenance/update-branch-with-pre-commit-fixes.sh
+++ b/Utilities/Maintenance/update-branch-with-pre-commit-fixes.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# This script documents how to update a branch
+# to apply pre-commit enforcements to every commit
+
+#branch_to_rebase_from=$1
+branch_to_rebase_from=jcfr/style-consistently-indent-cpp-files
+
+echo "For each commit that required changes,\n
+git add -p # <- Review the changes made and add them
+git commit --amend # <- amend the commit
+git rebase --continue # <- goto next commit
+"
+git rebase --exec "pre-commit run --from-ref HEAD~1 --to-ref HEAD --hook-stage=commit" ${branch_to_rebase_from}

--- a/Utilities/Maintenance/yaml_to_gcc_fmt.py
+++ b/Utilities/Maintenance/yaml_to_gcc_fmt.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import sys
+import yaml
+from pathlib import Path
+import os
+
+def yaml_to_gcc(path):
+    with open(path) as f:
+        doc = yaml.safe_load(f)
+
+    diagnostics = doc.get("Diagnostics", [])
+    for d in diagnostics:
+        level = d.get("Level", "Warning").lower()
+        msg = d["DiagnosticMessage"]["Message"].strip().strip("'")
+        file_name = d["DiagnosticMessage"]["FilePath"]
+        # Optional: FileOffset if exists
+        offset = d["DiagnosticMessage"].get("FileOffset", 0)
+        file_path: Path = Path(file_name)
+        if file_path.exists():
+            with open(file_path) as fid:
+                lines=fid.readlines()
+        bytes_consumed=0
+        line_number=0
+        column_number=0
+        for line in lines:
+            line_length=len(line)
+            if line_length < (offset - bytes_consumed):
+                bytes_consumed += line_length
+                line_number += 1
+            else:
+                column_number=(offset - bytes_consumed)
+                line_number +=1
+                break
+
+        # filename:line:column: error: message
+        print(f"{file_path}:{line_number}:{column_number}: {level}: {msg}")
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {os.path.basename(sys.argv[0])} <diagnostics.yaml>")
+        sys.exit(1)
+    yaml_to_gcc(sys.argv[1])
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
These are scripts used to assist with refactoring
for preparing code for Qt6 upgrades.

- **ENH: Add maintenance scripts to support Qt5 -> Qt6**
- **ENH: Add python scripts for updating Q_PROPERTIES for Qt6**
- **ENH: Add script to rebase branch with pre-commit fixes applied**
- **STYLE: Update scripts used for clang-tidy**

These are provided as starting points for updating the various other packages that might need updates:

PythonQt, CTK, QtTesting, .... etc.
