### PR TITLE
BUG: Update SampleData test for multi-file volume loading behavior

### DIFF
--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -1206,9 +1206,8 @@ class SampleDataTest(ScriptedLoadableModuleTest):
             fileNames=["MRHeadResampled.raw.gz", "MRHeadResampled.nhdr"],
             nodeNames=[None, "MRHeadResampled"],
             loadFiles=[False, True]))
-        self.assertEqual(len(nodes), 2)
-        self.assertEqual(os.path.basename(nodes[0]), "MRHeadResampled.raw.gz")
-        self.assertEqual(nodes[1], slicer.mrmlScene.GetFirstNodeByName("MRHeadResampled"))
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(nodes[0], slicer.mrmlScene.GetFirstNodeByName("MRHeadResampled"))
 
     def test_downloadFromSource_loadNodesWithLoadFileFalse(self):
         logic = SampleDataLogic()


### PR DESCRIPTION
Adapt SampleData test expectations to reflect the recent fix for multi-file volume loading. The test now asserts that only a single node is created (e.g., `.nhdr` + `.raw.gz` pair) instead of treating the sidecar file as a separate node.

Follows up on 2218414aeb ("BUG: Fix loading of multi-file volumes in SampleData module", 2025-09-08) introduced through the following pull request:
* https://github.com/Slicer/Slicer/pull/8710

---

This fixes failure like this one: https://slicer.cdash.org/tests/31072271
