### PR TITLE
ENH: Allow reading/writing of 2 component vector volumes

### DIFF
--- a/Libs/MRML/Core/vtkMRMLNRRDStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNRRDStorageNode.cxx
@@ -218,8 +218,10 @@ int vtkMRMLNRRDStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
   }
   else if (refNode->IsA("vtkMRMLVectorVolumeNode"))
   {
-    if (!(reader->GetPointDataType() == vtkDataSetAttributes::VECTORS //
-          || reader->GetPointDataType() == vtkDataSetAttributes::NORMALS))
+    if (!(reader->GetPointDataType() == vtkDataSetAttributes::VECTORS     //
+          || reader->GetPointDataType() == vtkDataSetAttributes::NORMALS  //
+          || (reader->GetPointDataType() == vtkDataSetAttributes::SCALARS //
+              && reader->GetNumberOfComponents() > 1)))
     {
       vtkErrorMacro("ReadData: MRMLVolumeNode does not match file kind");
       return 0;

--- a/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
@@ -246,7 +246,7 @@ vtkITKArchetypeImageSeriesReader* vtkMRMLVolumeArchetypeStorageNode::Instantiate
 
   vtkDebugMacro("ReadData: readerSeries number of file names = " << numberOfFileNames);
 
-  if (reader->GetNumberOfComponents() < 3)
+  if (reader->GetNumberOfComponents() < 2)
   {
     return nullptr;
   }

--- a/Libs/vtkITK/vtkITKImageWriter.cxx
+++ b/Libs/vtkITK/vtkITKImageWriter.cxx
@@ -408,6 +408,74 @@ void vtkITKImageWriter::Write()
       default: vtkErrorMacro(<< "Execute: Unknown output ScalarType"); return;
     }
   } // scalar
+  else if (inputNumberOfScalarComponents == 2)
+  {
+    // take into consideration the scalar type
+    switch (inputDataType)
+    {
+      case VTK_DOUBLE:
+      {
+        typedef itk::Vector<double, 2> PixelType;
+        ITKWriteVTKImage<PixelType>(this, inputImage, this->GetFileName(), this->RasToIJKMatrix);
+      }
+      break;
+      case VTK_FLOAT:
+      {
+        typedef itk::Vector<float, 2> PixelType;
+        ITKWriteVTKImage<PixelType>(this, inputImage, this->GetFileName(), this->RasToIJKMatrix);
+      }
+      break;
+      case VTK_LONG:
+      {
+        typedef itk::Vector<long, 2> PixelType;
+        ITKWriteVTKImage<PixelType>(this, inputImage, this->GetFileName(), this->RasToIJKMatrix);
+      }
+      break;
+      case VTK_UNSIGNED_LONG:
+      {
+        typedef itk::Vector<unsigned long, 2> PixelType;
+        ITKWriteVTKImage<PixelType>(this, inputImage, this->GetFileName(), this->RasToIJKMatrix);
+      }
+      break;
+      case VTK_INT:
+      {
+        typedef itk::Vector<int, 2> PixelType;
+        ITKWriteVTKImage<PixelType>(this, inputImage, this->GetFileName(), this->RasToIJKMatrix);
+      }
+      break;
+      case VTK_UNSIGNED_INT:
+      {
+        typedef itk::Vector<unsigned int, 2> PixelType;
+        ITKWriteVTKImage<PixelType>(this, inputImage, this->GetFileName(), this->RasToIJKMatrix);
+      }
+      break;
+      case VTK_SHORT:
+      {
+        typedef itk::Vector<short, 2> PixelType;
+        ITKWriteVTKImage<PixelType>(this, inputImage, this->GetFileName(), this->RasToIJKMatrix);
+      }
+      break;
+      case VTK_UNSIGNED_SHORT:
+      {
+        typedef itk::Vector<unsigned short, 2> PixelType;
+        ITKWriteVTKImage<PixelType>(this, inputImage, this->GetFileName(), this->RasToIJKMatrix);
+      }
+      break;
+      case VTK_CHAR:
+      {
+        typedef itk::Vector<char, 2> PixelType;
+        ITKWriteVTKImage<PixelType>(this, inputImage, this->GetFileName(), this->RasToIJKMatrix);
+      }
+      break;
+      case VTK_UNSIGNED_CHAR:
+      {
+        typedef itk::Vector<unsigned char, 2> PixelType;
+        ITKWriteVTKImage<PixelType>(this, inputImage, this->GetFileName(), this->RasToIJKMatrix);
+      }
+      break;
+      default: vtkErrorMacro(<< "Execute: Unknown output ScalarType"); return;
+    }
+  } // 2 - component
   else if (inputNumberOfScalarComponents == 3)
   {
     if (voxelVectorType == vtkITKImageWriter::VoxelVectorTypeColorRGB)

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
@@ -1105,10 +1105,14 @@ void vtkMRMLVolumeRenderingDisplayableManager::vtkInternal::UpdateDisplayNodePip
   vtkOpenGLGPUVolumeRayCastMapper* openGLMapper = vtkOpenGLGPUVolumeRayCastMapper::SafeDownCast(mapper);
   if (openGLMapper)
   {
-    int* dims = volumeNode->GetImageData()->GetDimensions();
-    unsigned short partitions[3] = { static_cast<unsigned short>(dims[0] / vtkMRMLVolumeRenderingDisplayableManager::Maximum3DTextureSize + 1),
-                                     static_cast<unsigned short>(dims[1] / vtkMRMLVolumeRenderingDisplayableManager::Maximum3DTextureSize + 1),
-                                     static_cast<unsigned short>(dims[2] / vtkMRMLVolumeRenderingDisplayableManager::Maximum3DTextureSize + 1) };
+    int dimensions[3] = { 0, 0, 0 };
+    if (imageData)
+    {
+      imageData->GetDimensions(dimensions);
+    }
+    unsigned short partitions[3] = { static_cast<unsigned short>(dimensions[0] / vtkMRMLVolumeRenderingDisplayableManager::Maximum3DTextureSize + 1),
+                                     static_cast<unsigned short>(dimensions[1] / vtkMRMLVolumeRenderingDisplayableManager::Maximum3DTextureSize + 1),
+                                     static_cast<unsigned short>(dimensions[2] / vtkMRMLVolumeRenderingDisplayableManager::Maximum3DTextureSize + 1) };
     openGLMapper->SetPartitions(partitions[0], partitions[1], partitions[2]);
   }
 


### PR DESCRIPTION
This commit allows 2 component volumes to be read/written into vtkMRMLVectorVolumenode.
- Added 2 component case handling to vtkITKImageWriter
- Added handling of scalar datasets with > 1 component to vtkMRMLNRRDStorageNode.
- Allow vtkMRMLVolumeArchetypeStorageNode::InstantiateVectorVolumeReader to return a reader with 2 components.