### PR TITLE
COMP: Update python packages to latest

### DIFF
--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -41,39 +41,39 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pydicom]
-  pydicom==2.4.4 --hash=sha256:f9f8e19b78525be57aa6384484298833e4d06ac1d6226c79459131ddb0bd7c42
+  pydicom==3.0.1 --hash=sha256:db32f78b2641bd7972096b8289111ddab01fb221610de8d7afa835eb938adb41
   # [/pydicom]
   # [six]
   six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
   # [/six]
   # [pillow]
   # Hashes correspond to the following packages:
-  #  - pillow-11.2.1-cp312-cp312-macosx_10_13_x86_64.whl
-  #  - pillow-11.2.1-cp312-cp312-macosx_11_0_arm64.whl
-  #  - pillow-11.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - pillow-11.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - pillow-11.2.1-cp312-cp312-manylinux_2_28_aarch64.whl
-  #  - pillow-11.2.1-cp312-cp312-manylinux_2_28_x86_64.whl
-  #  - pillow-11.2.1-cp312-cp312-musllinux_1_2_aarch64.whl
-  #  - pillow-11.2.1-cp312-cp312-musllinux_1_2_x86_64.whl
-  #  - pillow-11.2.1-cp312-cp312-win_amd64.whl
-  #  - pillow-11.2.1-cp312-cp312-win_arm64.whl
-  pillow==11.2.1 --hash=sha256:78afba22027b4accef10dbd5eed84425930ba41b3ea0a86fa8d20baaf19d807f \
-                 --hash=sha256:78092232a4ab376a35d68c4e6d5e00dfd73454bd12b230420025fbe178ee3b0b \
-                 --hash=sha256:25a5f306095c6780c52e6bbb6109624b95c5b18e40aab1c3041da3e9e0cd3e2d \
-                 --hash=sha256:0c7b29dbd4281923a2bfe562acb734cee96bbb129e96e6972d315ed9f232bef4 \
-                 --hash=sha256:3e645b020f3209a0181a418bffe7b4a93171eef6c4ef6cc20980b30bebf17b7d \
-                 --hash=sha256:b2dbea1012ccb784a65349f57bbc93730b96e85b42e9bf7b01ef40443db720b4 \
-                 --hash=sha256:da3104c57bbd72948d75f6a9389e6727d2ab6333c3617f0a89d72d4940aa0443 \
-                 --hash=sha256:598174aef4589af795f66f9caab87ba4ff860ce08cd5bb447c6fc553ffee603c \
-                 --hash=sha256:14e33b28bf17c7a38eede290f77db7c664e4eb01f7869e37fa98a5aa95978941 \
-                 --hash=sha256:21e1470ac9e5739ff880c211fc3af01e3ae505859392bf65458c224d0bf283eb
+  #  - pillow-12.0.0-cp312-cp312-macosx_10_13_x86_64.whl
+  #  - pillow-12.0.0-cp312-cp312-macosx_11_0_arm64.whl
+  #  - pillow-12.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+  #  - pillow-12.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  #  - pillow-12.0.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+  #  - pillow-12.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  #  - pillow-12.0.0-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - pillow-12.0.0-cp312-cp312-musllinux_1_2_x86_64.whl
+  #  - pillow-12.0.0-cp312-cp312-win_amd64.whl
+  #  - pillow-12.0.0-cp312-cp312-win_arm64.whl
+  pillow==12.0.0 --hash=sha256:53561a4ddc36facb432fae7a9d8afbfaf94795414f5cdc5fc52f28c1dca90371 \
+                 --hash=sha256:71db6b4c1653045dacc1585c1b0d184004f0d7e694c7b34ac165ca70c0838082 \
+                 --hash=sha256:2fa5f0b6716fc88f11380b88b31fe591a06c6315e955c096c35715788b339e3f \
+                 --hash=sha256:82240051c6ca513c616f7f9da06e871f61bfd7805f566275841af15015b8f98d \
+                 --hash=sha256:55f818bd74fe2f11d4d7cbc65880a843c4075e0ac7226bc1a23261dbea531953 \
+                 --hash=sha256:b87843e225e74576437fd5b6a4c2205d422754f84a06942cfaf1dc32243e45a8 \
+                 --hash=sha256:c607c90ba67533e1b2355b821fef6764d1dd2cbe26b8c1005ae84f7aea25ff79 \
+                 --hash=sha256:21f241bdd5080a15bc86d3466a9f6074a9c2c2b314100dd896ac81ee6db2f1ba \
+                 --hash=sha256:9fe611163f6303d1619bbcb653540a4d60f9e55e622d60a3108be0d5b441017a \
+                 --hash=sha256:7dfb439562f234f7d57b1ac6bc8fe7f838a4bd49c79230e0f6a1da93e82f1fad
   # [/pillow]
   # [retrying]
-  retrying==1.3.4 --hash=sha256:8cc4d43cb8e1125e0ff3344e9de678fefd85db3b750b81b2240dc0183af37b35
+  retrying==1.4.2 --hash=sha256:bbc004aeb542a74f3569aeddf42a2516efefcdaff90df0eb38fbfbf19f179f59
   # [/retrying]
   # [dicomweb-client]
-  dicomweb-client==0.60.0 --hash=sha256:fde6743036f9c9da74580dd643c66121a1650d16737184695bfbe076f3875e71
+  dicomweb-client==0.60.1 --hash=sha256:e128866a797b7acdcd4ad280a10ebced5af77a3ce1d1bde709389ad56583955d
   # [/dicomweb-client]
   ]===])
 

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -46,7 +46,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   smmap==5.0.2 --hash=sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e
   # [/smmap]
   # [GitPython]
-  GitPython==3.1.44 --hash=sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110
+  GitPython==3.1.45 --hash=sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77
   # [/GitPython]
   # [six]
   six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -34,46 +34,50 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [cryptography]
   # Hashes correspond to the following packages:
