### PR TITLE
ENH: Show storage path for nodes loaded from file in SH

### DIFF
--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
@@ -475,6 +475,21 @@ QIcon qSlicerSubjectHierarchyMarkupsPlugin::visibilityIcon(int visible)
 }
 
 //-----------------------------------------------------------------------------
+QString qSlicerSubjectHierarchyMarkupsPlugin::tooltip(vtkIdType itemID) const
+{
+  // Get basic tooltip from abstract plugin
+  QString tooltipString = Superclass::tooltip(itemID);
+
+  // Append the file path if available
+  QString filePath = this->tooltipWithStoragePath(itemID);
+  if (!filePath.isEmpty())
+  {
+    tooltipString.append(QString("\n  %1").arg(filePath));
+  }
+  return tooltipString;
+}
+
+//-----------------------------------------------------------------------------
 void qSlicerSubjectHierarchyMarkupsPlugin::setDisplayColor(vtkIdType itemID, QColor color, QMap<int, QVariant> terminologyMetaData)
 {
   this->setColorAndTerminologyToDisplayableNode(itemID, color, terminologyMetaData, true, false);

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
@@ -69,6 +69,9 @@ public:
   /// Get visibility icon for a visibility state
   QIcon visibilityIcon(int visible) override;
 
+  /// Generate tooltip for a owned subject hierarchy item
+  QString tooltip(vtkIdType itemID) const override;
+
   /// Set display color of an owned subject hierarchy item
   /// \param color Display color to set
   /// \param terminologyMetaData Map containing terminology meta data. Contents:

--- a/Modules/Loadable/Models/SubjectHierarchyPlugins/qSlicerSubjectHierarchyModelsPlugin.cxx
+++ b/Modules/Loadable/Models/SubjectHierarchyPlugins/qSlicerSubjectHierarchyModelsPlugin.cxx
@@ -224,6 +224,13 @@ QString qSlicerSubjectHierarchyModelsPlugin::tooltip(vtkIdType itemID) const
   }
   tooltipString.append(QString(")"));
 
+  // Append the storage path if available
+  QString storagePath = this->tooltipWithStoragePath(itemID);
+  if (!storagePath.isEmpty())
+  {
+    tooltipString.append(QString("\n  %1").arg(storagePath));
+  }
+
   return tooltipString;
 }
 

--- a/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.cxx
+++ b/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.cxx
@@ -377,8 +377,7 @@ QString qSlicerSubjectHierarchySegmentationsPlugin::tooltip(vtkIdType itemID) co
   tooltipString.append(tr(" (Representations: "));
   if (containedRepresentationNames.empty())
   {
-    tooltipString.append(tr("None)") //: used when there are no representations defined for the segmentation
-    );
+    tooltipString.append(tr("None)")); // Used when there are no representations defined for the segmentation
   }
   else
   {
@@ -395,6 +394,13 @@ QString qSlicerSubjectHierarchySegmentationsPlugin::tooltip(vtkIdType itemID) co
 
   // Number of segments
   tooltipString.append(tr(" (Number of segments: %1)").arg(segmentation->GetNumberOfSegments()));
+
+  // Append the storage path if available
+  QString storagePath = this->tooltipWithStoragePath(itemID);
+  if (!storagePath.isEmpty())
+  {
+    tooltipString.append(QString("\n  %1").arg(storagePath));
+  }
 
   return tooltipString;
 }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.cxx
@@ -285,6 +285,31 @@ QString qSlicerSubjectHierarchyAbstractPlugin::tooltip(vtkIdType itemID) const
 }
 
 //-----------------------------------------------------------------------------
