### PR TITLE
BUG: Prevent crash on SH reparent without displayable node

### DIFF
--- a/Libs/MRML/Core/vtkMRMLFolderDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLFolderDisplayNode.cxx
@@ -133,16 +133,19 @@ void vtkMRMLFolderDisplayNode::ProcessMRMLEvents(vtkObject* caller, unsigned lon
     }
     vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::SafeDownCast(caller);
     vtkMRMLDisplayableNode* displayableReparentedNode = vtkMRMLDisplayableNode::SafeDownCast(shNode->GetItemDataNode(reparentedItemID));
-    // Trigger display update for reparented displayable node if it is in a folder that applies
-    // display properties on its branch (only display nodes that allow overriding)
-    for (int i = 0; i < displayableReparentedNode->GetNumberOfDisplayNodes(); ++i)
+    if (displayableReparentedNode)
     {
-      vtkMRMLDisplayNode* currentDisplayNode = displayableReparentedNode->GetNthDisplayNode(i);
-      if (currentDisplayNode && currentDisplayNode->GetFolderDisplayOverrideAllowed())
+      // Trigger display update for reparented displayable node if it is in a folder that applies
+      // display properties on its branch (only display nodes that allow overriding)
+      for (int i = 0; i < displayableReparentedNode->GetNumberOfDisplayNodes(); ++i)
       {
-        currentDisplayNode->Modified();
-      }
-    } // For all display nodes
+        vtkMRMLDisplayNode* currentDisplayNode = displayableReparentedNode->GetNthDisplayNode(i);
+        if (currentDisplayNode && currentDisplayNode->GetFolderDisplayOverrideAllowed())
+        {
+          currentDisplayNode->Modified();
+        }
+      } // For all display nodes
+    }
   } // SubjectHierarchyItemReparentedEvent
 }
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.h
@@ -143,8 +143,7 @@ public:
   /// Name of color attribute in folder subject hierarchy items
   Q_INVOKABLE QString colorItemAttributeName() const { return "Color"; };
 
-  /// Create model display node for given item. If the folder item has an associated model hierarchy
-  /// node, then create a display node associated to that. Otherwise create display node for folder item
+  /// Create display node for given item.
   vtkMRMLDisplayNode* createDisplayNodeForItem(vtkIdType itemID);
 
   /// Add tree view to the list of view from which empty folders have been created.
@@ -165,8 +164,7 @@ protected slots:
   void onShowEmptyFoldersToggled(bool);
 
 protected:
-  /// Retrieve model display node for given item. If the folder item has an associated model display
-  /// node (created by the plugin), then return that. Otherwise see if it has a model hierarchy node
+  /// Retrieve display node for given item.
   /// with a display node.
   vtkMRMLDisplayNode* displayNodeForItem(vtkIdType itemID) const;
 


### PR DESCRIPTION
Fix crash if folder node does not have associated displayable node

The fix was proposed in https://github.com/Slicer/Slicer/pull/8058, but that contained other changes that may need more work.
