### PR TITLE
ENH: Update CTK to include PythonQt minimizing commontk fork deltas

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "833ae56e69d403bd0c83f2c331a32a8fd9c70285"
+    "1aa872029a94eec3a70cdd1114336387000a0171"
     QUIET
     )
 


### PR DESCRIPTION
This update rebases our fork onto the latest `MeVisLab/PythonQt`, upstreaming most of the `commontk/PythonQt`-specific changes and reducing our local delta.

It adds groundwork for Qt6 (dynamic header/framework discovery, generator tweaks), modernizes Python APIs for 3.12 (immortals, string/long replacements), improves cleanup stability, and clarifies wrapper-generation behavior (per-Qt, with CI updates).

List of CTK changes:

```
$ git shortlog 833ae56e6..1aa872029 --no-merges
Jean-Christophe Fillion-Robin (2):
      STYLE: Anticipate PythonQt update migrating to Python 3 Unicode and Long APIs
      ENH: Update PythonQt minimizing fork deltas
```

List of changes specific to `commontk/PythonQt` fork:

```
$ git shortlog f4769f19..c128afb1 --no-merges
James Butler (1):
      [commontk] Fix Qt 5.15 failing to use 5.15 wrappers

Jean-Christophe Fillion-Robin (3):
      [commontk] Revert part of r91 preventing QFlags from being wrapped
      [commontk] Re-enable CMake support importing historical improvements from commontk/PythonQt fork
      [commontk] Update PythonQtTestCleanup to adapt to this fork layout
```

List of changes specific to `MeVisLab/PythonQt` upstream:

