### PR TITLE
ENH: Add API to retrieve view displayable managers without Qt widgets

### DIFF
--- a/Base/Logic/CMakeLists.txt
+++ b/Base/Logic/CMakeLists.txt
@@ -58,6 +58,7 @@ set(include_dirs
   ${CMAKE_CURRENT_BINARY_DIR}
   ${MRMLCore_INCLUDE_DIRS}
   ${MRMLLogic_INCLUDE_DIRS}
+  ${MRMLDisplayableManager_INCLUDE_DIRS}
   ${vtkTeem_INCLUDE_DIRS}
   ${RemoteIO_INCLUDE_DIRS}
   ${LibArchive_INCLUDE_DIR}
@@ -138,6 +139,7 @@ add_library(${lib_name} ${srcs})
 
 set(libs
   MRMLLogic
+  MRMLDisplayableManager
   ${VTK_LIBRARIES}
   )
 

--- a/Base/Logic/vtkSlicerApplicationLogic.cxx
+++ b/Base/Logic/vtkSlicerApplicationLogic.cxx
@@ -16,12 +16,19 @@
 #include "vtkSlicerConfigure.h"
 #include "vtkSlicerTask.h"
 
+// MRMLDisplayableManager includes
+#include <vtkMRMLDisplayableManagerGroup.h>
+
 // MRML includes
 #include <vtkCacheManager.h>
 #include <vtkDataIOManagerLogic.h>
 #include <vtkMRMLRemoteIOLogic.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLSelectionNode.h>
+#include <vtkMRMLSliceLogic.h>
+#include <vtkMRMLSliceNode.h>
+#include <vtkMRMLViewLogic.h>
+#include <vtkMRMLViewNode.h>
 
 // VTKAddon includes
 #include <vtkPersonInformation.h>
@@ -980,4 +987,31 @@ void vtkSlicerApplicationLogic::RequestModifiedCallback(vtkObject* vtkNotUsed(ca
   vtkSlicerApplicationLogic* appLogic = static_cast<vtkSlicerApplicationLogic*>(clientData);
   vtkObject* modifiedObject = static_cast<vtkObject*>(callData);
   appLogic->RequestModified(modifiedObject);
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLAbstractDisplayableManager* vtkSlicerApplicationLogic::GetViewDisplayableManagerByClassName(vtkMRMLAbstractViewNode* viewNode, const char* className) const
+{
+  if (!viewNode || !className)
+  {
+    return nullptr;
+  }
+
+  vtkMRMLDisplayableManagerGroup* displayableManagerGroup = nullptr;
+
+  if (vtkMRMLViewLogic* viewLogic = this->GetViewLogic(vtkMRMLViewNode::SafeDownCast(viewNode)); viewLogic != nullptr)
+  {
+    displayableManagerGroup = vtkMRMLDisplayableManagerGroup::SafeDownCast(viewLogic->GetDisplayableManagerGroup());
+  }
+  else if (vtkMRMLSliceLogic* slicelogic = this->GetSliceLogic(vtkMRMLSliceNode::SafeDownCast(viewNode)); slicelogic != nullptr)
+  {
+    displayableManagerGroup = vtkMRMLDisplayableManagerGroup::SafeDownCast(slicelogic->GetDisplayableManagerGroup());
+  }
+
+  if (displayableManagerGroup != nullptr)
+  {
+    return displayableManagerGroup->GetDisplayableManagerByClassName(className);
+  }
+
+  return nullptr;
 }

--- a/Base/Logic/vtkSlicerApplicationLogic.h
+++ b/Base/Logic/vtkSlicerApplicationLogic.h
@@ -31,6 +31,8 @@
 #include <mutex>
 #include <thread>
 
+class vtkMRMLAbstractDisplayableManager;
+class vtkMRMLAbstractViewNode;
 class vtkMRMLSelectionNode;
 class vtkMRMLInteractionNode;
 class vtkMRMLRemoteIOLogic;
@@ -210,6 +212,25 @@ public:
   /// Callback function to request invoking a modified event on the main thread.
   /// This function may be called from any thread.
   static void RequestModifiedCallback(vtkObject* caller, unsigned long eid, void* clientData, void* callData);
+
+  /// Get view displayable manager given its class name.
+  ///
+  /// This provides a Qt-independent way to access displayable managers, by
+  /// looking up the vtkMRMLDisplayableManagerGroup associated with a
+  /// vtkMRMLViewNode (3D) or vtkMRMLSliceNode (2D).
+  ///
+  /// \param viewNode MRML view node (slice or 3D) whose displayable manager group will be queried.
+  /// \param className Class name of the displayable manager (e.g., "vtkMRMLCameraDisplayableManager").
+  ///
+  /// \return The displayable manager instance if found, otherwise nullptr.
+  ///  The returned pointer is owned by the displayable manager group and must
+  ///  not be deleted by the caller.
+  ///
+  /// This API is primarily intended for accessing low-level VTK actors or
+  /// widgets without going through Qt view classes, and is especially
+  /// useful in headless contexts or alternative frontends (e.g., trame).
+  ///
+  vtkMRMLAbstractDisplayableManager* GetViewDisplayableManagerByClassName(vtkMRMLAbstractViewNode* viewNode, const char* className) const;
 
 protected:
   vtkSlicerApplicationLogic();

--- a/Docs/developer_guide/modules/colors.md
+++ b/Docs/developer_guide/modules/colors.md
@@ -70,8 +70,10 @@ Access to the scalar bar VTK actor may can be useful for debugging and for exper
 ```python
 displayableNode = getNode('Model')
 colorLegendDisplayNode = slicer.modules.colors.logic().GetColorLegendDisplayNode(displayableNode)
-sliceView = slicer.app.layoutManager().sliceWidget('Red').sliceView()
-displayableManager = sliceView.displayableManagerByClassName("vtkMRMLColorLegendDisplayableManager")
+sliceViewLabel = "Red"
+sliceViewNode = slicer.mrmlScene.GetNodeByID(f"vtkMRMLSliceNode{sliceViewLabel}")
+appLogic = slicer.app.applicationLogic()
+displayableManager = appLogic.GetViewDisplayableManagerByClassName(sliceViewNode, "vtkMRMLColorLegendDisplayableManager")
 colorLegendActor = displayableManager.GetColorLegendActor(colorLegendDisplayNode)
 
 # Experimental adjustment of a parameter that is not exposed via the colorLegendDisplayNode

--- a/Docs/developer_guide/script_repository/gui.md
+++ b/Docs/developer_guide/script_repository/gui.md
@@ -525,8 +525,9 @@ If 2D display position (in pixels) of a model's surface point is known then this
 displayPosition = [10, 12]
 
 # Get model displayable manager
-threeDViewWidget = slicer.app.layoutManager().threeDWidget(0)
-modelDisplayableManager = threeDViewWidget.threeDView().displayableManagerByClassName("vtkMRMLModelDisplayableManager")
+threeDViewNode = slicer.mrmlScene.GetNodeByID("vtkMRMLViewNode1")
+appLogic = slicer.app.applicationLogic()
+modelDisplayableManager = appLogic.GetViewDisplayableManagerByClassName(threeDViewNode, "vtkMRMLModelDisplayableManager")
 
 # Use model displayable manager's point picker
 if modelDisplayableManager.Pick(displayPosition[0], displayPosition[1]) and modelDisplayableManager.GetPickedNodeID():
@@ -868,10 +869,12 @@ crosshair.SetCrosshairBehavior(crosshair.CenteredJumpSlice)
 For microscopy or micro-CT images you may want to switch unit to micrometer instead of the default mm. To do that, 1. change the unit in Application settings / Units and 2. update ruler display settings using the script below (it can be copied to your Application startup script):
 
 ```python
-lm = slicer.app.layoutManager()
-for sliceViewName in lm.sliceViewNames():
-  sliceView = lm.sliceWidget(sliceViewName).sliceView()
-  displayableManager = sliceView.displayableManagerByClassName("vtkMRMLRulerDisplayableManager")
+appLogic = slicer.app.applicationLogic()
+layoutManagerLogic = slicer.app.layoutManager().layoutLogic()
+for viewNode in layoutManagerLogic.GetViewNodes():
+  if type(viewNode) is not slicer.vtkMRMLSliceNode:
+    continue
+  displayableManager = appLogic.GetViewDisplayableManagerByClassName(viewNode, "vtkMRMLRulerDisplayableManager")
   displayableManager.RemoveAllRulerScalePresets()
   displayableManager.AddRulerScalePreset(   0.001, 5, 2, "nm", 1000.0)
   displayableManager.AddRulerScalePreset(   0.010, 5, 2, "nm", 1000.0)
@@ -1023,8 +1026,9 @@ Displayable managers are responsible for creating VTK filters, mappers, and acto
 Accessing displayable managers is useful for troubleshooting or for testing new features that are not exposed via MRML classes yet, as they provide usually allow low-level access to VTK actors.
 
 ```python
-threeDViewWidget = slicer.app.layoutManager().threeDWidget(0)
-modelDisplayableManager = threeDViewWidget.threeDView().displayableManagerByClassName("vtkMRMLModelDisplayableManager")
+threeDViewNode = slicer.mrmlScene.GetNodeByID("vtkMRMLViewNode1")
+appLogic = slicer.app.applicationLogic()
+modelDisplayableManager = appLogic.GetViewDisplayableManagerByClassName(threeDViewNode, "vtkMRMLModelDisplayableManager")
 if modelDisplayableManager is None:
   logging.error("Failed to find the model displayable manager")
 ```
@@ -1036,8 +1040,9 @@ This example shows how to access and modify VTK actor properties to experiment w
 ```python
 modelNode = slicer.util.getNode("MyModel")
 
-threeDViewWidget = slicer.app.layoutManager().threeDWidget(0)
-modelDisplayableManager = threeDViewWidget.threeDView().displayableManagerByClassName("vtkMRMLModelDisplayableManager")
+threeDViewNode = slicer.mrmlScene.GetNodeByID("vtkMRMLViewNode1")
+appLogic = slicer.app.applicationLogic()
+modelDisplayableManager = appLogic.GetViewDisplayableManagerByClassName(threeDViewNode, "vtkMRMLModelDisplayableManager")
 actor=modelDisplayableManager.GetActorByID(modelNode.GetDisplayNode().GetID())
 property=actor.GetProperty()
 property.SetInterpolationToPBR()
@@ -1111,8 +1116,9 @@ for (shortcutKey, callback) in shortcuts:
 #### Make the 3D view rotate using right-click-and-drag
 
 ```python
-threeDViewWidget = slicer.app.layoutManager().threeDWidget(0)
-cameraDisplayableManager = threeDViewWidget.threeDView().displayableManagerByClassName("vtkMRMLCameraDisplayableManager")
+threeDViewNode = slicer.mrmlScene.GetNodeByID("vtkMRMLViewNode1")
+appLogic = slicer.app.applicationLogic()
+cameraDisplayableManager = appLogic.GetViewDisplayableManagerByClassName(threeDViewNode, "vtkMRMLCameraDisplayableManager")
 cameraWidget = cameraDisplayableManager.GetCameraWidget()
 
 # Remove old mapping from right-click-and-drag
@@ -1129,8 +1135,10 @@ cameraWidget.SetEventTranslationClickAndDrag(cameraWidget.WidgetStateIdle, vtk.v
 ```python
 # Red slice view
 sliceViewLabel = "Red"
-sliceViewWidget = slicer.app.layoutManager().sliceWidget(sliceViewLabel)
-displayableManager = sliceViewWidget.sliceView().displayableManagerByClassName("vtkMRMLCrosshairDisplayableManager")
+sliceViewNode = slicer.mrmlScene.GetNodeByID(f"vtkMRMLSliceNode{sliceViewLabel}")
+appLogic = slicer.app.applicationLogic()
+displayableManager = appLogic.GetViewDisplayableManagerByClassName(sliceViewNode, "vtkMRMLCrosshairDisplayableManager")
+
 widget = displayableManager.GetSliceIntersectionWidget()
 
 # Set crosshair position by left-click
@@ -1146,8 +1154,9 @@ widget.SetEventTranslationClickAndDrag(widget.WidgetStateIdle, vtk.vtkCommand.Le
 
 ```python
 # 3D view
-threeDViewWidget = slicer.app.layoutManager().threeDWidget(0)
-cameraDisplayableManager = threeDViewWidget.threeDView().displayableManagerByClassName("vtkMRMLCameraDisplayableManager")
+threeDViewNode = slicer.mrmlScene.GetNodeByID("vtkMRMLViewNode1")
+appLogic = slicer.app.applicationLogic()
+cameraDisplayableManager = appLogic.GetViewDisplayableManagerByClassName(threeDViewNode, "vtkMRMLCameraDisplayableManager")
 widget = cameraDisplayableManager.GetCameraWidget()
 
 # Set crosshair position by left-click
@@ -1164,8 +1173,9 @@ Makes Ctrl + Right-click-and-drag gesture adjust window/level in red slice view.
 
 ```python
 sliceViewLabel = "Red"
-sliceViewWidget = slicer.app.layoutManager().sliceWidget(sliceViewLabel)
-displayableManager = sliceViewWidget.sliceView().displayableManagerByClassName("vtkMRMLScalarBarDisplayableManager")
+sliceViewNode = slicer.mrmlScene.GetNodeByID(f"vtkMRMLSliceNode{sliceViewLabel}")
+appLogic = slicer.app.applicationLogic()
+displayableManager = appLogic.GetViewDisplayableManagerByClassName(sliceViewNode, "vtkMRMLScalarBarDisplayableManager")
 w = displayableManager.GetWindowLevelWidget()
 w.SetEventTranslationClickAndDrag(w.WidgetStateIdle,
   vtk.vtkCommand.RightButtonPressEvent, vtk.vtkEvent.ControlModifier,

--- a/Docs/developer_guide/script_repository/markups.md
+++ b/Docs/developer_guide/script_repository/markups.md
@@ -810,8 +810,9 @@ Custom actions can be assigned to markups, which can be triggered by any interac
 # 3. Double-click on the markup -> this triggers toggleLabelVisibilty.
 # 4. Hover the mouse over a markup then pressing `q` and `w` keys -> this triggers shrinkControlPoints and growControlPoints.
 
-threeDViewWidget = slicer.app.layoutManager().threeDWidget(0)
-markupsDisplayableManager = threeDViewWidget.threeDView().displayableManagerByClassName('vtkMRMLMarkupsDisplayableManager')
+threeDViewNode = slicer.mrmlScene.GetNodeByID("vtkMRMLViewNode1")
+appLogic = slicer.app.applicationLogic()
+markupsDisplayableManager = appLogic.GetViewDisplayableManagerByClassName(threeDViewNode, "vtkMRMLMarkupsDisplayableManager")
 
 def shrinkControlPoints(caller, eventId):
   markupsDisplayNode = caller

--- a/Docs/developer_guide/script_repository/segmentations.md
+++ b/Docs/developer_guide/script_repository/segmentations.md
@@ -513,8 +513,9 @@ sliceViewLabel = "Red"  # any slice view where segmentation node is visible work
 
 def printSegmentNames(unused1=None, unused2=None):
 
-  sliceViewWidget = slicer.app.layoutManager().sliceWidget(sliceViewLabel)
-  segmentationsDisplayableManager = sliceViewWidget.sliceView().displayableManagerByClassName("vtkMRMLSegmentationsDisplayableManager2D")
+  sliceViewNode = slicer.mrmlScene.GetNodeByID(f"vtkMRMLSliceNode{sliceViewLabel}")
+  appLogic = slicer.app.applicationLogic()
+  segmentationsDisplayableManager = appLogic.GetViewDisplayableManagerByClassName(sliceViewNode, "vtkMRMLSegmentationsDisplayableManager2D")
   ras = [0,0,0]
   pointListNode.GetNthControlPointPositionWorld(0, ras)
   segmentIds = vtk.vtkStringArray()

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -2853,3 +2853,14 @@ vtkMRMLVolumeNode* vtkMRMLSliceLogic::GetFirstVolumeNode()
   }
   return nullptr;
 }
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceLogic::SetDisplayableManagerGroup(vtkObject* obj)
+{
+  if (obj && !obj->IsA("vtkMRMLDisplayableManagerGroup"))
+  {
+    vtkErrorMacro("SetDisplayableManagerGroup: expected vtkMRMLDisplayableManagerGroup");
+    return;
+  }
+  this->DisplayableManagerGroup = obj;
+}

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -34,6 +34,8 @@ class vtkMRMLSliceNode;
 class vtkMRMLVolumeNode;
 
 // VTK includes
+#include <vtkObject.h>
+#include <vtkWeakPointer.h>
 class vtkAlgorithmOutput;
 class vtkCollection;
 class vtkImageBlend;
@@ -379,6 +381,12 @@ public:
   /// Returns false if the information cannot be determined.
   bool GetSliceOffsetRangeResolution(double range[2], double& resolution);
 
+  /// @{
+  /// \brief Get/Set the displayable manager group associated with the logic.
+  vtkGetObjectMacro(DisplayableManagerGroup, vtkObject);
+  void SetDisplayableManagerGroup(vtkObject* obj);
+  /// @}
+
 protected:
   vtkMRMLSliceLogic();
   ~vtkMRMLSliceLogic() override;
@@ -469,6 +477,22 @@ protected:
   vtkMRMLModelDisplayNode* SliceModelDisplayNode;
   vtkMRMLLinearTransformNode* SliceModelTransformNode;
   double SliceSpacing[3];
+
+  // Weak reference to the view's displayable manager group.
+  //
+  // Stored as vtkObject to keep MRMLLogic independent of
+  // MRMLDisplayableManager headers. The expected dynamic type is
+  // vtkMRMLDisplayableManagerGroup.
+  //
+  // Set by the layout factories when the view widget is created, and used by
+  // vtkSlicerApplicationLogic::GetViewDisplayableManagerByClassName() to
+  // resolve managers without Qt. This works because vtkSlicerApplicationLogic
+  // lives in SlicerBaseLogic, which can depend on MRMLDisplayableManager.
+  //
+  // Ownership: the group is owned by the view/widget; this logic holds only a
+  // weak pointer. May be nullptr (e.g., headless or before view creation).
+  // Type is validated in SetDisplayableManagerGroup().
+  vtkWeakPointer<vtkObject> DisplayableManagerGroup;
 
 private:
   vtkMRMLSliceLogic(const vtkMRMLSliceLogic&) = delete;

--- a/Libs/MRML/Logic/vtkMRMLViewLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLViewLogic.cxx
@@ -324,3 +324,14 @@ const char* vtkMRMLViewLogic::GetName() const
 {
   return this->Name.c_str();
 }
+
+//----------------------------------------------------------------------------
+void vtkMRMLViewLogic::SetDisplayableManagerGroup(vtkObject* obj)
+{
+  if (obj && !obj->IsA("vtkMRMLDisplayableManagerGroup"))
+  {
+    vtkErrorMacro("SetDisplayableManagerGroup: expected vtkMRMLDisplayableManagerGroup");
+    return;
+  }
+  this->DisplayableManagerGroup = obj;
+}

--- a/Libs/MRML/Logic/vtkMRMLViewLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLViewLogic.h
@@ -23,6 +23,10 @@
 // MRMLLogic includes
 #include "vtkMRMLAbstractLogic.h"
 
+// VTK includes
+#include <vtkObject.h>
+#include <vtkWeakPointer.h>
+
 // STD includes
 #include <vector>
 #include <deque>
@@ -97,6 +101,12 @@ public:
   /// The name of the Logic is the same of the widget one to which it is associated
   static vtkMRMLCameraNode* GetCameraNode(vtkMRMLScene* scene, const char* layoutName);
 
+  /// @{
+  /// \brief Get/Set the displayable manager group associated with the logic.
+  vtkGetObjectMacro(DisplayableManagerGroup, vtkObject);
+  void SetDisplayableManagerGroup(vtkObject* obj);
+  /// @}
+
 protected:
   vtkMRMLViewLogic();
   ~vtkMRMLViewLogic() override;
@@ -117,6 +127,22 @@ protected:
   vtkMRMLViewNode* ViewNode;
   vtkMRMLCameraNode* CameraNode;
   bool UpdatingMRMLNodes;
+
+  // Weak reference to the view's displayable manager group.
+  //
+  // Stored as vtkObject to keep MRMLLogic independent of
+  // MRMLDisplayableManager headers. The expected dynamic type is
+  // vtkMRMLDisplayableManagerGroup.
+  //
+  // Set by the layout factories when the view widget is created, and used by
+  // vtkSlicerApplicationLogic::GetViewDisplayableManagerByClassName() to
+  // resolve managers without Qt. This works because vtkSlicerApplicationLogic
+  // lives in SlicerBaseLogic, which can depend on MRMLDisplayableManager.
+  //
+  // Ownership: the group is owned by the view/widget; this logic holds only a
+  // weak pointer. May be nullptr (e.g., headless or before view creation).
+  // Type is validated in SetDisplayableManagerGroup().
+  vtkWeakPointer<vtkObject> DisplayableManagerGroup;
 
 private:
   vtkMRMLViewLogic(const vtkMRMLViewLogic&) = delete;

--- a/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
@@ -39,6 +39,9 @@
 #include <qMRMLThreeDView.h>
 #include <qMRMLThreeDWidget.h>
 
+// MRMLDisplayableManager includes
+#include <vtkMRMLDisplayableManagerGroup.h>
+
 // MRMLLogic includes
 #include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLColorLogic.h>
@@ -106,6 +109,9 @@ QWidget* qMRMLLayoutThreeDViewFactory::createViewFromNode(vtkMRMLAbstractViewNod
   threeDWidget->setMRMLViewNode(vtkMRMLViewNode::SafeDownCast(viewNode));
 
   this->viewLogics()->AddItem(threeDWidget->viewLogic());
+
+  // Associate logic with its matching displayable manager group
+  threeDWidget->viewLogic()->SetDisplayableManagerGroup(threeDWidget->threeDView()->displayableManagerGroup());
 
   return threeDWidget;
 }
@@ -259,6 +265,9 @@ QWidget* qMRMLLayoutSliceViewFactory::createViewFromNode(vtkMRMLAbstractViewNode
   // initialize new views when switching to a new view layout that has more slice views.
   sliceWidget->setSliceLogics(this->sliceLogics());
   this->sliceLogics()->AddItem(sliceWidget->sliceLogic());
+
+  // Associate logic with its matching displayable manager group
+  sliceWidget->sliceLogic()->SetDisplayableManagerGroup(sliceWidget->sliceView()->displayableManagerGroup());
 
   sliceWidget->sliceController()->setControllerButtonGroup(this->SliceControllerButtonGroup);
   sliceWidget->setObjectName(QString("qMRMLSliceWidget%1").arg(viewNode->GetLayoutName()));

--- a/Libs/MRML/Widgets/qMRMLSliceView.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceView.cxx
@@ -505,3 +505,10 @@ void qMRMLSliceView::dropEvent(QDropEvent* event)
   }
   shNode->ShowItemsInView(shItemIdList, this->mrmlSliceNode());
 }
+
+//---------------------------------------------------------------------------
+vtkMRMLDisplayableManagerGroup* qMRMLSliceView::displayableManagerGroup() const
+{
+  Q_D(const qMRMLSliceView);
+  return d->DisplayableManagerGroup;
+}

--- a/Libs/MRML/Widgets/qMRMLSliceView.h
+++ b/Libs/MRML/Widgets/qMRMLSliceView.h
@@ -31,6 +31,7 @@ class QDropEvent;
 class qMRMLSliceViewPrivate;
 class vtkCollection;
 class vtkMRMLAbstractDisplayableManager;
+class vtkMRMLDisplayableManagerGroup;
 class vtkMRMLScene;
 class vtkMRMLSliceNode;
 class vtkMRMLSliceViewInteractorStyle;
@@ -117,6 +118,10 @@ public slots:
 
   /// Set the current \a viewNode to observe
   void setMRMLSliceNode(vtkMRMLSliceNode* newSliceNode);
+
+protected:
+  friend class qMRMLLayoutSliceViewFactory;
+  vtkMRMLDisplayableManagerGroup* displayableManagerGroup() const;
 
 private:
   Q_DECLARE_PRIVATE(qMRMLSliceView);

--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -655,3 +655,10 @@ void qMRMLThreeDView::setAmbientShadowsIntensityShift(double intensityShift)
   Q_D(const qMRMLThreeDView);
   d->ShadowsRenderPass->SetIntensityShift(intensityShift);
 }
+
+//---------------------------------------------------------------------------
+vtkMRMLDisplayableManagerGroup* qMRMLThreeDView::displayableManagerGroup() const
+{
+  Q_D(const qMRMLThreeDView);
+  return d->DisplayableManagerGroup;
+}

--- a/Libs/MRML/Widgets/qMRMLThreeDView.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.h
@@ -30,6 +30,7 @@
 class QDropEvent;
 class qMRMLThreeDViewPrivate;
 class vtkMRMLAbstractDisplayableManager;
+class vtkMRMLDisplayableManagerGroup;
 class vtkMRMLCameraNode;
 class vtkMRMLScene;
 class vtkMRMLThreeDViewInteractorStyle;
@@ -153,6 +154,10 @@ public slots:
   void setAmbientShadowsVolumeOpacityThreshold(double);
   void setAmbientShadowsIntensityScale(double);
   void setAmbientShadowsIntensityShift(double);
+
+protected:
+  friend class qMRMLLayoutThreeDViewFactory;
+  vtkMRMLDisplayableManagerGroup* displayableManagerGroup() const;
 
 private:
   Q_DECLARE_PRIVATE(qMRMLThreeDView);

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
@@ -93,6 +93,7 @@
 #include "qMRMLThreeDWidget.h"
 #include "qSlicerLayoutManager.h"
 #include "qSlicerApplication.h"
+#include "vtkSlicerApplicationLogic.h"
 #include "vtkMRMLSliceLogic.h"
 #include "vtkMRMLSliceLayerLogic.h"
 #include "vtkOrientedImageDataResample.h"
@@ -883,9 +884,16 @@ std::string qSlicerSegmentEditorPaintEffectPrivate::segmentAtPosition(qMRMLWidge
     return selectedSegmentID;
   }
 
+  vtkSlicerApplicationLogic* appLogic = qSlicerApplication::application()->applicationLogic();
+  if (!appLogic)
+  {
+    return selectedSegmentID;
+  }
+
   // Get slice displayable manager
+  vtkMRMLAbstractViewNode* viewNode = sliceWidget->mrmlSliceNode();
   vtkMRMLSegmentationsDisplayableManager2D* segmentationDisplayableManager2D =
-    vtkMRMLSegmentationsDisplayableManager2D::SafeDownCast(sliceWidget->sliceView()->displayableManagerByClassName("vtkMRMLSegmentationsDisplayableManager2D"));
+    vtkMRMLSegmentationsDisplayableManager2D::SafeDownCast(appLogic->GetViewDisplayableManagerByClassName(viewNode, "vtkMRMLSegmentationsDisplayableManager2D"));
   if (!segmentationDisplayableManager2D)
   {
     return selectedSegmentID;

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -2841,19 +2841,24 @@ void qMRMLSegmentEditorWidget::processEvents(vtkObject* caller, unsigned long ei
     return;
   }
 
+  vtkSlicerApplicationLogic* appLogic = qSlicerApplication::application()->applicationLogic();
+  if (!appLogic)
+  {
+    return;
+  }
+
   // Call processing function of active effect. Handle both interactor and view node events
   vtkRenderWindowInteractor* callerInteractor = vtkRenderWindowInteractor::SafeDownCast(caller);
   vtkMRMLAbstractViewNode* callerViewNode = vtkMRMLAbstractViewNode::SafeDownCast(caller);
-  if (callerInteractor)
+  if (callerInteractor != nullptr)
   {
-
     // Do not process events while a touch gesture is in progress (e.g., do not paint in the view
     // while doing multi-touch pinch/rotate).
     qMRMLSliceWidget* sliceWidget = qobject_cast<qMRMLSliceWidget*>(viewWidget);
     if (sliceWidget)
     {
       vtkMRMLCrosshairDisplayableManager* crosshairDisplayableManager =
-        vtkMRMLCrosshairDisplayableManager::SafeDownCast(sliceWidget->sliceView()->displayableManagerByClassName("vtkMRMLCrosshairDisplayableManager"));
+        vtkMRMLCrosshairDisplayableManager::SafeDownCast(appLogic->GetViewDisplayableManagerByClassName(sliceWidget->mrmlSliceNode(), "vtkMRMLCrosshairDisplayableManager"));
       if (crosshairDisplayableManager)
       {
         int widgetState = crosshairDisplayableManager->GetSliceIntersectionWidget()->GetWidgetState();
@@ -2863,11 +2868,12 @@ void qMRMLSegmentEditorWidget::processEvents(vtkObject* caller, unsigned long ei
         }
       }
     }
+
     qMRMLThreeDWidget* threeDWidget = qobject_cast<qMRMLThreeDWidget*>(viewWidget);
     if (threeDWidget)
     {
       vtkMRMLCameraDisplayableManager* cameraDisplayableManager =
-        vtkMRMLCameraDisplayableManager::SafeDownCast(threeDWidget->threeDView()->displayableManagerByClassName("vtkMRMLCameraDisplayableManager"));
+        vtkMRMLCameraDisplayableManager::SafeDownCast(appLogic->GetViewDisplayableManagerByClassName(threeDWidget->mrmlViewNode(), "vtkMRMLCameraDisplayableManager"));
       if (cameraDisplayableManager)
       {
         int widgetState = cameraDisplayableManager->GetCameraWidget()->GetWidgetState();
@@ -2886,7 +2892,7 @@ void qMRMLSegmentEditorWidget::processEvents(vtkObject* caller, unsigned long ei
       callbackCommand->SetAbortFlag(1);
     }
   }
-  else if (callerViewNode)
+  else if (callerViewNode != nullptr)
   {
     activeEffect->processViewNodeEvents(callerViewNode, eid, viewWidget);
   }


### PR DESCRIPTION
This adds `vtkSlicerApplicationLogic::GetViewDisplayableManagerByClassName` to access a view’s displayable manager by class name without relying on Qt view classes. The layout factories now propagate each view’s `vtkMRMLDisplayableManagerGroup` into the corresponding MRML logic (`vtkMRMLSliceLogic` / `vtkMRMLViewLogic`), which keeps a weak reference.

Motivation: decouple effects and scripts from Qt to support headless and trame-backed frontends.

Key changes:
- Base/Logic links against `MRMLDisplayableManager` and includes headers.
- Add `DisplayableManagerGroup` setters/getters to Slice/View logics with type validation.
- Refactor Segment Editor and Subject Hierarchy code paths to use the new ApplicationLogic API.
- Update developer docs and script repository examples accordingly.

Notes:
- Returns nullptr if inputs are invalid or the manager is not present. The returned pointer is owned by the displayable manager group.
- Existing Qt-based retrieval continues to work.