### PR TITLE
ENH: Add widget to select any node for scene views

### DIFF
--- a/Libs/MRML/Widgets/Resources/UI/qMRMLScreenShotDialog.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLScreenShotDialog.ui
@@ -6,66 +6,178 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>433</width>
-    <height>385</height>
+    <width>636</width>
+    <height>580</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Annotation Screenshot</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="7" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="toolTip">
-      <string>Save snapshot via File Save. Edit in Annotations module.</string>
+   <item row="1" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Thumbnail</string>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QTextEdit" name="descriptionTextEdit">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>100</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="ctkDoubleSpinBox" name="scaleFactorSpinBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>Adjust the Magnification factor.</string>
-     </property>
-     <property name="suffix">
-      <string>x</string>
-     </property>
-     <property name="decimals">
-      <number>1</number>
-     </property>
-     <property name="minimum">
-      <double>1.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>10.000000000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>1.000000000000000</double>
-     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="topRow" stretch="0,1">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QRadioButton" name="fullLayoutRadio">
+            <property name="text">
+             <string>Full layout</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../qMRMLWidgets.qrc">
+              <normaloff>:/Icons/LayoutFourUpView.png</normaloff>:/Icons/LayoutFourUpView.png</iconset>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="threeDViewRadio">
+            <property name="text">
+             <string>3D View</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../qMRMLWidgets.qrc">
+              <normaloff>:/Icons/LayoutOneUp3DView.png</normaloff>:/Icons/LayoutOneUp3DView.png</iconset>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="redSliceViewRadio">
+            <property name="text">
+             <string>Red Slice View</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../qMRMLWidgets.qrc">
+              <normaloff>:/Icons/LayoutOneUpRedSliceView.png</normaloff>:/Icons/LayoutOneUpRedSliceView.png</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="yellowSliceViewRadio">
+            <property name="text">
+             <string>Yellow Slice View</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../qMRMLWidgets.qrc">
+              <normaloff>:/Icons/LayoutOneUpYellowSliceView.png</normaloff>:/Icons/LayoutOneUpYellowSliceView.png</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="greenSliceViewRadio">
+            <property name="text">
+             <string>Green Slice View</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../qMRMLWidgets.qrc">
+              <normaloff>:/Icons/LayoutOneUpGreenSliceView.png</normaloff>:/Icons/LayoutOneUpGreenSliceView.png</iconset>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="ctkThumbnailLabel" name="ScreenshotWidget">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>200</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="textPosition">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="transformationMode">
+           <enum>Qt::SmoothTransformation</enum>
+          </property>
+          <property name="selectedColor">
+           <color alpha="0">
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="scaleFactorLayout">
+        <item>
+         <widget class="QLabel" name="scaleFactorLabel">
+          <property name="text">
+           <string>Scale factor:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="ctkDoubleSpinBox" name="scaleFactorSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Adjust the Magnification factor.</string>
+          </property>
+          <property name="suffix">
+           <string>x</string>
+          </property>
+          <property name="decimals">
+           <number>1</number>
+          </property>
+          <property name="minimum">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>10.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="saveAsButtonSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="saveAsButton">
+          <property name="text">
+           <string>Save As...</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="0" column="1">
@@ -78,133 +190,33 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="descriptionLabel">
-     <property name="text">
-      <string>Description:</string>
+   <item row="8" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="toolTip">
+      <string>Save snapshot via File Save. Edit in Annotations module.</string>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="scaleFactorLabel">
-     <property name="text">
-      <string>Scale factor:</string>
+   <item row="2" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Description</string>
      </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="screenshotLabel">
-     <property name="text">
-      <string>Thumbnail:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <layout class="QHBoxLayout" name="topRow" stretch="0,1">
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QRadioButton" name="fullLayoutRadio">
-         <property name="text">
-          <string>Full layout</string>
-         </property>
-         <property name="icon">
-          <iconset>
-           <normaloff>:/Icons/AnnotationLayout.png</normaloff>:/Icons/AnnotationLayout.png</iconset>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="threeDViewRadio">
-         <property name="text">
-          <string>3D View</string>
-         </property>
-         <property name="icon">
-          <iconset resource="../qMRMLWidgets.qrc">
-           <normaloff>:/Icons/LayoutOneUp3DView.png</normaloff>:/Icons/LayoutOneUp3DView.png</iconset>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="redSliceViewRadio">
-         <property name="text">
-          <string>Red Slice View</string>
-         </property>
-         <property name="icon">
-          <iconset resource="../qMRMLWidgets.qrc">
-           <normaloff>:/Icons/LayoutOneUpRedSliceView.png</normaloff>:/Icons/LayoutOneUpRedSliceView.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="yellowSliceViewRadio">
-         <property name="text">
-          <string>Yellow Slice View</string>
-         </property>
-         <property name="icon">
-          <iconset resource="../qMRMLWidgets.qrc">
-           <normaloff>:/Icons/LayoutOneUpYellowSliceView.png</normaloff>:/Icons/LayoutOneUpYellowSliceView.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="greenSliceViewRadio">
-         <property name="text">
-          <string>Green Slice View</string>
-         </property>
-         <property name="icon">
-          <iconset resource="../qMRMLWidgets.qrc">
-           <normaloff>:/Icons/LayoutOneUpGreenSliceView.png</normaloff>:/Icons/LayoutOneUpGreenSliceView.png</iconset>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="ctkThumbnailLabel" name="ScreenshotWidget">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="textPosition">
-        <set>Qt::AlignCenter</set>
-       </property>
-       <property name="transformationMode">
-        <enum>Qt::SmoothTransformation</enum>
-       </property>
-       <property name="selectedColor">
-        <color alpha="0">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="4" column="0">
-    <widget class="QPushButton" name="saveAsButton">
-     <property name="text">
-      <string>Save As...:</string>
-     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QTextEdit" name="descriptionTextEdit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/Libs/MRML/Widgets/qMRMLScreenShotDialog.cxx
+++ b/Libs/MRML/Widgets/qMRMLScreenShotDialog.cxx
@@ -266,6 +266,20 @@ bool qMRMLScreenShotDialog::showScaleFactorSpinBox() const
 }
 
 //-----------------------------------------------------------------------------
