### PR TITLE
COMP: Enable CMP0071 NEW behavior for extension builds

### DIFF
--- a/CMake/SlicerMacroBuildLoadableModule.cmake
+++ b/CMake/SlicerMacroBuildLoadableModule.cmake
@@ -44,6 +44,10 @@ macro(slicerMacroBuildLoadableModule)
     ${ARGN}
     )
 
+  # Setting this policy to NEW avoids error when running AUTOMOC with generated files
+  # from Slicer extension specifying a minimum required version older than 3.10.
+  cmake_policy(SET CMP0071 NEW)
+
   if(LOADABLEMODULE_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "Unknown keywords given to slicerMacroBuildLoadableModule(): \"${LOADABLEMODULE_UNPARSED_ARGUMENTS}\"")
   endif()


### PR DESCRIPTION
Extensions with a CMake minimum version < 3.10 will fail to build loadable modules with custom widgets due to AUTOMOC not running on generated files.  THe NEW policy behavior brings the extension in line with the Slicer behavior

See example: https://github.com/SlicerRt/SlicerRT/pull/290