### PR TITLE
ENH: Expose segment editor effect cursor functions

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.h
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.h
@@ -169,7 +169,7 @@ public:
   virtual void setupOptionsFrame() {};
 
   /// Create a cursor customized for the given effect, potentially for each view
-  virtual QCursor createCursor(qMRMLWidget* viewWidget);
+  Q_INVOKABLE virtual QCursor createCursor(qMRMLWidget* viewWidget);
 
   /// Callback function invoked when interaction happens
   /// \param callerInteractor Interactor object that was observed to catch the event

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -3093,3 +3093,9 @@ void qMRMLSegmentEditorWidget::resumeRender()
 {
   qSlicerApplication::application()->resumeRender();
 }
+
+void qMRMLSegmentEditorWidget::applySegmentEffectCursor(qSlicerSegmentEditorAbstractEffect* effect)
+{
+  Q_D(qMRMLSegmentEditorWidget);
+  d->setEffectCursor(effect);
+}

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
@@ -276,6 +276,9 @@ public:
   /// Returns true if automatic jump to current segment is enabled.
   bool jumpToSelectedSegmentEnabled() const;
 
+  /// Update the current cursor to incorporate the icon of a segment editor effect tool
+  Q_INVOKABLE void applySegmentEffectCursor(qSlicerSegmentEditorAbstractEffect* effect);
+
 public slots:
   /// Set the MRML \a scene associated with the widget
   void setMRMLScene(vtkMRMLScene* newScene) override;


### PR DESCRIPTION
## PR Summary

This PR adds the `Q_INVOKABLE` macro to `qSlicerSegmentEditorAbstractEffect::createCursor()` and adds a utility function for applying the cursor associated with a given segment editor effect to the active view widgets. 

The motivation for this PR is to address an issue affecting the [local threshold tool in the extra effects repository](https://github.com/lassoan/SlicerSegmentEditorExtraEffects/blob/master/SegmentEditorLocalThreshold/SegmentEditorLocalThreshold.py) which causes the effect-specific cursor to revert to the default arrow-pointer cursor when a user adds an ROI node from the tool's options panel. The utility function provided in this PR provides a route to restore the effect cursor.

## Issue (cursor reverts to default when user adds an ROI)

https://github.com/user-attachments/assets/1b6954a7-9420-4f22-8935-160a0b1859fe

## Example with solution integrated (cursor remains the same)

https://github.com/user-attachments/assets/38f19cb0-983c-4778-86cf-431beb34f8b9

