### PR TITLE
ENH: Last used DICOM import and 10 last used database directories are stored

### DIFF
--- a/Modules/Scripted/DICOM/Resources/UI/DICOM.ui
+++ b/Modules/Scripted/DICOM/Resources/UI/DICOM.ui
@@ -108,6 +108,76 @@
     </widget>
    </item>
    <item>
+    <widget class="ctkCollapsibleButton" name="browserSettingsFrame">
+     <property name="text">
+      <string>DICOM database settings</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="databaseDirectoryLabel">
+        <property name="text">
+         <string>Database location:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="ctkDirectoryButton" name="directoryButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="browserAutoHideLabel">
+        <property name="text">
+         <string>Auto-hide browser window:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="databaseMaintenanceLabel">
+        <property name="text">
+         <string>Maintenance:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="browserAutoHideCheckBox">
+        <property name="toolTip">
+         <string>Hide DICOM database browser after data loaded</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QPushButton" name="repairDatabaseButton">
+        <property name="toolTip">
+         <string>Remove all items from the DICOM database if referenced DICOM file is not found on disk.</string>
+        </property>
+        <property name="text">
+         <string>Remove unavailable data sets</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QPushButton" name="clearDatabaseButton">
+        <property name="toolTip">
+         <string>Removes all data from the database and all files that were copied into the database during import.</string>
+        </property>
+        <property name="text">
+         <string>Remove all data sets</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="ctkCollapsibleButton" name="networkingFrame">
      <property name="text">
       <string>DICOM networking</string>
@@ -201,69 +271,44 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="browserSettingsFrame">
+    <widget class="ctkCollapsibleButton" name="previousDatabaseLocationsFrame">
      <property name="text">
-      <string>DICOM database settings</string>
+      <string>Previous database locations</string>
      </property>
-     <layout class="QFormLayout" name="formLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="databaseDirectoryLabel">
-        <property name="text">
-         <string>Database location:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="ctkDirectoryButton" name="directoryButton">
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <item>
+       <widget class="QLabel" name="previousLocationsLabel">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="browserAutoHideLabel">
         <property name="text">
-         <string>Auto-hide browser window:</string>
+         <string>List of previous locations:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="databaseMaintenanceLabel">
-        <property name="text">
-         <string>Maintenance:</string>
-        </property>
-       </widget>
+      <item>
+       <widget class="ctkPathLineEdit" name="previousDatabaseLocationsPathLineEdit"/>
       </item>
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="browserAutoHideCheckBox">
-        <property name="toolTip">
-         <string>Hide DICOM database browser after data loaded</string>
+      <item>
+       <widget class="QPushButton" name="changeDatabaseToPreviousLocationButton">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
         <property name="text">
-         <string/>
+         <string>Apply</string>
         </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QPushButton" name="repairDatabaseButton">
-        <property name="toolTip">
-         <string>Remove all items from the DICOM database if referenced DICOM file is not found on disk.</string>
-        </property>
-        <property name="text">
-         <string>Remove unavailable data sets</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QPushButton" name="clearDatabaseButton">
-        <property name="toolTip">
-         <string>Removes all data from the database and all files that were copied into the database during import.</string>
-        </property>
-        <property name="text">
-         <string>Remove all data sets</string>
+        <property name="icon">
+         <iconset resource="../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc">
+          <normaloff>:/Icons/Medium/SlicerDatabase.png</normaloff>:/Icons/Medium/SlicerDatabase.png</iconset>
         </property>
        </widget>
       </item>
@@ -301,6 +346,11 @@
    <class>ctkMenuButton</class>
    <extends>QPushButton</extends>
    <header>ctkMenuButton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkPathLineEdit</class>
+   <extends>QWidget</extends>
+   <header>ctkPathLineEdit.h</header>
   </customwidget>
  </customwidgets>
  <resources>


### PR DESCRIPTION
In the [discourse](https://discourse.slicer.org/t/edit-default-dicom-import-directory/44704) there was a request for Slicer to remember the last DICOM directory imported as well as the last few DICOM database directories and to be able to change between them. All of this data is stored with QSettings.

For the first part, storing the last DICOM directory imported. This will be stored in the DICOM group with the key `LastImportDirectory` in the QSettings.

On the `__init__` of SlicerDICOMBrowser this is added, to check if there is a value stored, if so the dialog for the import will point to the directory specified.

```
        if self.settings.value("DICOM/LastImportDirectory") is not None:
            lastImportDirectory = self.settings.value("DICOM/LastImportDirectory")
            if os.path.exists(lastImportDirectory):
                self.changeDialogDirectory(lastImportDirectory)
```

To store this value, also in SlicerDICOMBrowser, this was added to the `onDirectoryImported` method:

```
        if self.useExpertimentalVisualDICOMBrowser:
            browserUsed = self.dicomVisualBrowser
        else:
            browserUsed = self.dicomBrowser

        newDirectory = browserUsed.importDialog().directory().path()
        self.settings.setValue("DICOM/LastImportDirectory", newDirectory)
        self.changeDialogDirectory(newDirectory)
```

For the second part, storing and allowing easy access to the last 10 used DICOM database directories, the DICOM.ui was changed:

<div align='center'><img width="516" height="347" alt="image" src="https://github.com/user-attachments/assets/bf291344-0083-4a7f-8320-b3e5976f0010" /></div>

A new collapsible button was added, in which there is a ComboBox that displays the 10 last used DICOM database directories, as well as a button to switch between them.

The storage of the 10 directories is done in a similar way to the last import directory, however this time the storage is done whenever `updateDatabaseDirectoryFromWidget` on the DICOMWidget is run.

This is how it all would appear in the .ini file:

```
LastImportDirectory=D:/DICOMTEST
NumberOfDirectoriesToKeep=10
LastDatabaseDirectory\0=D:/DICOMTEST4
LastDatabaseDirectory\1=D:/DICOMTEST5
LastDatabaseDirectory\2=D:/DICOMTEST9
LastDatabaseDirectory\3=D:/DICOMTEST8
LastDatabaseDirectory\4=D:/DICOMTEST11
LastDatabaseDirectory\5=D:/DICOMTEST10
LastDatabaseDirectory\6=D:/DICOMTEST7
LastDatabaseDirectory\7=D:/DICOMTEST6
LastDatabaseDirectory\8=D:/DICOMTEST3
LastDatabaseDirectory\9=D:/DICOMTEST2
```


[Re -> Discourse](https://discourse.slicer.org/t/edit-default-dicom-import-directory/44704)
