### PR TITLE
ENH: Restore OpenGL core profile usage on Windows platform

### DIFF
--- a/Libs/MRML/Widgets/qMRMLWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLWidget.cxx
@@ -91,23 +91,8 @@ void qMRMLWidget::preInitializeApplication()
 
   QString openGLProfileStr = qgetenv(MRML_APPLICATION_OPENGL_PROFILE_ENV);
   openGLProfileStr = openGLProfileStr.toLower();
-  if (openGLProfileStr.isEmpty() || openGLProfileStr == "default")
+  if (!openGLProfileStr.isEmpty() && openGLProfileStr != "default")
   {
-    // Use default profile
-#ifdef _WIN32
-    // Enable OpenGL compatibility profile on Windows.
-    // It fixes display update issues and should not have any
-    // side effect.
-    // Compatibility profile is only requested for Windows, as it is
-    // not fully supported on Mac, and there is no known issue
-    // on Linux that would require requesting compatibility profile.
-    // More details: https://gitlab.kitware.com/vtk/vtk/issues/17572
-    format.setProfile(QSurfaceFormat::CompatibilityProfile);
-#endif
-  }
-  else
-  {
-    // Force a specific profile
     if (openGLProfileStr == "no")
     {
       format.setProfile(QSurfaceFormat::NoProfile);
@@ -119,6 +104,12 @@ void qMRMLWidget::preInitializeApplication()
     else if (openGLProfileStr == "compatibility")
     {
       format.setProfile(QSurfaceFormat::CompatibilityProfile);
+    }
+    else
+    {
+      qCritical("Invalid OpenGL profile option '%s' set in %s. Valid options are: 'default', 'no', 'core', 'compatibility'.",
+                qPrintable(openGLProfileStr),
+                MRML_APPLICATION_OPENGL_PROFILE_ENV);
     }
   }
 


### PR DESCRIPTION
This closes #8647.

This is a follow-up to https://github.com/Slicer/Slicer/commit/47e89f94da6c8c8faa55de1ddcb50b5608d92a2f which removes the workaround that was setting the OpenGL compatibility profile as default on the Windows platform. The original rendering issues on Intel integrated graphics while use the OpenGL core profile appear to happen less often. Removing the workaround is motivated by rendering issues observed when Nvidia GPUs using the compatibility profile faced rendering issues related to Plot Markers which were not issues upon switching to the core profile.

See https://github.com/Slicer/Slicer/issues/8647#issuecomment-3203747715 for more details.