### PR TITLE
PERF: Improve sequence node storage performance for simple nodes

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -850,6 +850,9 @@ public:
   /// could be gz, nii.gz, or file.nii.gz and only one of them is correct).
   static std::string CreateUniqueFileName(const std::string& filename, const std::string& knownExtension = "");
 
+  /// Returns name of the subfolder where hidden nodes (scene view nodes, etc.) are saved.
+  static std::string GetPrivateFolderName();
+
 protected:
   typedef std::map<std::string, std::set<std::string>> NodeReferencesType;
 

--- a/Libs/MRML/Core/vtkMRMLSequenceStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLSequenceStorageNode.h
@@ -44,6 +44,9 @@ public:
   /// Return true if the reference node can be read in
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
 
+  /// Return true if the node can be written by using the writer.
+  bool CanWriteFromReferenceNode(vtkMRMLNode* refNode) override;
+
   // fileName: fCal_Test_Validation_3NWires_fCal2.0-ProbeToTracker-Seq.seq.mha
   // itemName: ProbeToTracker
   // return: fCal_Test_Validation_3NWires_fCal2.0
@@ -53,6 +56,9 @@ public:
   // itemName: Image
   // return: fCal_Test_Validation_3NWires_fCal2.0-Image-Seq
   static std::string GetSequenceNodeName(const std::string& baseName, const std::string& itemName);
+
+  /// Returns true if the sequence requires MRB file for storage (because additional data files need to be saved)
+  bool IsMRBStorageRequired(vtkMRMLNode* refNode);
 
 protected:
   vtkMRMLSequenceStorageNode();


### PR DESCRIPTION
Simple non-storable nodes that can save their entire state into the MRML scene (without using additional data files) are now saved as a simple `.mrml` file instead of a `.mrb` file. This improves the reading and writing performance of the sequence nodes, as there is no need to zip/unzip the file.

---

> [!NOTE]
>
> This pull request was created cherry-picking commit from @lassoan that was originally associated with https://github.com/Slicer/Slicer/pull/8693