-  #  - cryptography-45.0.3-cp311-abi3-macosx_10_9_universal2.whl
-  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_28_aarch64.whl
-  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_28_x86_64.whl
-  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_34_aarch64.whl
-  #  - cryptography-45.0.3-cp311-abi3-manylinux_2_34_x86_64.whl
-  #  - cryptography-45.0.3-cp311-abi3-musllinux_1_2_aarch64.whl
-  #  - cryptography-45.0.3-cp311-abi3-musllinux_1_2_x86_64.whl
-  #  - cryptography-45.0.3-cp311-abi3-win_amd64.whl
-  #  - cryptography-45.0.3-cp37-abi3-macosx_10_9_universal2.whl
-  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_28_aarch64.whl
-  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_28_x86_64.whl
-  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_34_aarch64.whl
-  #  - cryptography-45.0.3-cp37-abi3-manylinux_2_34_x86_64.whl
-  #  - cryptography-45.0.3-cp37-abi3-musllinux_1_2_aarch64.whl
-  #  - cryptography-45.0.3-cp37-abi3-musllinux_1_2_x86_64.whl
-  #  - cryptography-45.0.3-cp37-abi3-win_amd64.whl
-  cryptography==45.0.3 --hash=sha256:7573d9eebaeceeb55285205dbbb8753ac1e962af3d9640791d12b36864065e71 \
-                       --hash=sha256:d377dde61c5d67eb4311eace661c3efda46c62113ff56bf05e2d679e02aebb5b \
-                       --hash=sha256:fae1e637f527750811588e4582988932c222f8251f7b7ea93739acb624e1487f \
-                       --hash=sha256:ca932e11218bcc9ef812aa497cdf669484870ecbcf2d99b765d6c27a86000942 \
-                       --hash=sha256:2f8f8f0b73b885ddd7f3d8c2b2234a7d3ba49002b0223f58cfde1bedd9563c56 \
-                       --hash=sha256:9cc80ce69032ffa528b5e16d217fa4d8d4bb7d6ba8659c1b4d74a1b0f4235fca \
-                       --hash=sha256:c824c9281cb628015bfc3c59335163d4ca0540d49de4582d6c2637312907e4b1 \
-                       --hash=sha256:5833bb4355cb377ebd880457663a972cd044e7f49585aee39245c0d592904578 \
-                       --hash=sha256:9bb5bf55dcb69f7067d80354d0a348368da907345a2c448b0babc4215ccd3497 \
-                       --hash=sha256:97787952246a77d77934d41b62fb1b6f3581d83f71b44796a4158d93b8f5c490 \
-                       --hash=sha256:c92519d242703b675ccefd0f0562eb45e74d438e001f8ab52d628e885751fb06 \
-                       --hash=sha256:c5edcb90da1843df85292ef3a313513766a78fbbb83f584a5a58fb001a5a9d57 \
-                       --hash=sha256:38deed72285c7ed699864f964a3f4cf11ab3fb38e8d39cfcd96710cd2b5bb716 \
-                       --hash=sha256:5555365a50efe1f486eed6ac7062c33b97ccef409f5970a0b6f205a7cfab59c8 \
-                       --hash=sha256:cfd84777b4b6684955ce86156cfb5e08d75e80dc2585e10d69e47f014f0a5342 \
-                       --hash=sha256:a2b56de3417fd5f48773ad8e91abaa700b678dc7fe1e0c757e1ae340779acf7b \
-                       --hash=sha256:57a6500d459e8035e813bd8b51b671977fb149a8c95ed814989da682314d0782 \
-                       --hash=sha256:f22af3c78abfbc7cbcdf2c55d23c3e022e1a462ee2481011d518c7fb9c9f3d65 \
-                       --hash=sha256:232954730c362638544758a8160c4ee1b832dc011d2c41a306ad8f7cccc5bb0b \
-                       --hash=sha256:d54ae41e6bd70ea23707843021c778f151ca258081586f0cfa31d936ae43d1b2
+  #  - cryptography-46.0.3-cp311-abi3-macosx_10_9_universal2.whl
+  #  - cryptography-46.0.3-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+  #  - cryptography-46.0.3-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  #  - cryptography-46.0.3-cp311-abi3-manylinux_2_28_aarch64.whl
+  #  - cryptography-46.0.3-cp311-abi3-manylinux_2_28_x86_64.whl
+  #  - cryptography-46.0.3-cp311-abi3-manylinux_2_34_aarch64.whl
+  #  - cryptography-46.0.3-cp311-abi3-manylinux_2_34_x86_64.whl
+  #  - cryptography-46.0.3-cp311-abi3-musllinux_1_2_aarch64.whl
+  #  - cryptography-46.0.3-cp311-abi3-musllinux_1_2_x86_64.whl
+  #  - cryptography-46.0.3-cp311-abi3-win_amd64.whl
+  #  - cryptography-46.0.3-cp311-abi3-win_arm64.whl
+  #  - cryptography-46.0.3-cp38-abi3-macosx_10_9_universal2.whl
+  #  - cryptography-46.0.3-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+  #  - cryptography-46.0.3-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  #  - cryptography-46.0.3-cp38-abi3-manylinux_2_28_aarch64.whl
+  #  - cryptography-46.0.3-cp38-abi3-manylinux_2_28_x86_64.whl
+  #  - cryptography-46.0.3-cp38-abi3-manylinux_2_34_aarch64.whl
+  #  - cryptography-46.0.3-cp38-abi3-manylinux_2_34_x86_64.whl
+  #  - cryptography-46.0.3-cp38-abi3-musllinux_1_2_aarch64.whl
+  #  - cryptography-46.0.3-cp38-abi3-musllinux_1_2_x86_64.whl
+  #  - cryptography-46.0.3-cp38-abi3-win_amd64.whl
+  #  - cryptography-46.0.3-cp38-abi3-win_arm64.whl
+  cryptography==46.0.3 --hash=sha256:109d4ddfadf17e8e7779c39f9b18111a09efb969a301a31e987416a0191ed93a \
+                       --hash=sha256:09859af8466b69bc3c27bdf4f5d84a665e0f7ab5088412e9e2ec49758eca5cbc \
+                       --hash=sha256:01ca9ff2885f3acc98c29f1860552e37f6d7c7d013d7334ff2a9de43a449315d \
+                       --hash=sha256:6eae65d4c3d33da080cff9c4ab1f711b15c1d9760809dad6ea763f3812d254cb \
+                       --hash=sha256:a2c0cd47381a3229c403062f764160d57d4d175e022c1df84e168c6251a22eec \
+                       --hash=sha256:549e234ff32571b1f4076ac269fcce7a808d3bf98b76c8dd560e42dbc66d7d91 \
+                       --hash=sha256:10b01676fc208c3e6feeb25a8b83d81767e8059e1fe86e1dc62d10a3018fa926 \
+                       --hash=sha256:0abf1ffd6e57c67e92af68330d05760b7b7efb243aab8377e583284dbab72c71 \
+                       --hash=sha256:a04bee9ab6a4da801eb9b51f1b708a1b5b5c9eb48c03f74198464c66f0d344ac \
+                       --hash=sha256:a9a3008438615669153eb86b26b61e09993921ebdd75385ddd748702c5adfddb \
+                       --hash=sha256:5d7f93296ee28f68447397bf5198428c9aeeab45705a55d53a6343455dcb2c3c \
+                       --hash=sha256:cb3d760a6117f621261d662bccc8ef5bc32ca673e037c83fbe565324f5c46936 \
+                       --hash=sha256:4b7387121ac7d15e550f5cb4a43aef2559ed759c35df7336c402bb8275ac9683 \
+                       --hash=sha256:15ab9b093e8f09daab0f2159bb7e47532596075139dd74365da52ecc9cb46c5d \
+                       --hash=sha256:46acf53b40ea38f9c6c229599a4a13f0d46a6c3fa9ef19fc1a124d62e338dfa0 \
+                       --hash=sha256:1000713389b75c449a6e979ffc7dcc8ac90b437048766cef052d4d30b8220971 \
+                       --hash=sha256:b02cf04496f6576afffef5ddd04a0cb7d49cf6be16a9059d793a30b035f6b6ac \
+                       --hash=sha256:402b58fc32614f00980b66d6e56a5b4118e6cb362ae8f3fda141ba4689bd4506 \
+                       --hash=sha256:ef639cb3372f69ec44915fafcd6698b6cc78fbe0c2ea41be867f6ed612811963 \
+                       --hash=sha256:3b51b8ca4f1c6453d8829e1eb7299499ca7f313900dd4d89a24b8b87c0a780d4 \
+                       --hash=sha256:416260257577718c05135c55958b674000baef9a1c7d9e8f306ec60d71db850f \
+                       --hash=sha256:d89c3468de4cdc4f08a57e214384d0471911a3830fcdaf7a8cc587e42a866372
   # [/cryptography]
   # Specifying "[crypto]" is required since PyGithub 1.58.1
   # See https://github.com/Slicer/Slicer/issues/7112
@@ -82,66 +86,84 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [/PyJWT]
   # [wrapt]
   # Hashes correspond to the following packages:
