### PR TITLE
BUG: Fix MIP and MinIP VolumeRendering with SSAO render pass

### DIFF
--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -271,7 +271,19 @@ qMRMLThreeDView::qMRMLThreeDView(QWidget* _parent)
 }
 
 // --------------------------------------------------------------------------
-qMRMLThreeDView::~qMRMLThreeDView() = default;
+qMRMLThreeDView::~qMRMLThreeDView()
+{
+  Q_D(qMRMLThreeDView);
+
+  if (this->renderer())
+  {
+    this->renderer()->SetPass(nullptr);
+    if (d->ShadowsRenderPass)
+    {
+      d->ShadowsRenderPass->ReleaseGraphicsResources(this->renderer()->GetRenderWindow());
+    }
+  }
+}
 
 //------------------------------------------------------------------------------
 void qMRMLThreeDView::setInteractor(vtkRenderWindowInteractor* interactor)

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
@@ -40,12 +40,10 @@
 #include "vtkEventBroker.h"
 
 // VTK includes
-#include <vtkVersion.h> // must precede reference to VTK_MAJOR_VERSION
 #include "vtkAddonMathUtilities.h"
 #include <vtkCallbackCommand.h>
 #include <vtkClipVolume.h>
-#include <vtkNew.h>
-#include <vtkObjectFactory.h>
+#include <vtkDoubleArray.h>
 #include <vtkFixedPointVolumeRayCastMapper.h>
 #include <vtkGPUVolumeRayCastMapper.h>
 #include <vtkImageAppendComponents.h>
@@ -53,15 +51,18 @@
 #include <vtkImageData.h>
 #include <vtkImageGaussianSmooth.h>
 #include <vtkImageLuminance.h>
+#include <vtkImageMathematicsAddon.h>
 #include <vtkImageStencil.h>
 #include <vtkImageStencilData.h>
-#include <vtkImageMathematicsAddon.h>
 #include <vtkImplicitBoolean.h>
 #include <vtkImplicitFunctionCollection.h>
 #include <vtkImplicitFunctionToImageStencil.h>
 #include <vtkImplicitInvertableBoolean.h>
 #include <vtkInteractorStyle.h>
 #include <vtkMatrix4x4.h>
+#include <vtkMultiVolume.h>
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
 #include <vtkOpenGLGPUVolumeRayCastMapper.h>
 #include <vtkPlane.h>
 #include <vtkPlaneCollection.h>
@@ -70,11 +71,10 @@
 #include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkRenderer.h>
-#include <vtkMultiVolume.h>
+#include <vtkVersion.h> // must precede reference to VTK_MAJOR_VERSION
 #include <vtkVolume.h>
-#include <vtkVolumeProperty.h>
-#include <vtkDoubleArray.h>
 #include <vtkVolumePicker.h>
+#include <vtkVolumeProperty.h>
 
 #include <vtkImageData.h>         //TODO: Used for workaround. Remove when fixed
 #include <vtkTrivialProducer.h>   //TODO: Used for workaround. Remove when fixed


### PR DESCRIPTION
SSAO pass is not compatible with MIP and MinIP Volume rendering blend modes.

When the SSAO pass is active and the volume has MIP or MinIP blend modes, the SSAO pass is removed from the actor's `vtkOpenGLRenderPass::RenderPasses()` information. key.

The `vtkOpenGLRenderPass::RenderPasses()` key is entirely removed if after SSAO pass removal the key is empty to avoid crashes in the GPU mapper.

Following this fix, some visual artifacts remain when displaying geometry inside the volume in MIP / MinIP due to improper SSAO texture cleanup. These artifacts can only be addressed in the VTK shader code.

Closes #7560

<img width="664" height="583" alt="image" src="https://github.com/user-attachments/assets/30f539b3-c35a-4aa3-b2f3-83a4202f2c91" />
