### PR TITLE
COMP: Update VTK to 9.5.1

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,8 +139,8 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "454bb391dff78c6ff463298a5143ab5b4f0aa083") # slicer-v9.4.2-2025-03-26-13acb1a5d
     set(vtk_dist_info_version "9.4.2")
   elseif("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.5")
-    set(_git_tag "294f4a76942be86a785345e89e7e93bd6bd52536") # slicer-v9.5.0-2025-06-19-e70c856bd
-    set(vtk_dist_info_version "9.5.0")
+    set(_git_tag "3b61f10ef11fbcc4ad13abc5e88ec11b421d71a2") # slicer-v9.5.1-2025-08-25-9bd2ddd86
+    set(vtk_dist_info_version "9.5.1")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR.Slicer_VTK_VERSION_MINOR: ${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}")
   endif()


### PR DESCRIPTION
This includes a collection of bug fixes including a fix for ImageSliceMapper with Apple Clang 17.0.0. See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12347.

On Windows:
Build: ✔️  
Package: ✔️  
Test: ✔️ (no new tests failing compared to current `main`)

<img width="688" height="154" alt="{3295FD57-E547-4DDE-A95C-1D1A5D34D803}" src="https://github.com/user-attachments/assets/c6933b5f-8ce1-432f-a28d-09693e19c6d2" />

