### PR TITLE
COMP: Fix linux build always installing zlib-ng library is "lib" directory

### DIFF
--- a/SuperBuild/External_zlib.cmake
+++ b/SuperBuild/External_zlib.cmake
@@ -56,6 +56,7 @@ if(NOT DEFINED ZLIB_ROOT AND NOT Slicer_USE_SYSTEM_${proj})
       -DZLIB_COMPAT:BOOL=ON
       -DZLIB_ENABLE_TESTS:BOOL=OFF
       # Install directories
+      -DCMAKE_INSTALL_LIBDIR:STRING=lib  # Override value set in GNUInstallDirs CMake module
       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
     DEPENDS
       ${${proj}_DEPENDENCIES}


### PR DESCRIPTION
Follow-up of cd73e84d93 ("COMP: Switch from zlib 1.2.3 to maintained zlib-ng 2.2.4 fork", 2022-11-28) introduced through the following pull request:
* https://github.com/Slicer/Slicer/pull/6708