### PR TITLE
BUG: Replace u8‑prefixed unit suffix literals with narrow strings

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLTextStorageNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTextStorageNodeTest1.cxx
@@ -45,7 +45,7 @@ int vtkMRMLTextStorageNodeTest1(int argc, char* argv[])
   scene->SetRootDirectory(tempDir);
 
   CHECK_EXIT_SUCCESS(TestReadWriteData(scene.GetPointer(), ".txt", "Hello world!", VTK_ENCODING_US_ASCII));
-  CHECK_EXIT_SUCCESS(TestReadWriteData(scene.GetPointer(), "UTF8.txt", u8"Hell\u00F3 vil\u00E1g!", VTK_ENCODING_UTF_8));
+  CHECK_EXIT_SUCCESS(TestReadWriteData(scene.GetPointer(), "UTF8.txt", static_cast<const char*>(u8"Hell\u00F3 vil\u00E1g!"), VTK_ENCODING_UTF_8));
   CHECK_EXIT_SUCCESS(TestReadWriteData(scene.GetPointer(), ".xml", "<Hello World=True/>", VTK_ENCODING_US_ASCII));
   CHECK_EXIT_SUCCESS(TestReadWriteData(scene.GetPointer(), ".json", "{\"Hello\":\"World\"}", VTK_ENCODING_US_ASCII));
 

--- a/Libs/MRML/Widgets/Testing/qMRMLUtf8Test1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLUtf8Test1.cxx
@@ -100,8 +100,8 @@ int qMRMLUtf8Test1(int argc, char* argv[])
   QString actualDisplayNodeName = QString::fromUtf8(volumeDisplayNode->GetName());
   // expectedDisplayNodeName contains a number of unicode characters that are not found in Latin1 character set
   // (the word is "a'rvi'ztu"ro" tu:ko:rfu'ro'ge'p" - https://en.wikipedia.org/wiki/Mojibake#Examples)
-  QString expectedDisplayNodeName =
-    QString::fromUtf8(u8"\u00e1\u0072\u0076\u00ed\u007a\u0074\u0171\u0072\u0151\u0020\u0074\u00fc\u006b\u00f6\u0072\u0066\u00fa\u0072\u00f3\u0067\u00e9\u0070");
+  QString expectedDisplayNodeName = QString::fromUtf8(
+    static_cast<const char*>(u8"\u00e1\u0072\u0076\u00ed\u007a\u0074\u0171\u0072\u0151\u0020\u0074\u00fc\u006b\u00f6\u0072\u0066\u00fa\u0072\u00f3\u0067\u00e9\u0070"));
   CHECK_BOOL(actualDisplayNodeName == expectedDisplayNodeName, true);
 
   // Check that volume can be saved into filename with special character and that file can be loaded

--- a/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx
+++ b/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx
@@ -229,7 +229,8 @@ void vtkSlicerUnitsLogic::AddBuiltInUnits(vtkMRMLScene* scene)
   this->AddUnitNodeToScene(scene,
     "Millimeter", "length", "", "mm", 4, -10000., 10000., Self::GetDisplayCoefficient("milli", "milli"), 0.);
   this->AddUnitNodeToScene(scene,
-    "Micrometer", "length", "", u8"\u00b5m", 4, -10000., 10000., Self::GetDisplayCoefficient("micro", "milli"), 0.);
+    "Micrometer", "length", "",
+    static_cast<const char*>(u8"\u00b5m"), 4, -10000., 10000., Self::GetDisplayCoefficient("micro", "milli"), 0.);
   this->AddUnitNodeToScene(scene,
     "Nanometer", "length", "", "nm", 4, -10000., 10000., Self::GetDisplayCoefficient("nano", "milli"), 0.);
 