-  #  - wrapt-1.17.2-cp312-cp312-macosx_10_13_universal2.whl
-  #  - wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl
-  #  - wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl
-  #  - wrapt-1.17.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - wrapt-1.17.2-cp312-cp312-musllinux_1_2_aarch64.whl
-  #  - wrapt-1.17.2-cp312-cp312-musllinux_1_2_x86_64.whl
-  #  - wrapt-1.17.2-cp312-cp312-win_amd64.whl
-  #  - wrapt-1.17.2-py3-none-any.whl
-  wrapt==1.17.2 --hash=sha256:d5e2439eecc762cd85e7bd37161d4714aa03a33c5ba884e26c81559817ca0925 \
-                --hash=sha256:3fc7cb4c1c744f8c05cd5f9438a3caa6ab94ce8344e952d7c45a8ed59dd88392 \
-                --hash=sha256:8fdbdb757d5390f7c675e558fd3186d590973244fab0c5fe63d373ade3e99d40 \
-                --hash=sha256:5bb1d0dbf99411f3d871deb6faa9aabb9d4e744d67dcaaa05399af89d847a91d \
-                --hash=sha256:bc570b5f14a79734437cb7b0500376b6b791153314986074486e0b0fa8d71d98 \
-                --hash=sha256:6d9187b01bebc3875bac9b087948a2bccefe464a7d8f627cf6e48b1bbae30f82 \
-                --hash=sha256:e8b2816ebef96d83657b56306152a93909a83f23994f4b30ad4573b00bd11bb9 \
-                --hash=sha256:ec89ed91f2fa8e3f52ae53cd3cf640d6feff92ba90d62236a81e4e563ac0e991 \
-                --hash=sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8
+  #  - wrapt-2.0.1-cp312-cp312-macosx_10_13_universal2.whl
+  #  - wrapt-2.0.1-cp312-cp312-macosx_10_13_x86_64.whl
+  #  - wrapt-2.0.1-cp312-cp312-macosx_11_0_arm64.whl
+  #  - wrapt-2.0.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  #  - wrapt-2.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  #  - wrapt-2.0.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl
+  #  - wrapt-2.0.1-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - wrapt-2.0.1-cp312-cp312-musllinux_1_2_riscv64.whl
+  #  - wrapt-2.0.1-cp312-cp312-musllinux_1_2_x86_64.whl
+  #  - wrapt-2.0.1-cp312-cp312-win_amd64.whl
+  #  - wrapt-2.0.1-cp312-cp312-win_arm64.whl
+  #  - wrapt-2.0.1-py3-none-any.whl
+  wrapt==2.0.1 --hash=sha256:1fdbb34da15450f2b1d735a0e969c24bdb8d8924892380126e2a293d9902078c \
+               --hash=sha256:3d32794fe940b7000f0519904e247f902f0149edbe6316c710a8562fb6738841 \
+               --hash=sha256:386fb54d9cd903ee0012c09291336469eb7b244f7183d40dc3e86a16a4bace62 \
+               --hash=sha256:7b219cb2182f230676308cdcacd428fa837987b89e4b7c5c9025088b8a6c9faf \
+               --hash=sha256:641e94e789b5f6b4822bb8d8ebbdfc10f4e4eae7756d648b717d980f657a9eb9 \
+               --hash=sha256:fe21b118b9f58859b5ebaa4b130dee18669df4bd111daad082b7beb8799ad16b \
+               --hash=sha256:17fb85fa4abc26a5184d93b3efd2dcc14deb4b09edcdb3535a536ad34f0b4dba \
+               --hash=sha256:b89ef9223d665ab255ae42cc282d27d69704d94be0deffc8b9d919179a609684 \
+               --hash=sha256:a453257f19c31b31ba593c30d997d6e5be39e3b5ad9148c2af5a7314061c63eb \
+               --hash=sha256:2da620b31a90cdefa9cd0c2b661882329e2e19d1d7b9b920189956b76c564d75 \
+               --hash=sha256:aea9c7224c302bc8bfc892b908537f56c430802560e827b75ecbde81b604598b \
+               --hash=sha256:4d2ce1bf1a48c5277d7969259232b57645aae5686dba1eaeade39442277afbca
   # [/wrapt]
   # [Deprecated]
-  Deprecated==1.2.18 --hash=sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec
+  Deprecated==1.3.1 --hash=sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f
   # [/Deprecated]
   # [pycparser]
-  pycparser==2.22 --hash=sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
+  pycparser==2.23 --hash=sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934
   # [/pycparser]
   # [cffi]
   # Hashes correspond to the following packages:
-  #  - cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl
-  #  - cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl
-  #  - cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl
-  #  - cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl
-  #  - cffi-1.17.1-cp312-cp312-win_amd64.whl
-  cffi==1.17.1 --hash=sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4 \
-               --hash=sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c \
-               --hash=sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5 \
-               --hash=sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93 \
-               --hash=sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3 \
-               --hash=sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8 \
-               --hash=sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903
+  #  - cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl
+  #  - cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
+  #  - cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+  #  - cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  #  - cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl
+  #  - cffi-2.0.0-cp312-cp312-win_amd64.whl
+  #  - cffi-2.0.0-cp312-cp312-win_arm64.whl
+  cffi==2.0.0 --hash=sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d \
+              --hash=sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c \
+              --hash=sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062 \
+              --hash=sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba \
+              --hash=sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94 \
+              --hash=sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187 \
+              --hash=sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5 \
+              --hash=sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6
   # [/cffi]
   # [PyNaCl]
   # Hashes correspond to the following packages:
-  #  - PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl
-  #  - PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl
-  #  - PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl
-  #  - PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_aarch64.whl
-  #  - PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl
-  #  - PyNaCl-1.5.0-cp36-abi3-win_amd64.whl
-  PyNaCl==1.5.0 --hash=sha256:401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1 \
-                --hash=sha256:52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92 \
-                --hash=sha256:a36d4a9dda1f19ce6e03c9a784a2921a4b726b02e1c736600ca9c22029474394 \
-                --hash=sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d \
-                --hash=sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858 \
-                --hash=sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b \
-                --hash=sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff \
-                --hash=sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93
+  #  - pynacl-1.6.1-cp38-abi3-macosx_10_10_universal2.whl
+  #  - pynacl-1.6.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+  #  - pynacl-1.6.1-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  #  - pynacl-1.6.1-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
+  #  - pynacl-1.6.1-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
+  #  - pynacl-1.6.1-cp38-abi3-manylinux_2_34_aarch64.whl
+  #  - pynacl-1.6.1-cp38-abi3-manylinux_2_34_x86_64.whl
+  #  - pynacl-1.6.1-cp38-abi3-musllinux_1_1_aarch64.whl
+  #  - pynacl-1.6.1-cp38-abi3-musllinux_1_1_x86_64.whl
+  #  - pynacl-1.6.1-cp38-abi3-musllinux_1_2_aarch64.whl
+  #  - pynacl-1.6.1-cp38-abi3-musllinux_1_2_x86_64.whl
+  #  - pynacl-1.6.1-cp38-abi3-win_amd64.whl
+  #  - pynacl-1.6.1-cp38-abi3-win_arm64.whl
+  PyNaCl==1.6.1 --hash=sha256:a6f9fd6d6639b1e81115c7f8ff16b8dedba1e8098d2756275d63d208b0e32021 \
+                --hash=sha256:e49a3f3d0da9f79c1bec2aa013261ab9fa651c7da045d376bd306cf7c1792993 \
+                --hash=sha256:7713f8977b5d25f54a811ec9efa2738ac592e846dd6e8a4d3f7578346a841078 \
+                --hash=sha256:5a3becafc1ee2e5ea7f9abc642f56b82dcf5be69b961e782a96ea52b55d8a9fc \
+                --hash=sha256:4ce50d19f1566c391fedc8dc2f2f5be265ae214112ebe55315e41d1f36a7f0a9 \
+                --hash=sha256:543f869140f67d42b9b8d47f922552d7a967e6c116aad028c9bfc5f3f3b3a7b7 \
+                --hash=sha256:a2bb472458c7ca959aeeff8401b8efef329b0fc44a89d3775cffe8fad3398ad8 \
+                --hash=sha256:3206fa98737fdc66d59b8782cecc3d37d30aeec4593d1c8c145825a345bba0f0 \
+                --hash=sha256:53543b4f3d8acb344f75fd4d49f75e6572fce139f4bfb4815a9282296ff9f4c0 \
+                --hash=sha256:319de653ef84c4f04e045eb250e6101d23132372b0a61a7acf91bac0fda8e58c \
+                --hash=sha256:262a8de6bba4aee8a66f5edf62c214b06647461c9b6b641f8cd0cb1e3b3196fe \
+                --hash=sha256:a569a4069a7855f963940040f35e87d8bc084cb2d6347428d5ad20550a0a1a21 \
+                --hash=sha256:5953e8b8cfadb10889a6e7bd0f53041a745d1b3d30111386a1bb37af171e6daf
   # [/PyNaCl]
   # [python-dateutil]
   python-dateutil==2.9.0.post0 --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
