### PR TITLE
ENH: Add DM group and render window API to the abstract view node

### DIFF
--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
@@ -23,6 +23,7 @@
 
 // VTK includes
 #include <vtkSmartPointer.h>
+#include <vtkWeakPointer.h>
 
 // MRML includes
 #include "vtkMRMLNode.h"
@@ -298,6 +299,18 @@ public:
   vtkSetMacro(ScreenScaleFactor, double);
   //@}
 
+  //@{
+  /// \brief Get/Set the displayable manager group associated with the view.
+  vtkGetObjectMacro(DisplayableManagerGroup, vtkObject);
+  vtkSetObjectMacro(DisplayableManagerGroup, vtkObject);
+  //@}
+
+  //@{
+  /// \brief Get/Set the render window associated with the view.
+  vtkGetObjectMacro(RenderWindow, vtkObject);
+  vtkSetObjectMacro(RenderWindow, vtkObject);
+  //@}
+
 protected:
   vtkMRMLAbstractViewNode();
   ~vtkMRMLAbstractViewNode() override;
@@ -362,6 +375,9 @@ protected:
 
   static const char* ParentLayoutNodeReferenceRole;
   static const char* InteractionNodeReferenceRole;
+
+  vtkWeakPointer<vtkObject> DisplayableManagerGroup = nullptr;
+  vtkWeakPointer<vtkObject> RenderWindow = nullptr;
 };
 
 //------------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLSliceView.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceView.cxx
@@ -342,6 +342,18 @@ void qMRMLSliceView::setMRMLSliceNode(vtkMRMLSliceNode* newSliceNode)
     return;
   }
 
+  if (d->MRMLSliceNode)
+  {
+    d->MRMLSliceNode->SetDisplayableManagerGroup(nullptr);
+    d->MRMLSliceNode->SetRenderWindow(nullptr);
+  }
+
+  if (newSliceNode)
+  {
+    newSliceNode->SetDisplayableManagerGroup(d->DisplayableManagerGroup);
+    newSliceNode->SetRenderWindow(d->RenderWindow);
+  }
+
   d->qvtkReconnect(d->MRMLSliceNode, newSliceNode, vtkCommand::ModifiedEvent, d, SLOT(updateWidgetFromMRML()));
 
   d->MRMLSliceNode = newSliceNode;

--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -390,6 +390,18 @@ void qMRMLThreeDView::setMRMLViewNode(vtkMRMLViewNode* newViewNode)
     return;
   }
 
+  if (d->MRMLViewNode)
+  {
+    d->MRMLViewNode->SetDisplayableManagerGroup(nullptr);
+    d->MRMLViewNode->SetRenderWindow(nullptr);
+  }
+
+  if (newViewNode)
+  {
+    newViewNode->SetDisplayableManagerGroup(d->DisplayableManagerGroup);
+    newViewNode->SetRenderWindow(d->RenderWindow);
+  }
+
   d->qvtkReconnect(d->MRMLViewNode, newViewNode, vtkCommand::ModifiedEvent, d, SLOT(updateWidgetFromMRML()));
 
   d->MRMLViewNode = newViewNode;


### PR DESCRIPTION
To support decoupling 3D Slicer logic from the Qt layer, access to the displayable manager group and to the render window is required. This access is currently only possible through the `qMRMLThreeDView` and the `qMRMLSliceViews`.

This change allow direct access of the render window and the displayable manager group using the abstract view node directly.

To avoid adding a dependency from the `MRMLCore` library to the `MRMLDisplayableManager` library, objects are left as type `vtkObject`.

Access can be done using :

```cpp
vtkRenderWindow::SafeDownCast(viewNode->GetRenderWindow())
vtkMRMLDisplayableManagerGroup::SafeDownCast(viewNode->GetDisplayableManagerGroup())
```