### PR TITLE
BUG: Fix geometry initialization from empty segmentation file

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -749,6 +749,7 @@ int vtkMRMLSegmentationStorageNode::ReadBinaryLabelmapRepresentation(vtkMRMLSegm
       padder->SetOutputWholeExtent(imageExtentInFile);
       padder->Update();
       currentBinaryLabelmap->ShallowCopy(padder->GetOutput());
+      currentBinaryLabelmap->SetImageToWorldMatrix(imageToWorldMatrix.GetPointer());
 
       double scalarRange[2] = { 0 };
       currentBinaryLabelmap->GetScalarRange(scalarRange);
@@ -777,7 +778,6 @@ int vtkMRMLSegmentationStorageNode::ReadBinaryLabelmapRepresentation(vtkMRMLSegm
         }
         vtkSmartPointer<vtkSegment> currentSegment = vtkSmartPointer<vtkSegment>::New();
         currentSegment->SetLabelValue(labelValue);
-        currentBinaryLabelmap->SetImageToWorldMatrix(imageToWorldMatrix.GetPointer());
         currentSegment->AddRepresentation(vtkSegmentationConverter::GetBinaryLabelmapRepresentationName(), currentBinaryLabelmap);
         segments.push_back(currentSegment);
       }


### PR DESCRIPTION
When a `.seg.nrrd` file contained all zeros then the segmentation geometry was not initialized correctly (image axes were not set to the directions used in the input file).

fixes #8714