### PR TITLE
ENH: Show launcher splashscreen until Slicer is started

### DIFF
--- a/Base/QTApp/qSlicerApplicationHelper.hxx
+++ b/Base/QTApp/qSlicerApplicationHelper.hxx
@@ -188,6 +188,11 @@ int qSlicerApplicationHelper::postInitializeApplication(qSlicerApplication& app,
     splashScreen.reset(new QSplashScreen(pixmap, Qt::WindowStaysOnTopHint));
     splashMessage(splashScreen, qSlicerApplication::tr("Initializing..."));
     splashScreen->show();
+    // Write a new-line character on the process output to hide the application launcher's splashscreen
+    // (SPLASHSCREEN_IGNORE_OUTPUT option is disabled by default).
+    std::cout << std::endl;
+    // Ensure that the output is not delayed by buffering.
+    std::cout.flush();
   }
 
   DraggableWidgetEventFilter draggable;

--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -701,11 +701,13 @@ macro(slicerMacroBuildApplication)
       include(SlicerBlockCTKAppLauncherSettings)
 
       if(SLICERAPP_SPLASHSCREEN_ENABLED)
+        # Application launcher splashscreen is shown until the application is started (and writes something to its output)
+        # or SPLASHSCREEN_HIDE_DELAY_MS time is elapsed - whichever comes first.
+        # 3 minutes (180000ms) should be sufficient to get the application started on all platforms.
         set(_launcher_splashscreen_args
           SPLASH_IMAGE_PATH ${SLICERAPP_LAUNCHER_SPLASHSCREEN_FILE}
           SPLASH_IMAGE_INSTALL_SUBDIR ${Slicer_BIN_DIR}
-          SPLASHSCREEN_HIDE_DELAY_MS 3000
-          SPLASHSCREEN_IGNORE_OUTPUT
+          SPLASHSCREEN_HIDE_DELAY_MS 180000
           )
         set(_launcher_application_default_arguments "${SLICERAPP_APPLICATION_DEFAULT_ARGUMENTS}")
       else()


### PR DESCRIPTION
Previously, the splashscreen of the launcher was only displayed for 3 seconds, but often the application's splashscreen did not show up for 10-20 seconds. It was confusing for users to see two splashscreens appearing during Slicer startup, with some time between them when no splashscreen was displayed (and so users did not know if the application startup was in progress).

This commit makes the application launcher splashscreen displayed until the application can display its own splashscreen. This is implemented by leveraging the CTK application launcher's new feature, which hides its splashscreen when the launched application writes something on its output.

see #8638