### PR TITLE
ENH: Add volume reorientation to Crop Volume module

### DIFF
--- a/Docs/user_guide/modules/cropvolume.md
+++ b/Docs/user_guide/modules/cropvolume.md
@@ -22,7 +22,9 @@ Most frequently used for these scenarios:
 
 * **Registration of two objects that occupy smaller portions of the image**. In this scenario, cropping will allow you to focus the processing at the region of interest, and simplify registration initialization.
 
-* **Definition of new axis directions** for your image: [Interpolated cropping options](#interpolated-cropping-options) allows the output volume to have different axis directions that the original volume. The output volume's axis directions will be aligned with the ROI widget's axes. ROI widget axes can be rotated using the [Transforms](transforms.md) module.
+* **Fix orientation of the volume**: If the orientation of the input volume is not correct (i.e., does not correspond to the anatomical axes) then the "Reorient volume" section can be used for adjusting the orientation by clicking on `Initialize`, use the rotation handles in views to fix the orientation, then click `Apply`. After that it is recommended to change the ROI fitting mode (dropdown menu of `Fit to Volume` button) to `Align to world axes + Resize` so that the cropped volume's axes are aligned to anatomical directions.
+
+* **Definition of new axis directions** for your image: [Interpolated cropping options](#interpolated-cropping-options) allows the output volume to have different axis directions than the original volume. The output volume's axis directions will be aligned with the ROI widget's axes. ROI widget axes can be rotated using the [Transforms](transforms.md) module.
 
 * **Cropping of oblique sub-volumes**: This can be done by placing either or both of input volume and ROI under transform(s). These transforms will be taken into account while preparing the output.
 
@@ -36,11 +38,17 @@ Most frequently used for these scenarios:
 
 - **Input volume:** The scalar volume to crop.
 
+  - **Reorient volume:** Useful for correcting orientation of the volume before cropping. Click on `Initialize` to show rotation handles, adjust the orientation, then click `Apply` to permanently change the volume orientation and hide the rotation handles.
+
 - **Input ROI:** The region of interest driving the cropping process. ROIs have a box-like shape in which the interior of the box is the region to preserve and the exterior is the region to exclude. This combobox widget will allow the user to select an already existing ROI or create a new one (in addition, this widget will provide additional options such as rename or edit an existing ROI).
 
   - **Display ROI:** Turn on/off the display of the ROI representation. If this is on, a representation of the ROI will be visible in the Slice views (2D) or in the 3D view. The resulting ROI can be manipulated interactively in any of the Slice views (2D) or the 3D view.
 
-  - **Fit to Volume:** This will resize the ROI to fit the extent of the Input volume specified.
+  - **Fit to Volume:** This will resize the ROI to fit the extent of the Input volume specified. The button has a dropdown menu to tune its behavior, with the following options:
+
+    - **Align to volume axes + Resize:** rotate the ROI axes to align the ROI box orientation (and thus the cropped volume axes) to match the input volume axes directions. This is useful if the goal is to minimize changes compared to the input volume.
+    - **Align to world axes + Resize:** rotate the ROI axes to align the ROI box orientation (and thus the cropped volume axes) to the world coordinate system. This is useful to make the cropped volume axes to be anatomically aligned.
+    - **Resize only:** only resize the ROI and keep its current orientation. This is useful if the ROI orientation is already set to the desired value and only the size of the ROI needs to be adjusted to fully enclose the input volume.
 
 - **Output volume:** The output volume that represents the result of the cropping operation. This widget allows for the selection of an already existing volume (e.g., the input volume itself) or the creation of a new output volume node to store the results. By default, if no node is selected, output volume is created automatically.
 

--- a/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.h
+++ b/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.h
@@ -22,10 +22,13 @@
 
 // Slicer includes
 #include "vtkSlicerModuleLogic.h"
-class vtkMRMLVolumeNode;
 class vtkMRMLDisplayableNode;
-// vtk includes
+class vtkMRMLTransformNode;
+class vtkMRMLVolumeNode;
+
+// VTK includes
 class vtkMatrix4x4;
+
 // CropVolumes includes
 #include "vtkSlicerCropVolumeModuleLogicExport.h"
 class vtkMRMLCropVolumeParametersNode;
@@ -92,15 +95,24 @@ public:
                                                 int outputExtent[6],
                                                 double outputSpacing[3]);
 
+  /// Sets ROI to fit to input volume. Orientation of the ROI set based on FitROIMode setting.
+  static bool FitROI(vtkMRMLCropVolumeParametersNode* parametersNode);
+
   /// Sets ROI to fit to input volume.
   /// If ROI is under a non-linear transform then the ROI transform will be reset to RAS.
   static bool FitROIToInputVolume(vtkMRMLCropVolumeParametersNode* parametersNode);
 
   static void SnapROIToVoxelGrid(vtkMRMLCropVolumeParametersNode* parametersNode);
+  static void SnapROIToWorld(vtkMRMLCropVolumeParametersNode* parametersNode);
 
   static bool IsROIAlignedWithInputVolume(vtkMRMLCropVolumeParametersNode* parametersNode);
+  static bool IsROIAlignedWithWorld(vtkMRMLCropVolumeParametersNode* parametersNode);
 
   void RegisterNodes() override;
+
+  bool ReorientVolumeStart(vtkMRMLCropVolumeParametersNode* parametersNode);
+  bool ReorientVolumeEnd(vtkMRMLCropVolumeParametersNode* parametersNode, bool apply);
+  vtkMRMLTransformNode* GetReorientTransformNode(vtkMRMLCropVolumeParametersNode* parametersNode);
 
 protected:
   vtkSlicerCropVolumeLogic();

--- a/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.cxx
+++ b/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.cxx
@@ -57,6 +57,8 @@ vtkMRMLCropVolumeParametersNode::vtkMRMLCropVolumeParametersNode()
   this->IsotropicResampling = false;
   this->SpacingScalingConst = 1.;
   this->FillValue = 0.;
+
+  this->FitROIMode = vtkMRMLCropVolumeParametersNode::FitROIAlignToVolume;
 }
 
 //----------------------------------------------------------------------------
