### PR TITLE
BUG: Make DICOMProcess init cooperative so TLS mixin is initialized

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -72,6 +72,7 @@ class DICOMProcess:
             raise UserWarning("Could not find a valid path to DICOM helper applications")
 
     def __init__(self):
+        super().__init__()
         self.process = None
         self.connections = {}
         self.exeDir = self.getDCMTKToolsPath()


### PR DESCRIPTION
DICOMCommand inherits from both `DICOMProcess` and `DICOMProcessTLSMixin` but `DICOMProcess.__init__` did not call `super().__init__()`. As a side effect, the MRO stopped before `DICOMProcessTLSMixin.__init__` could set `_tlsSettingsKeyPrefix`.

This regression was introduced by c8d2b625516 ("ENH: Add TLS authentication support to DICOM Sender and Listener", 2024-12-31) and introduced the following error reported when running the test `py_nomainwindow_DCMTKPrivateDictTest`:

```
Traceback (most recent call last):
  File "<string>", line 5, in <module>
  File "<string>", line 8, in <module>
  File "C:\D\P\S-0-build\Slicer-build\lib\Slicer-5.9\qt-scripted-modules\DICOMLib\DICOMProcesses.py", line 279, in start
    self.args = self._args + self.tlsArguments()
                             ^^^^^^^^^^^^^^^^^^^
  File "C:\D\P\S-0-build\Slicer-build\lib\Slicer-5.9\qt-scripted-modules\DICOMLib\DICOMProcesses.py", line 256, in tlsArguments
    if self.tlsEnabled:
       ^^^^^^^^^^^^^^^
  File "C:\D\P\S-0-build\Slicer-build\lib\Slicer-5.9\qt-scripted-modules\DICOMLib\DICOMProcesses.py", line 223, in tlsEnabled
    return self.tlsPrivateKey is not None and self.tlsCertFile is not None
           ^^^^^^^^^^^^^^^^^^
  File "C:\D\P\S-0-build\Slicer-build\lib\Slicer-5.9\qt-scripted-modules\DICOMLib\DICOMProcesses.py", line 201, in tlsPrivateKey
    if self.tlsSettingsKeyPrefix:
       ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\D\P\S-0-build\Slicer-build\lib\Slicer-5.9\qt-scripted-modules\DICOMLib\DICOMProcesses.py", line 186, in tlsSettingsKeyPrefix
    return self._tlsSettingsKeyPrefix
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'DICOMCommand' object has no attribute '_tlsSettingsKeyPrefix'. Did you mean: 'tlsSettingsKeyPrefix'?
```