### PR TITLE
ENH: Expose material properties in Segmentation module GUI

### DIFF
--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager3D.cxx
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager3D.cxx
@@ -659,8 +659,8 @@ void vtkMRMLSegmentationsDisplayableManager3D::vtkInternal::UpdateDisplayNodePip
     }
     actorProperty->SetDiffuse(genericDisplayNode->GetDiffuse());
     actorProperty->SetSpecularPower(genericDisplayNode->GetPower());
-    actorProperty->SetMetallic(displayNode->GetMetallic());
-    actorProperty->SetRoughness(displayNode->GetRoughness());
+    actorProperty->SetMetallic(genericDisplayNode->GetMetallic());
+    actorProperty->SetRoughness(genericDisplayNode->GetRoughness());
     actorProperty->SetEdgeVisibility(genericDisplayNode->GetEdgeVisibility());
     actorProperty->SetEdgeColor(genericDisplayNode->GetEdgeColor());
 

--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentationDisplayNodeWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentationDisplayNodeWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>333</width>
-    <height>193</height>
+    <width>448</width>
+    <height>190</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -79,30 +79,10 @@
       <property name="spacing">
        <number>4</number>
       </property>
-      <item row="0" column="1">
-       <widget class="qMRMLDisplayNodeViewComboBox" name="DisplayNodeViewComboBox"/>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_Views">
         <property name="text">
          <string>Views:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="spinBox_SliceIntersectionThickness">
-        <property name="suffix">
-         <string> px</string>
-        </property>
-        <property name="maximum">
-         <number>10</number>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_Representation2D">
-        <property name="text">
-         <string>Representation in 2D views:</string>
         </property>
        </widget>
       </item>
@@ -113,20 +93,10 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_Representation3D">
-        <property name="toolTip">
-         <string>Representation that is shown as a model in 3D and as slice intersections in 2D if exists</string>
-        </property>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_Representation2D">
         <property name="text">
-         <string>Representation in 3D views:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="comboBox_DisplayedRepresentation2D">
-        <property name="toolTip">
-         <string>Representation that is shown in the 2D slice views</string>
+         <string>Representation in 2D views:</string>
         </property>
        </widget>
       </item>
@@ -137,7 +107,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
+      <item row="5" column="0" colspan="2">
        <widget class="QGroupBox" name="groupBox_SelectedSegment">
         <property name="title">
          <string>Selected segment</string>
@@ -302,6 +272,79 @@
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_Representation3D">
+        <property name="toolTip">
+         <string>Representation that is shown as a model in 3D and as slice intersections in 2D if exists</string>
+        </property>
+        <property name="text">
+         <string>Representation in 3D views:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="comboBox_DisplayedRepresentation2D">
+        <property name="toolTip">
+         <string>Representation that is shown in the 2D slice views</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="qMRMLDisplayNodeViewComboBox" name="DisplayNodeViewComboBox"/>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="spinBox_SliceIntersectionThickness">
+        <property name="suffix">
+         <string> px</string>
+        </property>
+        <property name="maximum">
+         <number>10</number>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox_Advanced3D">
+        <property name="title">
+         <string>3D Display</string>
+        </property>
+        <property name="collapsed">
+         <bool>true</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_5">
+         <property name="leftMargin">
+          <number>4</number>
+         </property>
+         <property name="topMargin">
+          <number>4</number>
+         </property>
+         <property name="rightMargin">
+          <number>4</number>
+         </property>
+         <property name="bottomMargin">
+          <number>4</number>
+         </property>
+         <property name="spacing">
+          <number>4</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="ctkVTKSurfaceMaterialPropertyWidget" name="MaterialPropertyWidget">
+           <property name="colorVisible">
+            <bool>false</bool>
+           </property>
+           <property name="opacityVisible">
+            <bool>false</bool>
+           </property>
+           <property name="backfaceCullingVisible">
+            <bool>false</bool>
+           </property>
+           <property name="interpolationModeVisible">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -505,7 +548,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="4">
+   <item row="5" column="0" colspan="4">
     <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox">
      <property name="title">
       <string>Clipping</string>
@@ -561,6 +604,27 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>ctkVTKSurfaceMaterialPropertyWidget</class>
+   <extends>ctkMaterialPropertyWidget</extends>
+   <header>ctkVTKSurfaceMaterialPropertyWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>ctkCollapsibleGroupBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkMaterialPropertyWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkMaterialPropertyWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkSliderWidget.h</header>
+  </customwidget>
+  <customwidget>
    <class>qMRMLCheckableNodeComboBox</class>
    <extends>qMRMLNodeComboBox</extends>
    <header>qMRMLCheckableNodeComboBox.h</header>
@@ -591,17 +655,6 @@
    <extends>QWidget</extends>
    <header>qMRMLWidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>ctkCollapsibleGroupBox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkSliderWidget</class>
-   <extends>QWidget</extends>
-   <header>ctkSliderWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationDisplayNodeWidget.cxx
@@ -36,6 +36,9 @@
 
 // VTK includes
 #include <vtkWeakPointer.h>
+#include <vtkProperty.h>
+#include <vtkSmartPointer.h>
+#include <vtkCommand.h>
 
 // Qt includes
 #include <QDebug>
@@ -58,6 +61,12 @@ public:
 
   /// Selected segment ID
   QString SelectedSegmentID;