@@ -76,6 +78,7 @@ void vtkMRMLCropVolumeParametersNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBooleanMacro(isotropicResampling, IsotropicResampling);
   vtkMRMLReadXMLFloatMacro(spaceScalingConst, SpacingScalingConst);
   vtkMRMLReadXMLFloatMacro(fillValue, FillValue);
+  vtkMRMLReadXMLEnumMacro(fitROIMode, FitROIMode);
   vtkMRMLReadXMLEndMacro();
 
   this->EndModify(disabledModify);
@@ -91,6 +94,7 @@ void vtkMRMLCropVolumeParametersNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBooleanMacro(isotropicResampling, IsotropicResampling);
   vtkMRMLWriteXMLFloatMacro(spaceScalingConst, SpacingScalingConst);
   vtkMRMLWriteXMLFloatMacro(fillValue, FillValue);
+  vtkMRMLWriteXMLEnumMacro(fitROIMode, FitROIMode);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -106,6 +110,7 @@ void vtkMRMLCropVolumeParametersNode::CopyContent(vtkMRMLNode* anode, bool deepC
   vtkMRMLCopyBooleanMacro(IsotropicResampling);
   vtkMRMLCopyFloatMacro(SpacingScalingConst);
   vtkMRMLCopyFloatMacro(FillValue);
+  vtkMRMLCopyEnumMacro(FitROIMode);
   vtkMRMLCopyEndMacro();
 }
 
@@ -119,6 +124,7 @@ void vtkMRMLCropVolumeParametersNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBooleanMacro(IsotropicResampling);
   vtkMRMLPrintFloatMacro(SpacingScalingConst);
   vtkMRMLPrintFloatMacro(FillValue);
+  vtkMRMLPrintEnumMacro(FitROIMode);
   vtkMRMLPrintEndMacro();
 }
 
@@ -206,4 +212,36 @@ void vtkMRMLCropVolumeParametersNode::DeleteROIAlignmentTransformNode()
       this->GetScene()->RemoveNode(transformNode);
     }
   }
+}
+
+//---------------------------------------------------------------------------
+const char* vtkMRMLCropVolumeParametersNode::GetFitROIModeAsString(int mode)
+{
+  switch (mode)
+  {
+    case vtkMRMLCropVolumeParametersNode::FitROIAlignToVolume: return "AlignToVolume";
+    case vtkMRMLCropVolumeParametersNode::FitROIAlignToWorld: return "AlignToWorld";
+    case vtkMRMLCropVolumeParametersNode::FitROIKeepOrientation: return "KeepOrientation";
+    default: vtkGenericWarningMacro("Unknown fit ROI mode: " << mode); return "";
+  }
+}
+
+//-----------------------------------------------------------
+int vtkMRMLCropVolumeParametersNode::GetFitROIModeFromString(const char* name)
+{
+  if (name == nullptr)
+  {
+    // invalid name
+    return -1;
+  }
+  for (int mode = 0; mode < FitROI_Last; mode++)
+  {
+    if (strcmp(name, GetFitROIModeAsString(mode)) == 0)
+    {
+      // found a matching name
+      return mode;
+    }
+  }
+  // unknown name
+  return -1;
 }

