### PR TITLE
ENH: qMRMLSubjectHierarchyTreeView: call setCurrentIndex rather than …

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -673,7 +673,9 @@ void qMRMLSubjectHierarchyTreeView::setCurrentItem(vtkIdType itemID)
   }
 
   QModelIndex itemIndex = d->SortFilterModel->indexFromSubjectHierarchyItem(itemID);
-  this->selectionModel()->select(itemIndex, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+  // Call selectionModel()->setCurrentIndex rather than selectionModel()->select because select method does not set the current index.
+  // It is only required if this method is called programmatically because mousePressEvent set the current index before selecting the item.
+  this->selectionModel()->setCurrentIndex(itemIndex, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
 }
 
 //------------------------------------------------------------------------------
@@ -739,7 +741,9 @@ void qMRMLSubjectHierarchyTreeView::setCurrentItems(QList<vtkIdType> items)
   {
     if (!previouslySelectedItems.contains(itemIndex))
     {
-      this->selectionModel()->select(itemIndex, QItemSelectionModel::Select | QItemSelectionModel::Rows);
+      // Call selectionModel()->setCurrentIndex rather than selectionModel()->select because select method does not set the current index.
+      // It is only required if this method is called programmatically because mousePressEvent set the current index before selecting the item.
+      this->selectionModel()->setCurrentIndex(itemIndex, QItemSelectionModel::Select | QItemSelectionModel::Rows);
     }
   }
 }


### PR DESCRIPTION
I had to create a custom scripted module to reproduce this issue.
It is the default scripted module created by the extension wizard with this modifications:
A new qMRMLSubjectHierarchyCombobox labeled "Input volume 2" is added below a qMRMLNodeCombobox "Input volume" to compare them.
noneEnabled property is set to true for both comboboxes 

**Steps to reproduce:**

Start 3d slicer

Download this archive which contains a small extension with only one scripted module:
[SubjectHierarchyComboboxReproducer.zip](https://github.com/user-attachments/files/22131045/SubjectHierarchyComboboxReproducer.zip)

Unzip it.
Add this extension into 3d slicer by using the extension wizard.

Download the attached zip file: 
[reproduce-subject-hierarchy-combobox-issue.zip](https://github.com/user-attachments/files/22131118/reproduce-subject-hierarchy-combobox-issue.zip)

Rename it reproduce-subject-hierarchy-combobox-issue.mrb

Load this mrb file into 3d slicer

Run this code into python interpreter:
shNode = slicer.mrmlScene.GetSubjectHierarchyNode()
volumeNode = slicer.util.getFirstNodeByName('4: Cor FSE PD')
volumeNodeItem = shNode.GetItemByDataNode(volumeNode)
slicer.modules.reproduceComboboxIssueWidget.ui.inputSelector2.setCurrentItem(volumeNodeItem)
slicer.modules.reproduceComboboxIssueWidget.ui.inputSelector.setCurrentNode(volumeNode)

Open "reproduceComboboxIssue" module
Check the value of each combobox: Input volume and Input volume 2 must point on "4: Cor FSE PD"
Open Data module
Delete  "4: Cor FSE PD"
Open "reproduceComboboxIssue" module

**Actual result**
Input volume 2 points on None

**Expected result**
Input volume 2 points on "3: Sag FRSE PD FS" (like Input Volume)

This fix 

