### PR TITLE
COMP: Update CTK to include changes for Qt5/Qt6 compatibility

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -71,7 +71,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "6a5df53bfeae2e0ff10deb622601b5aecfeb5a4a"
+    "dd4caeae7e979cf441e44ee85d3b0780120d113d"
     QUIET
     )
 


### PR DESCRIPTION
This updates CTK to include numerous changes for Qt5/Qt6 compatibility:
- Transitioning from QRegExp to QRegularExpression.
- Replacing deprecated QDesktopWidget usage with QScreen.
- Various code updates to handle deprecations and compatibility issues with Qt 6.

---

List of CTK changes:

```
$ git shortlog 6a5df53bf..dd4caeae7 --no-merges
Jean-Christophe Fillion-Robin (28):
      COMP: Switch to QStyleOption::initFrom anticipating Qt6 transition
      COMP: Explicitly include headers to support mocing with Qt6
      COMP: Replace QRegExp with QRegularExpression
      COMP: Update VTK from v9.2.2 to v9.5.2
      BUG: Update ctkButtonGroup signals to support Qt6
      COMP: Replace deprecated QDesktopWidget usage with QScreen
      COMP: Rename CTK_QT5_COMPONENTS to CTK_QT_COMPONENTS
      COMP: Exclude use of globalStrut() anticipating transition to Qt6
      COMP: Resolve various minor incompatibilities between Qt 5 and Qt 6
      COMP: Resolve various minor incompatibilities between Qt 5 and Qt 6
      COMP: Simplify integration of ctkIconEnginePlugin by removing proxy header
      COMP: Update Log4Qt to support Qt6
      COMP: Update DCMTK from 3.6.6_20210115 to 3.6.8_20241024
      COMP: Update ctkCommandLineParser to support Qt6
      COMP: Update QVariant to QMetaType for Qt6 compatibility
      COMP: Add compatibility for Qt 6 in mouse event handling
      COMP: Fix Qt 5/6 compatibility and Qt 6.4+ deprecations
      COMP: Remove EXCEPTION QVariant insertion incompatible with Qt 6
      COMP: Update active window handling for Qt 6.5+ in ctkBasePopupWidget
      COMP: Update ctkWorkflowWidget to use QRegularExpression and QMetaType APIs
      COMP: Update PythonQt with Qt6 support
      BUG: Fix null d_ptr in alternate ctkMessageBox constructor
      COMP: Enable AUTOMOC for in ScriptPythonCore test to prep for Qt6
      COMP: Fix build of ctkServiceListener test against Qt6
      COMP: Remove no-op code from ctkAbstractPythonManagerTester
      COMP: Update ctkTest to use qWarning() instead of deprecated QTest::qWarn()
      COMP: Update ctkPythonConsoleTest1 to use operator| for Qt 6 compatibility
      COMP: Update ctkPythonConsole to remove use of deprecated QString API

Stefan Dinkelacker (13):
      COMP: Replace QMap::insertMulti with QMultiMap in DICOM field generator
      COMP: Use QEnterEvent instead of QEvent for enterEvent() in Qt 6
      COMP: Use QOpenGLWidget instead of QGLWidget with Qt 6
      COMP: Use QRecursiveMutex (Qt >= 5.14) instead of QMutex(QMutex::Recursive)
      COMP: Prefer FilterRegularExpression setter/getter anticipating Qt6
      COMP: Use QLayout::setContentsMargins() instead of setMargin()
      COMP: Handle Qt6 QLocale::groupSeparator() in ctkDoubleSpinBox
      COMP: Resolve header incompatibilities between Qt 5 and Qt 6
      COMP: Use QDateTime::fromSecsSinceEpoch() instead of fromTime_t() for Qt 5.8+
      COMP: No need for AvailableSizesHook in Qt 6 anymore
      COMP: Use QtConcurrent::run lambda overload for background tasks
      COMP: Use QEnterEvent instead of QEvent for enterEvent() in Qt 6
      COMP: Fix Qt6 build by including <climits> for ULONG_MAX
```