@@ -150,10 +172,10 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
   # [/six]
   # [typing_extensions]
-  typing_extensions==4.14.0 --hash=sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af
+  typing_extensions==4.15.0 --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
   # [/typing_extensions]
   # [PyGithub]
-  PyGithub==2.6.1 --hash=sha256:6f2fa6d076ccae475f9fc392cc6cdbd54db985d4f69b8833a28397de75ed6ca3
+  PyGithub==2.8.1 --hash=sha256:23a0a5bca93baef082e03411bf0ce27204c32be8bfa7abc92fe4a3e132936df0
   # [/PyGithub]
   ]===])
 

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -31,24 +31,26 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [numpy]
   # Hashes correspond to the following packages:
-  #  - numpy-2.0.2-cp312-cp312-macosx_10_9_x86_64.whl
-  #  - numpy-2.0.2-cp312-cp312-macosx_11_0_arm64.whl
-  #  - numpy-2.0.2-cp312-cp312-macosx_14_0_arm64.whl
-  #  - numpy-2.0.2-cp312-cp312-macosx_14_0_x86_64.whl
-  #  - numpy-2.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - numpy-2.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - numpy-2.0.2-cp312-cp312-musllinux_1_1_x86_64.whl
-  #  - numpy-2.0.2-cp312-cp312-musllinux_1_2_aarch64.whl
-  #  - numpy-2.0.2-cp312-cp312-win_amd64.whl
-  numpy==2.0.2 --hash=sha256:df55d490dea7934f330006d0f81e8551ba6010a5bf035a249ef61a94f21c500b \
-               --hash=sha256:8df823f570d9adf0978347d1f926b2a867d5608f434a7cff7f7908c6570dcf5e \
-               --hash=sha256:9a92ae5c14811e390f3767053ff54eaee3bf84576d99a2456391401323f4ec2c \
-               --hash=sha256:a842d573724391493a97a62ebbb8e731f8a5dcc5d285dfc99141ca15a3302d0c \
-               --hash=sha256:c05e238064fc0610c840d1cf6a13bf63d7e391717d247f1bf0318172e759e692 \
-               --hash=sha256:0123ffdaa88fa4ab64835dcbde75dcdf89c453c922f18dced6e27c90d1d0ec5a \
-               --hash=sha256:96a55f64139912d61de9137f11bf39a55ec8faec288c75a54f93dfd39f7eb40c \
-               --hash=sha256:ec9852fb39354b5a45a80bdab5ac02dd02b15f44b3804e9f00c556bf24b4bded \
-               --hash=sha256:cfd41e13fdc257aa5778496b8caa5e856dc4896d4ccf01841daee1d96465467a
+  #  - numpy-2.3.4-cp312-cp312-macosx_10_13_x86_64.whl
+  #  - numpy-2.3.4-cp312-cp312-macosx_11_0_arm64.whl
+  #  - numpy-2.3.4-cp312-cp312-macosx_14_0_arm64.whl
+  #  - numpy-2.3.4-cp312-cp312-macosx_14_0_x86_64.whl
+  #  - numpy-2.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+  #  - numpy-2.3.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  #  - numpy-2.3.4-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - numpy-2.3.4-cp312-cp312-musllinux_1_2_x86_64.whl
+  #  - numpy-2.3.4-cp312-cp312-win_amd64.whl
+  #  - numpy-2.3.4-cp312-cp312-win_arm64.whl
+  numpy==2.3.4 --hash=sha256:ef1b5a3e808bc40827b5fa2c8196151a4c5abe110e1726949d7abddfe5c7ae11 \
+               --hash=sha256:c2f91f496a87235c6aaf6d3f3d89b17dba64996abadccb289f48456cff931ca9 \
+               --hash=sha256:f77e5b3d3da652b474cc80a14084927a5e86a5eccf54ca8ca5cbd697bf7f2667 \
+               --hash=sha256:8ab1c5f5ee40d6e01cbe96de5863e39b215a4d24e7d007cad56c7184fdf4aeef \
+               --hash=sha256:77b84453f3adcb994ddbd0d1c5d11db2d6bda1a2b7fd5ac5bd4649d6f5dc682e \
+               --hash=sha256:4121c5beb58a7f9e6dfdee612cb24f4df5cd4db6e8261d7f4d7450a997a65d6a \
+               --hash=sha256:65611ecbb00ac9846efe04db15cbe6186f562f6bb7e5e05f077e53a599225d16 \
+               --hash=sha256:dabc42f9c6577bcc13001b8810d300fe814b4cfbe8a92c873f269484594f9786 \
+               --hash=sha256:985f1e46358f06c2a09921e8921e2c98168ed4ae12ccd6e5e87a4f1857923f32 \
+               --hash=sha256:4635239814149e06e2cb9db3dd584b2fa64316c96f10656983b8026a82e6e4db
   # [/numpy]
   ]===])
 

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pip]
-  pip==25.1.1 --hash=sha256:2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af
+  pip==25.3 --hash=sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd
   # [/pip]
   ]===])
 

--- a/SuperBuild/External_python-pythonqt-requirements.cmake
+++ b/SuperBuild/External_python-pythonqt-requirements.cmake
@@ -35,7 +35,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   packaging==25.0 --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484
   # [/packaging]
   # [pyparsing]
-  pyparsing==3.2.3 --hash=sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf
+  pyparsing==3.2.5 --hash=sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e
   # [/pyparsing]
   # [six]
   six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -27,33 +27,39 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [certifi]
-  certifi==2025.4.26 --hash=sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3
+  certifi==2025.11.12 --hash=sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b
   # [/certifi]
   # [idna]
-  idna==3.10 --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
+  idna==3.11 --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea
   # [/idna]
   # [charset-normalizer]
   # Hashes correspond to the following packages:
-  #  - charset_normalizer-3.4.2-cp312-cp312-macosx_10_13_universal2.whl
-  #  - charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_aarch64.whl
-  #  - charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_x86_64.whl
-  #  - charset_normalizer-3.4.2-cp312-cp312-win_amd64.whl
-  #  - charset_normalizer-3.4.2-py3-none-any.whl
-  charset-normalizer==3.4.2 --hash=sha256:0c29de6a1a95f24b9a1aa7aefd27d2487263f00dfd55a77719b530788f75cff7 \
-                            --hash=sha256:cddf7bd982eaa998934a91f69d182aec997c6c468898efe6679af88283b498d3 \
-                            --hash=sha256:4e594135de17ab3866138f496755f302b72157d115086d100c3f19370839dd3a \
-                            --hash=sha256:a370b3e078e418187da8c3674eddb9d983ec09445c99a3a263c2011993522981 \
-                            --hash=sha256:dedb8adb91d11846ee08bec4c8236c8549ac721c245678282dcb06b221aab59f \
-                            --hash=sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e \
-                            --hash=sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0
+  #  - charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl
+  #  - charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  #  - charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  #  - charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl
+  #  - charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl
+  #  - charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl
+  #  - charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl
+  #  - charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl
+  #  - charset_normalizer-3.4.4-py3-none-any.whl
+  charset-normalizer==3.4.4 --hash=sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394 \
+                            --hash=sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25 \
+                            --hash=sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86 \
+                            --hash=sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a \
+                            --hash=sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f \
+                            --hash=sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15 \
+                            --hash=sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0 \
+                            --hash=sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525 \
+                            --hash=sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3 \
+                            --hash=sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f
   # [/charset-normalizer]
   # [urllib3]