```
$ git shortlog 37b0d31e5..f4769f19 --no-merges
Andreas Bohne (2):
      Fix typo in workflow file
      Rename master to main

Hans Johnson (8):
      COMP: Remove use of deprecated 'count()' function
      chore: Remove deprecated Qt5 paradigms
      chore: Remove obsolete Python 2 compatibility code
      chore: Remove outdated `PY_VERSION_HEX` conditional branches
      chore: Prefer c++11 range for to Qt macros
      chore(importer): read `sys.flags` (verbose/optimize) on Python >= 3.12; fallback to legacy globals
      ci(build.yml): Generate wrapper on macOS for both release and debug
      chore: remove old generated files

James Butler (1):
      Prevent crashes during and after cleanup (cont'd)

Jean-Christophe Fillion-Robin (64):
      vendor(simplecpp): Update simplecpp.{h,cpp} to master (538c5c4); was v1.2.0 (a853253) (PR-274)
      chore: Simplify Qt6 support introducing PythonQtUtils helpers
      chore: Consistently use QMetaType::UnknownType
      chore: Consistently use QMetaType::QByteArray
      Re-introduce support for QMatrix when building against Qt < 6.0
      Fix warning related to use of qrand() when building against Qt 5.15
      fix: Address warnings with QSet::fromList in Qt 5.15
      Replace NULL with nullptr
      addDecorators: Check for null object
      Fix "_invalid_parameter_noinfo_noreturn" link error
      vendor(simplecpp): Update PythonQt-specific patch to account for upstream changes
      vendor(simplecpp): Update simplecpp.{h,cpp} to master (37fa4f4); was master (538c5c4)
      Fix setRedirectStdInCallbackEnabled
      Add support for enabling stdout/stderr redirection
      Fix windows build error renaming stdout ivar
      fix(PythonQt): Explicitly support immortals introduced in Python >= 3.12
      chore(PythonQtObjectPtr): Remove redundant nullptr checks
      fix(cleanup): clear global enum-wrapper registry before tearing down class infos
      fix: guard InstanceWrapper during cleanup and Py_Finalize
      tests: isolate cleanup tests
      fix: gate asyncio import during init; disable it in cleanup CI to avoid early ssl load
      fix: Ensure proper cleanup in PythonQtTestCleanup
      tests(PythonQtTestCleanup): Fix unknown attribute in testCallQtMethodInDel
      ci(tests): suppress CPython 3.12 interned-unicode leak (PyUnicode_New) in sanitizer runs
      tests(cleanup): clarify destructor tests and add weakref-guarded variant
      fix(PythonQtPythonInclude): conditionally #undef ctype macros only on macOS C++ builds
      fix: Update main function signature used in examples
      style(PythonQtTestCleanup): Consistently indent test cases
      chore(PythonQtTestCleanup): Consistently use helper to run test scripts
      tests: Update PythonQtTestCleanup to test alternative cleanup order
      vendor(simplecpp): Update simplecpp.{h,cpp} to patched-2025-08-30-37fa4f49b (bfc53ad); was master (37fa4f4)
      feat(generator): discover Qt headers via QLibraryInfo; validate includes
      feat(generator): discover Qt include/framework paths dynamically; add PYTHONQT_FRAMEWORK
      feat(generator): detect Qt version from QtCore.framework on macOS
      ci: Simplify generator call & re-enable check verifying wrappers are generated on macOS
      fix(generator): Support additional qtcoreversion.h header paths
      chore: Improve const correctness
      chore(importer): add helpers for runtime flags
      chore(PythonQt): replace `PyInt_Type` with `PyLong_Type`
      chore(PythonQt): replace `PyInt_FromLong` with `PyLong_FromLong`
      chore(PythonQt): replace `PyInt_AS_LONG` with `PyLong_AS_LONG`
      chore(PythonQt): replace `PyInt_Check` with `PyLong_Check`
      chore(PythonQt): replace `PyInt_AsLong` with `PyLong_AsLong`
      chore(PythonQt): replace `PyString_FromString` with `PyUnicode_FromString`
      chore(PythonQt): replace `PyString_AS_STRING` with `PyUnicode_AsUTF8`
      chore(PythonQt): replace `PyString_AsString` with `PyUnicode_AsUTF8`
      chore(PythonQt): replace `PyString_FromFormat` with `PyUnicode_FromFormat`
      chore(PythonQt): replace `PyString_Check` with `PyUnicode_Check`
      chore(PythonQtPythonInclude, build/python.prf): Report error if using Python 2.x
      chore(generator): replace `PyString_FromString` with `PyUnicode_FromString`
      chore(generated_cpp_*): replace `PyString_FromString` with `PyUnicode_FromString`
      chore: Add support for defining PYTHONQT_USE_PYSTRING_SHIM
      chore(qmake): add toggles to build only the generator or exclude it
      ci(build): generate wrappers first; then build without generator
      chore(build/common.prf): prefer ../generated_cpp & keep Qt5 fallbacks
      fix(generator): normalize macOS framework includes to bare Qt headers
      ci(build_latest.yml): Switch from Qt 6.9 to Qt 6.10
      chore(build/common.prf): drop Qt5 versioned wrapper fallbacks; rely on explicit/generated path
      fix(generator/typesystem_core): Exclude std::string_view operator introduce in 6.10
      fix(generator/typesystem_core): Support Qt 6.10 excluding unsupported APIs
      docs(README): require per-Qt wrapper generation; add output path & qmake toggles
      fix(generator): Define __x86_64__ to support Qt SDK on multi-lib distribution
      ci: Fix generation of wrappers on rockylinux multi-lib distribution
      chore(generator): Prefer QTDIR for Qt headers/frameworks; fallback to QLibraryInfo

John Stark (1):
      Fix MSVC compilation issue when PythonQt Debug build against python Release

Max Smolens (5):
      Prevent crashes during and after cleanup
      Add cleanup/finalization tests
      Fix PythonQtSignalReceiver crash during cleanup
      Prevent crash when an object is destroyed after calling PythonQt::cleanup()
      fix: Resolve link error in PythonQtTestMain on Windows

Steve Pieper (1):
      fix(PythonQtPythonInclude): Undefine C <ctype> macros after Python.h to avoid libstdc++ <locale> clashes

Uwe Siems (6):
      Fixed: When generating wrappers for non-Qt code, includes lost their directories
      The algorithm that derived the package name for the init code...
      NumPy 2 defines its own "slots". To avoid the collision, use Q_SLOTS instead
      Extract primitive type definitions and general suppressions...
      Set an exception if the required method does not exist
      Enable wrapper for QAbstractEventDispatcher

dependabot[bot] (3):
      Bump actions/checkout from 4 to 5
      chore(deps): bump hendrikmuhs/ccache-action from 1.2.18 to 1.2.19
      chore(deps): bump actions/setup-python from 4 to 6

mrbean-bremen (2):
      Let the CI fail if no wrappers are generated
      Add workflow to delete caches on closed PRs
```