+void qMRMLScreenShotDialog::setSaveAsButtonVisibility(const bool& visible)
+{
+  Q_D(qMRMLScreenShotDialog);
+  d->saveAsButton->setVisible(visible);
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLScreenShotDialog::saveAsButtonVisibility() const
+{
+  Q_D(const qMRMLScreenShotDialog);
+  return d->saveAsButton->isVisible();
+}
+
+//-----------------------------------------------------------------------------
 void qMRMLScreenShotDialog::resetDialog()
 {
   Q_D(qMRMLScreenShotDialog);

--- a/Libs/MRML/Widgets/qMRMLScreenShotDialog.h
+++ b/Libs/MRML/Widgets/qMRMLScreenShotDialog.h
@@ -42,6 +42,7 @@ class QMRML_WIDGETS_EXPORT qMRMLScreenShotDialog : public QDialog
   Q_PROPERTY(QString nameEdit READ nameEdit WRITE setNameEdit)
   Q_PROPERTY(double scaleFactor READ scaleFactor WRITE setScaleFactor)
   Q_PROPERTY(bool showScaleFactorSpinBox READ showScaleFactorSpinBox WRITE setShowScaleFactorSpinBox)
+  Q_PROPERTY(bool saveAsButtonVisibility READ saveAsButtonVisibility WRITE setSaveAsButtonVisibility)
 public:
   typedef QDialog Superclass;
 
@@ -80,6 +81,9 @@ public:
 
   void setShowScaleFactorSpinBox(const bool& state);
   bool showScaleFactorSpinBox() const;
+
+  void setSaveAsButtonVisibility(const bool& visible);
+  bool saveAsButtonVisibility() const;
 
   /// set/return the image data of the screenshot
   void setImageData(vtkImageData* screenshot);

--- a/Modules/Loadable/SceneViews/GUI/qSlicerSceneViewsModuleDialog.cxx
+++ b/Modules/Loadable/SceneViews/GUI/qSlicerSceneViewsModuleDialog.cxx
@@ -17,8 +17,17 @@
 // MRML includes
 #include <vtkMRMLScene.h>
 
+// MRMLWidgets includes
+#include "qMRMLCheckableNodeComboBox.h"
+
+// Sequences MRML includes
+#include <vtkMRMLSequenceBrowserNode.h>
+
 // VTK includes
 #include <vtkImageData.h>
+
+// CTK includes
+#include <ctkCollapsibleGroupBox.h>
 
 // STD includes
 #include <string>
@@ -39,7 +48,16 @@ public:
   QCheckBox* CaptureDisplayNodesCheckBox{ nullptr };
   QCheckBox* CaptureViewNodesCheckBox{ nullptr };
 
+  ctkCollapsibleGroupBox* AdvancedNodeSelectionGroupBox{ nullptr };
+  qMRMLCheckableNodeComboBox* NodeSelectorComboBox{ nullptr };
+
   void setupUi(QDialog* dialog);
+  void updateCategorySelection();
+  void updateNodeSelection();
+  void updateDisplayNodesSelection(Qt::CheckState checkState);
+  void updateViewNodesSelection(Qt::CheckState checkState);
+  void updateExistingNodesSelection(Qt::CheckState checkState);
+  void updateNodeSelection(std::vector<vtkMRMLNode*> nodes, Qt::CheckState checkState);
 };
 
 //-----------------------------------------------------------------------------
@@ -69,33 +87,44 @@ void qSlicerSceneViewsModuleDialogPrivate::setupUi(QDialog* dialog)
   this->UpdateExistingNodesCheckBox->setText(qSlicerSceneViewsModuleDialog::tr("Update existing nodes"));
   this->UpdateExistingNodesCheckBox->setToolTip(
     qSlicerSceneViewsModuleDialog::tr("If checked, the nodes already contained in the scene view will be updated to match the current state of the scene."));
-
+  QObject::connect(this->UpdateExistingNodesCheckBox, SIGNAL(clicked()), dialog, SLOT(onUpdateExistingNodesClicked()));
   gridLayout->addWidget(this->UpdateExistingNodesCheckBox, newRowIndex++, 0, 1, 2);
 
-  QWidget* captureNodeTypesWidget = new QWidget(dialog);
-  captureNodeTypesWidget->setObjectName(QString::fromUtf8("updateNodeTypesWidget"));
-  QHBoxLayout* captureNodeTypesLayout = new QHBoxLayout(captureNodeTypesWidget);
-  captureNodeTypesLayout->setObjectName(QString::fromUtf8("captureNodeTypesLayout"));
-  captureNodeTypesLayout->setContentsMargins(0, 0, 0, 0);
-  captureNodeTypesLayout->setSpacing(6);
-  captureNodeTypesWidget->setLayout(captureNodeTypesLayout);
-
-  this->CaptureDisplayNodesCheckBox = new QCheckBox(captureNodeTypesWidget);
+  this->CaptureDisplayNodesCheckBox = new QCheckBox(dialog);
   this->CaptureDisplayNodesCheckBox->setObjectName(QString::fromUtf8("CaptureDisplayNodesCheckBox"));
   this->CaptureDisplayNodesCheckBox->setText(qSlicerSceneViewsModuleDialog::tr("Capture display nodes"));
   this->CaptureDisplayNodesCheckBox->setToolTip(
     qSlicerSceneViewsModuleDialog::tr("If checked, all display nodes in the scene will be added or updated in the current scene view."));
-  captureNodeTypesLayout->addWidget(this->CaptureDisplayNodesCheckBox);
+  QObject::connect(this->CaptureDisplayNodesCheckBox, SIGNAL(clicked()), dialog, SLOT(onCaptureDisplayNodesClicked()));
+  gridLayout->addWidget(this->CaptureDisplayNodesCheckBox, newRowIndex++, 0, 1, 2);
 
-  this->CaptureViewNodesCheckBox = new QCheckBox(captureNodeTypesWidget);
+  this->CaptureViewNodesCheckBox = new QCheckBox(dialog);
   this->CaptureViewNodesCheckBox->setObjectName(QString::fromUtf8("CaptureViewNodesCheckBox"));
   this->CaptureViewNodesCheckBox->setText(qSlicerSceneViewsModuleDialog::tr("Capture view nodes"));
   this->CaptureViewNodesCheckBox->setToolTip(qSlicerSceneViewsModuleDialog::tr("If checked, all view nodes in the scene will be added or updated in the current scene view."));
-  captureNodeTypesLayout->addWidget(this->CaptureViewNodesCheckBox);
+  QObject::connect(this->CaptureViewNodesCheckBox, SIGNAL(clicked()), dialog, SLOT(onCaptureViewNodesClicked()));
+  gridLayout->addWidget(this->CaptureViewNodesCheckBox, newRowIndex++, 0, 1, 2);
 
-  gridLayout->addWidget(captureNodeTypesWidget, newRowIndex++, 0, 1, 2);
+  this->AdvancedNodeSelectionGroupBox = new ctkCollapsibleGroupBox(dialog);
+  this->AdvancedNodeSelectionGroupBox->setObjectName(QString::fromUtf8("AdvancedNodeSelectionGroupBox"));
+  this->AdvancedNodeSelectionGroupBox->setTitle(qSlicerSceneViewsModuleDialog::tr("Advanced"));
+  this->AdvancedNodeSelectionGroupBox->setToolTip(qSlicerSceneViewsModuleDialog::tr("Select the nodes to be captured in the scene view."));
+  this->AdvancedNodeSelectionGroupBox->setCollapsed(true);
+  this->AdvancedNodeSelectionGroupBox->setLayout(new QGridLayout(this->AdvancedNodeSelectionGroupBox));
+  gridLayout->addWidget(this->AdvancedNodeSelectionGroupBox, newRowIndex++, 0, 1, 2);
 
-  gridLayout->addWidget(buttonBox, newRowIndex, 0, 1, 2);
+  QGridLayout* advancedNodeSelectionLayout = qobject_cast<QGridLayout*>(this->AdvancedNodeSelectionGroupBox->layout());
+
+  this->NodeSelectorComboBox = new qMRMLCheckableNodeComboBox(dialog);
+  this->NodeSelectorComboBox->setObjectName(QString::fromUtf8("NodeSelectorComboBox"));
+  this->NodeSelectorComboBox->setToolTip(qSlicerSceneViewsModuleDialog::tr("Select the nodes to be captured in the scene view."));
+  this->NodeSelectorComboBox->setShowHidden(true);
+  this->NodeSelectorComboBox->setMRMLScene(qSlicerApplication::application()->mrmlScene());
+  QObject::connect(this->NodeSelectorComboBox, SIGNAL(checkedNodesChanged()), dialog, SLOT(onNodeSelectionChanged()));
+  advancedNodeSelectionLayout->addWidget(new QLabel("Nodes to capture:"), 0, 0, 1, 1);
+  advancedNodeSelectionLayout->addWidget(this->NodeSelectorComboBox, 0, 1, 1, 1);
+
+  gridLayout->addWidget(buttonBox, newRowIndex++, 0, 1, 2);
 }
 
 //-----------------------------------------------------------------------------