@@ -240,7 +241,8 @@ void vtkSlicerUnitsLogic::AddBuiltInUnits(vtkMRMLScene* scene)
   this->AddUnitNodeToScene(scene,
     "Square Millimeter", "area", "", "mm2", 4, -10000., 10000., Self::GetDisplayCoefficient("milli", "milli", 2), 0.);
   this->AddUnitNodeToScene(scene,
-    "Square Micrometer", "area", "", u8"\u00b5m2", 4, -10000., 10000., Self::GetDisplayCoefficient("micro", "milli", 2), 0.);
+    "Square Micrometer", "area", "",
+    static_cast<const char*>(u8"\u00b5m2"), 4, -10000., 10000., Self::GetDisplayCoefficient("micro", "milli", 2), 0.);
   this->AddUnitNodeToScene(scene,
     "Square Nanometer", "area", "", "nm2", 4, -10000., 10000., Self::GetDisplayCoefficient("nano", "milli", 2), 0.);
 
@@ -251,7 +253,8 @@ void vtkSlicerUnitsLogic::AddBuiltInUnits(vtkMRMLScene* scene)
   this->AddUnitNodeToScene(scene,
     "Cubic Millimeter", "volume", "", "mm3", 5, -10000., 10000., Self::GetDisplayCoefficient("milli", "milli", 3), 0.);
   this->AddUnitNodeToScene(scene,
-    "Cubic Micrometer", "volume", "", u8"\u00b5m3", 5, -10000., 10000., Self::GetDisplayCoefficient("micro", "milli", 3), 0.);
+    "Cubic Micrometer", "volume", "",
+    static_cast<const char*>(u8"\u00b5m3"), 5, -10000., 10000., Self::GetDisplayCoefficient("micro", "milli", 3), 0.);
   this->AddUnitNodeToScene(scene,
     "Cubic Nanometer", "volume", "", "nm3", 5, -10000., 10000., Self::GetDisplayCoefficient("nano", "milli", 3), 0.);
 
@@ -271,7 +274,8 @@ void vtkSlicerUnitsLogic::AddBuiltInUnits(vtkMRMLScene* scene)
   this->AddUnitNodeToScene(scene,
     "Millisecond", "time", "", "ms", 3, -10000., 10000., Self::GetDisplayCoefficient("milli"), 0.);
   this->AddUnitNodeToScene(scene,
-    "Microsecond", "time", "", u8"\u00b5s", 3, -10000., 10000., Self::GetDisplayCoefficient("micro"), 0.);
+    "Microsecond", "time", "",
+    static_cast<const char*>(u8"\u00b5s"), 3, -10000., 10000., Self::GetDisplayCoefficient("micro"), 0.);
 
   this->AddUnitNodeToScene(scene,
     "Hertz", "frequency", "", "Hz", 3, -10000., 10000., Self::GetDisplayCoefficient(""), 0.);


### PR DESCRIPTION
Fixes build failures on C++20 due to invalid conversion from 'const char8_t*' to 'const char*' when using u8"\u00b5m"‑style literals for Micrometer, Square Micrometer, Cubic Micrometer, and Microsecond units. All u8"\u00b5…" suffixes have been changed to "\u00b5…" so that AddUnitNodeToScene(..., const char* suffix, ...) no longer rejects them.

Error log excerpt:

```
/usr/src/RPM/BUILD/slicer-5.8.0/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx:227:33: error: invalid conversion from 'const char8_t*' to 'const char*' [-fpermissive]
  227 |     "Micrometer", "length", "", u8"\u00b5m", 4, …
      |                                 ^~~~~~~~~~~
      |                                 |
      |                                 const char8_t*
/usr/src/RPM/BUILD/slicer-5.8.0/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx:121:34:
note:   initializing argument 5 of 'vtkMRMLUnitNode* vtkSlicerUnitsLogic::AddUnitNodeToScene(..., const char* suffix, ...)'
  121 |                      const char* suffix, int precision,
      |                                ~~~~~~~~~^~~~~~

--
```

```
$ g++ --version
x86_64-alt-linux-g++ (GCC) 14.2.1 20241028 (ALT Sisyphus 14.2.1-alt1)
```