### PR TITLE
ENH: Avoid changing selected volume rendering component when switching modes

### DIFF
--- a/Modules/Loadable/VolumeRendering/Widgets/qMRMLVolumePropertyNodeWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qMRMLVolumePropertyNodeWidget.cxx
@@ -123,6 +123,12 @@ void qMRMLVolumePropertyNodeWidget::updateFromVolumePropertyNode()
   d->VolumePropertyWidget->setVolumeProperty(newVolumeProperty);
 
   bool independentComponents = newVolumeProperty ? newVolumeProperty->GetIndependentComponents() : false;
+  int currentComponent = 0;
+  if (independentComponents)
+  {
+    currentComponent = d->ComponentSpinBox->value();
+  }
+  d->VolumePropertyWidget->setCurrentComponent(currentComponent);
 
   bool wasBlocking = d->ComponentsButtonGroup->blockSignals(true);
   d->RGBColorsRadioButton->setChecked(!independentComponents);
@@ -238,8 +244,4 @@ void qMRMLVolumePropertyNodeWidget::updateIndependentComponents()
   MRMLNodeModifyBlocker blocker(d->VolumePropertyNode);
   bool indepdendentComponents = d->IndependentRadioButton->isChecked();
   volumeProperty->SetIndependentComponents(indepdendentComponents);
-  if (d->RGBColorsRadioButton->isChecked())
-  {
-    d->ComponentSpinBox->setValue(0);
-  }
 }


### PR DESCRIPTION
This commit leaves the value of the spinbox when switching between RGBA/independent component modes. The value in the spinbox is only used in independent mode, otherwise the selected component is always 0.

See:
https://github.com/Slicer/Slicer/pull/8587#pullrequestreview-3034451745