### PR TITLE
BUG: Avoid cursor jump on edit in extension LineEdit

### DIFF
--- a/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
@@ -483,7 +483,12 @@ class QLineEditToStrConnector(GuiConnector):
         return self._widget.text
 
     def write(self, value: str) -> None:
-        self._widget.text = value
+        # Writing the text of a QLineEdit moves the cursor to the end.
+        # We tolerate that if the value is actually changing, but sometimes
+        # the value is written as a result of an update originating from
+        # the field, and then it is wrong.
+        if value != self._widget.text:
+            self._widget.text = value
 
 @parameterNodeGuiConnector
 class QLabelToStrConnector(GuiConnector):


### PR DESCRIPTION
Before this, the cursor jumps to the end if the LineEdit is connected to a ParameterNode field, and the editing is in the middle of the text.

Forum discussion https://discourse.slicer.org/t/qlineedit-in-extension-ui-cursor-jumping-to-end-of-line-bug/43954

Fixes #8620.
