### PR TITLE
ENH: Match color label title font size to legend font size

### DIFF
--- a/Modules/Loadable/Colors/VTKWidgets/vtkSlicerScalarBarActor.cxx
+++ b/Modules/Loadable/Colors/VTKWidgets/vtkSlicerScalarBarActor.cxx
@@ -278,7 +278,11 @@ void vtkSlicerScalarBarActor::LayoutTicks()
       targetHeight = this->P->TickBox.Size[0];
     }
 
-    vtkTextActor::SetMultipleConstrainedFontSize(this->P->Viewport, targetWidth, targetHeight, this->P->TextActors.PointerArray(), this->NumberOfLabels, labelSize);
+    int fontSize = vtkTextActor::SetMultipleConstrainedFontSize(this->P->Viewport, targetWidth, targetHeight, this->P->TextActors.PointerArray(), this->NumberOfLabels, labelSize);
+
+    // Match the font size of the title actor
+    this->TitleTextProperty->SetFontSize(fontSize);
+    this->TitleActor->GetTextProperty()->ShallowCopy(this->TitleTextProperty);
 
     // Now adjust scalar bar size by the half-size of the first and last ticks
     this->P->ScalarBarBox.Posn[this->P->TL[1]] += labelSize[this->P->TL[1]] / 2.;


### PR DESCRIPTION
Previously, the title actor font size was not updated, even as the legend font size changed with viewport size. This commit applies the same font size to both the title and legend actors.

See: https://github.com/Slicer/Slicer/issues/6111#issuecomment-1500592494

Previously:
<img width="833" height="541" alt="image" src="https://github.com/user-attachments/assets/6609681a-b2fb-4426-bfca-14b5acbc7251" />

Now:
<img width="832" height="544" alt="image" src="https://github.com/user-attachments/assets/c309efa8-ed31-4d2d-a63b-bfc5dfa0dd1e" />