-  urllib3==2.4.0 --hash=sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813
+  urllib3==2.5.0 --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
   # [/urllib3]
   # [requests]
-  requests==2.32.3 --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
+  requests==2.32.5 --hash=sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6
   # [/requests]
   ]===])
 

--- a/SuperBuild/External_python-scipy.cmake
+++ b/SuperBuild/External_python-scipy.cmake
@@ -31,18 +31,26 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [scipy]
   # Hashes correspond to the following packages:
-  #  - scipy-1.13.1-cp312-cp312-macosx_10_9_x86_64.whl
-  #  - scipy-1.13.1-cp312-cp312-macosx_12_0_arm64.whl
-  #  - scipy-1.13.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - scipy-1.13.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - scipy-1.13.1-cp312-cp312-musllinux_1_1_x86_64.whl
-  #  - scipy-1.13.1-cp312-cp312-win_amd64.whl
-  scipy==1.13.1 --hash=sha256:5d72782f39716b2b3509cd7c33cdc08c96f2f4d2b06d51e52fb45a19ca0c86a1 \
-                --hash=sha256:017367484ce5498445aade74b1d5ab377acdc65e27095155e448c88497755a5d \
-                --hash=sha256:949ae67db5fa78a86e8fa644b9a6b07252f449dcf74247108c50e1d20d2b4627 \
-                --hash=sha256:de3ade0e53bc1f21358aa74ff4830235d716211d7d077e340c7349bc3542e884 \
-                --hash=sha256:2ac65fb503dad64218c228e2dc2d0a0193f7904747db43014645ae139c8fad16 \
-                --hash=sha256:cdd7dacfb95fea358916410ec61bbc20440f7860333aee6d882bb8046264e949
+  #  - scipy-1.16.3-cp312-cp312-macosx_10_14_x86_64.whl
+  #  - scipy-1.16.3-cp312-cp312-macosx_12_0_arm64.whl
+  #  - scipy-1.16.3-cp312-cp312-macosx_14_0_arm64.whl
+  #  - scipy-1.16.3-cp312-cp312-macosx_14_0_x86_64.whl
+  #  - scipy-1.16.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+  #  - scipy-1.16.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  #  - scipy-1.16.3-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - scipy-1.16.3-cp312-cp312-musllinux_1_2_x86_64.whl
+  #  - scipy-1.16.3-cp312-cp312-win_amd64.whl
+  #  - scipy-1.16.3-cp312-cp312-win_arm64.whl
+  scipy==1.16.3 --hash=sha256:81fc5827606858cf71446a5e98715ba0e11f0dbc83d71c7409d05486592a45d6 \
+                --hash=sha256:c97176013d404c7346bf57874eaac5187d969293bf40497140b0a2b2b7482e07 \
+                --hash=sha256:2b71d93c8a9936046866acebc915e2af2e292b883ed6e2cbe5c34beb094b82d9 \
+                --hash=sha256:3d4a07a8e785d80289dfe66b7c27d8634a773020742ec7187b85ccc4b0e7b686 \
+                --hash=sha256:0553371015692a898e1aa858fed67a3576c34edefa6b7ebdb4e9dde49ce5c203 \
+                --hash=sha256:72d1717fd3b5e6ec747327ce9bda32d5463f472c9dce9f54499e81fbd50245a1 \
+                --hash=sha256:1fb2472e72e24d1530debe6ae078db70fb1605350c88a3d14bc401d6306dbffe \
+                --hash=sha256:c5192722cffe15f9329a3948c4b1db789fbb1f05c97899187dcf009b283aea70 \
+                --hash=sha256:56edc65510d1331dae01ef9b658d428e33ed48b4f77b1d51caf479a0253f96dc \
+                --hash=sha256:a8a26c78ef223d3e30920ef759e25625a0ecdd0d60e5a8818b7513c3e5384cf2
   # [/scipy]
   ]===])
 


