### PR TITLE
COMP: Update CTK to fix PythonQt build ensuring Qt DIR is passed

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "3e3c343efa08a6a03a7845e3d2a048dabd054894"
+    "6a5df53bfeae2e0ff10deb622601b5aecfeb5a4a"
     QUIET
     )
 


### PR DESCRIPTION
List of CTK changes:

```
$ git shortlog 3e3c343e..6a5df53b --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Fix PythonQt & PythonQtGenerator build ensuring Qt DIR is passed
```

---

See https://github.com/commontk/CTK/compare/3e3c343e...6a5df53b