### PR TITLE
ENH: Add "Flip normal" action to plane node

### DIFF
--- a/Libs/MRML/Core/vtkMRMLMarkupsPlaneNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsPlaneNode.cxx
@@ -1544,11 +1544,11 @@ void vtkMRMLMarkupsPlaneNode::UpdatePlaneSize()
     return;
   }
 
-  vtkNew<vtkMatrix4x4> objectToBaseMatrix;
-  this->GetBaseToWorldMatrix(objectToBaseMatrix);
+  vtkNew<vtkMatrix4x4> baseToWorldMatrix;
+  this->GetBaseToWorldMatrix(baseToWorldMatrix);
 
   vtkNew<vtkTransform> worldToBaseTransform;
-  worldToBaseTransform->SetMatrix(objectToBaseMatrix);
+  worldToBaseTransform->SetMatrix(baseToWorldMatrix);
   worldToBaseTransform->Inverse();
 
   double xMax_Base = 0.0;
@@ -1858,4 +1858,27 @@ vtkImplicitFunction* vtkMRMLMarkupsPlaneNode::GetImplicitFunctionWorld()
 {
   this->UpdateImplicitFunction();
   return this->ImplicitPlaneWorld;
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::FlipNormal()
+{
+  double xAxis_Node[3] = { 1.0, 0.0, 0.0 };
+  double yAxis_Node[3] = { 0.0, 1.0, 0.0 };
+  double zAxis_Node[3] = { 0.0, 0.0, 1.0 };
+  this->GetAxes(xAxis_Node, yAxis_Node, zAxis_Node);
+  double center_Node[3] = { 0.0, 0.0, 0.0 };
+  this->GetCenter(center_Node);
+
+  // 180deg rotation around the y axis
+  vtkNew<vtkTransform> oldToNewNormalTransform;
+  oldToNewNormalTransform->Translate(center_Node);
+  oldToNewNormalTransform->RotateWXYZ(180, yAxis_Node);
+  vtkMath::MultiplyScalar(center_Node, -1.0);
+  oldToNewNormalTransform->Translate(center_Node);
+  this->ApplyTransform(oldToNewNormalTransform);
+
+  this->UpdateControlPointsFromPlane();
+  this->UpdateImplicitFunction();
+  this->Modified();
 }

--- a/Libs/MRML/Core/vtkMRMLMarkupsPlaneNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsPlaneNode.h
@@ -164,6 +164,9 @@ public:
   void SetNormalWorld(double x, double y, double z);
   //@}
 
+  /// Flip the normal vector direction by 180deg rotation around Y axis at the plane center.
+  void FlipNormal();
+
   //@{
   /// Get/Set the origin of the plane in object or world coordinate system.
   void GetOrigin(double origin[3]);

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
@@ -94,6 +94,10 @@ public:
   /// These item context menu actions can be shown in the implementations of \sa showViewContextMenuActionsForItem
   QList<QAction*> viewContextMenuActions() const override;
 
+  /// Get item context menu item actions to add to tree view.
+  /// These item context menu actions can be shown in the implementations of \sa showContextMenuActionsForItem
+  QList<QAction*> itemContextMenuActions() const override;
+
   /// Show context menu actions valid for a given subject hierarchy item to be shown in the view.
   /// \param itemID Subject Hierarchy item to show the context menu items for
   /// \param eventData Supplementary data for the item that may be considered for the menu (sub-item ID, attribute, etc.)
@@ -139,6 +143,8 @@ protected slots:
   void toggleCurrentItemHandleTypeVisibility();
   /// toggle the visibility of the interaction handle type for the active node in view
   void toggleHandleTypeVisibility();
+  /// Called when clicking on flip plane normal action
+  void flipPlaneNormal();
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyMarkupsPluginPrivate> d_ptr;

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest4.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest4.cxx
@@ -136,6 +136,31 @@ int vtkMRMLMarkupsNodeTest4(int, char*[])
     double originDifference_World[3] = { 0.0 };
     vtkMath::Subtract(actualOrigin_World, expectedOrigin_World, originDifference_World);
     CHECK_DOUBLE_TOLERANCE(vtkMath::Norm(originDifference_World), 0.0, EPSILON);
+
+    /////////////
+    std::cout << "Test FlipNormal with plane offset and transform node" << std::endl;
+    double normalBeforeFlip_World[3] = { 0.0 };
+    planeNode->GetNormalWorld(normalBeforeFlip_World);
+    double originBeforeFlip_World[3] = { 0.0 };
+    planeNode->GetCenterWorld(originBeforeFlip_World);
+
+    planeNode->FlipNormal();
+
+    double normalAfterFlip_World[3] = { 0.0 };
+    planeNode->GetNormalWorld(normalAfterFlip_World);
+    double originAfterFlip_World[3] = { 0.0 };
+    planeNode->GetCenterWorld(originAfterFlip_World);
+
+    // Normal should be flipped (opposite direction)
+    double expectedNormalAfterFlip_World[3] = { -normalBeforeFlip_World[0], -normalBeforeFlip_World[1], -normalBeforeFlip_World[2] };
+    double normalFlipDifference_World[3] = { 0.0 };
+    vtkMath::Subtract(normalAfterFlip_World, expectedNormalAfterFlip_World, normalFlipDifference_World);
+    CHECK_DOUBLE_TOLERANCE(vtkMath::Norm(normalFlipDifference_World), 0.0, EPSILON);
+
+    // Origin should remain the same
+    double originFlipDifference_World[3] = { 0.0 };
+    vtkMath::Subtract(originAfterFlip_World, originBeforeFlip_World, originFlipDifference_World);
+    CHECK_DOUBLE_TOLERANCE(vtkMath::Norm(originFlipDifference_World), 0.0, EPSILON);
   }
 
   std::cout << "Success." << std::endl;

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsPlaneWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsPlaneWidget.ui
@@ -261,6 +261,16 @@
           </item>
          </layout>
         </item>