--- a/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.h
+++ b/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.h
@@ -35,6 +35,14 @@ public:
     InterpolationBSpline = 4
   };
 
+  enum
+  {
+    FitROIAlignToVolume = 0,   ///< Before resizing the ROI, ROI orientation is adjusted to align with the axes of the input volume
+    FitROIAlignToWorld = 1,    ///< Before resizing the ROI, ROI orientation is adjusted to align with the world coordinate system axes
+    FitROIKeepOrientation = 2, ///< The ROI orientation is not modified during fitting
+    FitROI_Last                ///< PositionStatus_Last: indicates the end of the enum (int first = 0, int last = FitROI_Last)
+  };
+
   static vtkMRMLCropVolumeParametersNode* New();
   vtkTypeMacro(vtkMRMLCropVolumeParametersNode, vtkMRMLNode);
   void PrintSelf(ostream& os, vtkIndent indent) override;
@@ -97,6 +105,16 @@ public:
   vtkSetMacro(FillValue, double);
   vtkGetMacro(FillValue, double);
 
+  /// Set method for fitting the ROI to the input volume.
+  /// Before resizing the ROI, orientation of the ROI is adjusted according to chosen option:
+  /// - FitROIAlignToVolume to align with the axes of the input volume (default)
+  /// - FitROIAlignToWorld to align with world coordinate system axes
+  /// - FitROIKeepOrientation to keep the current orientation
+  vtkSetMacro(FitROIMode, int);
+  vtkGetMacro(FitROIMode, int);
+  static const char* GetFitROIModeAsString(int slabReconstructionType);
+  static int GetFitROIModeFromString(const char* name);
+
 protected:
   vtkMRMLCropVolumeParametersNode();
   ~vtkMRMLCropVolumeParametersNode() override;
@@ -109,6 +127,7 @@ protected:
   bool IsotropicResampling;
   double SpacingScalingConst;
   double FillValue;
+  int FitROIMode;
 };
 
 #endif

--- a/Modules/Loadable/CropVolume/Resources/UI/qSlicerCropVolumeModuleWidget.ui
+++ b/Modules/Loadable/CropVolume/Resources/UI/qSlicerCropVolumeModuleWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>583</width>
-    <height>792</height>
+    <width>317</width>
+    <height>669</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -160,14 +160,14 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="InputROILabel">
         <property name="text">
          <string>Input ROI:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="qMRMLNodeComboBox" name="InputROIComboBox">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -197,7 +197,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_4">
         <property name="spacing">
          <number>6</number>
@@ -227,10 +227,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="ROIFitPushButton">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
+         <widget class="ctkMenuButton" name="ROIFitPushButton">
           <property name="text">
            <string>Fit to Volume</string>
           </property>
@@ -242,14 +239,14 @@
         </item>
        </layout>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="OutputVolumeLabel">
         <property name="text">
          <string>Output volume:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="qMRMLNodeComboBox" name="OutputVolumeComboBox">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -278,6 +275,42 @@
         <property name="noneDisplay">
          <string>Create new volume</string>
         </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="ctkCollapsibleGroupBox" name="ReorientInputVolumeGroupBox">
+        <property name="title">
+         <string>Reorient volume</string>
+        </property>
+        <property name="collapsed">
+         <bool>true</bool>
+        </property>
+        <property name="collapsedHeight">
+         <number>3</number>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_4">
+         <item row="1" column="0">
+          <widget class="QPushButton" name="ReorientInputVolumeCancelButton">
+           <property name="text">
+            <string>Cancel</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QPushButton" name="ReorientInputVolumeApplyButton">
+           <property name="text">
+            <string>Apply</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0" colspan="2">
+          <widget class="QPushButton" name="ReorientInputVolumeInitializeButton">
+           <property name="text">
+            <string>Initialize</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>
@@ -319,6 +352,35 @@
       <property name="bottomMargin">
        <number>4</number>
       </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="FillValueLabel">
