### PR TITLE
DOC: Add "Slicer integration in hospital/PACS context" to DICOM module docs

### DIFF
--- a/Docs/user_guide/modules/dicom.md
+++ b/Docs/user_guide/modules/dicom.md
@@ -352,6 +352,7 @@ Authors:
 - Alireza Mehrtash (BWH)
 - Csaba Pinter (PerkLab, Queen's)
 - Andras Lasso (PerkLab, Queen's)
+- Jean-Christophe Fillion-Robin (Kitware)
 
 ## Acknowledgements
 
@@ -365,3 +366,4 @@ This work is part of the [National Alliance for Medical Image Computing](https:/
 ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/logo_dicom_offis.png)
 ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/logo_spl.png)
 ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/logo_perklab.png)
+![](https://github.com/Slicer/Slicer/releases/download/docs-resources/logo_kitware.png)


### PR DESCRIPTION
This adds a concise, operations-oriented section describing how to integrate Slicer (or Slicer-based apps) with enterprise PACS/VNA environments.

---

> [!TIP]
> For convenience, here is the link to review the generated documentation.
>
> See https://slicer--8786.org.readthedocs.build/en/8786/user_guide/modules/dicom.html#slicer-integration-in-hospital-pacs-context