@@ -119,7 +148,6 @@ qSlicerSceneViewsModuleDialog::qSlicerSceneViewsModuleDialog(QWidget* parent /*=
 //-----------------------------------------------------------------------------
 qSlicerSceneViewsModuleDialog::~qSlicerSceneViewsModuleDialog()
 {
-
   if (this->m_Logic)
   {
     this->m_Logic = nullptr;
@@ -129,12 +157,264 @@ qSlicerSceneViewsModuleDialog::~qSlicerSceneViewsModuleDialog()
 //-----------------------------------------------------------------------------
 void qSlicerSceneViewsModuleDialog::setLogic(vtkSlicerSceneViewsModuleLogic* logic)
 {
+  Q_D(qSlicerSceneViewsModuleDialog);
   if (!logic)
   {
     qErrnoWarning("setLogic: We need the SceneViews module logic here!");
     return;
   }
   this->m_Logic = logic;
+  d->updateNodeSelection();
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSceneViewsModuleDialogPrivate::updateCategorySelection()
+{
+  Q_Q(qSlicerSceneViewsModuleDialog);
+
+  std::vector<std::string> displayNodeClasses;
+  q->m_Logic->GetDisplayNodeClasses(displayNodeClasses);
+
+  std::vector<std::string> viewNodeClasses;
+  q->m_Logic->GetViewNodeClasses(viewNodeClasses);
+
+  bool areAllDisplayNodesChecked = true;
+  bool areAllDisplayNodesUnchecked = true;
+
+  bool areAllViewNodesChecked = true;
+  bool areAllViewNodesUnchecked = true;
+
+  bool areAllUpdateExistingNodesChecked = true;
+  bool areAllUpdateExistingNodesUnchecked = true;
+
+  std::vector<vtkMRMLNode*> existingNodes;
+  int index = q->data().toInt();
+  if (index >= 0)
+  {
+    vtkMRMLSequenceBrowserNode* sequenceBrowser = q->m_Logic->GetNthSceneViewSequenceBrowserNode(index);
+    if (sequenceBrowser)
+    {
+      sequenceBrowser->GetAllProxyNodes(existingNodes);
+    }
+  }
+
+  for (auto node : this->NodeSelectorComboBox->nodes())
+  {
+
+    // Determine display node checkbox state
+    bool isDisplayNode = false;
+    for (const auto& displayNodeType : displayNodeClasses)
+    {
+      if (node->IsA(displayNodeType.c_str()))
+      {
+        isDisplayNode = true;
+        break;
+      }
+    }
+    if (isDisplayNode)
+    {
+      if (this->NodeSelectorComboBox->checkState(node) == Qt::Checked)
+      {
+        areAllDisplayNodesUnchecked = false;
+      }
+      else
+      {
+        areAllDisplayNodesChecked = false;
+      }
+    }
+
+    // Determine view node checkbox state
+    bool isViewNode = false;
+    for (const auto& viewNodeType : viewNodeClasses)
+    {
+      if (node->IsA(viewNodeType.c_str()))
+      {
+        isViewNode = true;
+        break;
+      }
+    }
+    if (isViewNode)
+    {
+      if (this->NodeSelectorComboBox->checkState(node) == Qt::Checked)
+      {
+        areAllViewNodesUnchecked = false;
+      }
+      else
+      {
+        areAllViewNodesChecked = false;
+      }
+    }
+
+    // Determine update existing nodes checkbox state
+    if (std::find(existingNodes.begin(), existingNodes.end(), node) != existingNodes.end())
+    {
+      if (this->NodeSelectorComboBox->checkState(node) == Qt::Checked)
+      {
+        areAllUpdateExistingNodesUnchecked = false;
+      }
+      else
+      {
+        areAllUpdateExistingNodesChecked = false;
+      }
+    }
+  }
+
+  Qt::CheckState displayCheckState = Qt::PartiallyChecked;
+  if (areAllDisplayNodesChecked)
+  {
+    displayCheckState = Qt::Checked;
+  }
+  else if (areAllDisplayNodesUnchecked)
+  {
+    displayCheckState = Qt::Unchecked;
+  }
+  this->CaptureDisplayNodesCheckBox->setTristate(areAllDisplayNodesChecked || areAllDisplayNodesUnchecked);
+  this->CaptureDisplayNodesCheckBox->setCheckState(displayCheckState);
+
+  Qt::CheckState viewCheckState = Qt::PartiallyChecked;
+  if (areAllViewNodesChecked)
+  {
+    viewCheckState = Qt::Checked;
+  }
+  else if (areAllViewNodesUnchecked)
+  {
+    viewCheckState = Qt::Unchecked;
+  }
+  this->CaptureViewNodesCheckBox->setTristate(areAllViewNodesChecked || areAllViewNodesUnchecked);
+  this->CaptureViewNodesCheckBox->setCheckState(viewCheckState);
+
+  Qt::CheckState updateExistingNodesCheckState = Qt::PartiallyChecked;
+  if (areAllUpdateExistingNodesChecked)
+  {
+    updateExistingNodesCheckState = Qt::Checked;
+  }
+  else if (areAllUpdateExistingNodesUnchecked)
+  {
+    updateExistingNodesCheckState = Qt::Unchecked;
+  }
+  this->UpdateExistingNodesCheckBox->setTristate(areAllUpdateExistingNodesChecked || areAllUpdateExistingNodesUnchecked);
+  this->UpdateExistingNodesCheckBox->setCheckState(updateExistingNodesCheckState);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSceneViewsModuleDialog::onUpdateExistingNodesClicked()
+{
+  Q_D(qSlicerSceneViewsModuleDialog);
+  d->UpdateExistingNodesCheckBox->setTristate(false);
+  d->updateExistingNodesSelection(d->UpdateExistingNodesCheckBox->checkState());
+  d->updateCategorySelection();
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSceneViewsModuleDialog::onCaptureDisplayNodesClicked()
+{
+  Q_D(qSlicerSceneViewsModuleDialog);
+  d->CaptureDisplayNodesCheckBox->setTristate(false);
+  d->updateDisplayNodesSelection(d->CaptureDisplayNodesCheckBox->checkState());
+  d->updateCategorySelection();
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSceneViewsModuleDialog::onCaptureViewNodesClicked()
+{
+  Q_D(qSlicerSceneViewsModuleDialog);
+  d->CaptureViewNodesCheckBox->setTristate(false);
+  d->updateViewNodesSelection(d->CaptureViewNodesCheckBox->checkState());
+  d->updateCategorySelection();
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSceneViewsModuleDialog::onNodeSelectionChanged()
+{
+  Q_D(qSlicerSceneViewsModuleDialog);
+  d->updateCategorySelection();
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSceneViewsModuleDialogPrivate::updateDisplayNodesSelection(Qt::CheckState checkState)
+{
+  Q_Q(qSlicerSceneViewsModuleDialog);
+  if (!q->m_Logic)
+  {
+    return;
+  }
+  std::vector<vtkMRMLNode*> displayNodes;
+  q->m_Logic->GetDisplayNodes(displayNodes);
+  this->updateNodeSelection(displayNodes, checkState);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSceneViewsModuleDialogPrivate::updateViewNodesSelection(Qt::CheckState checkState)
+{
+  Q_Q(qSlicerSceneViewsModuleDialog);
+  if (!q->m_Logic)
+  {
+    return;
+  }
+  std::vector<vtkMRMLNode*> viewNodes;
+  q->m_Logic->GetViewNodes(viewNodes);
+  this->updateNodeSelection(viewNodes, checkState);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSceneViewsModuleDialogPrivate::updateExistingNodesSelection(Qt::CheckState checkState)
+{
+  Q_Q(qSlicerSceneViewsModuleDialog);
+  if (!q->m_Logic)
+  {
+    return;
+  }
+  int index = q->data().toInt();
+  std::vector<vtkMRMLNode*> existingNodes;
+  if (index >= 0)
+  {
+    vtkMRMLSequenceBrowserNode* sequenceBrowser = q->m_Logic->GetNthSceneViewSequenceBrowserNode(index);
+    if (sequenceBrowser)
+    {
+      sequenceBrowser->GetAllProxyNodes(existingNodes);
+    }
+  }
+  this->updateNodeSelection(existingNodes, checkState);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSceneViewsModuleDialogPrivate::updateNodeSelection(std::vector<vtkMRMLNode*> nodes, Qt::CheckState checkState)
+{
+  Q_Q(qSlicerSceneViewsModuleDialog);
+  if (!q->m_Logic)
+  {
+    return;
+  }
+
+  if (checkState == Qt::PartiallyChecked)
+  {
+    // If the check state is partially checked, we do not change the check state of the nodes.
+    return;
+  }
+
+  bool wasBlocking = this->NodeSelectorComboBox->blockSignals(true);
+  for (auto node : nodes)
+  {
+    this->NodeSelectorComboBox->setCheckState(node, checkState);
+  }
+  this->NodeSelectorComboBox->blockSignals(wasBlocking);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSceneViewsModuleDialogPrivate::updateNodeSelection()
+{
+  Q_Q(qSlicerSceneViewsModuleDialog);
+  if (!q->m_Logic)
+  {
+    return;
+  }
+
+  bool wasBlocking = this->NodeSelectorComboBox->blockSignals(true);
+  this->updateViewNodesSelection(this->CaptureViewNodesCheckBox->checkState());
+  this->updateDisplayNodesSelection(this->CaptureDisplayNodesCheckBox->checkState());
+  this->updateExistingNodesSelection(this->UpdateExistingNodesCheckBox->checkState());
+  this->NodeSelectorComboBox->blockSignals(wasBlocking);
+  this->updateCategorySelection();
 }
 
 //-----------------------------------------------------------------------------
@@ -151,22 +431,13 @@ void qSlicerSceneViewsModuleDialog::loadSceneViewInfo(int index)
 
   this->setData(QVariant(index));
 
-  // get the name..
   std::string name = this->m_Logic->GetNthSceneViewName(index);
-
-  // ..and set it in the GUI
   this->setNameEdit(QString::fromStdString(name));
 
-  // get the description..
   std::string description = this->m_Logic->GetNthSceneViewDescription(index);
-
-  // ..and set it in the GUI
   this->setDescription(QString::fromStdString(description));
 
-  // get the screenshot type..
   int screenshotType = this->m_Logic->GetNthSceneViewScreenshotType(index);
-
-  // ..and set it in the GUI
   this->setWidgetType((qMRMLScreenShotDialog::WidgetType)screenshotType);
 
   vtkImageData* imageData = this->m_Logic->GetNthSceneViewScreenshot(index);
@@ -176,6 +447,7 @@ void qSlicerSceneViewsModuleDialog::loadSceneViewInfo(int index)
   d->UpdateExistingNodesCheckBox->setChecked(false);
   d->CaptureDisplayNodesCheckBox->setChecked(false);
   d->CaptureViewNodesCheckBox->setChecked(false);
+  d->updateNodeSelection();
 }
 
 //-----------------------------------------------------------------------------
@@ -206,6 +478,8 @@ void qSlicerSceneViewsModuleDialog::reset()
   d->UpdateExistingNodesCheckBox->setChecked(false);
   d->CaptureDisplayNodesCheckBox->setChecked(true);
   d->CaptureViewNodesCheckBox->setChecked(true);
+
+  d->updateNodeSelection();
 }
 
 //-----------------------------------------------------------------------------
@@ -230,11 +504,13 @@ void qSlicerSceneViewsModuleDialog::accept()
     index = this->data().toInt();
   }
 
+  QList<vtkMRMLNode*> selectedNodes = d->NodeSelectorComboBox->checkedNodes();
+  std::vector<vtkMRMLNode*> selectedNodesVector = std::vector<vtkMRMLNode*>(selectedNodes.begin(), selectedNodes.end());
+
   if (index < 0)
   {
     // this is a new SceneView
-    this->m_Logic->CreateSceneView(
-      nameBytes.data(), descriptionBytes.data(), screenshotType, this->imageData(), d->CaptureDisplayNodesCheckBox->isChecked(), d->CaptureViewNodesCheckBox->isChecked());
+    this->m_Logic->CreateSceneView(selectedNodesVector, nameBytes.data(), descriptionBytes.data(), screenshotType, this->imageData());
   }
   else
   {
@@ -243,7 +519,7 @@ void qSlicerSceneViewsModuleDialog::accept()
         || d->CaptureViewNodesCheckBox->isChecked())
     {
       // update the nodes saved in the scene view
-      this->m_Logic->UpdateNthSceneView(index, d->UpdateExistingNodesCheckBox->isChecked(), d->CaptureDisplayNodesCheckBox->isChecked(), d->CaptureViewNodesCheckBox->isChecked());
+      this->m_Logic->UpdateNthSceneView(index, selectedNodesVector, d->UpdateExistingNodesCheckBox->isChecked());
     }
 
     // update the name and description

--- a/Modules/Loadable/SceneViews/GUI/qSlicerSceneViewsModuleDialog.h
+++ b/Modules/Loadable/SceneViews/GUI/qSlicerSceneViewsModuleDialog.h
@@ -26,6 +26,12 @@ public:
 
   void accept() override;
 
+public slots:
+  void onUpdateExistingNodesClicked();
+  void onCaptureDisplayNodesClicked();
+  void onCaptureViewNodesClicked();
+  void onNodeSelectionChanged();
+
 private:
   Q_DECLARE_PRIVATE(qSlicerSceneViewsModuleDialog);
 

--- a/Modules/Loadable/SceneViews/GUI/qSlicerSceneViewsModuleWidget.cxx
+++ b/Modules/Loadable/SceneViews/GUI/qSlicerSceneViewsModuleWidget.cxx
@@ -266,11 +266,7 @@ void qSlicerSceneViewsModuleWidget::editSceneView(int index)
 {
   Q_D(qSlicerSceneViewsModuleWidget);
   d->sceneViewDialog()->loadSceneViewInfo(index);
-  QPushButton* saveAsButton = d->sceneViewDialog()->findChild<QPushButton*>("saveAsButton");
-  if (saveAsButton)
-  {
-    saveAsButton->hide();
-  }
+  d->sceneViewDialog()->setSaveAsButtonVisibility(false);
   d->sceneViewDialog()->exec();
   this->updateFromMRMLScene();
 }
@@ -392,11 +388,7 @@ void qSlicerSceneViewsModuleWidget::showSceneViewDialog()
 {
   Q_D(qSlicerSceneViewsModuleWidget);
   // show the dialog
-  QPushButton* saveAsButton = d->sceneViewDialog()->findChild<QPushButton*>("saveAsButton");
-  if (saveAsButton)
-  {
-    saveAsButton->setVisible(false);
-  }
+  d->sceneViewDialog()->setSaveAsButtonVisibility(false);
   d->sceneViewDialog()->reset();
   d->sceneViewDialog()->exec();
 }

--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
@@ -273,41 +273,37 @@ void vtkSlicerSceneViewsModuleLogic::RegisterNodes()
 //---------------------------------------------------------------------------
 void vtkSlicerSceneViewsModuleLogic::GetDisplayNodes(std::vector<vtkMRMLNode*>& nodes)
 {
-  std::vector<vtkMRMLNode*> displayNodes;
-  this->GetMRMLScene()->GetNodesByClass("vtkMRMLDisplayNode", displayNodes);
-  nodes.insert(nodes.end(), displayNodes.begin(), displayNodes.end());
+  std::vector<std::string> displayNodeClasses;
+  this->GetDisplayNodeClasses(displayNodeClasses);
+  if (displayNodeClasses.empty())
+  {
+    return;
+  }
 
-  std::vector<vtkMRMLNode*> volumePropertyNodes;
-  this->GetMRMLScene()->GetNodesByClass("vtkMRMLVolumePropertyNode", volumePropertyNodes);
-  nodes.insert(nodes.end(), volumePropertyNodes.begin(), volumePropertyNodes.end());
-
-  std::vector<vtkMRMLNode*> clipNodes;
-  this->GetMRMLScene()->GetNodesByClass("vtkMRMLClipNode", clipNodes);
-  nodes.insert(nodes.end(), clipNodes.begin(), clipNodes.end());
-
-  std::vector<vtkMRMLNode*> crosshairNodes;
-  this->GetMRMLScene()->GetNodesByClass("vtkMRMLCrosshairNode", crosshairNodes);
-  nodes.insert(nodes.end(), crosshairNodes.begin(), crosshairNodes.end());
+  for (const std::string& displayNodeClass : displayNodeClasses)
+  {
+    std::vector<vtkMRMLNode*> classNodes;
+    this->GetMRMLScene()->GetNodesByClass(displayNodeClass.c_str(), classNodes);
+    nodes.insert(nodes.end(), classNodes.begin(), classNodes.end());
+  }
 }
 
 //---------------------------------------------------------------------------
 void vtkSlicerSceneViewsModuleLogic::GetViewNodes(std::vector<vtkMRMLNode*>& nodes)
 {
-  std::vector<vtkMRMLNode*> viewNodes;
-  this->GetMRMLScene()->GetNodesByClass("vtkMRMLAbstractViewNode", viewNodes);
-  nodes.insert(nodes.end(), viewNodes.begin(), viewNodes.end());
+  std::vector<std::string> viewNodeClasses;
+  this->GetViewNodeClasses(viewNodeClasses);
+  if (viewNodeClasses.empty())
+  {
+    return;
+  }
 
-  std::vector<vtkMRMLNode*> cameraNodes;
-  this->GetMRMLScene()->GetNodesByClass("vtkMRMLCameraNode", cameraNodes);
-  nodes.insert(nodes.end(), cameraNodes.begin(), cameraNodes.end());
-
-  std::vector<vtkMRMLNode*> sliceCompositeNodes;
-  this->GetMRMLScene()->GetNodesByClass("vtkMRMLSliceCompositeNode", sliceCompositeNodes);
-  nodes.insert(nodes.end(), sliceCompositeNodes.begin(), sliceCompositeNodes.end());
-
-  std::vector<vtkMRMLNode*> layoutNodes;
-  this->GetMRMLScene()->GetNodesByClass("vtkMRMLLayoutNode", layoutNodes);
-  nodes.insert(nodes.end(), layoutNodes.begin(), layoutNodes.end());
+  for (const std::string& viewNodeClass : viewNodeClasses)
+  {
+    std::vector<vtkMRMLNode*> classNodes;
+    this->GetMRMLScene()->GetNodesByClass(viewNodeClass.c_str(), classNodes);
+    nodes.insert(nodes.end(), classNodes.begin(), classNodes.end());
+  }
 }
 
 //---------------------------------------------------------------------------
@@ -487,11 +483,11 @@ void vtkSlicerSceneViewsModuleLogic::UpdateNthSceneView(int sceneViewIndex, bool
   {
     this->GetViewNodes(savedNodes);
   }
-  this->UpdateNthSceneView(savedNodes, sceneViewIndex, updateExistingNodes);
+  this->UpdateNthSceneView(sceneViewIndex, savedNodes, updateExistingNodes);
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerSceneViewsModuleLogic::UpdateNthSceneView(vtkCollection* savedNodes, int sceneViewIndex, bool updateExistingNodes /*=true*/)
+void vtkSlicerSceneViewsModuleLogic::UpdateNthSceneView(int sceneViewIndex, vtkCollection* savedNodes, bool updateExistingNodes /*=true*/)
 {
   if (!this->GetMRMLScene())
   {
@@ -515,11 +511,11 @@ void vtkSlicerSceneViewsModuleLogic::UpdateNthSceneView(vtkCollection* savedNode
       savedNodesVector.push_back(node);
     }
   }
-  this->UpdateNthSceneView(savedNodesVector, sceneViewIndex, updateExistingNodes);
+  this->UpdateNthSceneView(sceneViewIndex, savedNodesVector, updateExistingNodes);
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerSceneViewsModuleLogic::UpdateNthSceneView(std::vector<vtkMRMLNode*> savedNodes, int sceneViewIndex, bool updateExistingNodes /*=true*/)
+void vtkSlicerSceneViewsModuleLogic::UpdateNthSceneView(int sceneViewIndex, std::vector<vtkMRMLNode*> savedNodes, bool updateExistingNodes /*=true*/)
 {
   if (!this->GetMRMLScene())
   {
@@ -1291,4 +1287,39 @@ bool vtkSlicerSceneViewsModuleLogic::IsSceneViewNode(vtkMRMLNode* node)
 
   const char* attributeValue = node->GetAttribute(vtkSlicerSceneViewsModuleLogic::GetSceneViewNodeAttributeName());
   return attributeValue && strcmp(attributeValue, vtkSlicerSceneViewsModuleLogic::GetSceneViewNodeAttributeValue()) == 0;
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerSceneViewsModuleLogic::GetDisplayNodeClasses(std::vector<std::string>& displayNodeTypes)
+{
+  displayNodeTypes.push_back("vtkMRMLDisplayNode");
+  displayNodeTypes.push_back("vtkMRMLVolumePropertyNode");
+  displayNodeTypes.push_back("vtkMRMLClipNode");
+  displayNodeTypes.push_back("vtkMRMLCrosshairNode");
+}
+
+//---------------------------------------------------------------------------
+std::vector<std::string> vtkSlicerSceneViewsModuleLogic::GetDisplayNodeClasses()
+{
+  std::vector<std::string> nodeTypes;
+  this->GetDisplayNodeClasses(nodeTypes);
+  return nodeTypes;
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerSceneViewsModuleLogic::GetViewNodeClasses(std::vector<std::string>& viewNodeTypes)
+{
+  viewNodeTypes.push_back("vtkMRMLAbstractViewNode");
+  viewNodeTypes.push_back("vtkMRMLCameraNode");
+  viewNodeTypes.push_back("vtkMRMLLayoutNode");
+  viewNodeTypes.push_back("vtkMRMLSliceNode");
+  viewNodeTypes.push_back("vtkMRMLSliceLogic");
+}
+
+//---------------------------------------------------------------------------
+std::vector<std::string> vtkSlicerSceneViewsModuleLogic::GetViewNodeClasses()
+{
+  std::vector<std::string> nodeTypes;
+  this->GetViewNodeClasses(nodeTypes);
+  return nodeTypes;
 }

--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.h
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.h
@@ -89,8 +89,8 @@ public:
   /// Update the contents of a sceneView to match the current state of the scene.
   /// If new nodes are specified, they will be added to the scene view.
   void UpdateNthSceneView(int sceneViewIndex, bool updateExistingNodes = true, bool saveDisplayNodes = true, bool saveViewNodes = true);
-  void UpdateNthSceneView(vtkCollection* savedNodes, int sceneViewIndex, bool updateExistingNodes = true);
-  void UpdateNthSceneView(std::vector<vtkMRMLNode*> savedNodes, int sceneViewIndex, bool updateExistingNodes = true);
+  void UpdateNthSceneView(int sceneViewIndex, vtkCollection* savedNodes, bool updateExistingNodes = true);
+  void UpdateNthSceneView(int sceneViewIndex, std::vector<vtkMRMLNode*> savedNodes, bool updateExistingNodes = true);
   //@}
 
   /// Convert the index of the scene view to the corresponding value index of the sequence browser that holds the snapshot.
@@ -190,6 +190,18 @@ public:
   bool IsSceneViewNode(vtkMRMLNode* node);
   //@}
 
+  /// Add all display-related nodes to the vector.
+  void GetDisplayNodes(std::vector<vtkMRMLNode*>& displayNodes);
+
+  /// Add all view-related nodes to the vector.
+  void GetViewNodes(std::vector<vtkMRMLNode*>& viewNodes);
+
+  void GetDisplayNodeClasses(std::vector<std::string>& displayNodeTypes);
+  std::vector<std::string> GetDisplayNodeClasses();
+
+  void GetViewNodeClasses(std::vector<std::string>& viewNodeTypes);
+  std::vector<std::string> GetViewNodeClasses();
+
 protected:
   vtkSlicerSceneViewsModuleLogic();
 
@@ -228,12 +240,6 @@ protected:
 
   /// Convert the specified vtkMRMLSceneViewNode to use sequences.
   vtkMRMLSequenceBrowserNode* ConvertSceneViewNodeToSequenceBrowserNode(vtkMRMLSceneViewNode* sceneView, vtkMRMLSequenceBrowserNode* sequenceBrowserNode);
-
-  /// Add all display-related nodes to the vector.
-  void GetDisplayNodes(std::vector<vtkMRMLNode*>& displayNodes);
-
-  /// Add all view-related nodes to the vector.
-  void GetViewNodes(std::vector<vtkMRMLNode*>& viewNodes);
 
   /// Returns the sequence node for a given proxy node. Will create a new vtkMRMLSequenceNode if none exists.
   vtkMRMLSequenceNode* GetOrAddSceneViewSequenceNode(vtkMRMLSequenceBrowserNode* sequenceBrowser, vtkMRMLNode* proxyNode);


### PR DESCRIPTION
Previously users could only select node categories "display", "view" or "existing" (when editing a scene view). With this change, the scene view dialog now contains an "Advanced" section that allows the user to select any nodes in the scene. This node selection section is synchronized with the "display" , "view", and "existing" node check boxes.

<img width="459" height="499" alt="image" src="https://github.com/user-attachments/assets/d4819ddf-bb6a-4a61-a052-eb85d77ba2e1" />