### PR TITLE
BUG: Fix crashes caused by range-based loops over temporary Qt containers

### DIFF
--- a/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
@@ -909,8 +909,12 @@ void qSlicerExtensionsManagerModelTester::testUninstallExtension()
       this->installHelper(&model, operatingSystem, extensionId, this->Tmp.absolutePath());
     }
 
-    for (const QString& extensionName : QStringList() //
-                                          << "MarkupsToModel")
+    QStringList extensionNames;
+
+    extensionNames = QStringList() //
+                     << "MarkupsToModel";
+
+    for (const QString& extensionName : extensionNames)
     {
       QVERIFY(this->uninstallHelper(&model, extensionName));
       QVERIFY(!model.isExtensionInstalled(extensionName));
@@ -922,21 +926,29 @@ void qSlicerExtensionsManagerModelTester::testUninstallExtension()
     model.setSlicerRequirements(slicerRevision, operatingSystem, architecture);
     model.updateModel();
 
-    for (const QString& extensionName : QStringList() //
-                                          << "ImageMaker"
-                                          << "CurveMaker")
+    QStringList extensionNames;
+
+    extensionNames = QStringList() //
+                     << "ImageMaker"
+                     << "CurveMaker";
+
+    for (const QString& extensionName : extensionNames)
     {
       QVERIFY(model.isExtensionInstalled(extensionName));
     }
 
-    for (const QString& extensionName : QStringList() //
-                                          << "MarkupsToModel")
+    extensionNames = QStringList() //
+                     << "MarkupsToModel";
+
+    for (const QString& extensionName : extensionNames)
     {
       QVERIFY(!model.isExtensionInstalled(extensionName));
     }
 
-    for (const QString& extensionName : QStringList() //
-                                          << "MarkupsToModel")
+    extensionNames = QStringList() //
+                     << "MarkupsToModel";
+
+    for (const QString& extensionName : extensionNames)
     {
       this->installHelper(&model, operatingSystem, this->expectedExtensionNames().indexOf(extensionName), this->Tmp.absolutePath());
     }
@@ -1222,9 +1234,13 @@ void qSlicerExtensionsManagerModelTester::testUpdateModel()
     model.setExtensionEnabled("ImageMaker", false);
     QCOMPARE(spyExtensionEnabledChanged.count(), 1);
 
+    const QStringList extensionNames{
+      "MarkupsToModel",
+      "CurveMaker",
+    };
+
     QCOMPARE(model.isExtensionEnabled("ImageMaker"), false);
-    for (const QString& extensionName : QStringList() << "MarkupsToModel"
-                                                      << "CurveMaker")
+    for (const QString& extensionName : extensionNames)
     {
       QCOMPARE(model.isExtensionEnabled(extensionName), true);
     }
@@ -1232,8 +1248,7 @@ void qSlicerExtensionsManagerModelTester::testUpdateModel()
     model.updateModel();
 
     QCOMPARE(model.isExtensionEnabled("ImageMaker"), false);
-    for (const QString& extensionName : QStringList() << "MarkupsToModel"
-                                                      << "CurveMaker")
+    for (const QString& extensionName : extensionNames)
     {
       QCOMPARE(model.isExtensionEnabled(extensionName), true);
     }

--- a/Base/QTCore/Testing/Cxx/qSlicerUtilsTest1.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerUtilsTest1.cxx
@@ -247,7 +247,9 @@ int isPluginInstalledBuiltinTest()
 
   createFile(__LINE__, tmp1, ".", "CMakeCache.txt");
 
-  for (const QString& relativePath : QStringList() << debug << release << relWithDebInfo << minSizeRel << foo << fooDebug << fooRelease << fooBar << fooBarDebug << fooBarRelease)
+  QStringList relativePaths;
+  relativePaths = QStringList() << debug << release << relWithDebInfo << minSizeRel << foo << fooDebug << fooRelease << fooBar << fooBarDebug << fooBarRelease;
+  for (const QString& relativePath : relativePaths)
   {
     createFile(__LINE__, tmp1, relativePath, "plugin.txt");
   }
@@ -327,7 +329,8 @@ int isPluginInstalledBuiltinTest()
   tmp3.mkdir(temporaryDirName);
   tmp3.cd(temporaryDirName);
 
-  for (const QString& relativePath : QStringList() << foo << fooBar)
+  relativePaths = QStringList() << foo << fooBar;
+  for (const QString& relativePath : relativePaths)
   {
     createFile(__LINE__, tmp1, relativePath, "plugin.txt");
   }
@@ -692,6 +695,8 @@ int setPermissionsRecursivelyTest()
   tmp.mkdir(temporaryDirName);
   tmp.cd(temporaryDirName);
 
+  QStringList relativeFilepaths;
+
   QString path1 = QLatin1String("any/foo/bar");
   QString path2 = QLatin1String("any/foo/bie");
 
@@ -701,8 +706,9 @@ int setPermissionsRecursivelyTest()
   createFile(__LINE__, tmp, path2, "sol.txt");
 
   // Let's confirm that created file are readable
-  for (const QString& relativeFilepath : QStringList() //
-                                           << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
+  relativeFilepaths = QStringList() //
+                      << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt";
+  for (const QString& relativeFilepath : relativeFilepaths)
   {
     CHECK_BOOL((QFile::permissions(tmp.filePath(relativeFilepath)) & QFile::ReadOwner) != 0, true);
   }
@@ -716,8 +722,9 @@ int setPermissionsRecursivelyTest()
   //  https://qt.gitorious.org/qt/qt/blobs/092cd760d5fddf9640a310214fe01929f0fff3a8/src/corelib/io/qfsfileengine_win.cpp#line1781
 
   // Since directory are *NOT* executable, files should *NOT* be readable
-  for (const QString& relativeFilepath : QStringList() //
-                                           << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
+  relativeFilepaths = QStringList() //
+                      << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt";
+  for (const QString& relativeFilepath : relativeFilepaths)
   {
     CHECK_BOOL((QFile::permissions(tmp.filePath(relativeFilepath)) & QFile::ReadOwner) != 0, false);
   }
@@ -725,8 +732,9 @@ int setPermissionsRecursivelyTest()
   CHECK_BOOL(qSlicerUtils::setPermissionsRecursively(tmp.path(), QFile::ReadOwner | QFile::ExeOwner, QFile::ReadOwner), true);
 
   // Since directory are executable, files should be readable
-  for (const QString& relativeFilepath : QStringList() //
-                                           << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
+  relativeFilepaths = QStringList() //
+                      << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt";
+  for (const QString& relativeFilepath : relativeFilepaths)
   {
     CHECK_BOOL((QFile::permissions(tmp.filePath(relativeFilepath)) & QFile::ReadOwner) != 0, true);
   }
@@ -735,8 +743,9 @@ int setPermissionsRecursivelyTest()
   CHECK_BOOL(ctk::removeDirRecursively(tmp.path()), false);
 #endif
 
-  for (const QString& relativeFilepath : QStringList() //
-                                           << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
+  relativeFilepaths = QStringList() //
+                      << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt";
+  for (const QString& relativeFilepath : relativeFilepaths)
   {
     // Since files are read-only, they should *NOT* be writable
     CHECK_BOOL((QFile::permissions(tmp.filePath(relativeFilepath)) & QFile::WriteOwner) != 0, false);
@@ -745,8 +754,9 @@ int setPermissionsRecursivelyTest()
   CHECK_BOOL(qSlicerUtils::setPermissionsRecursively(tmp.path(), QFile::ReadOwner | QFile::ExeOwner | QFile::WriteOwner, QFile::ReadOwner | QFile::WriteOwner), true);
 
   // Make sure files are readable and writable
-  for (const QString& relativeFilepath : QStringList() //
-                                           << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt")
+  relativeFilepaths = QStringList() //
+                      << path1 + "/sol.txt" << path1 + "/la.txt" << path2 + "/si.txt" << path2 + "/sol.txt";
+  for (const QString& relativeFilepath : relativeFilepaths)
   {
     CHECK_BOOL((QFile::permissions(tmp.filePath(relativeFilepath)) & QFile::WriteOwner) != 0, true);
   }

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -18,7 +18,7 @@
 
 ==============================================================================*/
 
-// standard library includes
+// STD includes
 #include <clocale>
 #include <stdexcept>
 
@@ -720,7 +720,12 @@ QString qSlicerCoreApplicationPrivate::discoverSlicerHomeDirectory()
   Q_Q(qSlicerCoreApplication);
   if (!this->isInstalled(slicerHome))
   {
-    for (const QString& subDir : QStringList() << Slicer_BIN_DIR << Slicer_CLIMODULES_BIN_DIR << "Cxx")
+    const QStringList subDirs{
+      Slicer_BIN_DIR,
+      Slicer_CLIMODULES_BIN_DIR,
+      "Cxx",
+    };
+    for (const QString& subDir : subDirs)
     {
       qSlicerUtils::pathWithoutIntDir(q->applicationDirPath(), subDir, this->IntDir);
       if (!this->IntDir.isEmpty())

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest8.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest8.cxx
@@ -224,16 +224,14 @@ int qMRMLNodeComboBoxTest8(int argc, char* argv[])
     std::cout << "After disabling remove action, new number of actions = " << expected << std::endl;
   }
 
-  // add a custom action starting respectively with:
-  //  * "Create new "
-  //  * "Delete current "
-  //  * "Edit current "
-  //  * "Rename current "
-  //  * "Create and rename "
-  for (const QString& actionPrefix : QStringList() << "Create new "
-                                                   << "Delete current "
-                                                   << "Edit current "
-                                                   << "Rename current ")
+  // add a custom actions
+  const QStringList actionPrefixes = {
+    "Create new ",
+    "Delete current ",
+    "Edit current ",
+    "Rename current ",
+  };
+  for (const QString& actionPrefix : actionPrefixes)
   {
     startingActions = sceneModel->postItems(sceneModel->mrmlSceneItem()).size();
 

--- a/Modules/Loadable/SlicerWelcome/qSlicerWelcomeModuleWidget.cxx
+++ b/Modules/Loadable/SlicerWelcome/qSlicerWelcomeModuleWidget.cxx
@@ -120,8 +120,13 @@ void qSlicerWelcomeModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
 
   // Update occurrences of documentation URLs
   qSlicerCoreApplication* app = qSlicerCoreApplication::application();
-  for (QWidget* const widget : QWidgetList() << this->FeedbackCollapsibleWidget << this->WelcomeAndAboutCollapsibleWidget << this->OtherUsefulHintsCollapsibleWidget
-                                             << this->AcknowledgmentCollapsibleWidget)
+
+  QWidgetList widgetList;
+  widgetList << this->FeedbackCollapsibleWidget         //
+             << this->WelcomeAndAboutCollapsibleWidget  //
+             << this->OtherUsefulHintsCollapsibleWidget //
+             << this->AcknowledgmentCollapsibleWidget;
+  for (QWidget* const widget : widgetList)
   {
     QTextBrowser* textBrowser = widget->findChild<QTextBrowser*>();
     if (!textBrowser)


### PR DESCRIPTION
This commit fixes regressions introduced in f06fab25fc ("COMP: Prefer C++11 range-for to Qt macros", 2025-07-16), which replaced `Q_FOREACH` with C++11 range-based `for` loops.

A segmentation fault was reported in `qSlicerWelcomeModuleWidgetPrivate::setupUi`, caused by iterating over a temporary `QWidgetList` constructed inline using the `<<` operator. Since range-based `for` loops do not extend the lifetime of temporaries, the container was destroyed after the loop header executed, leading to a **use-after-free** and a crash when dereferencing the iterator.

Similar crashes were observed in tests on Unix systems involving temporary `QStringList` instances. Although `QStringList` (a `QList<QString>`) uses implicit sharing, range-based iteration over a destroyed temporary is still undefined behavior and may result in a crash.

Additionally, a related use in `qSlicerCoreApplicationPrivate::discoverSlicerHomeDirectory`, which used `QStringList` in the same way, was only compiled on Windows. While this instance did not crash, it was also updated for correctness and consistency.

To address the issue this commit updates all affected range-based loops by:

* Assigning the container to a named local variable prior to iteration, ensuring its lifetime extends through the loop.

For reference, the previously used `Q_FOREACH` macro avoided this issue by explicitly storing the container in a local `_container_` variable:

```cpp
for (auto _container_ = QtPrivate::qMakeForeachContainer(container);
     _container_.i != _container_.e;
     ++_container_.i)
  if (variable = *_container_.i; false) {} else
```

--- 

Follow-up of the following pull request:
* https://github.com/Slicer/Slicer/pull/8580