### PR TITLE
ENH: Set Windows registry key to use high performance graphics

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -503,14 +503,25 @@ if(CPACK_GENERATOR STREQUAL "NSIS")
   set(CPACK_NSIS_FINISH_TITLE_3LINES True)
 
   # -------------------------------------------------------------------------
+  # Graphics Preference
+  # -------------------------------------------------------------------------
+  # Windows Settings -> System -> Display -> Graphics
+  # This area has options for setting custom graphics settings for an individual app with the following options:
+  # GpuPreference=0 -> "Let Windows Decide (default)"
+  # GpuPreference=1 -> "Power Saving" - uses integrated graphics
+  # GpuPreference=2 -> "High Performance" - uses discrete graphics
+  set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
+"WriteRegStr SHCTX \\\"SOFTWARE\\\\Microsoft\\\\DirectX\\\\UserGpuPreferences\\\" \\\"$INSTDIR\\\\bin\\\\${APPLICATION_NAME}App-real.exe\\\" \\\"GpuPreference=2;\\\"
+")
+  set(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
+"DeleteRegValue SHCTX \\\"SOFTWARE\\\\Microsoft\\\\DirectX\\\\UserGpuPreferences\\\" \\\"$INSTDIR\\\\bin\\\\${APPLICATION_NAME}App-real.exe\\\"
+")
+
+  # -------------------------------------------------------------------------
   # File extensions
   # -------------------------------------------------------------------------
   set(FILE_EXTENSIONS .mrml .xcat .mrb)
-
   if(FILE_EXTENSIONS)
-
-    set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS)
-    set(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS)
     foreach(ext ${FILE_EXTENSIONS})
       string(LENGTH "${ext}" len)
       math(EXPR len_m1 "${len} - 1")


### PR DESCRIPTION
Beginning with Windows 10 20H1 the Windows OS assigns the graphics processor to use for various application. It will override any settings made in third-party applications such as the NVIDIA Control Panel. If the OS does not have a GPU preference for an application, you can use a third-party app like NVIDIA Control Panel to set preferred graphics processor.

By default Windows has a "Let Windows Decide" option, but it has been observed that it always seems to prefer the power saving integrated graphics option even though there is a high performing graphics available and even when the device is plugged into power and not running on battery. Setting the default to use the "High-Performance Graphics" option avoids issues with new 3D Slicer users who want to do some volume rendering and then face suboptimal performance even when using "VTK GPU Ray Casting" rendering setting is defined because it is actually using the integrated graphics.

I used Windows Task Manager to observe graphics performance where GPU 0 is the integrated graphics and GPU 1 is an NVIDIA T1200 graphics card. This is a typical setup for a mobile workstation where there are 2 graphics options.
<img width="942" height="651" alt="image" src="https://github.com/user-attachments/assets/6a85311a-acec-427a-a062-d5a88be7a0bd" />

When using recent Slicer Preview and doing some volume rendering I observed that by default the application was using the integrated graphics - GPU 0.
<img width="1095" height="407" alt="image" src="https://github.com/user-attachments/assets/008bdb2a-7261-4588-8bcb-cfc51910febe" />

With this PR, the setting of the registry key is observed through Windows Settings->System->Display->Graphics. There is now a predefined entry for the install application that has the "High performance" graphics option selected by default. The "SlicerApp-real.exe" has to be picked instead of the Slicer.exe launcher because otherwise the graphics preference won't work as expected.
<img width="679" height="933" alt="image" src="https://github.com/user-attachments/assets/17d3da63-4310-4d35-81db-9c1bb1f035c6" />
Now when volume rendering I observe that by default the application is using the NVIDIA T1200 graphics - GPU 1 (it could be any discrete graphics card)
<img width="1088" height="409" alt="image" src="https://github.com/user-attachments/assets/6de120e3-7105-4a77-8e5a-bffedd012639" />

Note that when a system only has integrated graphics the "Power Saving" and "High Performance" options are mapped to the same entry so there will be no impact of the registry key.
<img width="263" height="99" alt="integrated-graphics-only" src="https://github.com/user-attachments/assets/f4f9f183-8266-47da-9429-0456173d93e0" />
