### PR TITLE
BUG: Use UVW layer opacities when building the UVW blending pipeline

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -1278,7 +1278,7 @@ void vtkMRMLSliceLogic::UpdatePipeline()
                                  this->SliceCompositeNode->GetClipToBackgroundVolume(),
                                  // Layers
                                  layerUVWPorts,
-                                 layerOpacities,
+                                 layerUVWOpacities,
                                  // Label
                                  this->GetNthLayerImageDataConnectionUVW(vtkMRMLSliceLogic::LayerLabel),
                                  this->SliceCompositeNode->GetNthLayerOpacity(vtkMRMLSliceLogic::LayerLabel));


### PR DESCRIPTION
The UVW pipeline (`PipelineUVW->AddLayers`) was mistakenly given `layerOpacities` (from XY/2D view) instead of `layerUVWOpacities`.

This fixes a regression introduced in 2c6838e586 ("ENH: Generalize blending pipeline to support arbitrary number of layers", 2025-02-18)