### PR TITLE
BUG: Fix traceback using line profile on 2D image

### DIFF
--- a/Modules/Scripted/LineProfile/LineProfile.py
+++ b/Modules/Scripted/LineProfile/LineProfile.py
@@ -379,11 +379,15 @@ class LineProfileLogic(ScriptedLoadableModuleLogic):
                 # keep their relative distance the same (or boost to 1e-6 if very small)
                 # but make sure the points are on the opposite side of the
                 # plane (to ensure probe filter considers the line crossing the image plane)
+                    lineStartPoint_IJK = list(lineStartPoint_IJK)
+                    lineEndPoint_IJK = list(lineEndPoint_IJK)
                     pointDistance = max(abs(lineStartPoint_IJK[axisIndex]-lineEndPoint_IJK[axisIndex]), 1e-6)
                     lineStartPoint_IJK[axisIndex] = -0.5 * pointDistance
                     lineEndPoint_IJK[axisIndex] = 0.5 * pointDistance
                     sampledCurvePoints_IJK.SetPoint(startPointIndex, lineStartPoint_IJK)
                     sampledCurvePoints_IJK.SetPoint(endPointIndex, lineEndPoint_IJK)
+                    lineStartPoint_IJK = tuple(lineStartPoint_IJK)
+                    lineEndPoint_IJK = tuple(lineEndPoint_IJK)
 
         # Set up probe filter
         probeFilter=vtk.vtkProbeFilter()


### PR DESCRIPTION
This is a fix for the following traceback
```
Traceback (most recent call last):
  File "C:/Program Files/Revvity/Freud 1.0.0-2025-08-15/bin/../lib/Freud-5.9/qt-scripted-modules/LineProfile.py", line 206, in parameterNodeModified
    self.logic.update()
  File "C:/Program Files/Revvity/Freud 1.0.0-2025-08-15/bin/../lib/Freud-5.9/qt-scripted-modules/LineProfile.py", line 277, in update
    self._updateOutputTable()
  File "C:/Program Files/Revvity/Freud 1.0.0-2025-08-15/bin/../lib/Freud-5.9/qt-scripted-modules/LineProfile.py", line 383, in _updateOutputTable
    lineStartPoint_IJK[axisIndex] = -0.5 * pointDistance
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
TypeError: 'tuple' object does not support item assignment
```

To replicate:
1. Load 2D image
2. Enter Line Profile module
3. Set 2D image as the `Input Volume` and `Create new line` as `Input Line`
4. Place fiducials for the line on the 2D image
5. Click "Compute intensity profile" and observe traceback