### PR TITLE
BUG: Select first component when RGBA volume rendering is selected

### DIFF
--- a/Modules/Loadable/VolumeRendering/Widgets/qMRMLVolumePropertyNodeWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qMRMLVolumePropertyNodeWidget.cxx
@@ -238,7 +238,7 @@ void qMRMLVolumePropertyNodeWidget::updateIndependentComponents()
   MRMLNodeModifyBlocker blocker(d->VolumePropertyNode);
   bool indepdendentComponents = d->IndependentRadioButton->isChecked();
   volumeProperty->SetIndependentComponents(indepdendentComponents);
-  if (d->IndependentRadioButton->isChecked())
+  if (d->RGBColorsRadioButton->isChecked())
   {
     d->ComponentSpinBox->setValue(0);
   }


### PR DESCRIPTION
When selecting RGBA volume rendering the intended behavior was to select the first component, which is used to control the volume opacity. Instead, the first component was selected when "independent" was enabled.

Fixed by using the check state of the RGBColorsRadioButton instead of IndependentRadioButton.