### PR TITLE
STYLE: Normalize insertion of braces after control statements

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,6 +15,7 @@ AlwaysBreakTemplateDeclarations: true
 BreakBeforeBinaryOperators: NonAssignment
 ConstructorInitializerIndentWidth: 2
 IndentPPDirectives: AfterHash
+InsertBraces: true
 PackConstructorInitializers: Never
 PPIndentWidth: 1
 

--- a/Base/Logic/vtkImageFillROI.cxx
+++ b/Base/Logic/vtkImageFillROI.cxx
@@ -669,7 +669,9 @@ static void vtkImageFillROIExecute(vtkImageFillROI* self, vtkImageData* outData,
 
   vtkPoints* points = self->GetPoints();
   if (points == nullptr)
+  {
     return;
+  }
 
   outData->GetExtent(outExt);
   nx = outExt[1] - outExt[0] + 1;
@@ -679,7 +681,9 @@ static void vtkImageFillROIExecute(vtkImageFillROI* self, vtkImageData* outData,
   // Convert to int
   nPts = points->GetNumberOfPoints();
   if (nPts == 0)
+  {
     return;
+  }
   xPts = new int[nPts];
   yPts = new int[nPts];
   for (i = 0, j = 0; i < nPts; i++)

--- a/Base/Logic/vtkImageFillROI.h
+++ b/Base/Logic/vtkImageFillROI.h
@@ -63,11 +63,17 @@ public:
   void SetShapeString(const char* str)
   {
     if (strcmp(str, "Polygon") == 0)
+    {
       this->SetShapeToPolygon();
+    }
     else if (strcmp(str, "Lines") == 0)
+    {
       this->SetShapeToLines();
+    }
     else
+    {
       this->SetShapeToPoints();
+    }
   }
 
   vtkSetMacro(Radius, int);

--- a/Base/Logic/vtkImageRectangularSource.cxx
+++ b/Base/Logic/vtkImageRectangularSource.cxx
@@ -44,7 +44,9 @@ vtkImageRectangularSource::~vtkImageRectangularSource()
   if (this->Corners)
   {
     for (int i = 0; i < 4; i++)
+    {
       delete[] this->Corners[i];
+    }
     delete[] this->Corners;
     this->Corners = nullptr;
   }
@@ -125,7 +127,9 @@ void vtkImageRectangularSource::SetCorners(int x1, int y1, int x2, int y2, int x
   assert(!this->Corners);
   this->Corners = new int*[4];
   for (int i = 0; i < 4; i++)
+  {
     this->Corners[i] = new int[2];
+  }
   this->Corners[0][0] = x1;
   this->Corners[0][1] = y1;
 
@@ -162,7 +166,9 @@ void vtkImageRectangularSourceExecute(vtkImageRectangularSource* self, vtkImageD
   {
     Min[i] = center[i] - size[i] / 2;
     if (Min[i] <= ext[2 * i])
+    {
       Min[i] = ext[2 * i];
+    }
     Max[i] = center[i] + size[i] / 2 + 1;
   }
   data->GetContinuousIncrements(ext, inc0, inc1, inc2);
@@ -174,27 +180,41 @@ void vtkImageRectangularSourceExecute(vtkImageRectangularSource* self, vtkImageD
   for (idx2 = ext[4]; idx2 <= ext[5]; ++idx2)
   {
     if (idx2 == Min[2])
+    {
       InFlag[2] = 1;
+    }
     else if (idx2 == Max[2])
+    {
       InFlag[2] = 0;
+    }
     InFlag[1] = 0;
     for (idx1 = ext[2]; !self->AbortExecute && idx1 <= ext[3]; ++idx1)
     {
       if (!(count % target))
+      {
         self->UpdateProgress(count / (50.0 * target));
+      }
       count++;
       if (idx1 == Min[1])
+      {
         InFlag[1] = InFlag[2];
+      }
       else if (idx1 == Max[1])
+      {
         InFlag[1] = 0;
+      }
       InFlag[0] = 0;
       for (idx0 = ext[0]; idx0 <= ext[1]; ++idx0)
       {
         // handle divide by zero
         if (idx0 == Min[0])
+        {
           InFlag[0] = InFlag[1];
+        }
         else if (idx0 == Max[0])
+        {
           InFlag[0] = 0;
+        }
         if (InFlag[0])
         {
           if (InsideGraySlopeFlag && size[0])
@@ -203,10 +223,14 @@ void vtkImageRectangularSourceExecute(vtkImageRectangularSource* self, vtkImageD
             *ptr = T((1.0 - grad) * double(inVal)) + T(grad * double(outVal));
           }
           else
+          {
             *ptr = inVal;
+          }
         }
         else
+        {
           *ptr = outVal;
+        }
         ++ptr;
         // inc0 is 0
       }
@@ -275,7 +299,9 @@ int DefineX(int* c1, int* c2, int y)
 {
   assert(c1[1] != c2[1]);
   if ((Min(c1[1], c2[1]) > y) || (Max(c1[1], c2[1]) < y))
+  {
     return -1;
+  }
 
   double lenY = c2[1] - c1[1];
   int lenX = c2[0] - c1[0];
@@ -295,24 +321,36 @@ template <class T>
 void DefineLine(int MinInX, int MaxInX, int LineLength, T inVal, T outVal, int InsideGraySlopeFlag, T* Result)
 {
   if (MinInX >= LineLength || MaxInX < 0 || MinInX > MaxInX)
+  {
     MinInX = LineLength;
+  }
   for (int x = 0; x < MinInX; x++)
+  {
     *Result++ = outVal;
+  }
   // We already went through entire image
   if (MinInX == LineLength)
+  {
     return;
+  }
 
   if (MinInX < 0)
+  {
     MinInX = 0;
+  }
   if (MaxInX >= LineLength)
+  {
     MaxInX = LineLength - 1;
+  }
 
   int inLength = MaxInX - MinInX + 1;
   double inCenter = double(MinInX) + double(inLength) / 2.0;
 
   // Otherwise everything is just black
   if (inLength < 2)
+  {
     InsideGraySlopeFlag = 0;
+  }
 
   for (int x = MinInX; x <= MaxInX; x++)
   {
@@ -321,11 +359,15 @@ void DefineLine(int MinInX, int MaxInX, int LineLength, T inVal, T outVal, int I
       *Result++ = CalculateGraySlope(inLength, inCenter, x, inVal, outVal);
     }
     else
+    {
       *Result++ = inVal;
+    }
   }
 
   for (int x = MaxInX + 1; x < LineLength; x++)
+  {
     *Result++ = outVal;
+  }
 }
 
 void DefineXMinMaxInTriangleNormal(int* c1, int* c2, int* c3, int y, int& MinX, int& MaxX)
@@ -350,10 +392,14 @@ void DefineXMinMaxInTriangleNormal(int* c1, int* c2, int* c3, int y, int& MinX, 
       return;
     }
     else
+    {
       x1 = -1;
+    }
   }
   else
+  {
     x1 = DefineX(c1, c2, y);
+  }
 
   if (c2[1] == c3[1])
   {
@@ -364,10 +410,14 @@ void DefineXMinMaxInTriangleNormal(int* c1, int* c2, int* c3, int y, int& MinX, 
       return;
     }
     else
+    {
       x2 = -1;
+    }
   }
   else
+  {
     x2 = DefineX(c2, c3, y);
+  }
 
   if (c1[1] == c3[1])
   {
@@ -378,10 +428,14 @@ void DefineXMinMaxInTriangleNormal(int* c1, int* c2, int* c3, int y, int& MinX, 
       return;
     }
     else
+    {
       x3 = -1;
+    }
   }
   else
+  {
     x3 = DefineX(c1, c3, y);
+  }
   // One of them has to be -1
   int xBlub;
 
@@ -389,24 +443,34 @@ void DefineXMinMaxInTriangleNormal(int* c1, int* c2, int* c3, int y, int& MinX, 
 
   // Special Case when all three lines have input
   if ((MinX == MaxX) && (xBlub > -1))
+  {
     MinX = xBlub;
+  }
 }
 
 void DefineXMinMaxInTriangle(int* c1, int* c2, int* c3, int y, int& MinX, int& MaxX)
 {
   DefineXMinMaxInTriangleNormal(c1, c2, c3, y, MinX, MaxX);
   if (MinX != MaxX)
+  {
     return;
+  }
 
   // When we are at a corners make sure that the piece is connected
   int MinX1, MaxX1;
   DefineXMinMaxInTriangleNormal(c1, c2, c3, y + 1, MinX1, MaxX1);
   if (MaxX1 < 0)
+  {
     DefineXMinMaxInTriangleNormal(c1, c2, c3, y - 1, MinX1, MaxX1);
+  }
   if (MaxX1 < 0)
+  {
     return;
+  }
   if (!(MaxX1 - MinX1))
+  {
     return;
+  }
 
   if (MinX < MinX1)
   {
@@ -415,7 +479,9 @@ void DefineXMinMaxInTriangle(int* c1, int* c2, int* c3, int y, int& MinX, int& M
   }
 
   if (MaxX > MaxX1)
+  {
     MinX = MaxX1 - 1;
+  }
   return;
 }
 
@@ -426,7 +492,9 @@ void DefineSlice(int** Corners, int RowLength, int LineLength, T inVal, T outVal
   int MaxInY = Max(Corners[0][1], Corners[1][1], Corners[2][1], Corners[3][1]);
 
   if (MinInY >= RowLength || MaxInY < 0 || MinInY > MaxInY)
+  {
     MinInY = RowLength;
+  }
   // Outside
   for (int y = 0; y < MinInY; y++)
   {
@@ -434,12 +502,18 @@ void DefineSlice(int** Corners, int RowLength, int LineLength, T inVal, T outVal
     Result += RowLength + IncResultY;
   }
   if (MinInY == RowLength)
+  {
     return;
+  }
 
   if (MinInY < 0)
+  {
     MinInY = 0;
+  }
   if (MaxInY >= RowLength)
+  {
     MaxInY = RowLength - 1;
+  }
 
   int inMinX1, inMinX2, inMaxX1, inMaxX2;
 
@@ -450,9 +524,13 @@ void DefineSlice(int** Corners, int RowLength, int LineLength, T inVal, T outVal
     DefineXMinMaxInTriangle(Corners[0], Corners[1], Corners[3], y, inMinX1, inMaxX1);
     DefineXMinMaxInTriangle(Corners[1], Corners[2], Corners[3], y, inMinX2, inMaxX2);
     if (inMaxX1 < 0)
+    {
       DefineLine(inMinX2, inMaxX2, LineLength, inVal, outVal, InsideGraySlopeFlag, Result);
+    }
     else if (inMaxX2 < 0)
+    {
       DefineLine(inMinX1, inMaxX1, LineLength, inVal, outVal, InsideGraySlopeFlag, Result);
+    }
     else
     {
 
@@ -461,14 +539,18 @@ void DefineSlice(int** Corners, int RowLength, int LineLength, T inVal, T outVal
         DefineLine(inMinX1, inMinX2 - 1, LineLength, inVal, outVal, InsideGraySlopeFlag, Result);
         int inMaxX3 = inMaxX1 - inMaxX2 - 1;
         if (inMaxX3 > -1)
+        {
           DefineLine(0, inMaxX3, LineLength, inVal, outVal, InsideGraySlopeFlag, Result + (inMaxX2 + 1));
+        }
       }
       else if ((inMinX2 <= inMinX1) && (inMaxX1 <= inMaxX2))
       {
         DefineLine(inMinX2, inMinX1 - 1, LineLength, inVal, outVal, InsideGraySlopeFlag, Result);
         int inMaxX3 = inMaxX2 - inMaxX1 - 1;
         if (inMaxX3 > -1)
+        {
           DefineLine(0, inMaxX3, LineLength, inVal, outVal, InsideGraySlopeFlag, Result + (inMaxX1 + 1));
+        }
       }
       else
       {

--- a/Base/QTGUI/qSlicerModuleFactoryFilterModel.cxx
+++ b/Base/QTGUI/qSlicerModuleFactoryFilterModel.cxx
@@ -360,7 +360,9 @@ bool qSlicerModuleFactoryFilterModel::dropMimeData(const QMimeData* data, Qt::Dr
   Q_D(qSlicerModuleFactoryFilterModel);
   // check if the action is supported
   if (!data || !(action == Qt::CopyAction))
+  {
     return false;
+  }
   // check if the format is supported
   QString format = QLatin1String("application/x-qstandarditemmodeldatalist");
   if (!data->hasFormat(format))

--- a/Libs/MRML/Core/Testing/vtkArchiveTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkArchiveTest1.cxx
@@ -26,13 +26,21 @@
 bool validFile(const char* fileName)
 {
   if (!strcmp(fileName, "."))
+  {
     return true;
+  }
   if (!strcmp(fileName, ".."))
+  {
     return true;
+  }
   if (!strcmp(fileName, "vol.mrml"))
+  {
     return true;
+  }
   if (!strcmp(fileName, "vol_and_cube.mrml"))
+  {
     return true;
+  }
   return false;
 }
 
@@ -94,7 +102,9 @@ int vtkArchiveTest1(int argc, char* argv[])
   {
     std::cout << "Extracted file: " << cwd.GetFile(i) << std::endl;
     if (validFile(cwd.GetFile(i)))
+    {
       validFiles++;
+    }
   }
 
   if (validFiles != 4)
@@ -159,7 +169,9 @@ int vtkArchiveTest1(int argc, char* argv[])
   {
     std::cerr << "Extracted file: " << cwd.GetFile(i) << std::endl;
     if (validFile(cwd.GetFile(i)))
+    {
       validFiles++;
+    }
   }
 
   if (validFiles != 4)

--- a/Libs/MRML/Core/Testing/vtkMRMLVolumeNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLVolumeNodeTest1.cxx
@@ -89,8 +89,12 @@ int vtkMRMLVolumeNodeTest1(int, char*[])
   // IJKToRASDirections
   double dirs[3][3];
   for (int i = 0; i < 3; i++)
+  {
     for (int j = 0; j < 3; j++)
+    {
       dirs[i][j] = 0.0;
+    }
+  }
   dirs[0][0] = 1;
   dirs[1][1] = 1;
   dirs[2][2] = 1;

--- a/Libs/MRML/Core/vtkEventBroker.h
+++ b/Libs/MRML/Core/vtkEventBroker.h
@@ -195,9 +195,13 @@ public:
   const char* GetEventModeAsString()
   {
     if (this->EventMode == vtkEventBroker::Synchronous)
+    {
       return ("Synchronous");
+    }
     if (this->EventMode == vtkEventBroker::Asynchronous)
+    {
       return ("Asynchronous");
+    }
     return "Undefined";
   }
 

--- a/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
@@ -320,11 +320,17 @@ int vtkMRMLColorTableStorageNode::ReadCsvFile(std::string fullFileName, vtkMRMLC
   auto GetIndexInEntryForIdType = [](std::string idType)
   {
     if (idType == "CodingScheme")
+    {
       return 0;
+    }
     else if (idType == "CodeValue")
+    {
       return 1;
+    }
     else if (idType == "CodeMeaning")
+    {
       return 2;
+    }
     vtkGenericWarningMacro("vtkMRMLColorTableStorageNode::ReadCsvFile::GetIndexInEntryForIdType: Invalid coded entry ID type" << idType);
     return 0;
   };

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -1190,7 +1190,9 @@ int vtkMRMLScene::Commit(const char* url, vtkMRMLMessageCollection* userMessages
     *os << vindent << "<" << node->GetNodeTagName() << "\n ";
 
     if (indent <= 0)
+    {
       indent = 1;
+    }
 
     vtkNew<vtkMRMLMessageCollection> nodeWritingMessages;
     nodeWritingMessages->SetObservedObject(node);

--- a/Libs/MRML/Core/vtkMRMLTransformDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformDisplayNode.cxx
@@ -372,7 +372,9 @@ void vtkMRMLTransformDisplayNode::ProcessMRMLEvents(vtkObject* caller, unsigned 
     this->Modified();
   }
   else
+  {
     this->Superclass::ProcessMRMLEvents(caller, event, callData);
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkObservation.cxx
+++ b/Libs/MRML/Core/vtkObservation.cxx
@@ -75,26 +75,42 @@ void vtkObservation::PrintSelf(ostream& os, vtkIndent indent)
   this->vtkObject::PrintSelf(os, indent);
 
   if (this->CallbackCommand)
+  {
     os << indent << "EventBroker: " << this->EventBroker << "\n";
+  }
   else
+  {
     os << indent << "EventBroker: " << "(none) \n";
+  }
 
   if (this->Subject)
+  {
     os << indent << "Subject: " << this->Subject << "\n";
+  }
   else
+  {
     os << indent << "Subject: " << "(none) \n";
+  }
 
   os << indent << "Event: " << this->Event << "\n";
 
   if (this->Observer)
+  {
     os << indent << "Observer: " << this->Observer << "\n";
+  }
   else
+  {
     os << indent << "Observer: " << "(none) \n";
+  }
 
   if (this->CallbackCommand)
+  {
     os << indent << "CallbackCommand: " << this->CallbackCommand << "\n";
+  }
   else
+  {
     os << indent << "CallbackCommand: " << "(none) \n";
+  }
 
   os << indent << "Script: " << (this->Script ? this->Script : "(none)") << "\n";
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLOrientationMarkerDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLOrientationMarkerDisplayableManager.cxx
@@ -514,13 +514,21 @@ void vtkMRMLOrientationMarkerDisplayableManager::vtkInternal::UpdateMarkerSize()
     double newViewport[4] = { 1.0 - viewPortSizeInPixels / double(rendererSizeInPixels[0]), 0.0, 1.0, viewPortSizeInPixels / double(rendererSizeInPixels[1]) };
     // Clip viewport to valid range
     if (newViewport[0] < 0.0)
+    {
       newViewport[0] = 0.0;
+    }
     if (newViewport[1] < 0.0)
+    {
       newViewport[1] = 0.0;
+    }
     if (newViewport[2] > 1.0)
+    {
       newViewport[1] = 1.0;
+    }
     if (newViewport[3] > 1.0)
+    {
       newViewport[3] = 1.0;
+    }
 
     // Update the viewport
     if (newViewport[0] != viewport[0]    //

--- a/Libs/MRML/Logic/vtkImageNeighborhoodFilter.cxx
+++ b/Libs/MRML/Logic/vtkImageNeighborhoodFilter.cxx
@@ -88,9 +88,15 @@ void vtkImageNeighborhoodFilter::SetNeighborTo4()
   // set 4 neighbors in center slice
   int z = 0;
   for (int y = -1; y <= 1; y++)
+  {
     for (int x = -1; x <= 1; x++)
+    {
       if (x * y == 0)
+      {
         this->Mask[(1 + z) * 9 + (1 + y) * 3 + (1 + x)] = 1;
+      }
+    }
+  }
 
   // unset center (current) pixel
   this->Mask[1 * 9 + 1 * 3 + 1] = 0;

--- a/Libs/MRML/Widgets/qMRMLNodeComboBoxDelegate.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBoxDelegate.cxx
@@ -45,8 +45,12 @@ void qMRMLNodeComboBoxDelegate::setSeparator(QAbstractItemModel* model, const QM
 {
   model->setData(index, QString::fromLatin1("separator"), Qt::AccessibleDescriptionRole);
   if (QStandardItemModel* m = qobject_cast<QStandardItemModel*>(model))
+  {
     if (QStandardItem* item = m->itemFromIndex(index))
+    {
       item->setFlags(item->flags() & ~(Qt::ItemIsSelectable | Qt::ItemIsEnabled));
+    }
+  }
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLTreeView.cxx
+++ b/Libs/MRML/Widgets/qMRMLTreeView.cxx
@@ -833,7 +833,9 @@ void qMRMLTreeView::saveTreeExpandState()
   if (this->isExpanded(sceneIndex))
   {
     if (sceneNode && this->sortFilterProxyModel()->mrmlScene()->IsNodePresent(sceneNode))
+    {
       d->ExpandedNodes->AddItem(sceneNode);
+    }
   }
   unsigned int numChildrenRows = this->sortFilterProxyModel()->rowCount(sceneIndex);
   for (unsigned int row = 0; row < numChildrenRows; ++row)

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.h
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.h
@@ -717,7 +717,9 @@ public:
 
     std::vector<float> aVector(3);
     for (unsigned int i = 0; i < 3; i++)
+    {
       aVector[i] = a[i];
+    }
     this->ImagePositionPatient.push_back(aVector);
     return (this->ImagePositionPatient.size() - 1);
   }

--- a/Libs/vtkTeem/vtkDiffusionTensorMathematics.cxx
+++ b/Libs/vtkTeem/vtkDiffusionTensorMathematics.cxx
@@ -551,16 +551,24 @@ static void vtkDiffusionTensorMathematicsExecute1Eigen(vtkDiffusionTensorMathema
             //              vtkGenericWarningMacro( "Warning: Eigenvalues are not properly sorted" );
             //            }
             if ((w[0] < 0) || (w[1] < 0) || (w[2] < 0))
+            {
               vtkGenericWarningMacro("Warning: Negative Eigenvalues after positivity fix");
+            }
           }
           else
           {
             if (w[0] < 0)
+            {
               w[0] = 0;
+            }
             if (w[1] < 0)
+            {
               w[1] = 0;
+            }
             if (w[2] < 0)
+            {
               w[2] = 0;
+            }
           }
 
           // pixel operation
@@ -866,13 +874,21 @@ int vtkDiffusionTensorMathematics::FixNegativeEigenvaluesMethod(double w[3])
   double wtmp[3];
   // Check for cardinality of negative eigenvalues
   if (w[0] < 0 && w[1] < 0 && w[2] < 0)
+  {
     cardinality = 3;
+  }
   else if (w[1] < 0 && w[2] < 0)
+  {
     cardinality = 2;
+  }
   else if (w[2] < 0)
+  {
     cardinality = 1;
+  }
   else
+  {
     cardinality = 0;
+  }
 
   switch (cardinality)
   {
@@ -884,7 +900,9 @@ int vtkDiffusionTensorMathematics::FixNegativeEigenvaluesMethod(double w[3])
     case 2:
       w[0] = w[0] + 0.5 * (w[1] + w[2]);
       if (w[0] < 0)
+      {
         w[0] = 0;
+      }
       w[1] = 0;
       break;
     case 1:
@@ -900,7 +918,9 @@ int vtkDiffusionTensorMathematics::FixNegativeEigenvaluesMethod(double w[3])
       {
         w[0] = w[0] + 0.5 * (w[1] + w[2]);
         if (w[0] < 0)
+        {
           w[0] = 0;
+        }
         w[1] = 0;
       }
       else
@@ -1229,9 +1249,13 @@ int vtkDiffusionTensorMathematics::TeemEigenSolver(double** m, double* w, double
   t[6] = m[2][2];
 
   if (v == nullptr)
+  {
     res = tenEigensolve_d(eval, nullptr, t);
+  }
   else
+  {
     res = tenEigensolve_d(eval, evec, t);
+  }
 
   unsigned int eval_indices[3] = { 0, 1, 2 };
 

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationControlPointsNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationControlPointsNode.cxx
@@ -305,7 +305,9 @@ void vtkMRMLAnnotationControlPointsNode::CreateAnnotationPointDisplayNode()
 {
   vtkMRMLAnnotationPointDisplayNode* node = this->GetAnnotationPointDisplayNode();
   if (node)
+  {
     return;
+  }
   if (!this->GetScene())
   {
     vtkErrorMacro("vtkMRMLAnnotationControlPointsNode::CreateAnnotationControlPointDisplayNode Annotation: No scene defined");
@@ -460,9 +462,13 @@ const char* vtkMRMLAnnotationControlPointsNode::GetAttributeTypesEnumAsString(in
     return vtkMRMLAnnotationNode::GetAttributeTypesEnumAsString(val);
   }
   if (val == CP_SELECTED)
+  {
     return "ctrlPtsSelected";
+  }
   if (val == CP_VISIBLE)
+  {
     return "ctrlPtsVisible";
+  }
   return "(unknown)";
 };
 

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLinesNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLinesNode.cxx
@@ -243,7 +243,9 @@ void vtkMRMLAnnotationLinesNode::CreateAnnotationLineDisplayNode()
 {
   vtkMRMLAnnotationLineDisplayNode* node = this->GetAnnotationLineDisplayNode();
   if (node)
+  {
     return;
+  }
   if (!this->GetScene())
   {
     vtkErrorMacro("vtkMRMLAnnotationLinesNode::CreateAnnotationLineDisplayNode AnnotationLine: No scene defined");
@@ -411,9 +413,13 @@ const char* vtkMRMLAnnotationLinesNode::GetAttributeTypesEnumAsString(int val)
     return vtkMRMLAnnotationControlPointsNode::GetAttributeTypesEnumAsString(val);
   }
   if (val == LINE_SELECTED)
+  {
     return "lineSelected";
+  }
   if (val == LINE_VISIBLE)
+  {
     return "lineVisible";
+  }
   return "(unknown)";
 };
 

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationNode.cxx
@@ -111,7 +111,9 @@ void vtkMRMLAnnotationNode::ReadXMLAttributes(const char** atts)
       while (endPos != std::string::npos)
       {
         if (endPos == startPos)
+        {
           this->AddText(nullptr, 1, 1);
+        }
         else
         {
           this->AddText(attValue.substr(startPos, endPos - startPos).c_str(), 1, 1);
@@ -557,9 +559,13 @@ int vtkMRMLAnnotationNode::GetNumberOfTexts()
 const char* vtkMRMLAnnotationNode::GetAttributeTypesEnumAsString(int val)
 {
   if (val == TEXT_SELECTED)
+  {
     return "textSelected";
+  }
   if (val == TEXT_VISIBLE)
+  {
     return "textVisible";
+  }
   return "(unknown)";
 };
 
@@ -602,7 +608,9 @@ void vtkMRMLAnnotationNode::CreateAnnotationTextDisplayNode()
 {
   vtkMRMLAnnotationTextDisplayNode* node = this->GetAnnotationTextDisplayNode();
   if (node)
+  {
     return;
+  }
   if (!this->GetScene())
   {
     vtkErrorMacro("vtkMRMLAnnotationNode::CreateAnnotationTextDisplayNode Annotation: No scene defined");

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -291,15 +291,21 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateAllPointsAndLabelsFromMRML()
       {
         case Active:
           if (!isPointActive)
+          {
             continue;
+          }
           break;
         case Unselected:
           if (isPointActive || markupsNode->GetNthControlPointSelected(pointIndex))
+          {
             continue;
+          }
           break;
         case Selected:
           if (isPointActive || !markupsNode->GetNthControlPointSelected(pointIndex))
+          {
             continue;
+          }
           break;
       }
 


### PR DESCRIPTION
Insert braces after control statements (if, else, for, do, and while) in C++ unless the control statements are inside macro definitions or the braces would enclose preprocessor directives.

See https://releases.llvm.org/20.1.0/tools/clang/docs/ClangFormatStyleOptions.html#insertbraces