### PR TITLE
BUG: Preserve `sys.path` during Slicer module discovery & add startup test

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -434,6 +434,14 @@ add_test(
     ${Slicer_LAUNCHER_EXECUTABLE}
   )
 
+# Check that sys.path modifications performed at module import are preserved after Slicer startup
+add_test(
+  NAME py_startup_preserve_sys_path
+  COMMAND ${PYTHON_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/SlicerStartupPreserveSysPathTest.py
+    ${Slicer_LAUNCHER_EXECUTABLE}
+  )
+
 # Check that stand-alone Python interpreter, without PythonQt support, can `import slicer` safely (#945)
 add_test(
   NAME py_standalonepython_import_slicer

--- a/Applications/SlicerApp/Testing/Python/SlicerStartupPreserveSysPathTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerStartupPreserveSysPathTest.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+
+#
+#  Program: 3D Slicer
+#
+#  Copyright (c) Kitware Inc.
+#
+#  See COPYRIGHT.txt
+#  or http://www.slicer.org/copyright/copyright.txt for details.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc.
+#  and was partially funded by NIH grant 1U24CA194354-01
+#
+
+import os
+import sys
+import tempfile
+
+from SlicerAppTesting import EXIT_SUCCESS, runSlicer
+
+"""
+This test verifies that a scripted module can modify `sys.path` during
+import (module load) and that those modifications are preserved after
+Slicer completes startup (both with and without the main window).
+
+Rationale:
+During startup, Slicer modules may extend `sys.path` to enable imports.
+Updating argv using PyConfig followed by `_PyInterpreterState_SetConfig`
+can replace `sys.path` from the config's module_search_paths. This test
+ensures `sys.path` modifications performed during module discovery remain
+in effect after startup completes.
+
+This test was based on `SlicerStartupCompletedTest.py` and it relies on
+`SlicerStartupPreserveSysPathTestHelperModule.py` and the `SlicerStartupPreserveSysPathTestHelperPackage`
+Python package.
+
+It uses an output file for communication because on Windows,
+standard output is not always enabled.
+
+Usage:
+    SlicerStartupPreserveSysPathTest.py /path/to/Slicer
+"""
+
+if __name__ == "__main__":
+    debug = False
+    # Set to True to:
+    #  * display the path of the expected test output file
+    #  * avoid deleting the created temporary directory
+
+    if len(sys.argv) != 2:
+        print(os.path.basename(sys.argv[0]) + " /path/to/Slicer")
+        exit(EXIT_FAILURE)
+
+    temporaryModuleDirPath = tempfile.mkdtemp().replace("\\", "/") + "/lib/Slicer-X.Y/qt-scripted-modules"
+    os.makedirs(temporaryModuleDirPath, exist_ok=True)
+    try:
+        # Copy helper module that:
+        # (1) imports the helper package that updates sys.path at module load
+        # (2) removes the output file if it already exists (the startup script recreates it)
+        currentDirPath = os.path.dirname(__file__).replace("\\", "/")
+        from shutil import copyfile, copytree
+        copyfile(currentDirPath + "/SlicerStartupPreserveSysPathTestHelperModule.py",
+                 temporaryModuleDirPath + "/SlicerStartupPreserveSysPathTestHelperModule.py")
+        copytree(currentDirPath + "/SlicerStartupPreserveSysPathTestHelperPackage",
+                 temporaryModuleDirPath + "/SlicerStartupPreserveSysPathTestHelperPackage")
+
+        slicer_executable = os.path.expanduser(sys.argv[1])
+        common_args = [
+            "--testing",
+            "--disable-builtin-cli-modules",
+            "--disable-builtin-loadable-modules",
+            "--disable-builtin-scripted-loadable-modules",
+            "--additional-module-path", temporaryModuleDirPath,
+            "--python-script", currentDirPath + "/SlicerStartupPreserveSysPathTestHelperScript.py",
+        ]
+
+        test_output_file = temporaryModuleDirPath + "/StartupModuleTest.out"
+        os.environ["SLICER_STARTUP_MODULE_TEST_OUTPUT"] = test_output_file
+        if debug:
+            print("SLICER_STARTUP_MODULE_TEST_OUTPUT=%s" % test_output_file)
+
+        # Test sys.path updates done while importing SlicerStartupPreserveSysPathTestHelperPackage
+        # during module load persists with main window
+        args = list(common_args)
+        (returnCode, stdout, stderr) = runSlicer(slicer_executable, args)
+        assert returnCode == EXIT_SUCCESS, stdout + "\n" + stderr
+        assert os.path.isfile(test_output_file), "startup helper script did not produce the output file"
+        os.remove(test_output_file)
+        print("Test startupCompleted with main window - passed\n")
+
+        # Test sys.path updates done while importing SlicerStartupPreserveSysPathTestHelperPackage
+        # during module load persists without main window
+        args = list(common_args)
+        args.extend(["--no-main-window"])
+        (returnCode, stdout, stderr) = runSlicer(slicer_executable, args)
+        assert returnCode == EXIT_SUCCESS, stdout + "\n" + stderr
+        assert os.path.isfile(test_output_file), "startup helper script did not produce the output file"
+        print("Test startupCompleted without main window - passed\n")
+
+    finally:
+        if not debug:
+            import shutil
+            shutil.rmtree(temporaryModuleDirPath)

--- a/Applications/SlicerApp/Testing/Python/SlicerStartupPreserveSysPathTestHelperModule.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerStartupPreserveSysPathTestHelperModule.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+from slicer.ScriptedLoadableModule import ScriptedLoadableModule
+
+# Ensure the helper package is importable during module load, so its
+# __init__ can modify sys.path immediately.
+currentDir = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(currentDir)
+
+from SlicerStartupPreserveSysPathTestHelperPackage import *
+
+class SlicerStartupPreserveSysPathTestHelperModule(ScriptedLoadableModule):
+    def __init__(self, parent):
+        ScriptedLoadableModule.__init__(self, parent)
+        self.parent.title = "SlicerStartupPreserveSysPathTest"
+        self.parent.categories = ["Testing.TestCases"]
+        self.parent.contributors = ["Rafael Palomar (Oslo University Hospital), Jean-Christophe Fillion-Robin (Kitware), Andras Lasso (PerkLab)"]
+        self.parent.widgetRepresentationCreationEnabled = False
+
+        self.testOutputFileName = os.environ["SLICER_STARTUP_MODULE_TEST_OUTPUT"]
+        if os.path.isfile(self.testOutputFileName):
+            os.remove(self.testOutputFileName)
+
+        print("SlicerStartupPreserveSysPathTestHelperModule initialized")

--- a/Applications/SlicerApp/Testing/Python/SlicerStartupPreserveSysPathTestHelperPackage/__init__.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerStartupPreserveSysPathTestHelperPackage/__init__.py
@@ -1,0 +1,7 @@
+import sys
+
+SENTINEL = "/test/slicer-start-preserve-sys-path/directory"
+
+# Insert a sentinel path at the front of sys.path to detect preservation.
+# We don't require the path to exist; we only assert presence.
+sys.path.insert(0, SENTINEL)

--- a/Applications/SlicerApp/Testing/Python/SlicerStartupPreserveSysPathTestHelperScript.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerStartupPreserveSysPathTestHelperScript.py
@@ -1,0 +1,13 @@
+import sys
+import os
+
+SENTINEL = "/test/slicer-start-preserve-sys-path/directory"
+if SENTINEL not in sys.path:
+    raise RuntimeError(f"{SENTINEL} not in sys.path as expected")
+
+testOutputFileName = os.environ["SLICER_STARTUP_MODULE_TEST_OUTPUT"]
+with open(testOutputFileName, "w") as file:
+    file.write("SlicerStartupPreserveSysPathTestHelperScript.py generated this file")
+    file.write(f"{SENTINEL} found in sys.path")
+
+exit(EXIT_SUCCESS)


### PR DESCRIPTION
_The original pull request description was update by @jcfr to describe the root cause and associated fix._

This PR fixes a regression where updating `argv` via the PyConfig API caused the live interpreter’s `sys.path` to be replaced with `config.module_search_paths`, dropping entries added during Slicer's module discovery. It also adds an application Python test.

## Background

In fa915a03fc4 ("BUG: Fix improper Python initialization causing inconsistent interpreter state", 2025-07-17) we switched to updating `argv` using `PyConfig_SetArgv()` and `_PyInterpreterState_SetConfig()`,

While correct for `argv`, the latter **repopulates `sys.path` from the config**, which typically lacks path inserted during Slicer module discovery. Result: imports depending on those entries could fail after startup.

## Summary

Add `py_startup_preserve_sys_path` test and update `qSlicerCoreApplication::handleCommandLineArguments` to perform the following steps:
* Before calling `_PyInterpreterState_SetConfig`, snapshot the current `sys.path` using PythonQt.
* Apply the updated config (to update `argv`).
* Restore the exact `sys.path` afterwards (`PythonQt::overwriteSysPath`), preserving order and duplicates.

---

<details><summary>Previous description</summary>
<p>


This adds a new python test which tries to (1) modify `sys.path` on module load and (2) verify preservation of the changes after slicer startup. The mock module structure as follows:

```txt
SlicerStartupModuleTestHelperModule.py                   # Mock module which imports SlicerStartupModuleTestHelperPackage
SlicerStartupModuleTestHelperPackage/__init__.py   # Mock Python package which modifies sys.path
SlicerStartupModuleTestHelperScript.py                      # Startup script which verifies if sys.path was modified accordingly
```


</p>
</details> 