### PR TITLE
BUG: Suppress unnecessary warning for hidden subject hierarchy items

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -773,12 +773,6 @@ void qMRMLSubjectHierarchyTreeView::setCurrentNode(vtkMRMLNode* node)
   }
 
   vtkIdType itemID = d->SubjectHierarchyNode->GetItemByDataNode(node);
-  if (!itemID)
-  {
-    qCritical() << Q_FUNC_INFO << ": Unable to find subject hierarchy item by data node " << node->GetName();
-    return;
-  }
-
   this->setCurrentItem(itemID);
 }
 


### PR DESCRIPTION
Nodes defined to be hidden from editors were being unnecessarily warned by the "Unable to find subject hierarchy item by data node" log message because it is expected for them to not be visible and available in the subject hierarchy as they are hidden.

Code that previously produced the unnecessary warning:
```python
slicer.util.selectModule("Markups")
line_node = slicer.vtkMRMLMarkupsLineNode()
line_node.SetHideFromEditors(True)
slicer.mrmlScene.AddNode(line_node)
```

| `main` | This PR |
|--------|---------|
|<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/388a7dc6-5038-4dbb-b6bd-ccaf1bac100c" />|<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/285684b5-bcf2-4fc8-812f-f7e87d18b22d" />|