### PR TITLE
BUG: Do not reset markups control points when reading XML attributes

### DIFF
--- a/Libs/MRML/Core/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -552,6 +552,7 @@ int vtkMRMLMarkupsFiducialStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
     {
       // clear out the list
       markupsNode->RemoveAllControlPoints();
+      markupsNode->ClearValueForAllMeasurements();
     }
 
     std::string line;

--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.cxx
@@ -133,9 +133,6 @@ void vtkMRMLMarkupsNode::ReadXMLAttributes(const char** atts)
 {
   MRMLNodeModifyBlocker blocker(this);
 
-  this->RemoveAllControlPoints();
-  this->ClearValueForAllMeasurements();
-
   Superclass::ReadXMLAttributes(atts);
 
   vtkMRMLReadXMLBeginMacro(atts);

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
@@ -367,6 +367,7 @@ bool vtkMRMLMarkupsJsonStorageNode::UpdateMarkupsNodeFromJsonValue(vtkMRMLMarkup
 
   // clear out the list
   markupsNode->RemoveAllControlPoints();
+  markupsNode->ClearValueForAllMeasurements();
 
   if (markupObject->HasMember("name"))
   {


### PR DESCRIPTION
Measurement values are properly reset when reading markups data. Control points are preserved during XML attribute reading, maintaining existing markup geometry and preventing unintended data loss.

Ref: https://github.com/Slicer/Slicer/pull/8141#discussion_r2372552810