```
$ git shortlog 294f4a7..3b61f10 --no-merges
Alexy Pellegrini (4):
      [Backport] Reduce build time and binary directory size of vtkCommonCore
      [Backport] Add vtk<Type>Array to bulk instantiation
      [Backport] Cleanup extern template declarations in data arrays
      [Backport] Reduce number of std::shared_ptr instantiations in StructuredPointArray.txx

Ben Boeckel (3):
      gitlab-ci: remove submodule support
      Filters/CellGrid: fix header list typo
      vtkMath: fix copy pasta for `EnableT` docs for `::Dot()`

Bengt Rosenberger (1):
      Fix division by zero error in vtkCellLocator

Cory Quammen (4):
      Test degenerate triangle input in vtkQuadricDecimationFilter
      vtkQuadricDecimation: skip handling of non-triangles
      vtkQuad.cxx: manually unroll short loops
      TestStructuredGridLIC2DXSlice: add alternate baseline

David Gobbi (11):
      Remove dead code in vtkMethodParser.py
      Clean up whitespace in vtkMethodParser.py
      Fix RenderingTk loading for unversioned install
      Export VTK_USE_COCOA on APPLE platform
      Fix extent for vtkSynchronizedTemplates2D
      Documentation for VTK_USE_COCOA
      Fix ordering of vtkDICOMImageReader spacing
      Fix ImageSliceMapper issue with Apple clang 17.0.0
      Report more info on vtkDICOMImageReader failure
      Fix unstructured grid UMR in vtkDataSetTriangleFilter
      Add a test for vtkCocoaAutoreleasePool

Guillaume Gisbert (1):
      Fix minor Tuple and Size inversion in the axis aligned transform filter

Jaswant Panchumarti (18):
      Add missing H1 header in ThirdParty/glad README.md
      Remove unnecessary line breaks in WebGPU README.md
      Fix link to VTK wasm demo applications in using_webassembly.md
      Update link from vtk-wasm-docker to vtk-wasm-sdk in using_webassembly.md
      Add homepage link for VTK.wasm in using_webassembly.md
      Remove marshalling_hints documentation and update object serialization section
      Fix unexpected indentation warning in vtkModuleTesting.cmake doc
      Support extra documentation directories beside module README.md
      Add serialization APIs documentation and update references in CMake files
      Add null check before flagging buffer as dirty in vtkDrawTexturedElements
      Add support for pseudo primitives in vtkOpenGLLowMemoryCellTypeAgent
      Remove redundant NumberOfInstances assignment in PreDrawInternal
      Improve line rendering with pseudo triangles in opengl low mem mapper
      Fix viewport calculations in vtkOpenGLLowMemoryPolyDataMapper
      Fix missing invokers for vtkDataArray and subclasses
      Do not discard fragments for apple silicon hardware
      Fix canvas in MultiCone example
      Fix toggling vertex visibility

Jaswant Panchumarti (Kitware) (5):
      Merge topic 'qvtkopengl'
      Merge topic 'clip-planes-for-gles'
      Merge topic 'fix-webgl-clipplanes'
      Merge topic 'fix-pipeline-rebuild'
      Merge topic 'fix-unintialized-variable'

Jean-Christophe Fillion-Robin (14):
      docs: Fix "invalid escape sequence" warning in vtk_documentation.py
      docs: Add hints to ensure supported compilers are consistently updated
      docs: Fix section headers associated with 9.4 author notes
      docs: Fix section headers associated with 9.5 author notes
      feat(docs): Add author notes to hidden toctree in release pages
      docs(fix): Remove non-breaking space from add-static-mesh-cache.md title
      docs: Consolidate 9.5 author notes into `9.5.md`
      docs: Exclude GitHub/GitLab TOCs from Sphinx-rendered release notes
      docs: Replace Markdown anchor syntax with HTML anchors in release notes
      docs: Copy release note image assets into Sphinx-accessible directory
      docs: Fix json snippet syntax in "9.4/catalyst2-amr-support.md" author note
      [Slicer] COMP: Remove custom FindOpenGL to ensure OpenGL_GL_PREFERENCE is considered
      [Slicer] BUG: Update vtkPythonUtil to disable relative import causing crash for Slicer modules
      [Slicer] COMP: Remove FindTBB and expect VTK to be configured with TBB_DIR

Lucas Gandel (1):
      Fix float/int comparison in surface probe mapper shader code

Nicolas Vuaille (2):
      Fix vtkAxisActor2D minor tick positions
      Update axisActor2D test

Quinn Powell (14):
      WrapSerDes: add auto serialization for indexed properties
      Marshalling: auto serialization for vtkPlane and vtkPlaneCollection
      Add vtkCharArray (de)serialization
      Use vtkSmartPointer for vtkUnstructuredGrid deserialization
      Marshalling: exclude redundant position/coordinate properties
      vtkCategoryLegend: enable reference counting for ScalarsToColors
      Add vtkSignedCharArray (de)serialization
      vtkPartitionedDataSet: enable deserialization of empty partitions
      Marshalling: fix vtkPolyData (de)serialization
      Marshalling: add auto serialization for vtkTextActor3D
      Marshalling: auto serialization for vtkOpenGLFluidMapper
      Marshalling: auto serialization for vtkPointGaussianMapper
      fix vtkAlgorithm multiple connections input deserialization
      vtkDataSetMapperSerDes: ensure input is serialized

Sean McBride (4):
      bumped libxml2 tag from for/vtk-20241206-2.13.5 to for/vtk-20250703-2.13.5
      Increased minimum Clang versions
      Added new class to create an NSAutoreleasePool
      Reverted  6a5b11dc: restore MakeCurrent() in RemoveViewProp()

Spiros Tsalikis (5):
      vtkAppendFilter: Fix connectivity writing for vtkPolyData
      QVTKInteractorAdapter: Fix static_cast
      vtkPolyhedron: Implement GetCentroid and use it in GetParametricCenter
      Add TestPolyhedronConcaveCentroid
      Add changelog

Thibault Pelletier (1):
      Fix vtkOpenGLResourceFreeCallback.h not present in the install tree

Vicente Adolfo Bolea Sanchez (12):
      java: support java bindings IO Avmesh and LANLX3D
      ci: disable marshaling in win/mac java builds
      maven: parametrize env name for upload deployments
      java: prepend build_type to native names
      java: upload jobs download from fedora job last
      maven: remove env var in servers in settings.xml
      ioss: depend on Ionit when external ioss
      ioss: do not use external variables when external ioss
      maven: fix release server ref pom.xml
      docs: Move dev release notes to 9.5
      docs: update release notes
      Update version number to 9.5.1

libxml2 Upstream (1):
      libxml2 2025-07-03 (d20b31eb)
```