### PR TITLE
BUG: Fixed cloning of composite transforms

### DIFF
--- a/Libs/MRML/Core/vtkMRMLTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.cxx
@@ -216,7 +216,7 @@ int vtkMRMLTransformNode::DeepCopyTransform(vtkAbstractTransform* dst, vtkAbstra
     // Copy the concatenated transforms
     vtkCollectionSimpleIterator it;
     vtkAbstractTransform* concatenatedTransform = nullptr;
-    dstGeneral->PreMultiply();
+    dstGeneral->PostMultiply();
     for (sourceTransformList->InitTraversal(it); (concatenatedTransform = vtkAbstractTransform::SafeDownCast(sourceTransformList->GetNextItemAsObject(it)));)
     {
       vtkAbstractTransform* concatenatedTransformCopy = concatenatedTransform->MakeTransform();


### PR DESCRIPTION
Order of composite transform components were reversed when deep-copying a transform node. This error has been in the code for several years, but the error was just recently reported probably because composite transforms are not used very frequently.

fixes #8766