### PR TITLE
BUG: Fix not accounting for closed surface rep for temp seg node

### DIFF
--- a/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
@@ -445,6 +445,14 @@ class SegmentStatisticsLogic(ScriptedLoadableModuleLogic):
                 transformedSegmentationNode.HideFromEditorsOn()
                 slicer.mrmlScene.AddNode(transformedSegmentationNode)
                 transformedSegmentationNode.HardenTransform()
+
+                # Check to see if a closed surface representation exists for the original segmentation
+                import vtkSegmentationCorePython as vtkSegmentationCore
+                containsClosedSurfaceRepresentation = segmentationNode.GetSegmentation().ContainsRepresentation(
+                    vtkSegmentationCore.vtkSegmentationConverter.GetSegmentationClosedSurfaceRepresentationName())
+                if containsClosedSurfaceRepresentation:
+                    # Recreate closed surface representation after hardening the transform
+                    transformedSegmentationNode.CreateClosedSurfaceRepresentation()
                 self.getParameterNode().SetParameter("Segmentation", transformedSegmentationNode.GetID())
 
             # Get segment ID list


### PR DESCRIPTION
If a segmentation node has a parent transform node and a closed surface representation, the temporary node will be created. However, no closed surface segmentation stats will be computed for the temp volume because the temporary node does not have a closed surface. https://github.com/Slicer/Slicer/blob/3220bf57f25c367baa45cbfaef9fb97f34837fa4/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/ClosedSurfaceSegmentStatisticsPlugin.py#L30

This PR adds a closed surface to the temporary node if exists, allowing the closed surface segmentation stats to be computed