### PR TITLE
BUG: Fix VTK errors drawing line profile plot with undefined points

### DIFF
--- a/Modules/Scripted/LineProfile/LineProfile.py
+++ b/Modules/Scripted/LineProfile/LineProfile.py
@@ -273,7 +273,7 @@ class LineProfileLogic(ScriptedLoadableModuleLogic):
 
         self._setAutoUpdateFromLineNode(parameterNode.inputLine if parameterNode.autoUpdate else None)
 
-        if parameterNode.inputLine.GetNumberOfDefinedControlPoints() < 2:
+        if parameterNode.inputLine.GetNumberOfControlPoints() < 2:
             self._resetOutput()
             return
 
@@ -336,7 +336,7 @@ class LineProfileLogic(ScriptedLoadableModuleLogic):
 
         if inputCurve is None or inputVolume is None or outputTable is None:
             return
-        if inputCurve.GetNumberOfDefinedControlPoints() < 2:
+        if inputCurve.GetNumberOfControlPoints() < 2:
             self._resetOutput()
             return
 


### PR DESCRIPTION
Change suggested by @jamesobutler 

This change allows for the line plot to be dynamically updated even before the user places the second point, and greatly reduces VTK warnings logged in the python console.

Main:

https://github.com/user-attachments/assets/7de323b3-2362-41e2-a13f-bd9540a35cdd


This PR:

https://github.com/user-attachments/assets/18c98d3a-848b-42a7-9dbe-96df5b48b93a

