### PR TITLE
ENH: Add support for storing modeling displacement field transforms

### DIFF
--- a/Libs/MRML/Core/Testing/CMakeLists.txt
+++ b/Libs/MRML/Core/Testing/CMakeLists.txt
@@ -86,7 +86,9 @@ create_test_sourcelist(Tests ${KIT}CxxTests.cxx
   vtkMRMLTransformableNodeOnNodeReferenceAddTest.cxx
   vtkMRMLTransformDisplayNodeTest1.cxx
   vtkMRMLTransformNodeTest1.cxx
+  vtkMRMLTransformSequenceStorageNodeTest1.cxx
   vtkMRMLTransformStorageNodeTest1.cxx
+  vtkMRMLTransformStorageNodeTest2.cxx
   vtkMRMLTransformableNodeTest1.cxx
   vtkMRMLUnitNodeTest1.cxx
   vtkMRMLVectorVolumeDisplayNodeTest1.cxx
@@ -202,6 +204,7 @@ simple_test( vtkMRMLTransformableNodeTest1 )
 simple_test( vtkMRMLTransformDisplayNodeTest1 )
 simple_test( vtkMRMLTransformNodeTest1 )
 simple_test( vtkMRMLTransformStorageNodeTest1 ${TEMP})
+simple_test( vtkMRMLTransformStorageNodeTest2 ${TEMP})
 simple_test( vtkMRMLUnitNodeTest1 )
 simple_test( vtkMRMLVectorVolumeDisplayNodeTest1 )
 simple_test( vtkMRMLVectorVolumeNodeTest1 )

--- a/Libs/MRML/Core/Testing/vtkMRMLTransformSequenceStorageNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTransformSequenceStorageNodeTest1.cxx
@@ -1,0 +1,229 @@
+/*=auto=========================================================================
+
+  Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH)
+  All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Program:   3D Slicer
+
+=========================================================================auto=*/
+
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLScene.h"
+#include "vtkMRMLTransformNode.h"
+#include "vtkMRMLSequenceNode.h"
+#include "vtkMRMLTransformSequenceStorageNode.h"
+
+#include <vtkImageData.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+#include <vtksys/SystemTools.hxx>
+#include <vtkOrientedGridTransform.h>
+#include <vtkGeneralTransform.h>
+#include <sstream>
+#include <iomanip>
+
+namespace
+{
+std::string tempFilename(std::string tempDir, std::string suffix, std::string fileExtension, bool remove = false)
+{
+  std::string filename = tempDir + "/vtkMRMLTransformSequenceStorageNodeTest1_" + suffix + "." + fileExtension;
+  // remove file if exists
+  if (remove && vtksys::SystemTools::FileExists(filename.c_str(), true))
+  {
+    vtksys::SystemTools::RemoveFile(filename.c_str());
+  }
+  return filename;
+}
+} // namespace
+
+//---------------------------------------------------------------------------
+int TestGridTransformSequenceStorage(const std::string tempDir, bool useTransformFromParent)
+{
+  std::string transformDirection = useTransformFromParent ? "FromParent" : "ToParent";
+  std::cout << "TestGridTransformSequenceStorage: Testing transform sequence " << transformDirection << std::endl;
+
+  vtkNew<vtkMRMLScene> scene;
+
+  // Create a sequence node to hold the transforms
+  vtkNew<vtkMRMLSequenceNode> sequenceNode;
+  scene->AddNode(sequenceNode);
+  sequenceNode->SetIndexName("mytime");
+  sequenceNode->SetIndexUnit("mys");
+
+  int dimensions[3] = { 6, 8, 11 };
+
+  // Create 5 grid transform nodes with varying displacement patterns
+  const int numberOfTransforms = 5;
+  for (int transformIndex = 0; transformIndex < numberOfTransforms; transformIndex++)
+  {
+    // Create a grid transform node
+    vtkNew<vtkMRMLTransformNode> transformNode;
+
+    // Create a displacement grid
+    vtkNew<vtkImageData> displacementGrid;
+    displacementGrid->SetDimensions(dimensions);
+    displacementGrid->SetOrigin(0.0, 0.0, 0.0);
+    displacementGrid->SetSpacing(1.0, 1.0, 1.0);
+    displacementGrid->AllocateScalars(VTK_DOUBLE, 3); // 3 components for X, Y, Z displacement
+
+    // Fill the displacement grid with simple test data that varies with transformIndex
+    double* displacementData = static_cast<double*>(displacementGrid->GetScalarPointer());
+    int index = 0;
+    double scaleFactor = (transformIndex + 1) * 0.1; // Scale increases with each transform
+    for (int k = 0; k < dimensions[2]; k++)
+    {
+      for (int j = 0; j < dimensions[1]; j++)
+      {
+        for (int i = 0; i < dimensions[0]; i++)
+        {
+          // Displacement pattern varies with transform index: displacement = (i*scaleFactor, j*scaleFactor, k*scaleFactor)
+          displacementData[index * 3 + 0] = i * scaleFactor; // X displacement
+          displacementData[index * 3 + 1] = j * scaleFactor; // Y displacement
+          displacementData[index * 3 + 2] = k * scaleFactor; // Z displacement
+          index++;
+        }
+      }
+    }
+
+    // Create the oriented grid transform
+    vtkNew<vtkOrientedGridTransform> gridTransform;
+    gridTransform->SetDisplacementGridData(displacementGrid);
+
+    // Set up the transform direction
+    if (useTransformFromParent)
+    {
+      transformNode->SetAndObserveTransformFromParent(gridTransform);
+    }
+    else
+    {
+      transformNode->SetAndObserveTransformToParent(gridTransform);
+    }
+
+    // Set node name
+    std::ostringstream nameStr;
+    nameStr << "GridTransform_" << std::setw(2) << std::setfill('0') << transformIndex;
+    transformNode->SetName(nameStr.str().c_str());
+
+    // Add to sequence with time index
+    std::ostringstream indexStr;
+    indexStr << transformIndex; // Time values: 0, 1, 2, 3, 4
+    sequenceNode->SetDataNodeAtValue(transformNode, indexStr.str().c_str());
+  }
+
+  // Create storage node and write the transform sequence
+  vtkNew<vtkMRMLTransformSequenceStorageNode> storageNode;
+  scene->AddNode(storageNode);
+
+  std::string filename = tempFilename(tempDir, "gridTransformSequence_" + transformDirection, "seq.nrrd", true);
+  storageNode->SetFileName(filename.c_str());
+  CHECK_BOOL(storageNode->WriteData(sequenceNode), true);
+
+  // Create a new sequence node and read back the data
+  vtkNew<vtkMRMLSequenceNode> sequenceNodeRead;
+  scene->AddNode(sequenceNodeRead);
+
+  CHECK_BOOL(storageNode->ReadData(sequenceNodeRead), true);
+
+  // Verify the sequence was read correctly
+  CHECK_INT(sequenceNodeRead->GetNumberOfDataNodes(), numberOfTransforms);
+  CHECK_STD_STRING(sequenceNodeRead->GetIndexName(), "mytime");
+  CHECK_STD_STRING(sequenceNodeRead->GetIndexUnit(), "mys");
+
+  // Verify each transform in the sequence
+  for (int transformIndex = 0; transformIndex < numberOfTransforms; transformIndex++)
+  {
+    vtkMRMLTransformNode* transformNodeRead = vtkMRMLTransformNode::SafeDownCast(sequenceNodeRead->GetNthDataNode(transformIndex));
+    CHECK_NOT_NULL(transformNodeRead);
+
+    // Verify the transform has the correct direction
+    vtkAbstractTransform* readTransformFromParent = transformNodeRead->GetTransformFromParent();
+    vtkAbstractTransform* readTransformToParent = transformNodeRead->GetTransformToParent();
+
+    if (useTransformFromParent)
+    {
+      CHECK_NOT_NULL(readTransformFromParent);
+    }
+    else
+    {
+      CHECK_NOT_NULL(readTransformToParent);
+    }
+
+    // Get the grid transform to verify content
+    vtkOrientedGridTransform* readGridTransform = nullptr;
+    if (useTransformFromParent && readTransformFromParent)
+    {
+      readGridTransform = vtkOrientedGridTransform::SafeDownCast(readTransformFromParent);
+    }
+    else if (!useTransformFromParent && readTransformToParent)
+    {
+      readGridTransform = vtkOrientedGridTransform::SafeDownCast(readTransformToParent);
+    }
+
+    CHECK_NOT_NULL(readGridTransform);
+
+    // Verify the displacement grid data matches at a few test points
+    vtkImageData* readDisplacementGrid = readGridTransform->GetDisplacementGrid();
+    CHECK_NOT_NULL(readDisplacementGrid);
+
+    // Check dimensions
+    int readDimensions[3];
+    readDisplacementGrid->GetDimensions(readDimensions);
+    CHECK_INT(readDimensions[0], dimensions[0]);
+    CHECK_INT(readDimensions[1], dimensions[1]);
+    CHECK_INT(readDimensions[2], dimensions[2]);
+
+    // Check some specific displacement values
+    double* readData = static_cast<double*>(readDisplacementGrid->GetScalarPointer());
+    double expectedScaleFactor = (transformIndex + 1) * 0.1;
+
+    // Test points
+    int testPoints[3][3] = { { 0, 0, 0 }, { 1, 1, 1 }, { 5, 3, 2 } };
+    for (int testPointIndex = 0; testPointIndex < 3; testPointIndex++)
+    {
+      int i = testPoints[testPointIndex][0];
+      int j = testPoints[testPointIndex][1];
+      int k = testPoints[testPointIndex][2];
+      int testIndex = i + j * dimensions[0] + k * dimensions[0] * dimensions[1];
+      double expectedX = i * expectedScaleFactor;
+      double expectedY = j * expectedScaleFactor;
+      double expectedZ = k * expectedScaleFactor;
+      CHECK_DOUBLE_TOLERANCE(readData[testIndex * 3 + 0], expectedX, 1e-6); // X displacement
+      CHECK_DOUBLE_TOLERANCE(readData[testIndex * 3 + 1], expectedY, 1e-6); // Y displacement
+      CHECK_DOUBLE_TOLERANCE(readData[testIndex * 3 + 2], expectedZ, 1e-6); // Z displacement
+    }
+
+    std::cout << "Transform " << transformIndex << " in sequence verified." << std::endl;
+  }
+
+  std::cout << "Grid transform sequence " << transformDirection << " test passed." << std::endl;
+  return EXIT_SUCCESS;
+}
+
+int vtkMRMLTransformSequenceStorageNodeTest1(int argc, char* argv[])
+{
+  if (argc != 2)
+  {
+    std::cerr << "Usage: " << argv[0] << " /path/to/temp" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const char* tempDir = argv[1];
+
+  // Test grid transform storage in both directions
+  std::cout << "Testing grid transform sequence storage..." << std::endl;
+
+  CHECK_EXIT_SUCCESS(TestGridTransformSequenceStorage(tempDir, true /*useTransformFromParent*/));
+  CHECK_EXIT_SUCCESS(TestGridTransformSequenceStorage(tempDir, false /*useTransformFromParent*/));
+
+  std::cout << "-----------------------------------------------------" << std::endl;
+
+  vtkNew<vtkMRMLTransformSequenceStorageNode> node1;
+  EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
+
+  std::cout << "\nTest passed." << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/Libs/MRML/Core/Testing/vtkMRMLTransformStorageNodeTest2.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTransformStorageNodeTest2.cxx
@@ -1,0 +1,199 @@
+/*=auto=========================================================================
+
+  Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH)
+  All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Program:   3D Slicer
+
+=========================================================================auto=*/
+
+// Test storage of displacement field transforms
+
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLScene.h"
+#include "vtkMRMLTransformNode.h"
+#include "vtkMRMLTransformStorageNode.h"
+
+#include <vtkImageData.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+#include <vtksys/SystemTools.hxx>
+#include <vtkOrientedGridTransform.h>
+#include <vtkGeneralTransform.h>
+#include <sstream>
+#include <iomanip>
+
+namespace
+{
+std::string tempFilename(std::string tempDir, std::string suffix, std::string fileExtension, bool remove = false)
+{
+  std::string filename = tempDir + "/vtkMRMLTransformStorageNodeTest1_" + suffix + "." + fileExtension;
+  // remove file if exists
+  if (remove && vtksys::SystemTools::FileExists(filename.c_str(), true))
+  {
+    vtksys::SystemTools::RemoveFile(filename.c_str());
+  }
+  return filename;
+}
+} // namespace
+
+//---------------------------------------------------------------------------
+int TestGridTransformStorage(const std::string& tempDir, bool useTransformFromParent, const std::string& fileExtension)
+{
+  std::string transformDirection = useTransformFromParent ? "FromParent" : "ToParent";
+  std::cout << "Testing grid transform " << transformDirection << " as " << fileExtension << " file..." << std::endl;
+
+  vtkNew<vtkMRMLScene> scene;
+
+  int dimensions[3] = { 6, 8, 11 };
+
+  // Create a grid transform node
+  vtkNew<vtkMRMLTransformNode> transformNode;
+
+  // Create a displacement grid
+  vtkNew<vtkImageData> displacementGrid;
+  displacementGrid->SetDimensions(dimensions);
+  displacementGrid->SetOrigin(0.0, 0.0, 0.0);
+  displacementGrid->SetSpacing(1.0, 1.0, 1.0);
+  displacementGrid->AllocateScalars(VTK_DOUBLE, 3); // 3 components for X, Y, Z displacement
+
+  // Fill the displacement grid with simple test data that varies with transformIndex
+  double* displacementData = static_cast<double*>(displacementGrid->GetScalarPointer());
+  int index = 0;
+  const double scaleFactor = 1.5;
+  for (int k = 0; k < dimensions[2]; k++)
+  {
+    for (int j = 0; j < dimensions[1]; j++)
+    {
+      for (int i = 0; i < dimensions[0]; i++)
+      {
+        // Displacement pattern varies with transform index: displacement = (i*scaleFactor, j*scaleFactor, k*scaleFactor)
+        displacementData[index * 3 + 0] = i * scaleFactor; // X displacement
+        displacementData[index * 3 + 1] = j * scaleFactor; // Y displacement
+        displacementData[index * 3 + 2] = k * scaleFactor; // Z displacement
+        index++;
+      }
+    }
+  }
+
+  // Create the oriented grid transform
+  vtkNew<vtkOrientedGridTransform> gridTransform;
+  gridTransform->SetDisplacementGridData(displacementGrid);
+
+  // Set up the transform direction
+  if (useTransformFromParent)
+  {
+    transformNode->SetAndObserveTransformFromParent(gridTransform);
+  }
+  else
+  {
+    transformNode->SetAndObserveTransformToParent(gridTransform);
+  }
+
+  // Create storage node and write the transform
+  vtkNew<vtkMRMLTransformStorageNode> storageNode;
+  scene->AddNode(storageNode);
+
+  std::string filename = tempFilename(tempDir, "gridTransform_" + transformDirection, fileExtension, true);
+  storageNode->SetFileName(filename.c_str());
+  CHECK_BOOL(storageNode->WriteData(transformNode), true);
+
+  // Create a new transform node and read back the data
+  vtkNew<vtkMRMLTransformNode> transformNodeRead;
+  scene->AddNode(transformNodeRead);
+
+  CHECK_BOOL(storageNode->ReadData(transformNodeRead), true);
+
+  // Verify the transform has the correct direction
+  vtkAbstractTransform* readTransformFromParent = transformNodeRead->GetTransformFromParent();
+  vtkAbstractTransform* readTransformToParent = transformNodeRead->GetTransformToParent();
+
+  if (useTransformFromParent)
+  {
+    CHECK_NOT_NULL(readTransformFromParent);
+  }
+  else
+  {
+    CHECK_NOT_NULL(readTransformToParent);
+  }
+
+  // Get the grid transform to verify content
+  vtkOrientedGridTransform* readGridTransform = nullptr;
+  if (useTransformFromParent && readTransformFromParent)
+  {
+    readGridTransform = vtkOrientedGridTransform::SafeDownCast(readTransformFromParent);
+  }
+  else if (!useTransformFromParent && readTransformToParent)
+  {
+    readGridTransform = vtkOrientedGridTransform::SafeDownCast(readTransformToParent);
+  }
+
+  CHECK_NOT_NULL(readGridTransform);
+
+  // Verify the displacement grid data matches at a few test points
+  vtkImageData* readDisplacementGrid = readGridTransform->GetDisplacementGrid();
+  CHECK_NOT_NULL(readDisplacementGrid);
+
+  // Check dimensions
+  int readDimensions[3];
+  readDisplacementGrid->GetDimensions(readDimensions);
+  CHECK_INT(readDimensions[0], dimensions[0]);
+  CHECK_INT(readDimensions[1], dimensions[1]);
+  CHECK_INT(readDimensions[2], dimensions[2]);
+
+  // Check some specific displacement values
+  double* readData = static_cast<double*>(readDisplacementGrid->GetScalarPointer());
+
+  // Test points
+  int testPoints[3][3] = { { 0, 0, 0 }, { 1, 1, 1 }, { 5, 3, 2 } };
+  for (int testPointIndex = 0; testPointIndex < 3; testPointIndex++)
+  {
+    int i = testPoints[testPointIndex][0];
+    int j = testPoints[testPointIndex][1];
+    int k = testPoints[testPointIndex][2];
+    int testIndex = i + j * dimensions[0] + k * dimensions[0] * dimensions[1];
+    double expectedX = i * scaleFactor;
+    double expectedY = j * scaleFactor;
+    double expectedZ = k * scaleFactor;
+    CHECK_DOUBLE_TOLERANCE(readData[testIndex * 3 + 0], expectedX, 1e-6); // X displacement
+    CHECK_DOUBLE_TOLERANCE(readData[testIndex * 3 + 1], expectedY, 1e-6); // Y displacement
+    CHECK_DOUBLE_TOLERANCE(readData[testIndex * 3 + 2], expectedZ, 1e-6); // Z displacement
+  }
+
+  std::cout << "Testing grid transform " << transformDirection << " as " << fileExtension << " file - success." << std::endl;
+
+  return EXIT_SUCCESS;
+}
+
+int vtkMRMLTransformStorageNodeTest2(int argc, char* argv[])
+{
+  if (argc != 2)
+  {
+    std::cerr << "Usage: " << argv[0] << " /path/to/temp" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const char* tempDir = argv[1];
+
+  // Test grid transform storage in both directions
+  std::cout << "Testing grid transform storage..." << std::endl;
+
+  // Test NRRD
+  CHECK_EXIT_SUCCESS(TestGridTransformStorage(tempDir, true /*useTransformFromParent*/, ".nrrd"));
+  CHECK_EXIT_SUCCESS(TestGridTransformStorage(tempDir, false /*useTransformFromParent*/, ".nrrd"));
+
+  // Test NIfTI
+  CHECK_EXIT_SUCCESS(TestGridTransformStorage(tempDir, true /*useTransformFromParent*/, ".nii.gz"));
+  // Writing ToParent as NIfTI should fail
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  int exitCode = TestGridTransformStorage(tempDir, false /*useTransformFromParent*/, ".nii.gz");
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_BOOL(exitCode != EXIT_SUCCESS, true);
+
+  std::cout << "\nTest passed." << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/Libs/MRML/Core/vtkMRMLTransformSequenceStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformSequenceStorageNode.h
@@ -93,8 +93,11 @@ protected:
   void InitializeSupportedWriteFileTypes() override;
 
   /// Get an oriented grid transform that is used as a common reference geometry.
-  /// Returns nullptr if not all transforms are grid transforms or identity.
-  vtkOrientedGridTransform* GetReferenceGridTransform(vtkMRMLSequenceNode* seqNode);
+  /// Returns nullptr if not all transforms are grid transforms or identity, or if transforms
+  /// have different directions (mix of TransformFromParent and TransformToParent).
+  /// isTransformFromParent will be set to true if all transforms use TransformFromParent,
+  /// false if all use TransformToParent.
+  vtkOrientedGridTransform* GetReferenceGridTransform(vtkMRMLSequenceNode* seqNode, bool& isTransformFromParent);
 };
 
 #endif

--- a/Libs/MRML/Core/vtkMRMLTransformStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformStorageNode.h
@@ -22,7 +22,15 @@ class vtkMRMLTransformNode;
 
 /// \brief MRML node for transform storage on disk.
 ///
-/// Storage nodes has methods to read/write transforms to/from disk.
+///  It can store any transforms as ITK transform file and it can store
+///  displacement field (grid) transforms as image file.
+///
+///  If displacement field transform is stored as image file then NRRD file format
+///  can handle transforms stored as both TransformFromParent and TransformToParent.
+///  It uses a metadata field "displacement field type" to indicate the transform direction
+///  ("resampling" or "modeling"). Other image file formats can only store resampling (from parent)
+///  transform.
+///
 class VTK_MRML_EXPORT vtkMRMLTransformStorageNode : public vtkMRMLStorageNode
 {
 public:
@@ -63,6 +71,12 @@ public:
   vtkGetMacro(PreferITKv3CompatibleTransforms, int);
   vtkSetMacro(PreferITKv3CompatibleTransforms, int);
   vtkBooleanMacro(PreferITKv3CompatibleTransforms, int);
+
+  /// Determine whether the transform is stored as FromParent or ToParent.
+  /// Returns true if stored as FromParent, false if stored as ToParent.
+  /// The most reliable way to determine this is to check which transform
+  /// allows modification (the original stored transform).
+  static bool IsTransformFromParentStored(vtkMRMLTransformNode* transformNode);
 
 protected:
   vtkMRMLTransformStorageNode();

--- a/Modules/Loadable/Sequences/qSlicerSequencesReader.cxx
+++ b/Modules/Loadable/Sequences/qSlicerSequencesReader.cxx
@@ -122,8 +122,7 @@ double qSlicerSequencesReader::canLoadFileConfidence(const QString& fileName) co
 
         bool looksLikeSequence = false;
 
-        // Supported 4D NRRD files contain "dimension: 4" line.
-        // 2D+t and 3D+color+t files are not yet supported.
+        // Supported 4D/5D NRRD files contain "dimension: 4" or "dimension: 5" line.
         QRegularExpression dimensionRe("dimension:([^\\n]+)");
         QRegularExpressionMatch dimensionMatch = dimensionRe.match(line);
         if (dimensionMatch.hasMatch())
@@ -146,6 +145,11 @@ double qSlicerSequencesReader::canLoadFileConfidence(const QString& fileName) co
                 looksLikeSequence = true;
               }
             }
+          }
+          else if (ok && dimension == 5)
+          {
+            // Transform sequence
+            looksLikeSequence = true;
           }
         }
         // If it looks like sequence then we need to set a confidence value that is larger than 0.55.


### PR DESCRIPTION
Displacement field transform can be defined using a vector field that transforms from the target coordinate system to the source object (a.k.a. resampling transform, because it can be used to transform images by resampling; "from parent" in Slicer naming convention), or that transforms form the source object coordinate system to the target (a.k.a. modeling transform, because it can be used to transform geometric objects by moving their points; "to parent" in Slicer naming convention).

We use ITK readers/writers for storing of transforms in files, and since ITK is an image-oriented toolkit, it always stores resampling transforms in files. Slicer worked around this limitation by introducing special "inverse" transform classes - which specify that those transforms need to be inverted before using them as resampling transform.

However, when displacement field transforms were stored as images. There was no way to specify in the image files that the displacement field should be used for resampling or modeling.

This commit adds the possibility to store displacement fields in NRRD files as either resampling and modeling transform, by introducing a new optional custom field: "displacement field type". This field can be set to "resampling" (default) or "modeling". For other file formats (NIFTI, MetaImage, ...) it is still assumed that the displacement field should be used for resampling.