### PR TITLE
ENH: Add vtkMRMLScriptedLightBoxRendererManagerProxy

### DIFF
--- a/Libs/MRML/DisplayableManager/CMakeLists.txt
+++ b/Libs/MRML/DisplayableManager/CMakeLists.txt
@@ -133,9 +133,11 @@ set_source_files_properties(
 if(MRMLDisplayableManager_USE_PYTHON)
   list(APPEND KIT_SRCS
     vtkMRMLScriptedDisplayableManager.cxx
+    vtkMRMLScriptedLightBoxRendererManagerProxy.cxx
     )
   set_source_files_properties(
     vtkMRMLScriptedDisplayableManager.cxx
+    vtkMRMLScriptedLightBoxRendererManagerProxy.cxx
     WRAP_EXCLUDE
     )
 endif()

--- a/Libs/MRML/DisplayableManager/vtkMRMLScriptedLightBoxRendererManagerProxy.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLScriptedLightBoxRendererManagerProxy.cxx
@@ -1,0 +1,65 @@
+#include "vtkMRMLScriptedLightBoxRendererManagerProxy.h"
+
+// VTK includes
+#include <vtkObjectFactory.h>
+#include <vtkPythonUtil.h>
+#include <vtkRenderer.h>
+#include <vtkSmartPyObject.h>
+
+//---------------------------------------------------------------------------
+vtkStandardNewMacro(vtkMRMLScriptedLightBoxRendererManagerProxy);
+
+//---------------------------------------------------------------------------
+vtkMRMLScriptedLightBoxRendererManagerProxy::vtkMRMLScriptedLightBoxRendererManagerProxy()
+  : m_object(nullptr)
+{
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLScriptedLightBoxRendererManagerProxy::~vtkMRMLScriptedLightBoxRendererManagerProxy() = default;
+
+//---------------------------------------------------------------------------
+vtkRenderer* vtkMRMLScriptedLightBoxRendererManagerProxy::GetRenderer(int lightboxId)
+{
+  if (!Py_IsInitialized() || !this->m_object)
+  {
+    return nullptr;
+  }
+
+  vtkPythonScopeGilEnsurer gilEnsurer;
+  PyObject* method = PyObject_GetAttrString(this->m_object, __func__);
+  if (!method || !PyCallable_Check(method))
+  {
+    vtkErrorMacro("" << __func__ << ": Python method doesn't exist or cannot be called.");
+    return nullptr;
+  }
+
+  vtkSmartPyObject pyArgs(PyTuple_Pack(1, PyLong_FromLongLong(lightboxId)));
+  PyObject* result = PyObject_CallObject(method, pyArgs);
+  if (!result)
+  {
+    PyErr_Print();
+    return nullptr;
+  }
+  return vtkRenderer::SafeDownCast(vtkPythonUtil::GetPointerFromObject(result, "vtkRenderer"));
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLScriptedLightBoxRendererManagerProxy::SetPythonObject(PyObject* object)
+{
+  if (!Py_IsInitialized())
+  {
+    return;
+  }
+
+  vtkPythonScopeGilEnsurer gilEnsurer;
+  if (!object || object == this->m_object)
+  {
+    return;
+  }
+
+  // Set the new python lambda
+  Py_XDECREF(this->m_object);
+  this->m_object = object;
+  Py_INCREF(this->m_object);
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLScriptedLightBoxRendererManagerProxy.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLScriptedLightBoxRendererManagerProxy.h
@@ -1,0 +1,47 @@
+/*==============================================================================
+
+Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __vtkMRMLScriptedLightBoxRendererManagerProxy_h
+#define __vtkMRMLScriptedLightBoxRendererManagerProxy_h
+
+// MRMLDisplayableManager include
+#include "vtkMRMLDisplayableManagerExport.h"
+#include "vtkMRMLLightBoxRendererManagerProxy.h"
+
+// VTK includes
+#include <vtkPython.h>
+
+/// \brief Scripted implementation for vtkMRMLLightBoxRendererManagerProxy
+/// Delegates renderer access to underlying Python object if any.
+class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLScriptedLightBoxRendererManagerProxy : public vtkMRMLLightBoxRendererManagerProxy
+{
+public:
+  static vtkMRMLScriptedLightBoxRendererManagerProxy* New();
+  vtkTypeMacro(vtkMRMLScriptedLightBoxRendererManagerProxy, vtkMRMLLightBoxRendererManagerProxy);
+
+  vtkRenderer* GetRenderer(int lightboxId) override;
+  void SetPythonObject(PyObject* object);
+
+protected:
+  vtkMRMLScriptedLightBoxRendererManagerProxy();
+  ~vtkMRMLScriptedLightBoxRendererManagerProxy() override;
+
+private:
+  PyObject* m_object;
+};
+
+#endif


### PR DESCRIPTION
Add scripted light box renderer manager proxy to allow python based applications, including slicer-trame, to provide light box renderer and activate associated features including cross hair display.

@jcfr & @lassoan let me know if this should go in Slicer or if I should put that in the SlicerTrame extension.