### PR TITLE
COMP: Fix Windows build error in debug mode due to python312_d.lib

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -22,9 +22,6 @@
 #include <clocale>
 #include <stdexcept>
 
-// Python include header
-#include <Python.h>
-
 // Qt includes
 #include <QDebug>
 #include <QDir>


### PR DESCRIPTION
Fixes the build error described in https://discourse.slicer.org/t/build-error-in-windows-in-debug-mode-due-to-python312-d-lib/43781/8

Python.h cannot be directly included in an application on Windows, because the linked library is specified in the Python.h header file, but the application's build mode (Debug, Release, etc.) is not always the same as Python's build mode (always Release in Slicer). This is a well-known issue and workarounds are implemented in PythonQt and VTK: https://github.com/commontk/PythonQt/blob/7f7105ba9ec59d719ded80090e049fa85ad76e79/src/PythonQtPythonInclude.h#L95 https://github.com/Slicer/VTK/blob/slicer-v9.5.0-2025-06-19-e70c856bd/Utilities/Python/vtkPython.h#L40

Since including "PythonQt.h" automatically includes "Python.h" with the appropriate workarounds, the best solution to the build error is simply not including "Python.h" directly.