### PR TITLE
DOC: Document the new .vp.json volume property file format

### DIFF
--- a/Docs/developer_guide/modules/volumerendering.md
+++ b/Docs/developer_guide/modules/volumerendering.md
@@ -8,9 +8,67 @@
 - [vtkMRMLMarkupsROINode](https://apidocs.slicer.org/main/classvtkMRMLMarkupsROINode.html) controls the clipping planes
 - [vtkMRMLVolumeRenderingDisplayableManager](https://apidocs.slicer.org/main/classvtkMRMLVolumeRenderingDisplayableManager.html) responsible for adding VTK actors to the renderers
 
+## Format of .vp.json (volume property JSON)
+
+Since Slicer version 5.9, volume rendering properties are stored in JSON format by default, with the file extension `.vp.json`. This format is self-describing and easier to interpret than the legacy text file format. Details are specified by this JSON schema: https://raw.githubusercontent.com/slicer/slicer/main/Modules/Loadable/VolumeRendering/Resources/Schema/volume-property-schema-v1.0.0.json
+
+Example `.vp.json` file:
+
+```json
+{
+    "@schema": "https://raw.githubusercontent.com/slicer/slicer/main/Modules/Loadable/VolumeRendering/Resources/Schema/volume-property-schema-v1.0.0.json#",
+    "volumeProperties": [
+        {
+            "effectiveRange": [0.0, 220.0],
+            "components": [
+                {
+                    "shade": true,
+                    "lighting": {
+                        "diffuse": 1.0,
+                        "ambient": 0.2,
+                        "specular": 0.0,
+                        "specularPower": 1.0
+                    },
+                    "rgbTransferFunction": {
+                        "type": "colorTransferFunction",
+                        "points": [
+                            { "x": 0.0, "color": [0.0, 0.0, 0.0] },
+                            { "x": 20.0, "color": [0.168627, 0.0, 0.0] },
+                            { "x": 40.0, "color": [0.403922, 0.145098, 0.0784314] },
+                            { "x": 40.0, "color": [0.403922, 0.145098, 0.0784314] },
+                            { "x": 120.0, "color": [0.780392, 0.607843, 0.380392] },
+                            { "x": 220.0, "color": [0.847059, 0.835294, 0.788235] },
+                            { "x": 1024.0, "color": [1.0, 1.0, 1.0] }
+                        ]
+                    },
+                    "scalarOpacityUnitDistance": 1.0,
+                    "scalarOpacity": {
+                        "type": "piecewiseLinearFunction",
+                        "points": [
+                            { "x": 0.0, "y": 0.0 },
+                            { "x": 120.0, "y": 0.3 },
+                            { "x": 220.0, "y": 0.375 },
+                            { "x": 1024.0, "y": 0.5 }
+                        ]
+                    },
+                    "gradientOpacity": {
+                        "type": "piecewiseLinearFunction",
+                        "points": [
+                            { "x": 0.0, "y": 1.0 },
+                            { "x": 255.0, "y": 1.0 }
+                        ]
+                    }
+                }
+            ]
+        }
+    ]
+}
+
+```
+
 ## Format of Volume Property (.vp) file
 
-Volume properties, separated by newline characters.
+Legacy text file format for storing volume properties. It is only supported for backward compatibility and it is recommended to use the .vp.json file format instead.
 
 Example:
 


### PR DESCRIPTION
Volume properties are now saved in .vp.json file format by default. Describe this in the documentation.