### PR TITLE
STYLE: Normalize qualifier order

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -37,6 +37,14 @@ ForEachMacros:
   - Q_FOREACH
   - Q_FOREVER
 
+QualifierAlignment: Custom
+QualifierOrder:
+  - friend
+  - static
+  - inline
+  - constexpr
+  - const
+  - type
 SortIncludes: false
 
 ---

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DExtended.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DExtended.h
@@ -47,7 +47,7 @@ public:
 
   // /Cast the component values of the tensor
   template <class C>
-  operator DiffusionTensor3DExtended<C> const();
+  operator const DiffusionTensor3DExtended<C>();
 };
 
 } // end namespace itk

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DExtended.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DExtended.txx
@@ -58,7 +58,7 @@ void DiffusionTensor3DExtended<T>::SetTensorFromMatrix(Matrix<C, 3, 3> matrix)
 
 template <class T>
 template <class C>
-DiffusionTensor3DExtended<T>::operator DiffusionTensor3DExtended<C> const()
+DiffusionTensor3DExtended<T>::operator const DiffusionTensor3DExtended<C>()
 {
   DiffusionTensor3DExtended<C> tmp;
   for (int i = 0; i < 6; i++)

--- a/Modules/CLI/ResampleDTIVolume/itkMatrixExtended.h
+++ b/Modules/CLI/ResampleDTIVolume/itkMatrixExtended.h
@@ -37,7 +37,7 @@ public:
   MatrixExtended(const Superclass& matrix);
   // /Cast the matrix
   template <class C, unsigned int NRowsC, unsigned int NColumnsC>
-  operator MatrixExtended<C, NRowsC, NColumnsC> const();
+  operator const MatrixExtended<C, NRowsC, NColumnsC>();
   Self operator=(const Self& matrix);
 
   Self operator=(const Superclass& matrix);

--- a/Modules/CLI/ResampleDTIVolume/itkMatrixExtended.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkMatrixExtended.txx
@@ -45,7 +45,7 @@ MatrixExtended<T, NRows, NColumns>::MatrixExtended(const InternalMatrixType& mat
 
 template <class T, unsigned int NRows, unsigned int NColumns>
 template <class C, unsigned int NRowsC, unsigned int NColumnsC>
-MatrixExtended<T, NRows, NColumns>::operator MatrixExtended<C, NRowsC, NColumnsC> const()
+MatrixExtended<T, NRows, NColumns>::operator const MatrixExtended<C, NRowsC, NColumnsC>()
 {
   MatrixExtended<C, NRowsC, NColumnsC> tmp;
   for (unsigned int i = 0; i < NRows; i++)

--- a/Modules/CLI/RobustStatisticsSegmenter/SFLSRobustStatSegmentor3DLabelMap_single.h
+++ b/Modules/CLI/RobustStatisticsSegmenter/SFLSRobustStatSegmentor3DLabelMap_single.h
@@ -78,7 +78,7 @@ protected:
   long m_statNeighborY;
   long m_statNeighborZ;
 
-  const static long m_numberOfFeature = 3;
+  static const long m_numberOfFeature = 3;
   /* Store the robust stat as the feature at each point
      0: median
      1: interquartile range (IRQ)

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorEraseEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorEraseEffect.cxx
@@ -73,7 +73,7 @@ QIcon qSlicerSegmentEditorEraseEffect::icon()
 }
 
 //---------------------------------------------------------------------------
-QString const qSlicerSegmentEditorEraseEffect::helpText() const
+const QString qSlicerSegmentEditorEraseEffect::helpText() const
 {
   return QString("<html>")
          + tr("Erase from current segment with a round brush<br>."

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
@@ -944,7 +944,7 @@ QIcon qSlicerSegmentEditorPaintEffect::icon()
 }
 
 //---------------------------------------------------------------------------
-QString const qSlicerSegmentEditorPaintEffect::helpText() const
+const QString qSlicerSegmentEditorPaintEffect::helpText() const
 {
   return QString("<html>")
          + tr("Paint with a round brush<br>."

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScissorsEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScissorsEffect.cxx
@@ -1171,7 +1171,7 @@ QIcon qSlicerSegmentEditorScissorsEffect::icon()
 }
 
 //---------------------------------------------------------------------------
-QString const qSlicerSegmentEditorScissorsEffect::helpText() const
+const QString qSlicerSegmentEditorScissorsEffect::helpText() const
 {
   return QString("<html>")
          + tr("Cut through the entire segment from the current viewpoint<br>."


### PR DESCRIPTION
This applies formatting to C++ source files based on `clang-format` settings introduced in the following commit.

The updated settings define `QualifierOrder` to enforce consistent qualifier placement (e.g., `const T` instead of `T const`) across the codebase.

The specific ordering was chosen to **minimize the number of changes** observed when running `clang-format` via `pre-commit`, resulting in minimal disruption.

This improves code readability and simplifies future refactoring.

Running `pre-commit` required updating the `.clang-format` configuration with
the following patch:

```diff
diff --git a/.clang-format b/.clang-format
--- a/.clang-format
+++ b/.clang-format
@@ -37,6 +37,14 @@ ForEachMacros:
   - Q_FOREACH
   - Q_FOREVER
 
+QualifierAlignment: Custom
+QualifierOrder:
+  - friend
+  - static
+  - inline
+  - constexpr
+  - const
+  - type
 SortIncludes: false
```