### PR TITLE
BUG: Update VTK to include vtkSurfaceNets3D fix for orientation consistency

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "454bb391dff78c6ff463298a5143ab5b4f0aa083") # slicer-v9.4.2-2025-03-26-13acb1a5d
     set(vtk_dist_info_version "9.4.2")
   elseif("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.5")
-    set(_git_tag "a0e770646e24c630cbec6f60c54e7070383c9f03") # slicer-v9.5.2-2025-09-16-7c0494a68
+    set(_git_tag "e21c90bd874fb15f1dc34986c238462b8aab4af8") # slicer-v9.5.2-2025-09-16-7c0494a68
     set(vtk_dist_info_version "9.5.2")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR.Slicer_VTK_VERSION_MINOR: ${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}")


### PR DESCRIPTION
See https://discourse.slicer.org/t/surface-normal-calculation-issue-using-surfacenets/40811

List of VTK changes:

```
$ git shortlog a0e770646e..e21c90bd87 --no-merges
Spiros Tsalikis (1):
      [Backport] vtkSurfaceNets3D: Fix orientation consistency and scalar data handling
```

Related issues:
* https://github.com/Slicer/Slicer/issues/8093