+QString qSlicerSubjectHierarchyAbstractPlugin::tooltipWithStoragePath(vtkIdType itemID) const
+{
+  vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();
+  if (!shNode)
+  {
+    qCritical() << Q_FUNC_INFO << ": Failed to access subject hierarchy node";
+    return QString();
+  }
+
+  // If associated data node is a storable node, get the file path from the URL
+  vtkMRMLNode* dataNode = shNode->GetItemDataNode(itemID);
+  if (dataNode != nullptr)
+  {
+    vtkMRMLStorableNode* storableNode = vtkMRMLStorableNode::SafeDownCast(dataNode);
+    if (storableNode != nullptr && storableNode->GetStorageNode() != nullptr
+      && storableNode->GetStorageNode()->GetFileName() != nullptr)
+    {
+      QString tooltipWithStoragePath = tr("Loaded from file: %1").arg(storableNode->GetStorageNode()->GetFileName());
+      return tooltipWithStoragePath;
+    }
+  }
+  return QString();
+}
+
+//-----------------------------------------------------------------------------
 void qSlicerSubjectHierarchyAbstractPlugin::setDisplayVisibility(vtkIdType itemID, int visible)
 {
   vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
@@ -112,8 +112,11 @@ public:
   /// The default implementation returns the associated data node's name if any, otherwise the item name
   Q_INVOKABLE virtual QString displayedItemName(vtkIdType itemID) const;
 
-  /// Generate tooltip for a owned subject hierarchy item
+  /// Generate tooltip for an owned subject hierarchy item
   Q_INVOKABLE virtual QString tooltip(vtkIdType itemID) const;
+
+  /// Generate tooltip with the file path the owned item was loaded from if any. Otherwise empty string.
+  Q_INVOKABLE virtual QString tooltipWithStoragePath(vtkIdType itemID) const;
 
   /// Set display visibility of an owned subject hierarchy item
   Q_INVOKABLE virtual void setDisplayVisibility(vtkIdType itemID, int visible);

--- a/Modules/Loadable/Tables/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTablesPlugin.cxx
+++ b/Modules/Loadable/Tables/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTablesPlugin.cxx
@@ -183,6 +183,21 @@ QIcon qSlicerSubjectHierarchyTablesPlugin::visibilityIcon(int visible)
   return qSlicerSubjectHierarchyPluginHandler::instance()->defaultPlugin()->visibilityIcon(visible);
 }
 
+//-----------------------------------------------------------------------------
+QString qSlicerSubjectHierarchyTablesPlugin::tooltip(vtkIdType itemID) const
+{
+  // Get basic tooltip from abstract plugin
+  QString tooltipString = Superclass::tooltip(itemID);
+
+  // Append the file path if available
+  QString filePath = this->tooltipWithStoragePath(itemID);
+  if (!filePath.isEmpty())
+  {
+    tooltipString.append(QString("\n  %1").arg(filePath));
+  }
+  return tooltipString;
+}
+
 //---------------------------------------------------------------------------
 void qSlicerSubjectHierarchyTablesPlugin::setDisplayVisibility(vtkIdType itemID, int visible)
 {

--- a/Modules/Loadable/Tables/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTablesPlugin.h
+++ b/Modules/Loadable/Tables/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTablesPlugin.h
@@ -72,6 +72,9 @@ public:
   /// Get visibility icon for a visibility state
   QIcon visibilityIcon(int visible) override;
 
+  /// Generate tooltip for a owned subject hierarchy item
+  QString tooltip(vtkIdType itemID) const override;
+
   /// Set display visibility of a owned subject hierarchy item
   void setDisplayVisibility(vtkIdType itemID, int visible) override;
 

--- a/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.cxx
+++ b/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.cxx
@@ -704,6 +704,13 @@ QString qSlicerSubjectHierarchyTransformsPlugin::tooltip(vtkIdType itemID) const
     tooltipString.append(transformInfo);
   }
 
+  // Append the file path if available
+  QString filePath = this->tooltipWithStoragePath(itemID);
+  if (!filePath.isEmpty())
+  {
+    tooltipString.append(QString("\n  %1").arg(filePath));
+  }
+
   return tooltipString;
 }
 

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
@@ -490,6 +490,13 @@ QString qSlicerSubjectHierarchyVolumesPlugin::tooltip(vtkIdType itemID) const
                            .arg(spacing[0], 0, 'g', 3)
                            .arg(spacing[1], 0, 'g', 3)
                            .arg(spacing[2], 0, 'g', 3));
+
+    // Append the file path if available
+    QString filePath = this->tooltipWithStoragePath(itemID);
+    if (!filePath.isEmpty())
+    {
+      tooltipString.append(QString("\n  %1").arg(filePath));
+    }
   }
   else
   {


### PR DESCRIPTION
Re https://discourse.slicer.org/t/data-file-information/44274/8

As discussed in the above forum topic, I added a small feature that shows the file path each node is loaded from (if loaded from file and its storage node contains a path). These types of nodes support this feature for now:

Volume:
<img width="416" height="83" alt="image" src="https://github.com/user-attachments/assets/86c03725-7b63-451c-9a13-503f0bc15e72" />

Model:
<img width="516" height="77" alt="image" src="https://github.com/user-attachments/assets/74227078-100a-4796-905e-e716a6113fcd" />

Segmentation
<img width="760" height="65" alt="image" src="https://github.com/user-attachments/assets/6ebb4637-800e-4f17-a31d-3fa507ab4c07" />

Table
<img width="292" height="68" alt="image" src="https://github.com/user-attachments/assets/3ede3cec-b3c3-4271-a908-ab1b03e31e06" />

Markup
<img width="216" height="69" alt="image" src="https://github.com/user-attachments/assets/0133b063-99e3-466c-8777-eeae9803f8a3" />

Transform
<img width="465" height="142" alt="image" src="https://github.com/user-attachments/assets/1d1a98d6-8808-4291-bc88-7ca7e7be9d5c" />

