### PR TITLE
BUG: Update CTK to fix AUTOMOC DCMTK/Python clash and chart refresh

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "887a81c91a99ed1568f0fb56f75aa89ce486dd98"
+    "3e3c343efa08a6a03a7845e3d2a048dabd054894"
     QUIET
     )
 


### PR DESCRIPTION
This unblocks Windows builds with AUTOMOC enabled and improves plotting behavior.

For reference, AUTOMOC was enabled in 25c8a5783cc ("COMP: Update CTK with support for AUTOUIC, AUTORCC and AUTOMOC", 2025-11-04)

List of CTK changes:

```
$ git shortlog 887a81c9..3e3c343e --no-merges
Jean-Christophe Fillion-Robin (2):
      COMP: Resolve DCMTK/Python macro redefs in AUTOGEN mocs TU; prevent Windows pid_t clash
      COMP: Set CMP0177 to ensure install() DESTINATION paths are normalized

Xavier Riobé (1):
      BUG: Fix chart update when resetting axes range
```

---

Related CTK pull requests:
* https://github.com/commontk/CTK/pull/1265
* https://github.com/commontk/CTK/pull/1273
* https://github.com/commontk/CTK/pull/1275