+        <item row="5" column="1">
+         <widget class="QPushButton" name="flipPlaneNormalButton">
+          <property name="text">
+           <string>Flip normal</string>
+          </property>
+          <property name="toolTip">
+           <string>Reverse direction of the plane normal</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsPlaneWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsPlaneWidget.cxx
@@ -88,6 +88,7 @@ void qMRMLMarkupsPlaneWidgetPrivate::setupUi(qMRMLMarkupsPlaneWidget* widget)
   QObject::connect(this->normalVisibilityCheckBox, SIGNAL(stateChanged(int)), q, SLOT(onNormalVisibilityCheckBoxChanged()));
 #endif
   QObject::connect(this->normalOpacitySlider, SIGNAL(valueChanged(double)), q, SLOT(onNormalOpacitySliderChanged()));
+  QObject::connect(this->flipPlaneNormalButton, SIGNAL(clicked()), q, SLOT(onFlipPlaneNormalButtonClicked()));
 
   q->setEnabled(vtkMRMLMarkupsPlaneNode::SafeDownCast(q->MarkupsNode) != nullptr);
   q->setVisible(vtkMRMLMarkupsPlaneNode::SafeDownCast(q->MarkupsNode) != nullptr);
@@ -300,6 +301,17 @@ void qMRMLMarkupsPlaneWidget::onNormalOpacitySliderChanged()
   }
 
   displayNode->SetNormalOpacity(d->normalOpacitySlider->value());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsPlaneWidget::onFlipPlaneNormalButtonClicked()
+{
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->MarkupsNode);
+  if (!planeNode)
+  {
+    return;
+  }
+  planeNode->FlipNormal();
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsPlaneWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsPlaneWidget.h
@@ -74,6 +74,7 @@ protected slots:
   void onPlaneBoundsSpinBoxChanged();
   void onNormalVisibilityCheckBoxChanged();
   void onNormalOpacitySliderChanged();
+  void onFlipPlaneNormalButtonClicked();
 
 protected:
   void setup();


### PR DESCRIPTION
Flip normal action is now available in view context menu (when right-clicking on a plane node in a view), in subject hierarchy item context menu (shown when right-clicking a plane node in a subject hierarchy tree), and as a button in the plane markup options in Markups module.