### PR TITLE
ENH: Prevent slice offset set outside bounds of single slice volume

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -2806,32 +2806,21 @@ bool vtkMRMLSliceLogic::GetSliceOffsetRangeResolution(double range[2], double& r
   this->GetLowestVolumeSliceBounds(sliceBounds, true);
 
   const double* sliceSpacing = this->GetLowestVolumeSliceSpacing();
-  if (!sliceSpacing)
+  if (!sliceSpacing || (sliceBounds[5] - sliceBounds[4]) <= 0.0)
   {
-    range[0] = -1.0;
-    range[1] = 1.0;
-    resolution = 1.0;
+    // No valid volume data - use default values
+    range[0] = sliceSpacing ? -sliceSpacing[2] / 2 : -1.0;
+    range[1] = sliceSpacing ? sliceSpacing[2] / 2 : 1.0;
+    resolution = sliceSpacing ? sliceSpacing[2] / 2 : 1.0;
     return false;
   }
 
-  // Set the scale increments to match the z spacing (rotated into slice space)
-  resolution = sliceSpacing ? sliceSpacing[2] : 1.0;
+  // Set resolution based on slice spacing
+  resolution = sliceSpacing[2];
 
-  bool singleSlice = ((sliceBounds[5] - sliceBounds[4]) < resolution);
-  if (singleSlice)
-  {
-    // add one blank slice before and after the current slice to make the slider appear in the center when
-    // we are centered on the slice
-    double centerPos = (sliceBounds[4] + sliceBounds[5]) / 2.0;
-    range[0] = centerPos - resolution;
-    range[1] = centerPos + resolution;
-  }
-  else
-  {
-    // there are at least two slices in the range
-    range[0] = sliceBounds[4];
-    range[1] = sliceBounds[5];
-  }
+  // Use the actual volume bounds as the range
+  range[0] = sliceBounds[4];
+  range[1] = sliceBounds[5];
 
   return true;
 }

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -1214,15 +1214,18 @@ void qMRMLSliceControllerWidgetPrivate::onSliceLogicModifiedEvent()
 
   double offsetRange[2] = { -1.0, 1.0 };
   double offsetResolution = 1.0;
-  if (!this->SliceLogic || !this->SliceLogic->GetSliceOffsetRangeResolution(offsetRange, offsetResolution))
+  if (this->SliceLogic)
   {
-    return;
+    this->SliceLogic->GetSliceOffsetRangeResolution(offsetRange, offsetResolution);
   }
 
   bool wasBlocking = this->SliceOffsetSlider->blockSignals(true);
-  q->setSliceOffsetRange(offsetRange[0], offsetRange[1]);
+  q->setSliceOffsetRange(offsetRange[0], offsetRange[1] - 0.00001); // Slightly reduce range to ensure volume is displayed at max offset
   q->setSliceOffsetResolution(offsetResolution);
-  this->SliceOffsetSlider->setValue(this->SliceLogic->GetSliceOffset());
+  if (this->SliceLogic)
+  {
+    this->SliceOffsetSlider->setValue(this->SliceLogic->GetSliceOffset());
+  }
   this->SliceOffsetSlider->blockSignals(wasBlocking);
 
   emit q->renderRequested();

--- a/Libs/MRML/Widgets/qMRMLSliceVerticalControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceVerticalControllerWidget.cxx
@@ -121,7 +121,7 @@ void qMRMLSliceVerticalControllerWidgetPrivate::onSliceLogicModifiedEvent()
   }
 
   bool wasBlocking = this->SliceVerticalOffsetSlider->blockSignals(true);
-  q->setSliceOffsetRange(offsetRange[0], offsetRange[1]);
+  q->setSliceOffsetRange(offsetRange[0], offsetRange[1] - 0.00001); // Slightly reduce range to ensure volume is displayed at max offset
   q->setSliceOffsetResolution(offsetResolution);
   this->SliceVerticalOffsetSlider->setValue(this->SliceLogic->GetSliceOffset());
   this->SliceVerticalOffsetSlider->blockSignals(wasBlocking);


### PR DESCRIPTION
This is an attempt to update the handling of slice offset bounds for volumes with a dimension with a single slice voxel. The purpose of this change is to avoid user confusion about why moving the slice offset slider for a volume with a single slice voxel results in the slice view going black due to the offset going outside the volume bounds. For testing I was using a Slicer logo png (see below). 

I also considered hiding the slice offset slider where there is only one voxel in the given dimension such as `slicer.app.layoutManager().sliceWidget("Red").sliceController().setShowSliceOffsetSlider(False)`, but I decided to keep the slider visible at all times allowing to navigate the single voxel using an offset resolution that is half the voxel size.

<img width="513" height="512" alt="slicer-logo" src="https://github.com/user-attachments/assets/2b221113-dccc-4a9d-a7f9-7583db8dad4d" />


Slicer 5.9.0-2025-09-06 (bounds -1mm to 1mm even though single slice volume of 1mm Z spacing is from -0.5mm to 0.5mm):

https://github.com/user-attachments/assets/ba753215-51d6-4ade-94d5-57be4701eb01

This PR (bounds -0.5mm to 0.5mm for single slice volume of 1mm Z spacing):

https://github.com/user-attachments/assets/0c9178c5-02d3-480f-a035-f503734c1264

