### PR TITLE
BUG: Update CTK to ensure VTK views are always up-to-date

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "fcf31fc6d18ae7f8823060b2e8770a3a4f47ef65"
+    "7ef24ed9ab867684fea33241907078df91432a09"
     QUIET
     )
 


### PR DESCRIPTION
On some computers, VTK views were not updating until the mouse was moved on the screen.

This was due to Qt not repainting the view after the VTK rendering was completed, because the widget was not scheduled for repaint.

List of CTK changes:

```
$ git shortlog fcf31fc6d..7ef24ed9a --no-merges
Andras Lasso (1):
      BUG: Fixed VTK views not updating

Davide Punzo (4):
      COMP: Exclude VSCode settings files
      COMP: Create a dedicated class for ctkDICOMMetadataDialog
      ENH: Set ctkDICOMMetadataDialog as non-modal window
      COMP: Fix ctkDICOMSchedulerTest1 test

Hans Johnson (1):
      COMP: Replace QDir assignment with setPath() (PR-1248)
```

Fixes #7206