### PR TITLE
DOC: Add dedicated GOVERNANCE document and reference it from the about page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,48 +139,5 @@ and developers that introduced changes resulting in build or test failures are n
 email.
 
 
-### Decision-making process
-
-1. Given the topic of interest, initiate discussion on the [Slicer forum][slicer-forum].
-
-2. Identify a small circle of community members that are interested to study the
-   topic in more depth.
-
-3. Take the discussion off the general list, work on the analysis of options and
-   alternatives, summarize findings on the wiki or similar. [Labs](https://www.slicer.org/wiki/Documentation/Labs)
-   page are usually a good ground for such summary.
-
-4. Announce on the [Slicer forum][slicer-forum] the in-depth discussion of the topic for the
-   [Slicer Community hangout](https://discourse.slicer.org/c/community/hangout),
-   encourage anyone that is interested in weighing in on the topic to join the
-   discussion. If there is someone who is interested to participate in the discussion,
-   but cannot join the meeting due to conflict, they should notify the leaders of
-   the given project and identify the time suitable for everyone.
-
-5. Hopefully, reach consensus at the hangout and proceed with the agreed plan.
-
-
-*The initial version of these guidelines was established during the [winter
- project week 2017](https://www.na-mic.org/Wiki/index.php/2017_Winter_Project_Week/UpdatingCommunityForums).*
-
-#### Benevolent dictators for life
-
-The [benevolent dictators](https://slicer.readthedocs.io/en/latest/developer_guide/contributing.html#benevolent-dictators-for-life) can
-integrate changes to keep the platform healthy and help interpret
-or address conflict related to the contribution guidelines.
-
-
-These currently include:
-
-* Jean-Christophe Fillion-Robin
-* Andras Lasso
-* Steve Pieper
-
-*Alphabetically ordered by last name.*
-
-The Slicer community is inclusive and welcomes anyone to work to become a core
-developer and then a BDFL. This happens with hard work and approval of the existing
-BDFL.
-
 [slicer-forum]: https://discourse.slicer.org
 [slicer-issues]: https://github.com/Slicer/Slicer/issues

--- a/Docs/user_guide/about.md
+++ b/Docs/user_guide/about.md
@@ -209,6 +209,15 @@ Many companies prefer not to disclose what software components they use in their
 
 _Listed in alphabetical order._
 
+## Governance
+
+This section outlines the governance model for the Slicer project, including how decisions are made and who is responsible for maintaining the health of the project.
+
+```{include} ../../GOVERNANCE.md
+:start-after: <!-- governance-start -->
+:end-before: <!-- governance-end -->
+```
+
 ## Contact us
 
 It is recommended to post any questions, bug reports, or enhancement requests to the [Slicer forum](https://discourse.slicer.org).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,58 @@
+# Governance
+
+This document outlines the governance model for the Slicer project, including how decisions are made and who is responsible for maintaining the health of the project.
+
+<!--
+  The sections below start with ### headers to ensure proper nesting
+  when this content is included under a ## heading (e.g., in about.md).
+  Do not change header levels unless updating all dependent includes.
+-->
+
+<!-- governance-start -->
+
+### Decision-making process
+
+1. Given the topic of interest, initiate discussion on the [Slicer forum][slicer-forum].
+
+2. Identify a small circle of community members that are interested to study the
+   topic in more depth.
+
+3. Take the discussion off the general list, work on the analysis of options and
+   alternatives, summarize findings on the wiki or similar. [Labs](https://www.slicer.org/wiki/Documentation/Labs)
+   page are usually a good ground for such summary.
+
+4. Announce on the [Slicer forum][slicer-forum] the in-depth discussion of the topic for the
+   [Slicer Community hangout](https://discourse.slicer.org/c/community/hangout),
+   encourage anyone that is interested in weighing in on the topic to join the
+   discussion. If there is someone who is interested to participate in the discussion,
+   but cannot join the meeting due to conflict, they should notify the leaders of
+   the given project and identify the time suitable for everyone.
+
+5. Hopefully, reach consensus at the hangout and proceed with the agreed plan.
+
+
+*The initial version of these guidelines was established during the [winter
+ project week 2017](https://www.na-mic.org/Wiki/index.php/2017_Winter_Project_Week/UpdatingCommunityForums).*
+
+### Benevolent dictators for life
+
+The [benevolent dictators](https://slicer.readthedocs.io/en/latest/user_guide/about.html#benevolent-dictators-for-life) can
+integrate changes to keep the platform healthy and help interpret
+or address conflict related to the contribution guidelines.
+
+
+These currently include:
+
+* Jean-Christophe Fillion-Robin
+* Andras Lasso
+* Steve Pieper
+
+*Alphabetically ordered by last name.*
+
+The Slicer community is inclusive and welcomes anyone to work to become a core
+developer and then a BDFL. This happens with hard work and approval of the existing
+BDFL.
+
+[slicer-forum]: https://discourse.slicer.org
+
+<!-- governance-end -->


### PR DESCRIPTION
This change extracts the decision-making process and the list of benevolent dictators for life (BDFLs) from `CONTRIBUTING.md` into a new `GOVERNANCE.md` document.

It also updates the about page to include a reference to the new governance document.