### PR TITLE
BUG: Fix OpenGL error at startup in debug mode

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewInteractorStyle.cxx
@@ -121,11 +121,13 @@ bool vtkMRMLThreeDViewInteractorStyle::DelegateInteractionEventToDisplayableMana
   }
 
   vtkNew<vtkMRMLInteractionEventData> ed;
-  ed->SetType(inputEventData->GetType());
+  int eventType = inputEventData->GetType();
+  ed->SetType(eventType);
   int displayPositionCorrected[2] = { displayPositionInt[0] - pokedRenderer->GetOrigin()[0], displayPositionInt[1] - pokedRenderer->GetOrigin()[1] };
   ed->SetDisplayPosition(displayPositionCorrected);
+  bool eventHasPosition = (eventType != vtkCommand::ConfigureEvent);
   double worldPosition[4] = { 0.0, 0.0, 0.0, 1.0 };
-  if (this->QuickPick(displayPositionInt[0], displayPositionInt[1], worldPosition))
+  if (eventHasPosition && this->QuickPick(displayPositionInt[0], displayPositionInt[1], worldPosition))
   {
     // set "inaccurate" world position
     ed->SetWorldPosition(worldPosition, false);


### PR DESCRIPTION
Window resize events caused vtkMRMLThreeDViewInteractorStyle::DelegateInteractionEventToDisplayableManagers to attempt to look up 3D coordinates using the z buffer, which led to OpenGL errors (visible in debug mode only) when the window has never been rendered.

Fixed the issue by not looking up 3D coordinates for window resize (vtkCommand::ConfigureEvent) events.