### PR TITLE
COMP: Ensure BUILD_JOB_SERVER_AWARE is set for external projects

### DIFF
--- a/CMake/ExternalProjectDependency.cmake
+++ b/CMake/ExternalProjectDependency.cmake
@@ -529,6 +529,15 @@ function(_sb_get_external_project_arguments proj varname)
     # See https://cmake.org/cmake/help/latest/policy/CMP0135.html
     list(APPEND _ep_arguments DOWNLOAD_EXTRACT_TIMESTAMP 1)
   endif()
+  if(CMAKE_VERSION VERSION_EQUAL "3.28" OR CMAKE_VERSION VERSION_GREATER "3.28")
+    # Address "gmake[N]: *** read jobs pipe: Bad file descriptor." issue associated with
+    # build command.
+    # For more details:
+    # - https://gitlab.kitware.com/cmake/cmake/-/issues/26398
+    # - https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8667
+    # - https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10014
+    list(APPEND _ep_arguments BUILD_JOB_SERVER_AWARE ON)
+  endif()
   set(${varname} ${_ep_arguments} PARENT_SCOPE)
 endfunction()
 

--- a/Extensions/CMake/SlicerBlockBuildPackageAndUploadExtensions.cmake
+++ b/Extensions/CMake/SlicerBlockBuildPackageAndUploadExtensions.cmake
@@ -222,6 +222,12 @@ foreach(EXTENSION_NAME ${EXTENSION_LIST})
     message(STATUS \"build_${proj}_error_file: ${build_error_file}\")
     ")
 
+  if(CMAKE_VERSION GREATER_EQUAL "3.28")
+    set(maybe_JOB_SERVER_AWARE "JOB_SERVER_AWARE 1")
+  else()
+    set(maybe_JOB_SERVER_AWARE "")
+  endif()
+
   # Add extension external project
   #message("ext_ep_download_command:${ext_ep_download_command}")
   ExternalProject_Add(${proj}
@@ -231,6 +237,7 @@ foreach(EXTENSION_NAME ${EXTENSION_LIST})
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${CMAKE_COMMAND} -DCTEST_BUILD_CONFIGURATION=$<CONFIG> -P ${build_extension_wrapper_script}
     INSTALL_COMMAND ""
+    ${maybe_JOB_SERVER_AWARE}
     ${EP_ARG_EXTENSION_DEPENDS}
     )
   # This custom external project step forces the build and later

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "7ef24ed9ab867684fea33241907078df91432a09"
+    "833ae56e69d403bd0c83f2c331a32a8fd9c70285"
     QUIET
     )
 


### PR DESCRIPTION
This pull request updates the build system to ensure the `BUILD_JOB_SERVER_AWARE` option is set for external projects when using CMake >= 3.28. It addresses the `gmake[N]: *** read jobs  pipe: Bad file descriptor.` issue associated with the build command.

1. Modify `ExternalProjectDependency.cmake` to set `BUILD_JOB_SERVER_AWARE`.
2. Update CTK configuration to ensure `BUILD_JOB_SERVER_AWARE` is set.
3. Ensure this option is also set for extensions external projects

See https://discourse.slicer.org/t/slicer-build-environment-upgraded-to-qt5-almalinux8-gcc14/43802/8?u=jcfr