+
+  /// VTK property for material properties
+  vtkSmartPointer<vtkProperty> Property;
+
+  /// Flag to prevent recursive updates
+  bool IsUpdatingWidgetFromMRML;
 };
 
 //-----------------------------------------------------------------------------
@@ -65,6 +74,8 @@ qMRMLSegmentationDisplayNodeWidgetPrivate::qMRMLSegmentationDisplayNodeWidgetPri
   : q_ptr(&object)
 {
   this->SegmentationDisplayNode = nullptr;
+  this->Property = vtkSmartPointer<vtkProperty>::New();
+  this->IsUpdatingWidgetFromMRML = false;
 }
 
 //-----------------------------------------------------------------------------
@@ -72,6 +83,10 @@ void qMRMLSegmentationDisplayNodeWidgetPrivate::init()
 {
   Q_Q(qMRMLSegmentationDisplayNodeWidget);
   this->setupUi(q);
+
+  // Setup material property widget
+  this->MaterialPropertyWidget->setProperty(this->Property);
+  q->qvtkConnect(this->Property, vtkCommand::ModifiedEvent, q, SLOT(onMaterialPropertiesChanged()));
 
   // Make connections
   QObject::connect(this->checkBox_Visible, SIGNAL(stateChanged(int)), q, SLOT(onVisibilityChanged(int)));
@@ -256,9 +271,17 @@ void qMRMLSegmentationDisplayNodeWidget::updateWidgetFromMRML()
   {
     return;
   }
+
+  if (d->IsUpdatingWidgetFromMRML)
+  {
+    return;
+  }
+  d->IsUpdatingWidgetFromMRML = true;
+
   vtkMRMLSegmentationNode* segmentationNode = vtkMRMLSegmentationNode::SafeDownCast(d->SegmentationDisplayNode->GetDisplayableNode());
   if (!segmentationNode)
   {
+    d->IsUpdatingWidgetFromMRML = false;
     return;
   }
 
@@ -324,8 +347,19 @@ void qMRMLSegmentationDisplayNodeWidget::updateWidgetFromMRML()
   d->SlicerWidget_ClipNodeDisplayProperties->setMRMLDisplayNode(d->SegmentationDisplayNode);
   d->SlicerWidget_ClipNodeProperties->setMRMLClipNode(d->SegmentationDisplayNode->GetClipNode());
 
+  // Update material properties
+  d->Property->SetInterpolation(d->SegmentationDisplayNode->GetInterpolation());
+  d->Property->SetAmbient(d->SegmentationDisplayNode->GetAmbient());
+  d->Property->SetDiffuse(d->SegmentationDisplayNode->GetDiffuse());
+  d->Property->SetSpecular(d->SegmentationDisplayNode->GetSpecular());
+  d->Property->SetSpecularPower(d->SegmentationDisplayNode->GetPower());
+  d->Property->SetMetallic(d->SegmentationDisplayNode->GetMetallic());
+  d->Property->SetRoughness(d->SegmentationDisplayNode->GetRoughness());
+
   // Update selected segment visibility and opacity section
   this->updateSelectedSegmentSection();
+
+  d->IsUpdatingWidgetFromMRML = false;
 }
 
 //-----------------------------------------------------------------------------
@@ -702,4 +736,31 @@ void qMRMLSegmentationDisplayNodeWidget::onClipNodeChanged(vtkMRMLNode* node)
 
   vtkMRMLClipNode* clipNode = vtkMRMLClipNode::SafeDownCast(node);
   d->SegmentationDisplayNode->SetAndObserveClipNodeID(clipNode ? clipNode->GetID() : nullptr);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationDisplayNodeWidget::onMaterialPropertiesChanged()
+{
+  Q_D(qMRMLSegmentationDisplayNodeWidget);
+
+  if (d->IsUpdatingWidgetFromMRML)
+  {
+    return;
+  }
+
+  if (!d->SegmentationDisplayNode.GetPointer())
+  {
+    return;
+  }
+
+  MRMLNodeModifyBlocker blocker(d->SegmentationDisplayNode);
+
+  // Update material properties in the segmentation node from the GUI
+  d->SegmentationDisplayNode->SetInterpolation(d->Property->GetInterpolation());
+  d->SegmentationDisplayNode->SetAmbient(d->Property->GetAmbient());
+  d->SegmentationDisplayNode->SetDiffuse(d->Property->GetDiffuse());
+  d->SegmentationDisplayNode->SetSpecular(d->Property->GetSpecular());
+  d->SegmentationDisplayNode->SetPower(d->Property->GetSpecularPower());
+  d->SegmentationDisplayNode->SetMetallic(d->Property->GetMetallic());
+  d->SegmentationDisplayNode->SetRoughness(d->Property->GetRoughness());
 }

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationDisplayNodeWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationDisplayNodeWidget.h
@@ -98,6 +98,7 @@ public slots:
   void onEnableCappingChanged(int);
   void onCappingOpacityChanged(double);
   void onClipNodeChanged(vtkMRMLNode*);
+  void onMaterialPropertiesChanged();
 
   /// Handles segment selection changes when connecting directly to a \sa qMRMLSegmentsTableView
   void onSegmentSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);


### PR DESCRIPTION
Material properties (Interpolation, Ambient, Diffuse, Specular, Power, Metallic, Roughness) can now be set for segmentation nodes in Display / Advanced / 3D Display section.

see #8780

<img width="1262" height="1841" alt="image" src="https://github.com/user-attachments/assets/95208085-c24a-4a21-93f3-af4a374ed79f" />

