### PR TITLE
BUG: Fix Windows graphics preference not set when installing app with admin privileges

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -510,11 +510,12 @@ if(CPACK_GENERATOR STREQUAL "NSIS")
   # GpuPreference=0 -> "Let Windows Decide (default)"
   # GpuPreference=1 -> "Power Saving" - uses integrated graphics
   # GpuPreference=2 -> "High Performance" - uses discrete graphics
+  # Note: This is a user setting that has to be applied at the HKCU (HKEY_CURRENT_USER) level and cannot be set at the HKLM (HKEY_LOCAL_MACHINE) level
   set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
-"WriteRegStr SHCTX \\\"SOFTWARE\\\\Microsoft\\\\DirectX\\\\UserGpuPreferences\\\" \\\"$INSTDIR\\\\bin\\\\${APPLICATION_NAME}App-real.exe\\\" \\\"GpuPreference=2;\\\"
+"WriteRegStr HKCU \\\"SOFTWARE\\\\Microsoft\\\\DirectX\\\\UserGpuPreferences\\\" \\\"$INSTDIR\\\\bin\\\\${APPLICATION_NAME}App-real.exe\\\" \\\"GpuPreference=2;\\\"
 ")
   set(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
-"DeleteRegValue SHCTX \\\"SOFTWARE\\\\Microsoft\\\\DirectX\\\\UserGpuPreferences\\\" \\\"$INSTDIR\\\\bin\\\\${APPLICATION_NAME}App-real.exe\\\"
+"DeleteRegValue HKCU \\\"SOFTWARE\\\\Microsoft\\\\DirectX\\\\UserGpuPreferences\\\" \\\"$INSTDIR\\\\bin\\\\${APPLICATION_NAME}App-real.exe\\\"
 ")
 
   # -------------------------------------------------------------------------


### PR DESCRIPTION
This is a follow-up to https://github.com/Slicer/Slicer/commit/fd55fbc130a45d5f85e0e04b294d2a8169bc811d.

SHCTX or SHELL_CONTEXT is set to HKLM if the shell context is for all and is set to HKCU if shell context is set to current user. Slicer is by default set to install with regular user privileges where SHCTX was working by representing HKCU, but then it would not work when installing Slicer with elevated privileges to a system location like "C:/Program Files". This commit fixes the issue by always writing to the HKCU location as this graphics preference setting is a user specific setting.