### PR TITLE
BUG: Fix invalid node type in GetViewNodeClasses()

### DIFF
--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
@@ -1312,8 +1312,7 @@ void vtkSlicerSceneViewsModuleLogic::GetViewNodeClasses(std::vector<std::string>
   viewNodeTypes.push_back("vtkMRMLAbstractViewNode");
   viewNodeTypes.push_back("vtkMRMLCameraNode");
   viewNodeTypes.push_back("vtkMRMLLayoutNode");
-  viewNodeTypes.push_back("vtkMRMLSliceNode");
-  viewNodeTypes.push_back("vtkMRMLSliceLogic");
+  viewNodeTypes.push_back("vtkMRMLSliceCompositeNode");
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
In vtkSlicerSceneViewsModuleLogic::GetViewNodeClasses(), vtkMRMLSliceLogic should be vtkMRMLSliceCompositeNode.