### PR TITLE
BUG: Restore https download on macOS fixing packaging of SSL python modules

### DIFF
--- a/CMake/SlicerCPackBundleFixup.cmake.in
+++ b/CMake/SlicerCPackBundleFixup.cmake.in
@@ -190,8 +190,8 @@ function(fixup_bundle_with_plugins app)
   set(Slicer_USE_PYTHONQT_WITH_OPENSSL "@Slicer_USE_PYTHONQT_WITH_OPENSSL@")
   if(Slicer_USE_PYTHONQT_WITH_OPENSSL)
     list(APPEND candidates_pattern
-      "${app_dir}/Contents/lib/Python/${PYTHON_STDLIB_SUBDIR}/lib-dynload/_hashlib.so"
-      "${app_dir}/Contents/lib/Python/${PYTHON_STDLIB_SUBDIR}/lib-dynload/_ssl.so"
+      "${app_dir}/Contents/lib/Python/${PYTHON_STDLIB_SUBDIR}/lib-dynload/_hashlib*.so"
+      "${app_dir}/Contents/lib/Python/${PYTHON_STDLIB_SUBDIR}/lib-dynload/_ssl*.so"
       )
   endif()
 


### PR DESCRIPTION
This commit fixes a regression introduced in 5e952f7c5b ("ENH: Upgrade from python 3.9.10 to 3.12.10", 2025-06-02) ensuring the corresponding compiled modules (`_ssl` and `_hashlib`) are effectively selected for fix-up.

For additional context, the SOABI suffix was officially introduced in Python 3.8 but it was added to the `python-cmake-buildsystem` only recently through these commits:
* python-cmake-buildsystem/python-cmake-buildsystem@3c74c4b ("cmake: Starting with Python3.8, append SOABI to extension shared library name", 2025-05-09)
* python-cmake-buildsystem/python-cmake-buildsystem@fbd152b ("cmake: Fix generation of ".pyd" module removing extra dot", 2025-05-14)

This explained why the packaging of the `_ssl` and `_hashlib` modules worked as expected in Slicer 5.8 despite of being built against Python 3.9.