### PR TITLE
BUG: Fix py_nomainwindow_test_slicer_parameter_node_wrapper_guis test

### DIFF
--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
@@ -806,21 +806,21 @@ class ParameterNodeWrapperGuiTest(unittest.TestCase):
         self.assertEqual(param.alpha, pathlib.Path())
         self.assertEqual(pathlib.Path(directoryButtonAlpha.directory), pathlib.Path())
         self.assertEqual(param.bravo, pathlib.Path("some/path"))
-        self.assertEqual(pathlib.Path(directoryButtonBravo.directory), pathlib.Path("some/path"))
+        self.assertEqual(pathlib.Path(directoryButtonBravo.directory), pathlib.Path("some/path").resolve())
 
         # Phase 1 - write to GUI
         directoryButtonAlpha.directory = "pathy/path"
-        self.assertEqual(param.alpha, pathlib.Path("pathy/path"))
-        self.assertEqual(pathlib.Path(directoryButtonAlpha.directory), pathlib.Path("pathy/path"))
+        self.assertEqual(param.alpha, pathlib.Path("pathy/path").resolve())
+        self.assertEqual(pathlib.Path(directoryButtonAlpha.directory), pathlib.Path("pathy/path").resolve())
         self.assertEqual(param.bravo, pathlib.Path("some/path"))
-        self.assertEqual(pathlib.Path(directoryButtonBravo.directory), pathlib.Path("some/path"))
+        self.assertEqual(pathlib.Path(directoryButtonBravo.directory), pathlib.Path("some/path").resolve())
 
         # Phase 2 - write to parameterNode
         param.bravo = pathlib.Path("magnificent/path/bravo")
-        self.assertEqual(param.alpha, pathlib.Path("pathy/path"))
-        self.assertEqual(pathlib.Path(directoryButtonAlpha.directory), pathlib.Path("pathy/path"))
+        self.assertEqual(param.alpha, pathlib.Path("pathy/path").resolve())
+        self.assertEqual(pathlib.Path(directoryButtonAlpha.directory), pathlib.Path("pathy/path").resolve())
         self.assertEqual(param.bravo, pathlib.Path("magnificent/path/bravo"))
-        self.assertEqual(pathlib.Path(directoryButtonBravo.directory), pathlib.Path("magnificent/path/bravo"))
+        self.assertEqual(pathlib.Path(directoryButtonBravo.directory), pathlib.Path("magnificent/path/bravo").resolve())
 
     def impl_qMRMLToNodeConnector(self, widgettype, clearFunc):
         """


### PR DESCRIPTION
The ctkDirectoryButton returns an absolute path, which needs to be taken into account when comparing with the expected path.
