### PR TITLE
BUG: Initialize environment from launcher before Python to fix macOS startup

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication_p.h
+++ b/Base/QTCore/qSlicerCoreApplication_p.h
@@ -66,6 +66,15 @@ public:
   qSlicerCoreApplicationPrivate(qSlicerCoreApplication& object, qSlicerCoreCommandOptions* coreCommandOptions, qSlicerCoreIOManager* coreIOManager);
   virtual ~qSlicerCoreApplicationPrivate();
 
+  // Initialize process environment as early as possible.
+  //
+  // Reads launcher settings (.ini) and discovers Slicer home to populate
+  // environment variables needed by early subsystems (notably Python).
+  // Must run before parseArguments() and any Python initialization to
+  // avoid incomplete interpreter state (e.g., import failures on macOS
+  // installers).
+  virtual void initializeEnvironmentFromLauncher();
+
   virtual void init();
 
   /// Terminates the calling process "immediately".
@@ -185,6 +194,8 @@ public:
 #ifdef Slicer_BUILD_APPLICATIONUPDATE_SUPPORT
   QSharedPointer<qSlicerApplicationUpdateManager> ApplicationUpdateManager;
 #endif
+
+  bool EnvironmentInitializedFromLauncher{ false };
 
   QProcessEnvironment Environment;
 

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -508,6 +508,7 @@ qSlicerApplication::qSlicerApplication(int& _argc, char** _argv)
   : Superclass(new qSlicerApplicationPrivate(*this, new qSlicerCommandOptions, nullptr), _argc, _argv)
 {
   Q_D(qSlicerApplication);
+  d->initializeEnvironmentFromLauncher();
   d->init();
   // Note: Since QWidget/QDialog requires a QApplication to be successfully instantiated,
   //       qSlicerIOManager is not added to the constructor initialization list.


### PR DESCRIPTION
This PR introduces `initializeEnvironmentFromLauncher()` and ensures it runs before argument parsing and Python interpreter initialization. The method reads launcher `.ini` settings, discovers Slicer home, and sets environment variables required by early subsystems (e.g Python).

In the context of macOS installer where no launcher is used (only launcher settings file is provided along side the "real" executable), the previous init order could start Python with a partial environment, causing early import failures.

Follow-up to fa915a03fc ("BUG: Fix improper Python initialization causing inconsistent interpreter state") introduced through the follow pull request:
* https://github.com/Slicer/Slicer/pull/8582