### PR DESCRIPTION
Python packages were last updated on June 2nd 2025 (https://github.com/Slicer/Slicer/commit/c6e992e783699cabfd9fa4ce9968995753837247) through https://github.com/Slicer/Slicer/pull/8455. This PR updates python packages to their latest versions. This type of update is something I usually do on about a quarterly cadence (every 3 months).

Packages such as numpy and scipy also now have Windows on arm whl files available. This supports ongoing arm support efforts which have primarily been for Apple Silicon arm (https://github.com/Slicer/Slicer/issues/6811), but is also valid for Windows on arm such as the Qualcomm laptops running Windows on arm (https://www.qualcomm.com/snapdragon/laptops).

Packages built from sources:
* SimpleITK isn't being updated here as we build it from source rather than using the provided whl on pypi.
* VTK is also not being updated because we build it from source rather than using the provided whl on pypi.

```
PS C:\Users\butlej30383\AppData\Local\slicer.org\3D Slicer 5.11.0-2025-11-10\bin> ./PythonSlicer.exe "C:\Slicer\Utilities\Scripts\python_package_updater.py"
Searching external projects in C:\Slicer\SuperBuild
Validate external projects
Package            Version       Latest     Type
------------------ ------------- ---------- -----
certifi            2025.4.26     2025.11.12 wheel
cffi               1.17.1        2.0.0      wheel
charset-normalizer 3.4.2         3.4.4      wheel
cryptography       45.0.3        46.0.3     wheel
Deprecated         1.2.18        1.3.1      wheel
dicomweb-client    0.60.0        0.60.1     wheel
GitPython          3.1.44        3.1.45     wheel
idna               3.10          3.11       wheel
numpy              2.0.2         2.3.4      wheel
pillow             11.2.1        12.0.0     wheel
pip                25.1.1        25.3       wheel
pycparser          2.22          2.23       wheel
pydicom            2.4.4         3.0.1      wheel
PyGithub           2.6.1         2.8.1      wheel
PyNaCl             1.5.0         1.6.1      wheel
pyparsing          3.2.3         3.2.5      wheel
requests           2.32.3        2.32.5     wheel
retrying           1.3.4         1.4.2      wheel
scipy              1.13.1        1.16.3     wheel
simpleitk          2.5.2rc2.dev6 2.5.2      wheel
typing_extensions  4.14.0        4.15.0     wheel
urllib3            2.4.0         2.5.0      wheel
wrapt              1.17.2        2.0.1      wheel

  certifi==2025.11.12 --hash=sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b
  # Hashes correspond to the following packages:
  #  - cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl
  #  - cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
  #  - cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
  #  - cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
  #  - cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl
  #  - cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl
  #  - cffi-2.0.0-cp312-cp312-win_amd64.whl
  #  - cffi-2.0.0-cp312-cp312-win_arm64.whl
  cffi==2.0.0 --hash=sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d \
              --hash=sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c \
              --hash=sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062 \
              --hash=sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba \
              --hash=sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94 \
              --hash=sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187 \
              --hash=sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5 \
              --hash=sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6
  # Hashes correspond to the following packages:
  #  - charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl
  #  - charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
  #  - charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
  #  - charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl
  #  - charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl
  #  - charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl
  #  - charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl
  #  - charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl
  #  - charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl
  #  - charset_normalizer-3.4.4-py3-none-any.whl
  charset-normalizer==3.4.4 --hash=sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394 \
                            --hash=sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25 \
                            --hash=sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86 \
                            --hash=sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a \
                            --hash=sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f \
                            --hash=sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15 \
                            --hash=sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0 \
                            --hash=sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525 \
                            --hash=sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3 \
                            --hash=sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f
  # Hashes correspond to the following packages:
  #  - cryptography-46.0.3-cp311-abi3-macosx_10_9_universal2.whl
  #  - cryptography-46.0.3-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
  #  - cryptography-46.0.3-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
  #  - cryptography-46.0.3-cp311-abi3-manylinux_2_28_aarch64.whl
  #  - cryptography-46.0.3-cp311-abi3-manylinux_2_28_x86_64.whl
  #  - cryptography-46.0.3-cp311-abi3-manylinux_2_34_aarch64.whl
  #  - cryptography-46.0.3-cp311-abi3-manylinux_2_34_x86_64.whl
  #  - cryptography-46.0.3-cp311-abi3-musllinux_1_2_aarch64.whl
  #  - cryptography-46.0.3-cp311-abi3-musllinux_1_2_x86_64.whl
  #  - cryptography-46.0.3-cp311-abi3-win_amd64.whl
  #  - cryptography-46.0.3-cp311-abi3-win_arm64.whl
  #  - cryptography-46.0.3-cp38-abi3-macosx_10_9_universal2.whl
  #  - cryptography-46.0.3-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
  #  - cryptography-46.0.3-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
  #  - cryptography-46.0.3-cp38-abi3-manylinux_2_28_aarch64.whl
  #  - cryptography-46.0.3-cp38-abi3-manylinux_2_28_x86_64.whl
  #  - cryptography-46.0.3-cp38-abi3-manylinux_2_34_aarch64.whl
  #  - cryptography-46.0.3-cp38-abi3-manylinux_2_34_x86_64.whl
  #  - cryptography-46.0.3-cp38-abi3-musllinux_1_2_aarch64.whl
  #  - cryptography-46.0.3-cp38-abi3-musllinux_1_2_x86_64.whl
  #  - cryptography-46.0.3-cp38-abi3-win_amd64.whl
  #  - cryptography-46.0.3-cp38-abi3-win_arm64.whl
  cryptography==46.0.3 --hash=sha256:109d4ddfadf17e8e7779c39f9b18111a09efb969a301a31e987416a0191ed93a \
                       --hash=sha256:09859af8466b69bc3c27bdf4f5d84a665e0f7ab5088412e9e2ec49758eca5cbc \
                       --hash=sha256:01ca9ff2885f3acc98c29f1860552e37f6d7c7d013d7334ff2a9de43a449315d \
                       --hash=sha256:6eae65d4c3d33da080cff9c4ab1f711b15c1d9760809dad6ea763f3812d254cb \
                       --hash=sha256:a2c0cd47381a3229c403062f764160d57d4d175e022c1df84e168c6251a22eec \
                       --hash=sha256:549e234ff32571b1f4076ac269fcce7a808d3bf98b76c8dd560e42dbc66d7d91 \
                       --hash=sha256:10b01676fc208c3e6feeb25a8b83d81767e8059e1fe86e1dc62d10a3018fa926 \
                       --hash=sha256:0abf1ffd6e57c67e92af68330d05760b7b7efb243aab8377e583284dbab72c71 \
                       --hash=sha256:a04bee9ab6a4da801eb9b51f1b708a1b5b5c9eb48c03f74198464c66f0d344ac \
                       --hash=sha256:a9a3008438615669153eb86b26b61e09993921ebdd75385ddd748702c5adfddb \
                       --hash=sha256:5d7f93296ee28f68447397bf5198428c9aeeab45705a55d53a6343455dcb2c3c \
                       --hash=sha256:cb3d760a6117f621261d662bccc8ef5bc32ca673e037c83fbe565324f5c46936 \
                       --hash=sha256:4b7387121ac7d15e550f5cb4a43aef2559ed759c35df7336c402bb8275ac9683 \
                       --hash=sha256:15ab9b093e8f09daab0f2159bb7e47532596075139dd74365da52ecc9cb46c5d \
                       --hash=sha256:46acf53b40ea38f9c6c229599a4a13f0d46a6c3fa9ef19fc1a124d62e338dfa0 \
                       --hash=sha256:1000713389b75c449a6e979ffc7dcc8ac90b437048766cef052d4d30b8220971 \
                       --hash=sha256:b02cf04496f6576afffef5ddd04a0cb7d49cf6be16a9059d793a30b035f6b6ac \
                       --hash=sha256:402b58fc32614f00980b66d6e56a5b4118e6cb362ae8f3fda141ba4689bd4506 \
                       --hash=sha256:ef639cb3372f69ec44915fafcd6698b6cc78fbe0c2ea41be867f6ed612811963 \
                       --hash=sha256:3b51b8ca4f1c6453d8829e1eb7299499ca7f313900dd4d89a24b8b87c0a780d4 \
                       --hash=sha256:416260257577718c05135c55958b674000baef9a1c7d9e8f306ec60d71db850f \
                       --hash=sha256:d89c3468de4cdc4f08a57e214384d0471911a3830fcdaf7a8cc587e42a866372
  Deprecated==1.3.1 --hash=sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f
  dicomweb-client==0.60.1 --hash=sha256:e128866a797b7acdcd4ad280a10ebced5af77a3ce1d1bde709389ad56583955d
  GitPython==3.1.45 --hash=sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77
  idna==3.11 --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea
  # Hashes correspond to the following packages:
  #  - numpy-2.3.4-cp312-cp312-macosx_10_13_x86_64.whl
  #  - numpy-2.3.4-cp312-cp312-macosx_11_0_arm64.whl
  #  - numpy-2.3.4-cp312-cp312-macosx_14_0_arm64.whl
  #  - numpy-2.3.4-cp312-cp312-macosx_14_0_x86_64.whl
  #  - numpy-2.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
  #  - numpy-2.3.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
  #  - numpy-2.3.4-cp312-cp312-musllinux_1_2_aarch64.whl
  #  - numpy-2.3.4-cp312-cp312-musllinux_1_2_x86_64.whl
  #  - numpy-2.3.4-cp312-cp312-win_amd64.whl
  #  - numpy-2.3.4-cp312-cp312-win_arm64.whl
  numpy==2.3.4 --hash=sha256:ef1b5a3e808bc40827b5fa2c8196151a4c5abe110e1726949d7abddfe5c7ae11 \
               --hash=sha256:c2f91f496a87235c6aaf6d3f3d89b17dba64996abadccb289f48456cff931ca9 \
               --hash=sha256:f77e5b3d3da652b474cc80a14084927a5e86a5eccf54ca8ca5cbd697bf7f2667 \
               --hash=sha256:8ab1c5f5ee40d6e01cbe96de5863e39b215a4d24e7d007cad56c7184fdf4aeef \
               --hash=sha256:77b84453f3adcb994ddbd0d1c5d11db2d6bda1a2b7fd5ac5bd4649d6f5dc682e \
               --hash=sha256:4121c5beb58a7f9e6dfdee612cb24f4df5cd4db6e8261d7f4d7450a997a65d6a \
               --hash=sha256:65611ecbb00ac9846efe04db15cbe6186f562f6bb7e5e05f077e53a599225d16 \
               --hash=sha256:dabc42f9c6577bcc13001b8810d300fe814b4cfbe8a92c873f269484594f9786 \
               --hash=sha256:985f1e46358f06c2a09921e8921e2c98168ed4ae12ccd6e5e87a4f1857923f32 \
               --hash=sha256:4635239814149e06e2cb9db3dd584b2fa64316c96f10656983b8026a82e6e4db
  # Hashes correspond to the following packages:
  #  - pillow-12.0.0-cp312-cp312-macosx_10_13_x86_64.whl
  #  - pillow-12.0.0-cp312-cp312-macosx_11_0_arm64.whl
  #  - pillow-12.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
  #  - pillow-12.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
  #  - pillow-12.0.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
  #  - pillow-12.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
  #  - pillow-12.0.0-cp312-cp312-musllinux_1_2_aarch64.whl
  #  - pillow-12.0.0-cp312-cp312-musllinux_1_2_x86_64.whl
  #  - pillow-12.0.0-cp312-cp312-win_amd64.whl
  #  - pillow-12.0.0-cp312-cp312-win_arm64.whl
  pillow==12.0.0 --hash=sha256:53561a4ddc36facb432fae7a9d8afbfaf94795414f5cdc5fc52f28c1dca90371 \
                 --hash=sha256:71db6b4c1653045dacc1585c1b0d184004f0d7e694c7b34ac165ca70c0838082 \
                 --hash=sha256:2fa5f0b6716fc88f11380b88b31fe591a06c6315e955c096c35715788b339e3f \
                 --hash=sha256:82240051c6ca513c616f7f9da06e871f61bfd7805f566275841af15015b8f98d \
                 --hash=sha256:55f818bd74fe2f11d4d7cbc65880a843c4075e0ac7226bc1a23261dbea531953 \
                 --hash=sha256:b87843e225e74576437fd5b6a4c2205d422754f84a06942cfaf1dc32243e45a8 \
                 --hash=sha256:c607c90ba67533e1b2355b821fef6764d1dd2cbe26b8c1005ae84f7aea25ff79 \
                 --hash=sha256:21f241bdd5080a15bc86d3466a9f6074a9c2c2b314100dd896ac81ee6db2f1ba \
                 --hash=sha256:9fe611163f6303d1619bbcb653540a4d60f9e55e622d60a3108be0d5b441017a \
                 --hash=sha256:7dfb439562f234f7d57b1ac6bc8fe7f838a4bd49c79230e0f6a1da93e82f1fad
  pip==25.3 --hash=sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd
  pycparser==2.23 --hash=sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934
  pydicom==3.0.1 --hash=sha256:db32f78b2641bd7972096b8289111ddab01fb221610de8d7afa835eb938adb41
  PyGithub==2.8.1 --hash=sha256:23a0a5bca93baef082e03411bf0ce27204c32be8bfa7abc92fe4a3e132936df0
  # Hashes correspond to the following packages:
  #  - pynacl-1.6.1-cp38-abi3-macosx_10_10_universal2.whl
  #  - pynacl-1.6.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
  #  - pynacl-1.6.1-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
  #  - pynacl-1.6.1-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
  #  - pynacl-1.6.1-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
  #  - pynacl-1.6.1-cp38-abi3-manylinux_2_34_aarch64.whl
  #  - pynacl-1.6.1-cp38-abi3-manylinux_2_34_x86_64.whl
  #  - pynacl-1.6.1-cp38-abi3-musllinux_1_1_aarch64.whl
  #  - pynacl-1.6.1-cp38-abi3-musllinux_1_1_x86_64.whl
  #  - pynacl-1.6.1-cp38-abi3-musllinux_1_2_aarch64.whl
  #  - pynacl-1.6.1-cp38-abi3-musllinux_1_2_x86_64.whl
  #  - pynacl-1.6.1-cp38-abi3-win_amd64.whl
  #  - pynacl-1.6.1-cp38-abi3-win_arm64.whl
  PyNaCl==1.6.1 --hash=sha256:a6f9fd6d6639b1e81115c7f8ff16b8dedba1e8098d2756275d63d208b0e32021 \
                --hash=sha256:e49a3f3d0da9f79c1bec2aa013261ab9fa651c7da045d376bd306cf7c1792993 \
                --hash=sha256:7713f8977b5d25f54a811ec9efa2738ac592e846dd6e8a4d3f7578346a841078 \
                --hash=sha256:5a3becafc1ee2e5ea7f9abc642f56b82dcf5be69b961e782a96ea52b55d8a9fc \
                --hash=sha256:4ce50d19f1566c391fedc8dc2f2f5be265ae214112ebe55315e41d1f36a7f0a9 \
                --hash=sha256:543f869140f67d42b9b8d47f922552d7a967e6c116aad028c9bfc5f3f3b3a7b7 \
                --hash=sha256:a2bb472458c7ca959aeeff8401b8efef329b0fc44a89d3775cffe8fad3398ad8 \
                --hash=sha256:3206fa98737fdc66d59b8782cecc3d37d30aeec4593d1c8c145825a345bba0f0 \
                --hash=sha256:53543b4f3d8acb344f75fd4d49f75e6572fce139f4bfb4815a9282296ff9f4c0 \
                --hash=sha256:319de653ef84c4f04e045eb250e6101d23132372b0a61a7acf91bac0fda8e58c \
                --hash=sha256:262a8de6bba4aee8a66f5edf62c214b06647461c9b6b641f8cd0cb1e3b3196fe \
                --hash=sha256:a569a4069a7855f963940040f35e87d8bc084cb2d6347428d5ad20550a0a1a21 \
                --hash=sha256:5953e8b8cfadb10889a6e7bd0f53041a745d1b3d30111386a1bb37af171e6daf
  pyparsing==3.2.5 --hash=sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e
  requests==2.32.5 --hash=sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6
  retrying==1.4.2 --hash=sha256:bbc004aeb542a74f3569aeddf42a2516efefcdaff90df0eb38fbfbf19f179f59
  # Hashes correspond to the following packages:
  #  - scipy-1.16.3-cp312-cp312-macosx_10_14_x86_64.whl
  #  - scipy-1.16.3-cp312-cp312-macosx_12_0_arm64.whl
  #  - scipy-1.16.3-cp312-cp312-macosx_14_0_arm64.whl
  #  - scipy-1.16.3-cp312-cp312-macosx_14_0_x86_64.whl
  #  - scipy-1.16.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
  #  - scipy-1.16.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
  #  - scipy-1.16.3-cp312-cp312-musllinux_1_2_aarch64.whl
  #  - scipy-1.16.3-cp312-cp312-musllinux_1_2_x86_64.whl
  #  - scipy-1.16.3-cp312-cp312-win_amd64.whl
  #  - scipy-1.16.3-cp312-cp312-win_arm64.whl
  scipy==1.16.3 --hash=sha256:81fc5827606858cf71446a5e98715ba0e11f0dbc83d71c7409d05486592a45d6 \
                --hash=sha256:c97176013d404c7346bf57874eaac5187d969293bf40497140b0a2b2b7482e07 \
                --hash=sha256:2b71d93c8a9936046866acebc915e2af2e292b883ed6e2cbe5c34beb094b82d9 \
                --hash=sha256:3d4a07a8e785d80289dfe66b7c27d8634a773020742ec7187b85ccc4b0e7b686 \
                --hash=sha256:0553371015692a898e1aa858fed67a3576c34edefa6b7ebdb4e9dde49ce5c203 \
                --hash=sha256:72d1717fd3b5e6ec747327ce9bda32d5463f472c9dce9f54499e81fbd50245a1 \
                --hash=sha256:1fb2472e72e24d1530debe6ae078db70fb1605350c88a3d14bc401d6306dbffe \
                --hash=sha256:c5192722cffe15f9329a3948c4b1db789fbb1f05c97899187dcf009b283aea70 \
                --hash=sha256:56edc65510d1331dae01ef9b658d428e33ed48b4f77b1d51caf479a0253f96dc \
                --hash=sha256:a8a26c78ef223d3e30920ef759e25625a0ecdd0d60e5a8818b7513c3e5384cf2
  typing_extensions==4.15.0 --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
  urllib3==2.5.0 --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
  # Hashes correspond to the following packages:
  #  - wrapt-2.0.1-cp312-cp312-macosx_10_13_universal2.whl
  #  - wrapt-2.0.1-cp312-cp312-macosx_10_13_x86_64.whl
  #  - wrapt-2.0.1-cp312-cp312-macosx_11_0_arm64.whl
  #  - wrapt-2.0.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
  #  - wrapt-2.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
  #  - wrapt-2.0.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl
  #  - wrapt-2.0.1-cp312-cp312-musllinux_1_2_aarch64.whl
  #  - wrapt-2.0.1-cp312-cp312-musllinux_1_2_riscv64.whl
  #  - wrapt-2.0.1-cp312-cp312-musllinux_1_2_x86_64.whl
  #  - wrapt-2.0.1-cp312-cp312-win_amd64.whl
  #  - wrapt-2.0.1-cp312-cp312-win_arm64.whl
  #  - wrapt-2.0.1-py3-none-any.whl
  wrapt==2.0.1 --hash=sha256:1fdbb34da15450f2b1d735a0e969c24bdb8d8924892380126e2a293d9902078c \
               --hash=sha256:3d32794fe940b7000f0519904e247f902f0149edbe6316c710a8562fb6738841 \
               --hash=sha256:386fb54d9cd903ee0012c09291336469eb7b244f7183d40dc3e86a16a4bace62 \
               --hash=sha256:7b219cb2182f230676308cdcacd428fa837987b89e4b7c5c9025088b8a6c9faf \
               --hash=sha256:641e94e789b5f6b4822bb8d8ebbdfc10f4e4eae7756d648b717d980f657a9eb9 \
               --hash=sha256:fe21b118b9f58859b5ebaa4b130dee18669df4bd111daad082b7beb8799ad16b \
               --hash=sha256:17fb85fa4abc26a5184d93b3efd2dcc14deb4b09edcdb3535a536ad34f0b4dba \
               --hash=sha256:b89ef9223d665ab255ae42cc282d27d69704d94be0deffc8b9d919179a609684 \
               --hash=sha256:a453257f19c31b31ba593c30d997d6e5be39e3b5ad9148c2af5a7314061c63eb \
               --hash=sha256:2da620b31a90cdefa9cd0c2b661882329e2e19d1d7b9b920189956b76c564d75 \
               --hash=sha256:aea9c7224c302bc8bfc892b908537f56c430802560e827b75ecbde81b604598b \
               --hash=sha256:4d2ce1bf1a48c5277d7969259232b57645aae5686dba1eaeade39442277afbca
PS C:\Users\butlej30383\AppData\Local\slicer.org\3D Slicer 5.11.0-2025-11-10\bin>
```
Changes to note with the numpy version update from 2.0 to 2.3 are the following:

https://numpy.org/doc/stable/release/2.1.0-notes.html#deprecations
https://numpy.org/doc/stable/release/2.1.0-notes.html#expired-deprecations
https://numpy.org/doc/stable/release/2.2.0-notes.html#deprecations
https://numpy.org/doc/stable/release/2.2.0-notes.html#expired-deprecations
https://numpy.org/doc/stable/release/2.3.0-notes.html#deprecations
https://numpy.org/doc/stable/release/2.3.0-notes.html#expired-deprecations

Changes to note with the scipy version update from 1.13 to 1.16 are the following:

https://scipy.github.io/devdocs/release/1.14.0-notes.html#deprecated-features
https://scipy.github.io/devdocs/release/1.14.0-notes.html#expired-deprecations
https://scipy.github.io/devdocs/release/1.15.0-notes.html#deprecated-features
https://scipy.github.io/devdocs/release/1.15.0-notes.html#expired-deprecations
https://scipy.github.io/devdocs/release/1.16.0-notes.html#deprecated-features
https://scipy.github.io/devdocs/release/1.16.0-notes.html#expired-deprecations

Since scipy is not directly used in Slicer core, we may have to update extensions to account for changes.

Additionally re https://github.com/Slicer/Slicer/pull/6590#issuecomment-1282762511, on macOS, the dependent libraries shipped with scipy remain the same
```
Directory: C:\Users\butlej30383\Downloads\scipy-1.13.1-cp312-cp312-macosx_10_9_x86_64\scipy\.dylibs

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----        11/12/2025  12:03 PM         126416 libgcc_s.1.1.dylib
-a----        11/12/2025  12:03 PM        6786304 libgfortran.5.dylib
-a----        11/12/2025  12:03 PM       68969792 libopenblas.0.dylib
-a----        11/12/2025  12:03 PM         352704 libquadmath.0.dylib

Directory: C:\Users\butlej30383\Downloads\scipy-1.16.3-cp312-cp312-macosx_10_14_x86_64\scipy\.dylibs

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----        11/12/2025  12:08 PM         138704 libgcc_s.1.1.dylib
-a----        11/12/2025  12:08 PM        6786304 libgfortran.5.dylib
-a----        11/12/2025  12:08 PM         352704 libquadmath.0.dylib
-a----        11/12/2025  12:08 PM       68560032 libscipy_openblas.dylib

Directory: C:\Users\butlej30383\Downloads\scipy-1.16.3-cp312-cp312-macosx_14_0_x86_64\scipy\.dylibs

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----        11/12/2025  12:06 PM         244384 libgcc_s.1.1.dylib
-a----        11/12/2025  12:06 PM        3497360 libgfortran.5.dylib
-a----        11/12/2025  12:06 PM         381088 libquadmath.0.dylib
```


Python packages with more than just a patch release update (newest release date to oldest):
```
Package           Version       Latest      Release Date
----------------- ------------- ----------- -----
certifi            2025.4.26     2025.11.12 2025-11-12
Deprecated         1.2.18        1.3.1      2025-10-29 (date for 1.3.0)
pip                25.1.1        25.3       2025-10-24
wrapt              1.17.2        2.0.1      2025-10-19
pillow             11.2.1        12.0.0     2025-10-15
idna               3.10          3.11       2025-10-12
cryptography       45.0.3        46.0.3     2025-09-16 (date for 46.0.0)
PyNaCl             1.5.0         1.6.1      2025-09-10 (date for 1.6.0)
pycparser          2.22          2.23       2025-09-09
cffi               1.17.1        2.0.0      2025-09-08
pydicom            2.4.4         3.0.1      2024-09-08 (date for 3.0.0)
PyGithub           2.6.1         2.8.1      2025-09-02 (date for 2.8.0)
typing_extensions  4.14.0        4.15.0     2025-08-25
retrying           1.3.4         1.4.2      2025-06-24 (date for 1.4.0)
scipy              1.13.1        1.16.3     2025-06-22 (date for 1.16.0)
urllib3            2.4.0         2.5.0      2025-06-18
numpy              2.0.2         2.3.4      2025-06-07 (date for 2.3.0)
```


## Testing Results:
Windows
- Build ✔️    
- Packaging ✔️    
- Tests ✔️     

macOS
- Build ✔️    
- Packaging ✔️      
- Tests ✔️ (failing tests appear to be unrelated to the python updates here and could be due to my specific build environment)
```
353 - py_nomainwindow_SegmentationsModuleTest2 (Failed) (RunTimeError: std::logic_error: vector)
357 - qSlicerSequencesModuleWidgetGenericTest (Failed)
483 - CastScalarVolumeTest_UnsignedChar (Failed)
486 - CastScalarVolumeTest_UnsignedShort (Failed)
638 - py_WebEngine (Failed)
```