+        <property name="text">
+         <string>Fill value:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="ctkDoubleSpinBox" name="FillValueSpinBox">
+        <property name="toolTip">
+         <string>Voxel values outside the input volume will be filled with this value</string>
+        </property>
+        <property name="decimalsOption">
+         <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts|ctkDoubleSpinBox::DecimalsByValue|ctkDoubleSpinBox::InsertDecimals</set>
+        </property>
+        <property name="minimum">
+         <double>-65536.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>65535.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>10.000000000000000</double>
+        </property>
+        <property name="setMode">
+         <enum>ctkDoubleSpinBox::SetAlways</enum>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="IsotropicOutputVoxelLabel_2">
         <property name="text">
@@ -388,13 +450,6 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="InterpolatorLabel">
-        <property name="text">
-         <string>Interpolator:</string>
-        </property>
-       </widget>
-      </item>
       <item row="4" column="1">
        <layout class="QGridLayout" name="gridLayout_3">
         <item row="1" column="1">
@@ -438,35 +493,6 @@
          </widget>
         </item>
        </layout>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="FillValueLabel">
-        <property name="text">
-         <string>Fill value:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="ctkDoubleSpinBox" name="FillValueSpinBox">
-        <property name="toolTip">
-         <string>Voxel values outside the input volume will be filled with this value</string>
-        </property>
-        <property name="decimalsOption">
-         <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts|ctkDoubleSpinBox::DecimalsByValue|ctkDoubleSpinBox::InsertDecimals</set>
-        </property>
-        <property name="minimum">
-         <double>-65536.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>65535.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>10.000000000000000</double>
-        </property>
-        <property name="setMode">
-         <enum>ctkDoubleSpinBox::SetAlways</enum>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>
@@ -722,6 +748,39 @@
     </spacer>
    </item>
   </layout>
+  <action name="ROIFitAlignToVolumeAction">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Align to volume axes + Resize</string>
+   </property>
+   <property name="toolTip">
+    <string>Set axes of the ROI box to match the volume axes</string>
+   </property>
+  </action>
+  <action name="ROIFitAlignToWorldAction">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Align to world axes + Resize</string>
+   </property>
+   <property name="toolTip">
+    <string>Set axes of the ROI box to match the world coordinate system axes</string>
+   </property>
+  </action>
+  <action name="ROIFitKeepOrientationAction">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Resize only</string>
+   </property>
+   <property name="toolTip">
+    <string>Do not change ROI box orientation</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -753,6 +812,12 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>ctkCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>ctkCollapsibleGroupBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>ctkCoordinatesWidget</class>
    <extends>QWidget</extends>
    <header>ctkCoordinatesWidget.h</header>
@@ -766,6 +831,11 @@
    <class>ctkFittedTextBrowser</class>
    <extends>QTextBrowser</extends>
    <header>ctkFittedTextBrowser.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkMenuButton</class>
+   <extends>QPushButton</extends>
+   <header>ctkMenuButton.h</header>
   </customwidget>
  </customwidgets>
  <resources>
@@ -962,22 +1032,6 @@
     <hint type="destinationlabel">
      <x>154</x>
      <y>149</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>InputROIComboBox</sender>
-   <signal>currentNodeChanged(bool)</signal>
-   <receiver>ROIFitPushButton</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>279</x>
-     <y>129</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>278</x>
-     <y>160</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.h
+++ b/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.h
@@ -35,12 +35,16 @@ protected slots:
   void setInputVolume(vtkMRMLNode*);
   void setOutputVolume(vtkMRMLNode* node);
   void setInputROI(vtkMRMLNode*);
+  void setFitROIMode(int);
   void initializeInputROI(vtkMRMLNode*);
   /// when ROIs get added to the node selector, if the selector doesn't
   /// have a current node, select it
   void onInputROIAdded(vtkMRMLNode* node);
 
   void onROIVisibilityChanged(bool);
+  void onReorientInputVolumeInitialize();
+  void onReorientInputVolumeApply();
+  void onReorientInputVolumeCancel();
   void onROIFit();
   void onInterpolationModeChanged();
   void onApply();


### PR DESCRIPTION
Orientation of the input volume can now be easily fixed in Crop Volume module using the new "Reorient volume" section.

Options are added to tune "Fit to volume" beheavior. It is now possible to align the cropped volume's ROI to the world coordinate system (or keep the current ROI orientation). This is useful if the user wants to align the cropped volume axes to the world coordinate system, for example to make segmentation in anatomical planes easier.

fixes #8415

<img width="1282" height="1027" alt="image" src="https://github.com/user-attachments/assets/270c25cf-7b08-4f5d-9ac1-1da266aa824f" />

@muratmaga 