### PR TITLE
BUG: Fix Undo/Redo in the segment editor logic

### DIFF
--- a/Modules/Loadable/Segmentations/Logic/vtkSegmentEditorLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSegmentEditorLogic.cxx
@@ -764,6 +764,9 @@ void vtkSegmentEditorLogic::SetSegmentEditorNode(vtkMRMLSegmentEditorNode* newSe
       });
 
     this->SegmentEditorNodeObs = newSegmentEditorNode->AddObserver(vtkCommand::ModifiedEvent, updateCommand);
+
+    // Update the segment editor's segmentation node observers
+    this->ReconnectSegmentationNodeObserver();
   }
 }
 
@@ -2212,6 +2215,9 @@ void vtkSegmentEditorLogic::ReconnectSegmentationNodeObserver()
 
     auto obs = newSegmentationNode->AddObserver(vtkCommand::ModifiedEvent, updateCommand);
     this->SegmentationObs = std::make_tuple(obs, newSegmentationNode);
+
+    // Synchronize the segmentation history for the new segmentation node
+    this->SynchronizeSegmentationHistorySegmentation();
   }
 }
 


### PR DESCRIPTION
Fix Undo/Redo in the segment editor not activated when loading a saved scene.

Problem was due to not observing the segmentation node modified event and not synchronizing the segmentation history to the segmentation the first time it was set.

This fix properly calls the observer reconnect and segmentation history synchronization methods on set.

Closes #8721