### PR TITLE
BUG: Fix crash in vtkSegmentation::CollapseBinaryLabelmaps

### DIFF
--- a/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.cxx
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.cxx
@@ -696,10 +696,26 @@ bool vtkOrientedImageDataResample::CalculateEffectiveExtent(vtkOrientedImageData
   // Return with failure if effective input extent is empty
   if (effectiveExtent[0] > effectiveExtent[1] || effectiveExtent[2] > effectiveExtent[3] || effectiveExtent[4] > effectiveExtent[5])
   {
+    vtkOrientedImageDataResample::InvalidateExtent(effectiveExtent);
     return false;
   }
 
   return true;
+}
+
+//----------------------------------------------------------------------------
+void vtkOrientedImageDataResample::InvalidateExtent(int extent[6])
+{
+  if (!extent)
+  {
+    return;
+  }
+
+  for (int i = 0; i < 3; ++i)
+  {
+    extent[2 * i] = 0;
+    extent[2 * i + 1] = -1;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -1614,13 +1630,13 @@ void vtkOrientedImageDataResample::GetLabelValuesInMask(std::vector<int>& labelV
 {
   labelValues.clear();
 
-  int binaryExtent[6] = { 0 };
+  int binaryExtent[6] = { 0, -1, 0, -1, 0, -1 };
   binaryLabelmap->GetExtent(binaryExtent);
 
-  int maskExtent[6] = { 0 };
+  int maskExtent[6] = { 0, -1, 0, -1, 0, -1 };
   mask->GetExtent(maskExtent);
 
-  int effectiveExtent[6] = { 0 };
+  int effectiveExtent[6] = { 0, -1, 0, -1, 0, -1 };
   for (int i = 0; i < 3; ++i)
   {
     effectiveExtent[2 * i] = std::max(binaryExtent[2 * i], maskExtent[2 * i]);
@@ -1761,14 +1777,14 @@ bool vtkOrientedImageDataResample::IsLabelInMask(vtkOrientedImageData* binaryLab
   vtkNew<vtkTransform> binaryToMaskTransform;
   vtkOrientedImageDataResample::GetTransformBetweenOrientedImages(binaryLabelmap, mask, binaryToMaskTransform);
 
-  int binaryExtent[6] = { 0 };
+  int binaryExtent[6] = { 0, -1, 0, -1, 0, -1 };
   binaryLabelmap->GetExtent(binaryExtent);
   vtkOrientedImageDataResample::TransformExtent(binaryExtent, binaryToMaskTransform, binaryExtent);
 
-  int maskExtent[6] = { 0 };
+  int maskExtent[6] = { 0, -1, 0, -1, 0, -1 };
   mask->GetExtent(maskExtent);
 
-  int effectiveExtent[6] = { 0 };
+  int effectiveExtent[6] = { 0, -1, 0, -1, 0, -1 };
   for (int i = 0; i < 3; ++i)
   {
     effectiveExtent[2 * i] = std::max(binaryExtent[2 * i], maskExtent[2 * i]);

--- a/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.h
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.h
@@ -132,6 +132,9 @@ public:
   /// Calculate effective extent of an image: the IJK extent where non-zero voxels are located
   static bool CalculateEffectiveExtent(vtkOrientedImageData* image, int effectiveExtent[6], double threshold = 0.0);
 
+  /// Set extent to [0,-1,0,-1,0,-1]
+  static void InvalidateExtent(int extent[6]);
+
   /// Determine if geometries of two oriented image data objects match.
   /// Origin, spacing and direction are considered, extent is not.
   static bool DoGeometriesMatch(vtkOrientedImageData* image1, vtkOrientedImageData* image2);

--- a/Libs/vtkSegmentationCore/vtkSegmentation.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.cxx
@@ -2559,7 +2559,7 @@ void vtkSegmentation::CollapseBinaryLabelmaps(bool forceToSingleLayer /*=false*/
         thresholdedLabelmap->ShallowCopy(imageThreshold->GetOutput());
         thresholdedLabelmap->CopyDirections(currentLabelmap);
 
-        int effectiveExtent[6] = { 0 };
+        int effectiveExtent[6] = { 0, -1, 0, -1, 0, -1 };
         vtkOrientedImageDataResample::CalculateEffectiveExtent(thresholdedLabelmap, effectiveExtent);
 
         vtkNew<vtkOrientedImageData> referenceImage;
@@ -2596,7 +2596,7 @@ void vtkSegmentation::CollapseBinaryLabelmaps(bool forceToSingleLayer /*=false*/
 
           if (currentLabelmap)
           {
-            int extent[6] = { 0 };
+            int extent[6] = { 0, -1, 0, -1, 0, -1 };
             currentLabelmap->GetExtent(extent);
             // If the current labelmap is empty, we don't need to merge the image.
             if (extent[0] <= extent[1] || extent[2] <= extent[3] || extent[4] <= extent[5])

--- a/Libs/vtkSegmentationCore/vtkSegmentationModifier.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentationModifier.cxx
@@ -461,7 +461,7 @@ void vtkSegmentationModifier::ShrinkSegmentToEffectiveExtent(vtkOrientedImageDat
   else
   {
     bool isPaddingRequired = false;
-    int segmentExtent[6] = { 0 };
+    int segmentExtent[6] = { 0, -1, 0, -1, 0, -1 };
     segmentLabelmap->GetExtent(segmentExtent);
     for (int i = 0; i < 3; ++i)
     {


### PR DESCRIPTION
When calling vtkSegmentation::CollapseBinaryLabelmaps with an empty segment, vtkOrientedImageDataResample::CalculateEffectiveExtent would find a maximum "invalid" extent, rather than the minimal one. Ex for an empty 1x1x1 image:
  [1, -1, 1, -1, 1,-1]
Instead of:
  [0, -1, 0, -1, 0, -1]

When calling SetExtent on an image, this could cause an error, since the size of the invalid extent could be negative, which would cause a bad_alloc error in vtkGenericDataArray.txx#428.

Fixed by setting invalid extents from vtkOrientedImageDataResample::CalculateEffectiveExtent to the minimal [0, -1, 0, -1, 0, -1]. Added tests with collapsing empty or small segments to vtkSegmentationTest2. Added proper initialization of extents.