### PR TITLE
COMP: Update CTK to modernize PythonQt integration

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "6d406da677bdea3ff9889f50dcf572c7d02d77bd"
+    "887a81c91a99ed1568f0fb56f75aa89ce486dd98"
     QUIET
     )
 


### PR DESCRIPTION
List of CTK changes:

```
$ git shortlog  6d406da6..887a81c9 --no-merges
Hans Johnson (2):
      ENH: Use modern QWheelEvent ctor for Qt 5.15+/Qt 6 in event player
      COMP: Migrate deprecated Q_ENUMS to Q_ENUM (Qt >= 5.5)

Jean-Christophe Fillion-Robin (9):
      COMP: Fix enum name typo in ctkCmdLineModuleFrontend
      COMP: Update minimum required version from 3.16.3 to 3.20.6
      COMP: Fix VTK external project hard-coding expected VTK Python version to 3
      ENH: Update PythonQt adding Python3 support and modernizing its build-system
      COMP: Update PythonQt external project decoupling source download
      COMP: Update PythonQt and add for building wrappers based on current Qt version
      COMP: Fix PythonQt GenerateWrapper step to ensure Qt libraries are in PATH
      COMP: Improve logging for PythonQt GenerateWrapper build step
      COMP: Fix AUTOUIC include dir for multi-config generators
```