### PR TITLE
COMP: Remove unneeded setting of WORDS_BIGENDIAN/WORDS_LITTLEENDIAN macros

### DIFF
--- a/Base/CLI/vtkSlicerBaseCLIConfigure.h.in
+++ b/Base/CLI/vtkSlicerBaseCLIConfigure.h.in
@@ -10,13 +10,6 @@
 #pragma warning ( disable : 4275 )
 #endif
 
-#cmakedefine CMAKE_WORDS_BIGENDIAN
-#ifdef CMAKE_WORDS_BIGENDIAN
-  #define WORDS_BIGENDIAN
-#else
-  #define WORDS_LITTLEENDIAN
-#endif
-
 #cmakedefine BUILD_SHARED_LIBS
 #ifndef BUILD_SHARED_LIBS
 #define VTKSLICER_STATIC

--- a/Base/Logic/vtkSlicerBaseLogicConfigure.h.in
+++ b/Base/Logic/vtkSlicerBaseLogicConfigure.h.in
@@ -10,13 +10,6 @@
 #pragma warning ( disable : 4275 )
 #endif
 
-#cmakedefine CMAKE_WORDS_BIGENDIAN
-#ifdef CMAKE_WORDS_BIGENDIAN
-  #define WORDS_BIGENDIAN
-#else
-  #define WORDS_LITTLEENDIAN
-#endif
-
 #cmakedefine BUILD_SHARED_LIBS
 #ifndef BUILD_SHARED_LIBS
 #define VTKSLICER_STATIC

--- a/CMake/vtkSlicerConfigure.h.in
+++ b/CMake/vtkSlicerConfigure.h.in
@@ -20,13 +20,6 @@
 #pragma warning ( disable : 4275 )
 #endif
 
-#cmakedefine CMAKE_WORDS_BIGENDIAN
-#ifdef CMAKE_WORDS_BIGENDIAN
-  #define WORDS_BIGENDIAN
-#else
-  #define WORDS_LITTLEENDIAN
-#endif
-
 #cmakedefine BUILD_SHARED_LIBS
 #ifndef BUILD_SHARED_LIBS
 #define VTKSLICER_STATIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,15 +177,6 @@ include(SlicerBlockPlatformCheck)
 mark_as_superbuild(Slicer_PLATFORM_CHECK:BOOL)
 
 #-----------------------------------------------------------------------------
-# Determine endian type
-#-----------------------------------------------------------------------------
-if(CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
-  set(CMAKE_WORDS_BIGENDIAN TRUE)
-else()
-  set(CMAKE_WORDS_BIGENDIAN FALSE)
-endif()
-
-#-----------------------------------------------------------------------------
 # Prerequisites
 #-----------------------------------------------------------------------------
 find_package(Git)


### PR DESCRIPTION
This pull request removes the redundant setting of `WORDS_BIGENDIAN` and `WORDS_LITTLEENDIAN` macros from the Slicer codebase. These macros, initially introduced in Slicer 3.x, are no longer necessary. The corresponding VTK macros may be used instead.

---

The setting of those macros was originally introduced in this iteration of the Slicer >= 3.x code base through 1e59efb9c6 ("COMP: Initial checkins of build structure plus edits to make some things build", 2006-02-14)

While were no explicit use of `WORDS_BIGENDIAN` or `WORDS_LITTLEENDIAN` in Slicer, the corresponding VTK macros was used. For reference, the first use of `VTK_WORDS_BIGENDIAN` was originally introduced in Slicer 2.x  through pieper/slicer2@02afc26d ("Enhanced DICOM support.", 2000-10-19) to return the expected value for function like `vtkImageDICOMReader::GetDataByteOrder()`.