### PR TITLE
BUG: Fix loading of orientation marker and fonts

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -248,10 +248,10 @@ public:
 
   /// Get slicer share directory
   ///
-  /// This returns the partial path where slicer resources are located, which
-  /// is normally of the form <code>"share/Slicer-<i>version</i>"</code>.
+  /// This returns the relative path from the slicer home directory where shared resources are located.
+  /// The path is usually <code>"share/Slicer-<i>version</i>"</code>.
   ///
-  /// \sa slicerSharePath, slicerHome()
+  /// \sa slicerHome()
   QString slicerSharePath() const;
 
   /// Returns True if module identified by \a moduleFileName is a descendant of slicer home.

--- a/Libs/MRML/DisplayableManager/vtkMRMLOrientationMarkerDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLOrientationMarkerDisplayableManager.cxx
@@ -251,17 +251,7 @@ vtkProp3D* vtkMRMLOrientationMarkerDisplayableManager::vtkInternal::GetCubeActor
 //----------------------------------------------------------------------------
 std::string vtkMRMLOrientationMarkerDisplayableManager::vtkInternal::GetOrientationMarkerModelPath(const char* modelFileName)
 {
-  std::vector<std::string> filesVector;
-  filesVector.emplace_back(""); // The first two components do not add a slash.
-  filesVector.push_back(this->External->GetMRMLApplicationLogic()->GetShareDirectory());
-  filesVector.emplace_back(ORIENTATION_MARKERS_DIR);
-  filesVector.emplace_back(modelFileName);
-  std::string fullPath = vtksys::SystemTools::JoinPath(filesVector);
-  if (!vtksys::SystemTools::FileExists(fullPath, true))
-  {
-    vtkErrorWithObjectMacro(this->External, "GetOrientationMarkerModelPath: file does not exist: " << fullPath);
-  }
-  return fullPath;
+  return this->External->GetMRMLApplicationLogic()->GetShareFilePath(ORIENTATION_MARKERS_DIR, modelFileName);
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -1233,24 +1233,45 @@ const std::string& vtkMRMLApplicationLogic::GetShareDirectory() const
 //----------------------------------------------------------------------------
 std::string vtkMRMLApplicationLogic::GetFontFilePath(const std::string& fontFileName)
 {
-  std::vector<std::string> filesVector;
-  // Add an empty component because JoinPath does not add a slash for the first two components.
-  filesVector.emplace_back("");
-  filesVector.emplace_back(this->GetShareDirectory());
-  filesVector.emplace_back(FONTS_DIR);
-  filesVector.emplace_back(fontFileName);
-  std::string fullPath = vtksys::SystemTools::JoinPath(filesVector);
-  return fullPath;
+  return this->GetShareFilePath(FONTS_DIR, fontFileName);
 }
 
 //----------------------------------------------------------------------------
 std::string vtkMRMLApplicationLogic::GetFontsDirectory()
 {
+  return this->GetShareFilePath(FONTS_DIR);
+}
+
+//----------------------------------------------------------------------------
+std::string vtkMRMLApplicationLogic::GetShareFilePath(const std::string& fileName) const
+{
+  return this->GetShareFilePath("", fileName);
+}
+
+//----------------------------------------------------------------------------
+std::string vtkMRMLApplicationLogic::GetShareFilePath(const std::string& subfolderName, const std::string& fileName) const
+{
+  if (this->GetHomeDirectory().empty())
+  {
+    vtkWarningMacro("vtkMRMLApplicationLogic::GetShareFilePath: Home directory is not set. Returned path may be invalid.");
+  }
+  if (this->GetShareDirectory().empty())
+  {
+    vtkWarningMacro("vtkMRMLApplicationLogic::GetShareFilePath: Share directory is not set. Returned path may be invalid.");
+  }
   std::vector<std::string> filesVector;
   // Add an empty component because JoinPath does not add a slash for the first two components.
   filesVector.emplace_back("");
+  filesVector.emplace_back(this->GetHomeDirectory());
   filesVector.emplace_back(this->GetShareDirectory());
-  filesVector.emplace_back(FONTS_DIR);
+  if (!subfolderName.empty())
+  {
+    filesVector.emplace_back(subfolderName);
+  }
+  if (!fileName.empty())
+  {
+    filesVector.emplace_back(fileName);
+  }
   std::string fullPath = vtksys::SystemTools::JoinPath(filesVector);
   return fullPath;
 }

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -303,11 +303,19 @@ public:
   /// @}
 
   /// @{
-  /// Applications must set this variable to a meaningful value.
-  /// This path is relative, modules will generally resolve it from GetHomeDirectory().
-  /// For example, the slicer application will set this to "share/slicer-X-Y".
+  /// Applications must set this variable to a meaningful value (typically to something like "share/slicer-X-Y").
+  /// This path is relative to HomeDirectory. Absolute path of a file in the share directory can be constructed
+  /// using GetShareFilePath() convenience method.
+  /// \sa GetHomeDirectory, GetShareFilePath
   void SetShareDirectory(const std::string& path);
   const std::string& GetShareDirectory() const;
+  /// @}
+
+  /// @{
+  /// Get full path to a file (or a relative path) in the Share folder.
+  /// The path is constructed as HomeDirectory/ShareDirectory/subfolderName/shareFileName
+  std::string GetShareFilePath(const std::string& fileName) const;
+  std::string GetShareFilePath(const std::string& subfolderName, const std::string& fileName) const;
   /// @}
 
 protected:

--- a/Modules/Loadable/Colors/Logic/vtkSlicerColorLogic.cxx
+++ b/Modules/Loadable/Colors/Logic/vtkSlicerColorLogic.cxx
@@ -109,18 +109,9 @@ std::vector<std::string> vtkSlicerColorLogic::FindDefaultColorFiles()
     return {};
   }
 
-  // build up the vector
-  std::vector<std::string> filesVector;
-  filesVector.emplace_back(""); // The first two components do not add a slash.
-  filesVector.push_back(homeDir);
-  filesVector.push_back(shareDir + "/ColorFiles");
-  std::string resourcesDirString = vtksys::SystemTools::JoinPath(filesVector);
-
-  // now make up a vector to iterate through of dirs to look in
+  // Find color files in the application share folder
   std::vector<std::string> DirectoriesToCheck;
-
-  DirectoriesToCheck.push_back(resourcesDirString);
-
+  DirectoriesToCheck.push_back(appLogic->GetShareFilePath("ColorFiles"));
   return this->FindColorFiles(DirectoriesToCheck);
 }
 


### PR DESCRIPTION
_Updated description from @lassoan:_

Recent changes in application initialization resulted in incorrectly computed paths for orientation marker and font files.

The root cause of the issue was that `vtkMRMLApplicationLogic::GetShareDirectory()` returns a relative path.

Fixed the issue by properly constructing full path from the relative path. Added a convenience function that makes it easier and less error-prone to get the full path of files and folders in the application share folder.

---


<details><summary><i>Original description by @ruffsl</i></summary>
<p>


This pull request updates how the `ShareDirectory` path is resolved in the `vtkMRMLApplicationLogic` class, improving robustness when handling relative and absolute paths. The main change is that `GetShareDirectory()` now returns an absolute path when possible and gracefully handles errors if required information is missing.

</p>
</details> 

---

Fixes https://github.com/Slicer/Slicer/issues/8793