### PR TITLE
COMP: Set BUILD_JOB_SERVER_AWARE for extension ExternalProject on CMake ≥ 3.28

### DIFF
--- a/Extensions/CMake/SlicerBlockBuildPackageAndUploadExtensions.cmake
+++ b/Extensions/CMake/SlicerBlockBuildPackageAndUploadExtensions.cmake
@@ -223,9 +223,9 @@ foreach(EXTENSION_NAME ${EXTENSION_LIST})
     ")
 
   if(CMAKE_VERSION GREATER_EQUAL "3.28")
-    set(maybe_JOB_SERVER_AWARE "JOB_SERVER_AWARE 1")
+    set(maybe_BUILD_JOB_SERVER_AWARE "BUILD_JOB_SERVER_AWARE 1")
   else()
-    set(maybe_JOB_SERVER_AWARE "")
+    set(maybe_BUILD_JOB_SERVER_AWARE "")
   endif()
 
   # Add extension external project
@@ -237,7 +237,7 @@ foreach(EXTENSION_NAME ${EXTENSION_LIST})
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${CMAKE_COMMAND} -DCTEST_BUILD_CONFIGURATION=$<CONFIG> -P ${build_extension_wrapper_script}
     INSTALL_COMMAND ""
-    ${maybe_JOB_SERVER_AWARE}
+    ${maybe_BUILD_JOB_SERVER_AWARE}
     ${EP_ARG_EXTENSION_DEPENDS}
     )
   # This custom external project step forces the build and later


### PR DESCRIPTION
Follow-up to 8cb7fc9d5d (“COMP: Ensure BUILD_JOB_SERVER_AWARE option is set for extensions external projects”, 2025-09-03) introduced through https://github.com/Slicer/Slicer/pull/8691.

Fix the `ExternalProject_Add()` argument: use `BUILD_JOB_SERVER_AWARE` (not `JOB_SERVER_AWARE`). The latter applies to custom steps, whereas the former enables GNU Make jobserver propagation for the ExternalProject’s build when a `BUILD_COMMAND` is used.

This prevents intermittent `gmake[*]: *** read jobs pipe: Bad file descriptor.` errors seen on builders using CMake ≥ 3.28 with parallel GNU Make.