### PR TITLE
COMP: Require Qt XmlPatterns only when QtTesting is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -653,9 +653,15 @@ endif()
     Network OpenGL
     PrintSupport
     UiTools #no dll
-    Xml XmlPatterns
+    Xml
     Svg Sql
     )
+
+  if(Slicer_USE_QtTesting)
+    list(APPEND Slicer_REQUIRED_QT_MODULES
+      XmlPatterns
+      )
+  endif()
 
   if(Slicer_BUILD_MULTIMEDIA_SUPPORT)
     list(APPEND Slicer_REQUIRED_QT_MODULES


### PR DESCRIPTION
Qt XmlPatterns C++ classes are only used by `ctkXMLEventSource` in CTK’s QtTesting support code (`CTK/Libs/QtTesting`). Other XmlPatterns usages are limited to CTK components (`CTK/Libs/CommandLineModules`, `CTK/Applications/ctkCommandLineModuleExplorer`) that Slicer does not depend on.

Note that the upstream QtTesting library itself (`github.com/commontk/QtTesting`) does not depend on Qt XmlPatterns.

Update `Slicer_REQUIRED_QT_MODULES` to add `XmlPatterns` only when `Slicer_USE_QtTesting` is enabled, avoiding an unnecessary global dependency and preparing for Qt6 integration, where XmlPatterns is no longer available.