### PR TITLE
DOC: Reference "Code of Conduct" in Governance section and Update contribution processes

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,15 @@
 
 # Contributor Covenant Code of Conduct
 
+<!--
+  Note: The sections below use "##" headings intentionally.
+  This ensures correct nesting when included in other documents (e.g., about.md)
+  with a specified heading-offset.
+  Do not modify heading levels unless all dependent includes are updated accordingly.
+-->
+
+<!-- code-of-conduct-start -->
+
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in our
@@ -91,3 +100,5 @@ see https://github.com/Slicer/Slicer/commits/main/CODE_OF_CONDUCT.md.
 [Mozilla CoC]: https://github.com/mozilla/diversity
 [FAQ]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations
+
+<!-- code-of-conduct-end -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders listed
-[here](https://github.com/Slicer/Slicer/blob/master/CONTRIBUTING.md#benevolent-dictators-for-life)
+[here](https://github.com/Slicer/Slicer/blob/master/GOVERNANCE.md#benevolent-dictators-for-life)
 via private message on the [Slicer forum](https://discourse.slicer.org).
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,9 +105,9 @@ Getting your contributions integrated is relatively straightforward, here
 is the checklist:
 
 * All tests pass
-* Consensus is reached. This usually means that at least two reviewers approved
-  the changes (or added a `LGTM` comment) and at least one business day passed
-  without anyone objecting. `LGTM` is an acronym for _Looks Good to Me_.
+* Consensus is reached. This usually means that at least one reviewers approved
+  the changes and at least one business day passed
+  without anyone objecting.
 * To accommodate developers explicitly asking for more time to test the
   proposed changes, integration time can be delayed by few more days.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,4 @@
-Contributing to Slicer
-======================
+# Contributing to Slicer
 
 There are many ways to contribute to Slicer, with varying levels of effort.  Do try to
 look through the [documentation](https://slicer.readthedocs.io/en/latest/index.html) first if something is unclear, and let us know how we can
@@ -12,8 +11,7 @@ do better.
 We encourage a range of Pull Requests, from patches that include passing tests and
 documentation, all the way down to half-baked ideas that launch discussions.
 
-The PR Process, Circle CI, and Related Gotchas
-----------------------------------------------
+## Submitting a Pull Request
 
 ### How to submit a PR ?
 
@@ -120,15 +118,14 @@ is the checklist:
 
 ### Automatic testing of pull requests
 
-Every pull request is tested automatically using CircleCI each time you push a
-commit to it. The Github UI will restrict users from merging pull requests until
-the CI build has returned with a successful result indicating that all tests have
-passed.
+Every pull request (PR) is automatically tested using GitHub Actions each time a
+commit is pushed. The GitHub interface prevents merging until all required CI workflows
+have completed successfully, ensuring that changes meet the project’s testing and
+quality standards.
 
-The testing infrastructure is described in details in the
-[3D Slicer Improves Testing for Pull Requests Using Docker and CircleCI](https://blog.kitware.com/3d-slicer-improves-testing-for-pull-requests-using-docker-and-circleci/)
-blog post.
-
+The testing infrastructure was migrated from CircleCI to GitHub Actions, but the
+principles described in the blog post [3D Slicer Improves Testing for Pull Requests Using Docker and CircleCI](https://blog.kitware.com/3d-slicer-improves-testing-for-pull-requests-using-docker-and-circleci/)
+remain relevant for understanding the overall approach and concepts.
 
 ### Nightly tests
 

--- a/Docs/user_guide/about.md
+++ b/Docs/user_guide/about.md
@@ -211,11 +211,29 @@ _Listed in alphabetical order._
 
 ## Governance
 
-This section outlines the governance model for the Slicer project, including how decisions are made and who is responsible for maintaining the health of the project.
+This section introduces the guiding principles and decision-making framework of the
+Slicer project, including the Code of Conduct and governance model that describe how
+decisions are made and who is responsible for maintaining the health of the project.
+
+### Code of Conduct
+
+The Slicer community is committed to fostering a welcoming, respectful, and
+inclusive environment. Details are outlined in the Code of Conduct below.
 
 <!--
-  Notes: Includes GOVERNANCE.md content, excluding its top-level header
+  Notes: Includes CODE_OF_CONDUCT.md content, excluding its top-level header
   and intro.
+-->
+
+```{include} ../../CODE_OF_CONDUCT.md
+:start-after: <!-- code-of-conduct-start -->
+:end-before: <!-- code-of-conduct-end -->
+:heading-offset: 2
+```
+
+<!--
+  Notes: Includes GOVERNANCE.md content, excluding the top-level header, intro,
+  and the Code of Conduct section (already included above).
 -->
 
 ```{include} ../../GOVERNANCE.md

--- a/Docs/user_guide/about.md
+++ b/Docs/user_guide/about.md
@@ -213,9 +213,15 @@ _Listed in alphabetical order._
 
 This section outlines the governance model for the Slicer project, including how decisions are made and who is responsible for maintaining the health of the project.
 
+<!--
+  Notes: Includes GOVERNANCE.md content, excluding its top-level header
+  and intro.
+-->
+
 ```{include} ../../GOVERNANCE.md
 :start-after: <!-- governance-start -->
 :end-before: <!-- governance-end -->
+:heading-offset: 1
 ```
 
 ## Contact us

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -57,3 +57,15 @@ BDFL.
 [slicer-forum]: https://discourse.slicer.org
 
 <!-- governance-end -->
+
+<!--
+  Note: The "Code of Conduct" section below is intentionally excluded from the
+  governance-[start|end] include markers, since the Code of Conduct is already
+  included explicitly in docs/user_guide/about.md.
+-->
+
+## Code of Conduct
+
+Participation in the Slicer community is governed by the principles outlined in our
+[Code of Conduct](CODE_OF_CONDUCT.md). All community members, contributors, and leaders are expected
+to uphold these standards to foster a welcoming, respectful, and inclusive environment.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -3,14 +3,15 @@
 This document outlines the governance model for the Slicer project, including how decisions are made and who is responsible for maintaining the health of the project.
 
 <!--
-  The sections below start with ### headers to ensure proper nesting
-  when this content is included under a ## heading (e.g., in about.md).
-  Do not change header levels unless updating all dependent includes.
+  Note: The sections below use "##" headings intentionally.
+  This ensures correct nesting when included in other documents (e.g., about.md)
+  with a specified heading-offset.
+  Do not modify heading levels unless all dependent includes are updated accordingly.
 -->
 
 <!-- governance-start -->
 
-### Decision-making process
+## Decision-making process
 
 1. Given the topic of interest, initiate discussion on the [Slicer forum][slicer-forum].
 
@@ -34,7 +35,7 @@ This document outlines the governance model for the Slicer project, including ho
 *The initial version of these guidelines was established during the [winter
  project week 2017](https://www.na-mic.org/Wiki/index.php/2017_Winter_Project_Week/UpdatingCommunityForums).*
 
-### Benevolent dictators for life
+## Benevolent dictators for life
 
 The [benevolent dictators](https://slicer.readthedocs.io/en/latest/user_guide/about.html#benevolent-dictators-for-life) can
 integrate changes to keep the platform healthy and help interpret


### PR DESCRIPTION
Key changes include:
- Correcting the BDFL reference in `CODE_OF_CONDUCT.md`
- Simplifying the integration of `GOVERNANCE.md` content in `about.md` using the `heading-offset` option for the `include` directive.
- Adding a dedicated "Code of Conduct" subsection to the About page.
- Updating the `CONTRIBUTING.md` file to reference GitHub Actions for CI testing.
- Reflecting the current review process in `CONTRIBUTING.md`, specifying that at least one review approval is required.
