### PR TITLE
ENH: Add support for reading/writing 2 component sequence files

### DIFF
--- a/Libs/vtkITK/vtkITKImageSequenceReader.cxx
+++ b/Libs/vtkITK/vtkITKImageSequenceReader.cxx
@@ -481,20 +481,35 @@ void vtkITKImageSequenceReader::ExecuteDataWithInformation(vtkDataObject* output
             }
             switch (imageIO->GetComponentType())
             {
-              case itk::ImageIOBase::IOComponentEnum::UCHAR: //
-                vtkITKExecuteDataFromFile<itk::Vector<unsigned char>, 3>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
-                break;
-              case itk::ImageIOBase::IOComponentEnum::USHORT: //
-                vtkITKExecuteDataFromFile<itk::Vector<unsigned short>, 3>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
-                break;
-              case itk::ImageIOBase::IOComponentEnum::INT: //
-                vtkITKExecuteDataFromFile<itk::Vector<int>, 3>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+              case itk::ImageIOBase::IOComponentEnum::DOUBLE: //
+                vtkITKExecuteDataFromFile<itk::Vector<double>, 3>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
                 break;
               case itk::ImageIOBase::IOComponentEnum::FLOAT: //
                 vtkITKExecuteDataFromFile<itk::Vector<float>, 3>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
                 break;
-              case itk::ImageIOBase::IOComponentEnum::DOUBLE: //
-                vtkITKExecuteDataFromFile<itk::Vector<double>, 3>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+              case itk::ImageIOBase::IOComponentEnum::LONG: //
+                vtkITKExecuteDataFromFile<itk::Vector<long>, 3>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::ULONG: //
+                vtkITKExecuteDataFromFile<itk::Vector<unsigned long>, 3>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::INT: //
+                vtkITKExecuteDataFromFile<itk::Vector<int>, 3>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::UINT: //
+                vtkITKExecuteDataFromFile<itk::Vector<unsigned int>, 3>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::SHORT: //
+                vtkITKExecuteDataFromFile<itk::Vector<short>, 3>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::USHORT: //
+                vtkITKExecuteDataFromFile<itk::Vector<unsigned short>, 3>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::CHAR: //
+                vtkITKExecuteDataFromFile<itk::Vector<char>, 3>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::UCHAR: //
+                vtkITKExecuteDataFromFile<itk::Vector<unsigned char>, 3>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
                 break;
               default:
                 vtkErrorMacro("Unexpected component type for 4 or less component vector voxel: " //
@@ -534,17 +549,17 @@ void vtkITKImageSequenceReader::ExecuteDataWithInformation(vtkDataObject* output
           case itk::CommonEnums::IOPixel::SCALAR:
             switch (imageIO->GetComponentType())
             {
-              case itk::ImageIOBase::IOComponentEnum::UCHAR: //
-                vtkITKExecuteDataFromFile<unsigned char, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+              case itk::ImageIOBase::IOComponentEnum::DOUBLE: //
+                vtkITKExecuteDataFromFile<double, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
                 break;
-              case itk::ImageIOBase::IOComponentEnum::CHAR: //
-                vtkITKExecuteDataFromFile<char, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+              case itk::ImageIOBase::IOComponentEnum::FLOAT: //
+                vtkITKExecuteDataFromFile<float, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
                 break;
-              case itk::ImageIOBase::IOComponentEnum::USHORT: //
-                vtkITKExecuteDataFromFile<unsigned short, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+              case itk::ImageIOBase::IOComponentEnum::LONG: //
+                vtkITKExecuteDataFromFile<long, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
                 break;
-              case itk::ImageIOBase::IOComponentEnum::SHORT: //
-                vtkITKExecuteDataFromFile<short, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+              case itk::ImageIOBase::IOComponentEnum::ULONG: //
+                vtkITKExecuteDataFromFile<unsigned long, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
                 break;
               case itk::ImageIOBase::IOComponentEnum::INT: //
                 vtkITKExecuteDataFromFile<int, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
@@ -552,11 +567,17 @@ void vtkITKImageSequenceReader::ExecuteDataWithInformation(vtkDataObject* output
               case itk::ImageIOBase::IOComponentEnum::UINT: //
                 vtkITKExecuteDataFromFile<unsigned int, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
                 break;
-              case itk::ImageIOBase::IOComponentEnum::FLOAT: //
-                vtkITKExecuteDataFromFile<float, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+              case itk::ImageIOBase::IOComponentEnum::SHORT: //
+                vtkITKExecuteDataFromFile<short, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
                 break;
-              case itk::ImageIOBase::IOComponentEnum::DOUBLE: //
-                vtkITKExecuteDataFromFile<double, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+              case itk::ImageIOBase::IOComponentEnum::USHORT: //
+                vtkITKExecuteDataFromFile<unsigned short, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::CHAR: //
+                vtkITKExecuteDataFromFile<char, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::UCHAR: //
+                vtkITKExecuteDataFromFile<unsigned char, 4>(this, this->CachedImages, listDim, imageIO->GetAxesReorder(), this->VoxelVectorType);
                 break;
               default:
                 vtkErrorMacro("Unexpected component type for scalar voxel: " //
@@ -597,27 +618,101 @@ void vtkITKImageSequenceReader::ExecuteDataWithInformation(vtkDataObject* output
             }
             switch (imageIO->GetNumberOfComponents())
             {
+              case 2:
+                this->SetVoxelVectorType(vtkITKImageWriter::VoxelVectorTypeUndefined);
+                switch (imageIO->GetComponentType())
+                {
+                  case itk::ImageIOBase::IOComponentEnum::DOUBLE:         //
+                    vtkITKExecuteDataFromFile<itk::Vector<double, 2>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::FLOAT:         //
+                    vtkITKExecuteDataFromFile<itk::Vector<float, 2>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::LONG:         //
+                    vtkITKExecuteDataFromFile<itk::Vector<long, 2>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::ULONG:                 //
+                    vtkITKExecuteDataFromFile<itk::Vector<unsigned long, 2>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::INT:         //
+                    vtkITKExecuteDataFromFile<itk::Vector<int, 2>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::UINT:                 //
+                    vtkITKExecuteDataFromFile<itk::Vector<unsigned int, 2>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::SHORT:         //
+                    vtkITKExecuteDataFromFile<itk::Vector<short, 2>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::USHORT:                 //
+                    vtkITKExecuteDataFromFile<itk::Vector<unsigned short, 2>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::CHAR:         //
+                    vtkITKExecuteDataFromFile<itk::Vector<char, 2>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::UCHAR:                 //
+                    vtkITKExecuteDataFromFile<itk::Vector<unsigned char, 2>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  default:
+                    vtkErrorMacro("Unexpected component type for vector voxel: " << imageIO->GetComponentTypeAsString(imageIO->GetComponentType()));
+                    this->SetErrorCode(vtkErrorCode::UnrecognizedFileTypeError);
+                    return;
+                }
+                break;
               case 3:
                 switch (imageIO->GetComponentType())
                 {
-                  case itk::ImageIOBase::IOComponentEnum::UCHAR:              //
-                    vtkITKExecuteDataFromFile<itk::Vector<unsigned char>, 4>( //
-                      this,
-                      this->CachedImages,
-                      listDim,
-                      imageIO->GetAxesReorder(),
-                      this->VoxelVectorType);
-                    break;
-                  case itk::ImageIOBase::IOComponentEnum::USHORT:              //
-                    vtkITKExecuteDataFromFile<itk::Vector<unsigned short>, 4>( //
-                      this,
-                      this->CachedImages,
-                      listDim,
-                      imageIO->GetAxesReorder(),
-                      this->VoxelVectorType);
-                    break;
-                  case itk::ImageIOBase::IOComponentEnum::INT:      //
-                    vtkITKExecuteDataFromFile<itk::Vector<int>, 4>( //
+                  case itk::ImageIOBase::IOComponentEnum::DOUBLE:      //
+                    vtkITKExecuteDataFromFile<itk::Vector<double>, 4>( //
                       this,
                       this->CachedImages,
                       listDim,
@@ -632,8 +727,64 @@ void vtkITKImageSequenceReader::ExecuteDataWithInformation(vtkDataObject* output
                       imageIO->GetAxesReorder(),
                       this->VoxelVectorType);
                     break;
-                  case itk::ImageIOBase::IOComponentEnum::DOUBLE:      //
-                    vtkITKExecuteDataFromFile<itk::Vector<double>, 4>( //
+                  case itk::ImageIOBase::IOComponentEnum::LONG:      //
+                    vtkITKExecuteDataFromFile<itk::Vector<long>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::ULONG:              //
+                    vtkITKExecuteDataFromFile<itk::Vector<unsigned long>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::INT:      //
+                    vtkITKExecuteDataFromFile<itk::Vector<int>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::UINT:              //
+                    vtkITKExecuteDataFromFile<itk::Vector<unsigned int>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::SHORT:      //
+                    vtkITKExecuteDataFromFile<itk::Vector<short>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::USHORT:              //
+                    vtkITKExecuteDataFromFile<itk::Vector<unsigned short>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::CHAR:      //
+                    vtkITKExecuteDataFromFile<itk::Vector<char>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::UCHAR:              //
+                    vtkITKExecuteDataFromFile<itk::Vector<unsigned char>, 4>( //
                       this,
                       this->CachedImages,
                       listDim,
@@ -650,24 +801,8 @@ void vtkITKImageSequenceReader::ExecuteDataWithInformation(vtkDataObject* output
                 this->SetVoxelVectorType(vtkITKImageWriter::VoxelVectorTypeUndefined);
                 switch (imageIO->GetComponentType())
                 {
-                  case itk::ImageIOBase::IOComponentEnum::UCHAR:                 //
-                    vtkITKExecuteDataFromFile<itk::Vector<unsigned char, 4>, 4>( //
-                      this,
-                      this->CachedImages,
-                      listDim,
-                      imageIO->GetAxesReorder(),
-                      this->VoxelVectorType);
-                    break;
-                  case itk::ImageIOBase::IOComponentEnum::USHORT:                 //
-                    vtkITKExecuteDataFromFile<itk::Vector<unsigned short, 4>, 4>( //
-                      this,
-                      this->CachedImages,
-                      listDim,
-                      imageIO->GetAxesReorder(),
-                      this->VoxelVectorType);
-                    break;
-                  case itk::ImageIOBase::IOComponentEnum::INT:         //
-                    vtkITKExecuteDataFromFile<itk::Vector<int, 4>, 4>( //
+                  case itk::ImageIOBase::IOComponentEnum::DOUBLE:         //
+                    vtkITKExecuteDataFromFile<itk::Vector<double, 4>, 4>( //
                       this,
                       this->CachedImages,
                       listDim,
@@ -682,8 +817,64 @@ void vtkITKImageSequenceReader::ExecuteDataWithInformation(vtkDataObject* output
                       imageIO->GetAxesReorder(),
                       this->VoxelVectorType);
                     break;
-                  case itk::ImageIOBase::IOComponentEnum::DOUBLE:         //
-                    vtkITKExecuteDataFromFile<itk::Vector<double, 4>, 4>( //
+                  case itk::ImageIOBase::IOComponentEnum::LONG:         //
+                    vtkITKExecuteDataFromFile<itk::Vector<long, 4>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::ULONG:                 //
+                    vtkITKExecuteDataFromFile<itk::Vector<unsigned long, 4>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::INT:         //
+                    vtkITKExecuteDataFromFile<itk::Vector<int, 4>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::UINT:                 //
+                    vtkITKExecuteDataFromFile<itk::Vector<unsigned int, 4>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::SHORT:         //
+                    vtkITKExecuteDataFromFile<itk::Vector<short, 4>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::USHORT:                 //
+                    vtkITKExecuteDataFromFile<itk::Vector<unsigned short, 4>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::CHAR:         //
+                    vtkITKExecuteDataFromFile<itk::Vector<char, 4>, 4>( //
+                      this,
+                      this->CachedImages,
+                      listDim,
+                      imageIO->GetAxesReorder(),
+                      this->VoxelVectorType);
+                    break;
+                  case itk::ImageIOBase::IOComponentEnum::UCHAR:                 //
+                    vtkITKExecuteDataFromFile<itk::Vector<unsigned char, 4>, 4>( //
                       this,
                       this->CachedImages,
                       listDim,
@@ -696,30 +887,18 @@ void vtkITKImageSequenceReader::ExecuteDataWithInformation(vtkDataObject* output
                     return;
                 }
                 break;
+              default:
+                vtkErrorMacro("Unexpected number of components for vector voxel: " << imageIO->GetNumberOfComponents());
+                this->SetErrorCode(vtkErrorCode::UnrecognizedFileTypeError);
+                return;
             }
             break;
           case itk::CommonEnums::IOPixel::COVARIANTVECTOR:
             this->SetVoxelVectorType(vtkITKImageWriter::VoxelVectorTypeSpatialCovariant);
             switch (imageIO->GetComponentType())
             {
-              case itk::ImageIOBase::IOComponentEnum::UCHAR:                       //
-                vtkITKExecuteDataFromFile<itk::CovariantVector<unsigned char>, 4>( //
-                  this,
-                  this->CachedImages,
-                  listDim,
-                  imageIO->GetAxesReorder(),
-                  this->VoxelVectorType);
-                break;
-              case itk::ImageIOBase::IOComponentEnum::USHORT:                       //
-                vtkITKExecuteDataFromFile<itk::CovariantVector<unsigned short>, 4>( //
-                  this,
-                  this->CachedImages,
-                  listDim,
-                  imageIO->GetAxesReorder(),
-                  this->VoxelVectorType);
-                break;
-              case itk::ImageIOBase::IOComponentEnum::INT:               //
-                vtkITKExecuteDataFromFile<itk::CovariantVector<int>, 4>( //
+              case itk::ImageIOBase::IOComponentEnum::DOUBLE:               //
+                vtkITKExecuteDataFromFile<itk::CovariantVector<double>, 4>( //
                   this,
                   this->CachedImages,
                   listDim,
@@ -734,8 +913,64 @@ void vtkITKImageSequenceReader::ExecuteDataWithInformation(vtkDataObject* output
                   imageIO->GetAxesReorder(),
                   this->VoxelVectorType);
                 break;
-              case itk::ImageIOBase::IOComponentEnum::DOUBLE:               //
-                vtkITKExecuteDataFromFile<itk::CovariantVector<double>, 4>( //
+              case itk::ImageIOBase::IOComponentEnum::LONG:               //
+                vtkITKExecuteDataFromFile<itk::CovariantVector<long>, 4>( //
+                  this,
+                  this->CachedImages,
+                  listDim,
+                  imageIO->GetAxesReorder(),
+                  this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::ULONG:                       //
+                vtkITKExecuteDataFromFile<itk::CovariantVector<unsigned long>, 4>( //
+                  this,
+                  this->CachedImages,
+                  listDim,
+                  imageIO->GetAxesReorder(),
+                  this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::INT:               //
+                vtkITKExecuteDataFromFile<itk::CovariantVector<int>, 4>( //
+                  this,
+                  this->CachedImages,
+                  listDim,
+                  imageIO->GetAxesReorder(),
+                  this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::UINT:                       //
+                vtkITKExecuteDataFromFile<itk::CovariantVector<unsigned int>, 4>( //
+                  this,
+                  this->CachedImages,
+                  listDim,
+                  imageIO->GetAxesReorder(),
+                  this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::SHORT:               //
+                vtkITKExecuteDataFromFile<itk::CovariantVector<short>, 4>( //
+                  this,
+                  this->CachedImages,
+                  listDim,
+                  imageIO->GetAxesReorder(),
+                  this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::USHORT:                       //
+                vtkITKExecuteDataFromFile<itk::CovariantVector<unsigned short>, 4>( //
+                  this,
+                  this->CachedImages,
+                  listDim,
+                  imageIO->GetAxesReorder(),
+                  this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::CHAR:               //
+                vtkITKExecuteDataFromFile<itk::CovariantVector<char>, 4>( //
+                  this,
+                  this->CachedImages,
+                  listDim,
+                  imageIO->GetAxesReorder(),
+                  this->VoxelVectorType);
+                break;
+              case itk::ImageIOBase::IOComponentEnum::UCHAR:                       //
+                vtkITKExecuteDataFromFile<itk::CovariantVector<unsigned char>, 4>( //
                   this,
                   this->CachedImages,
                   listDim,

--- a/Libs/vtkITK/vtkITKImageSequenceWriter.cxx
+++ b/Libs/vtkITK/vtkITKImageSequenceWriter.cxx
@@ -476,7 +476,75 @@ void vtkITKImageSequenceWriter::Write()
         case VTK_UNSIGNED_SHORT: ITKWriteVTKImage<unsigned short>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix); break;
         case VTK_CHAR: ITKWriteVTKImage<char>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix); break;
         case VTK_UNSIGNED_CHAR: ITKWriteVTKImage<unsigned char>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix); break;
-        default: vtkErrorMacro(<< "Execute: Unknown output ScalarType"); return;
+        default: vtkErrorMacro(<< "Execute: Unknown output ScalarType " << inputDataType); return;
+      }
+    }
+    else if (inputNumberOfScalarComponents == 2)
+    {
+      // 2-component vector image
+      switch (inputDataType)
+      {
+        case VTK_DOUBLE:
+        {
+          typedef itk::Vector<double, 2> PixelType;
+          ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+          break;
+        }
+        case VTK_FLOAT:
+        {
+          typedef itk::Vector<float, 2> PixelType;
+          ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+          break;
+        }
+        case VTK_LONG:
+        {
+          typedef itk::Vector<long, 2> PixelType;
+          ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+          break;
+        }
+        case VTK_UNSIGNED_LONG:
+        {
+          typedef itk::Vector<unsigned long, 2> PixelType;
+          ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+          break;
+        }
+        case VTK_INT:
+        {
+          typedef itk::Vector<int, 2> PixelType;
+          ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+          break;
+        }
+        case VTK_UNSIGNED_INT:
+        {
+          typedef itk::Vector<unsigned int, 2> PixelType;
+          ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+          break;
+        }
+        case VTK_SHORT:
+        {
+          typedef itk::Vector<short, 2> PixelType;
+          ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+          break;
+        }
+        case VTK_UNSIGNED_SHORT:
+        {
+          typedef itk::Vector<unsigned short, 2> PixelType;
+          ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+          break;
+        }
+        case VTK_CHAR:
+        {
+          typedef itk::Vector<char, 2> PixelType;
+          ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+          break;
+        }
+        case VTK_UNSIGNED_CHAR:
+        {
+          typedef itk::Vector<unsigned char, 2> PixelType;
+          ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+          break;
+        }
+        default: vtkErrorMacro(<< "Execute: Unknown output ScalarType " << inputDataType); return;
       }
     }
     else if (inputNumberOfScalarComponents == 3)
@@ -498,9 +566,45 @@ void vtkITKImageSequenceWriter::Write()
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
             break;
           }
+          case VTK_LONG:
+          {
+            typedef itk::RGBPixel<long> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_UNSIGNED_LONG:
+          {
+            typedef itk::RGBPixel<unsigned long> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_INT:
+          {
+            typedef itk::RGBPixel<int> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_UNSIGNED_INT:
+          {
+            typedef itk::RGBPixel<unsigned int> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_SHORT:
+          {
+            typedef itk::RGBPixel<short> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
           case VTK_UNSIGNED_SHORT:
           {
             typedef itk::RGBPixel<unsigned short> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_CHAR:
+          {
+            typedef itk::RGBPixel<char> PixelType;
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
             break;
           }
@@ -510,7 +614,7 @@ void vtkITKImageSequenceWriter::Write()
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
             break;
           }
-          default: vtkErrorMacro(<< "Execute: Unknown output ScalarType"); return;
+          default: vtkErrorMacro(<< "Execute: Unknown output ScalarType " << inputDataType); return;
         }
       }
       else if (this->VoxelVectorType == vtkITKImageWriter::VoxelVectorTypeSpatialCovariant)
@@ -530,9 +634,45 @@ void vtkITKImageSequenceWriter::Write()
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
             break;
           }
+          case VTK_LONG:
+          {
+            typedef itk::CovariantVector<long, 3> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+            break;
+          }
+          case VTK_UNSIGNED_LONG:
+          {
+            typedef itk::CovariantVector<unsigned long, 3> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+            break;
+          }
+          case VTK_INT:
+          {
+            typedef itk::CovariantVector<int, 3> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+            break;
+          }
+          case VTK_UNSIGNED_INT:
+          {
+            typedef itk::CovariantVector<unsigned int, 3> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+            break;
+          }
+          case VTK_SHORT:
+          {
+            typedef itk::CovariantVector<short, 3> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+            break;
+          }
           case VTK_UNSIGNED_SHORT:
           {
             typedef itk::CovariantVector<unsigned short, 3> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+            break;
+          }
+          case VTK_CHAR:
+          {
+            typedef itk::CovariantVector<char, 3> PixelType;
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
             break;
           }
@@ -542,7 +682,7 @@ void vtkITKImageSequenceWriter::Write()
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
             break;
           }
-          default: vtkErrorMacro(<< "Execute: Unknown output ScalarType"); return;
+          default: vtkErrorMacro(<< "Execute: Unknown output ScalarType " << inputDataType); return;
         }
       }
       else
@@ -562,9 +702,45 @@ void vtkITKImageSequenceWriter::Write()
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
             break;
           }
+          case VTK_LONG:
+          {
+            typedef itk::Vector<long, 3> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+            break;
+          }
+          case VTK_UNSIGNED_LONG:
+          {
+            typedef itk::Vector<unsigned long, 3> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+            break;
+          }
+          case VTK_INT:
+          {
+            typedef itk::Vector<int, 3> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+            break;
+          }
+          case VTK_UNSIGNED_INT:
+          {
+            typedef itk::Vector<unsigned int, 3> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+            break;
+          }
+          case VTK_SHORT:
+          {
+            typedef itk::Vector<short, 3> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+            break;
+          }
           case VTK_UNSIGNED_SHORT:
           {
             typedef itk::Vector<unsigned short, 3> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
+            break;
+          }
+          case VTK_CHAR:
+          {
+            typedef itk::Vector<char, 3> PixelType;
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
             break;
           }
@@ -574,7 +750,7 @@ void vtkITKImageSequenceWriter::Write()
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix, measurementFrameMatrix, voxelVectorType);
             break;
           }
-          default: vtkErrorMacro(<< "Execute: Unknown output ScalarType"); return;
+          default: vtkErrorMacro(<< "Execute: Unknown output ScalarType " << inputDataType); return;
         }
       }
     }
@@ -597,9 +773,45 @@ void vtkITKImageSequenceWriter::Write()
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
             break;
           }
+          case VTK_LONG:
+          {
+            typedef itk::RGBAPixel<long> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_UNSIGNED_LONG:
+          {
+            typedef itk::RGBAPixel<unsigned long> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_INT:
+          {
+            typedef itk::RGBAPixel<int> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_UNSIGNED_INT:
+          {
+            typedef itk::RGBAPixel<unsigned int> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_SHORT:
+          {
+            typedef itk::RGBAPixel<short> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
           case VTK_UNSIGNED_SHORT:
           {
             typedef itk::RGBAPixel<unsigned short> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_CHAR:
+          {
+            typedef itk::RGBAPixel<char> PixelType;
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
             break;
           }
@@ -609,7 +821,7 @@ void vtkITKImageSequenceWriter::Write()
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
             break;
           }
-          default: vtkErrorMacro(<< "Execute: Unknown output ScalarType"); return;
+          default: vtkErrorMacro(<< "Execute: Unknown output ScalarType " << inputDataType); return;
         }
       }
       else
@@ -629,9 +841,45 @@ void vtkITKImageSequenceWriter::Write()
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
             break;
           }
+          case VTK_LONG:
+          {
+            typedef itk::Vector<long, 4> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_UNSIGNED_LONG:
+          {
+            typedef itk::Vector<unsigned long, 4> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_INT:
+          {
+            typedef itk::Vector<int, 4> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_UNSIGNED_INT:
+          {
+            typedef itk::Vector<unsigned int, 4> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_SHORT:
+          {
+            typedef itk::Vector<short, 4> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
           case VTK_UNSIGNED_SHORT:
           {
             typedef itk::Vector<unsigned short, 4> PixelType;
+            ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
+            break;
+          }
+          case VTK_CHAR:
+          {
+            typedef itk::Vector<char, 4> PixelType;
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
             break;
           }
@@ -641,7 +889,7 @@ void vtkITKImageSequenceWriter::Write()
             ITKWriteVTKImage<PixelType>(this, inputImageCollection, this->GetFileName(), this->RasToIJKMatrix);
             break;
           }
-          default: vtkErrorMacro(<< "Execute: Unknown output ScalarType"); return;
+          default: vtkErrorMacro(<< "Execute: Unknown output ScalarType " << inputDataType); return;
         }
       }
     }


### PR DESCRIPTION
Previously vtkITKImageSequenceReader/Writer was not able to handle 2 component image sequences. This commit adds case handling for image sequences with 2 components.