### PR TITLE
COMP: Fix AUTOUIC include dir for multi-config generators

### DIFF
--- a/CMake/SlicerMacroBuildBaseQtLibrary.cmake
+++ b/CMake/SlicerMacroBuildBaseQtLibrary.cmake
@@ -116,13 +116,20 @@ macro(SlicerMacroBuildBaseQtLibrary)
   #-----------------------------------------------------------------------------
   # Update Slicer_Base_INCLUDE_DIRS
   #-----------------------------------------------------------------------------
+  get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
   set(Slicer_Base_INCLUDE_DIRS ${Slicer_Base_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
     # Ensure generated AUTOUIC headers (ui_*.h) are discoverable.
     #
     # By default CMake writes them to:
-    #   <AUTOGEN_BUILD_DIR>/include
+    #
+    #   - Single-config generators (Ninja/Makefiles):
+    #       <AUTOGEN_BUILD_DIR>/include
+    #
+    #   - Multi-config generators (VS, Xcode, Ninja Multi-Config):
+    #       <AUTOGEN_BUILD_DIR>/include_<CONFIG>
     #
     # where AUTOGEN_BUILD_DIR defaults to:
     #   <target-binary-dir>/<target-name>_autogen
@@ -130,7 +137,7 @@ macro(SlicerMacroBuildBaseQtLibrary)
     # References:
     # - https://cmake.org/cmake/help/latest/manual/cmake-qt.7.html#autouic
     # - https://cmake.org/cmake/help/latest/prop_tgt/AUTOGEN_BUILD_DIR.html
-    ${CMAKE_CURRENT_BINARY_DIR}/${lib_name}_autogen/include
+    ${CMAKE_CURRENT_BINARY_DIR}/${lib_name}_autogen/include$<$<BOOL:${_isMultiConfig}>:_$<CONFIG>>
     CACHE INTERNAL "Slicer Base includes" FORCE)
 
   #-----------------------------------------------------------------------------

--- a/CMake/SlicerMacroBuildLoadableModule.cmake
+++ b/CMake/SlicerMacroBuildLoadableModule.cmake
@@ -92,13 +92,20 @@ macro(slicerMacroBuildLoadableModule)
     set(${lib_name}_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "" FORCE)
   endif()
 
+  get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
   set(${lib_name}_INCLUDE_DIRS
     ${${lib_name}_SOURCE_DIR}
     ${${lib_name}_BINARY_DIR}
     # Ensure generated AUTOUIC headers (ui_*.h) are discoverable.
     #
     # By default CMake writes them to:
-    #   <AUTOGEN_BUILD_DIR>/include
+    #
+    #   - Single-config generators (Ninja/Makefiles):
+    #       <AUTOGEN_BUILD_DIR>/include
+    #
+    #   - Multi-config generators (VS, Xcode, Ninja Multi-Config):
+    #       <AUTOGEN_BUILD_DIR>/include_<CONFIG>
     #
     # where AUTOGEN_BUILD_DIR defaults to:
     #   <target-binary-dir>/<target-name>_autogen
@@ -106,7 +113,7 @@ macro(slicerMacroBuildLoadableModule)
     # References:
     # - https://cmake.org/cmake/help/latest/manual/cmake-qt.7.html#autouic
     # - https://cmake.org/cmake/help/latest/prop_tgt/AUTOGEN_BUILD_DIR.html
-    ${CMAKE_CURRENT_BINARY_DIR}/${lib_name}_autogen/include
+    ${CMAKE_CURRENT_BINARY_DIR}/${lib_name}_autogen/include$<$<BOOL:${_isMultiConfig}>:_$<CONFIG>>
     CACHE INTERNAL "" FORCE)
 
   include_directories(

--- a/CMake/SlicerMacroBuildModuleQtLibrary.cmake
+++ b/CMake/SlicerMacroBuildModuleQtLibrary.cmake
@@ -69,6 +69,8 @@ macro(SlicerMacroBuildModuleQtLibrary)
   # --------------------------------------------------------------------------
   # Set <MODULEQTLIBRARY_NAME>_INCLUDE_DIRS
   # --------------------------------------------------------------------------
+  get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
   set(_include_dirs
     ${${MODULEQTLIBRARY_NAME}_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -76,7 +78,12 @@ macro(SlicerMacroBuildModuleQtLibrary)
     # Ensure generated AUTOUIC headers (ui_*.h) are discoverable.
     #
     # By default CMake writes them to:
-    #   <AUTOGEN_BUILD_DIR>/include
+    #
+    #   - Single-config generators (Ninja/Makefiles):
+    #       <AUTOGEN_BUILD_DIR>/include
+    #
+    #   - Multi-config generators (VS, Xcode, Ninja Multi-Config):
+    #       <AUTOGEN_BUILD_DIR>/include_<CONFIG>
     #
     # where AUTOGEN_BUILD_DIR defaults to:
     #   <target-binary-dir>/<target-name>_autogen
@@ -84,7 +91,7 @@ macro(SlicerMacroBuildModuleQtLibrary)
     # References:
     # - https://cmake.org/cmake/help/latest/manual/cmake-qt.7.html#autouic
     # - https://cmake.org/cmake/help/latest/prop_tgt/AUTOGEN_BUILD_DIR.html
-    ${CMAKE_CURRENT_BINARY_DIR}/${lib_name}_autogen/include
+    ${CMAKE_CURRENT_BINARY_DIR}/${lib_name}_autogen/include$<$<BOOL:${_isMultiConfig}>:_$<CONFIG>>
     )
   # Since module developer may have already set the variable to some
   # specific values in the module CMakeLists.txt, we make sure to

--- a/Libs/MRML/Widgets/CMakeLists.txt
+++ b/Libs/MRML/Widgets/CMakeLists.txt
@@ -443,13 +443,20 @@ endif()
 # --------------------------------------------------------------------------
 # Set INCLUDE_DIRS variable
 # --------------------------------------------------------------------------
+get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
 set(${PROJECT_NAME}_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   # Ensure generated AUTOUIC headers (ui_*.h) are discoverable.
   #
   # By default CMake writes them to:
-  #   <AUTOGEN_BUILD_DIR>/include
+  #
+  #   - Single-config generators (Ninja/Makefiles):
+  #       <AUTOGEN_BUILD_DIR>/include
+  #
+  #   - Multi-config generators (VS, Xcode, Ninja Multi-Config):
+  #       <AUTOGEN_BUILD_DIR>/include_<CONFIG>
   #
   # where AUTOGEN_BUILD_DIR defaults to:
   #   <target-binary-dir>/<target-name>_autogen
@@ -457,5 +464,5 @@ set(${PROJECT_NAME}_INCLUDE_DIRS
   # References:
   # - https://cmake.org/cmake/help/latest/manual/cmake-qt.7.html#autouic
   # - https://cmake.org/cmake/help/latest/prop_tgt/AUTOGEN_BUILD_DIR.html
-  ${CMAKE_CURRENT_BINARY_DIR}/${lib_name}_autogen/include
+  ${CMAKE_CURRENT_BINARY_DIR}/${lib_name}_autogen/include$<$<BOOL:${_isMultiConfig}>:_$<CONFIG>>
   CACHE INTERNAL "${PROJECT_NAME} include dirs" FORCE)


### PR DESCRIPTION
Add the autogen include path with the per-config suffix when `GENERATOR_IS_MULTI_CONFIG` is true:

```
<binary>/<target>_autogen/include_$<CONFIG>
```

This ensures ui_*.h headers are found under VS/Xcode/Ninja Multi-Config, while preserving the single-config layout:

```
<binary>/<target>_autogen/include
```

It fixes regression introduced in 8a44717a61b ("COMP: Enable AUTOUIC to simplify UI generation and prep for Qt6", 2025-11-02) through the following pull request:
* https://github.com/Slicer/Slicer/pull/8814