### PR TITLE
COMP: Replace deprecated QRegExp usage

### DIFF
--- a/Base/QTCore/qSlicerCoreIOManager.h
+++ b/Base/QTCore/qSlicerCoreIOManager.h
@@ -27,6 +27,7 @@
 #include <QList>
 #include <QMap>
 #include <QObject>
+#include <QRegularExpression>
 #include <QString>
 #include <QVariantMap>
 
@@ -105,7 +106,7 @@ public:
   /// extension. Example of supported extensions:
   /// "", "*", ".*", ".jpg", ".png" ".tar.gz"...
   /// An empty extension or "*" means any filename (or directory) is valid
-  Q_INVOKABLE static QRegExp fileNameRegExp(const QString& extension = QString());
+  Q_INVOKABLE static QRegularExpression fileNameRegularExpression(const QString& extension = QString());
 
   /// Remove characters that are likely to cause problems in a filename
   Q_INVOKABLE static QString forceFileNameValidCharacters(const QString& filename);

--- a/Base/QTGUI/qSlicerExtensionsManagerWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsManagerWidget.cxx
@@ -26,6 +26,7 @@
 #include <QInputDialog>
 #include <QMenu>
 #include <QMessageBox>
+#include <QRegularExpression>
 #include <QTimer>
 #include <QTimerEvent>
 #include <QToolButton>
@@ -59,7 +60,7 @@ namespace
 QString jsQuote(QString text)
 {
   // NOTE: This assumes that 'text' does not contain '\r' or other control characters
-  static QRegExp reSpecialCharacters("([\'\"\\\\])");
+  static QRegularExpression reSpecialCharacters("([\'\"\\\\])");
   text.replace(reSpecialCharacters, "\\\\1").replace("\n", "\\n");
   return QString("\'%1\'").arg(text);
 }
@@ -476,11 +477,7 @@ void qSlicerExtensionsManagerWidget::onEditBookmarksTriggered()
     return;
   }
   // Split along whitespaces and common separator characters
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-  QStringList newList = newStr.split(QRegExp("\\s+|,|;"), Qt::SkipEmptyParts);
-#else
-  QStringList newList = newStr.split(QRegExp("\\s+|,|;"), QString::SkipEmptyParts);
-#endif
+  QStringList newList = newStr.split(QRegularExpression("\\s+|,|;"), Qt::SkipEmptyParts);
   newList.removeDuplicates();
 
   // Update bookmarks

--- a/Base/QTGUI/qSlicerModuleFactoryFilterModel.cxx
+++ b/Base/QTGUI/qSlicerModuleFactoryFilterModel.cxx
@@ -23,6 +23,7 @@
 #include <QDebug>
 #include <QIODevice>
 #include <QMimeData>
+#include <QRegularExpression>
 #include <QSortFilterProxyModel>
 #include <QStandardItem>
 #include <QStandardItemModel>
@@ -249,7 +250,7 @@ void qSlicerModuleFactoryFilterModel::setShowModules(const QStringList& modules)
   }
   else
   {
-    this->setFilterRegExp(QString("\\b(") + d->ShowModules.join("|") + QString(")\\b"));
+    this->setFilterRegularExpression(QRegularExpression(QString("\\b(") + d->ShowModules.join("|") + QString(")\\b")));
   }
   this->sort(0);
   emit showModulesChanged(d->ShowModules);

--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -26,8 +26,6 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QMessageBox>
-#include <QRegExp>
-#include <QRegExpValidator>
 #include <QSettings>
 
 /// CTK includes

--- a/Libs/MRML/Widgets/qMRMLItemDelegate.cxx
+++ b/Libs/MRML/Widgets/qMRMLItemDelegate.cxx
@@ -23,6 +23,7 @@
 #include <QEvent>
 #include <QHBoxLayout>
 #include <QDebug>
+#include <QRegularExpression>
 
 // CTK includes
 #include <ctkColorDialog.h>
@@ -94,8 +95,8 @@ bool qMRMLItemDelegate::is0To1Value(const QModelIndex& index) const
   {
     return false;
   }
-  QRegExp regExp0To1With2Decimals("[01]\\.[0-9][0-9]");
-  bool res = regExp0To1With2Decimals.exactMatch(editData.toString());
+  QRegularExpression regExp0To1With2Decimals("^[01]\\.[0-9][0-9]$");
+  bool res = regExp0To1With2Decimals.match(editData.toString()).hasMatch();
   return res;
 }
 

--- a/Modules/Loadable/Colors/Widgets/qMRMLColorListView.cxx
+++ b/Modules/Loadable/Colors/Widgets/qMRMLColorListView.cxx
@@ -120,7 +120,11 @@ void qMRMLColorListView::setShowOnlyNamedColors(bool enable)
 //------------------------------------------------------------------------------
 bool qMRMLColorListView::showOnlyNamedColors() const
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+  return this->sortFilterProxyModel()->filterRegularExpression().pattern().isEmpty();
+#else
   return this->sortFilterProxyModel()->filterRegExp().isEmpty();
+#endif
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/Colors/Widgets/qMRMLColorPickerWidget.cxx
+++ b/Modules/Loadable/Colors/Widgets/qMRMLColorPickerWidget.cxx
@@ -23,6 +23,10 @@
 #include <QDialog>
 #include <QKeyEvent>
 #include <QStringListModel>
+#include <QRegularExpression>
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
+# include <QRegExp>
+#endif
 
 // qMRML includes
 #include "qMRMLColorPickerWidget.h"
@@ -188,8 +192,14 @@ void qMRMLColorPickerWidget::onCurrentColorNodeChanged(vtkMRMLNode* colorNode)
 void qMRMLColorPickerWidget::onTextChanged(const QString& colorText)
 {
   Q_D(qMRMLColorPickerWidget);
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+  QRegularExpression regExp(colorText, QRegularExpression::CaseInsensitiveOption);
+  d->MRMLColorListView->sortFilterProxyModel()->setFilterRegularExpression(regExp);
+#else
   QRegExp regExp(colorText, Qt::CaseInsensitive, QRegExp::RegExp);
   d->MRMLColorListView->sortFilterProxyModel()->setFilterRegExp(regExp);
+#endif
 
   QModelIndex newCurrentIndex;
 

--- a/Modules/Loadable/Colors/Widgets/qMRMLColorTableView.cxx
+++ b/Modules/Loadable/Colors/Widgets/qMRMLColorTableView.cxx
@@ -142,7 +142,11 @@ void qMRMLColorTableView::setShowOnlyNamedColors(bool enable)
 //------------------------------------------------------------------------------
 bool qMRMLColorTableView::showOnlyNamedColors() const
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+  return this->sortFilterProxyModel()->filterRegularExpression().pattern().isEmpty();
+#else
   return this->sortFilterProxyModel()->filterRegExp().isEmpty();
+#endif
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/qSlicerAnnotationsIOOptionsWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerAnnotationsIOOptionsWidget.cxx
@@ -21,6 +21,7 @@
 /// Qt includes
 #include <QButtonGroup>
 #include <QFileInfo>
+#include <QRegularExpression>
 
 // CTK includes
 #include <ctkFlowLayout.h>
@@ -121,9 +122,9 @@ void qSlicerAnnotationsIOOptionsWidget::setFileNames(const QStringList& fileName
     }
     // Because '_' is considered as a word character (\w), \b
     // doesn't consider '_' as a word boundary.
-    QRegExp fiducialName("(\\b|_)(F)(\\b|_)");
-    QRegExp rulerName("(\\b|_)(M)(\\b|_)");
-    QRegExp roiName("(\\b|_)(R)(\\b|_)");
+    QRegularExpression fiducialName("(\\b|_)(F)(\\b|_)");
+    QRegularExpression rulerName("(\\b|_)(M)(\\b|_)");
+    QRegularExpression roiName("(\\b|_)(R)(\\b|_)");
     QAbstractButton* activeButton = nullptr;
     /*    QRegExp listName("(\\b|_)(List)(\\b|_)");
         if (fileInfo.baseName().contains(listName))

--- a/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.cxx
@@ -24,6 +24,10 @@
 #include "qMRMLTransformDisplayNodeWidget.h"
 #include "ui_qMRMLTransformDisplayNodeWidget.h"
 
+// Qt includes
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
+
 // MRML includes
 #include <vtkMRMLColorNode.h>
 #include <vtkMRMLTransformNode.h>
@@ -186,8 +190,9 @@ void qMRMLTransformDisplayNodeWidgetPrivate::init()
   QObject::connect(this->GridShowNonWarped, SIGNAL(toggled(bool)), q, SLOT(setGridShowNonWarped(bool)));
 
   // Contour Parameters
-  QRegExp rx("^(([0-9]+(.[0-9]+)?)[ ]?)*([0-9]+(.[0-9]+)?)[ ]?$");
-  this->ContourLevelsMm->setValidator(new QRegExpValidator(rx, q));
+  QRegularExpression rx("^(([0-9]+(.[0-9]+)?)[ ]?)*([0-9]+(.[0-9]+)?)[ ]?$");
+  this->ContourLevelsMm->setValidator(new QRegularExpressionValidator(rx, q));
+
   QObject::connect(this->ContourLevelsMm, SIGNAL(textChanged(QString)), q, SLOT(setContourLevelsMm(QString)));
   QObject::connect(this->ContourResolutionMm, SIGNAL(valueChanged(double)), q, SLOT(setContourResolutionMm(double)));
   QObject::connect(this->ContourOpacityPercent, SIGNAL(valueChanged(double)), q, SLOT(setContourOpacityPercent(double)));

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerGPUMemoryComboBox.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerGPUMemoryComboBox.cxx
@@ -29,6 +29,8 @@
 // Qt includes
 #include <QDebug>
 #include <QLineEdit>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
 
 //-----------------------------------------------------------------------------
 class qSlicerGPUMemoryComboBoxPrivate
@@ -47,7 +49,7 @@ public:
   double memoryFromString(const QString& memory) const;
   QString memoryToString(double memory) const;
 
-  QRegExp MemoryRegExp;
+  QRegularExpression MemoryRegExp;
   QString DefaultText;
 };
 
@@ -59,7 +61,7 @@ qSlicerGPUMemoryComboBoxPrivate::qSlicerGPUMemoryComboBoxPrivate(qSlicerGPUMemor
   : q_ptr(&object)
   , DefaultText("0 MB (Default)")
 {
-  this->MemoryRegExp = QRegExp("^(\\d+(?:\\.\\d*)?)\\s?(MB|GB|\\%)$");
+  this->MemoryRegExp = QRegularExpression("^(\\d+(?:\\.\\d*)?)\\s?(MB|GB|\\%)$");
 }
 
 //-----------------------------------------------------------------------------
@@ -71,7 +73,7 @@ void qSlicerGPUMemoryComboBoxPrivate::init()
   Q_Q(qSlicerGPUMemoryComboBox);
 
   q->setEditable(true);
-  q->lineEdit()->setValidator(new QRegExpValidator(this->MemoryRegExp, q));
+  q->lineEdit()->setValidator(new QRegularExpressionValidator(this->MemoryRegExp, q));
   q->addItem(DefaultText);
   // q->addItem(qSlicerGPUMemoryComboBox::tr("25 %")); //TODO: Uncomment when totalGPUMemoryInMB works
   // q->addItem(qSlicerGPUMemoryComboBox::tr("50 %"));
@@ -107,15 +109,15 @@ double qSlicerGPUMemoryComboBoxPrivate::memoryFromString(const QString& memory) 
     return 0.0;
   }
 
-  int pos = this->MemoryRegExp.indexIn(memory);
-  if (pos < 0)
+  QRegularExpressionMatch match = this->MemoryRegExp.match(memory);
+  if (!match.hasMatch())
   {
     return 0.0;
   }
 
-  QString memoryValue = this->MemoryRegExp.cap(1);
+  QString memoryValue = match.captured(1);
   double value = memoryValue.toDouble();
-  QString memoryUnit = this->MemoryRegExp.cap(2);
+  QString memoryUnit = match.captured(2);
 
   if (memoryUnit == "%")
   {

--- a/Modules/Loadable/Volumes/qSlicerVolumesIOOptionsWidget.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesIOOptionsWidget.cxx
@@ -20,6 +20,7 @@
 
 /// Qt includes
 #include <QFileInfo>
+#include <QRegularExpression>
 
 // CTK includes
 #include <ctkFlowLayout.h>
@@ -141,13 +142,13 @@ void qSlicerVolumesIOOptionsWidget::setFileNames(const QStringList& fileNames)
       // Single file
       // If the name (or the extension) is just a number, then it must be a 2D
       // slice from a 3D volume, so uncheck Single File.
-      onlyNumberInName = QRegExp("[0-9\\.\\-\\_\\@\\(\\)\\~]+").exactMatch(fileBaseName);
+      onlyNumberInName = QRegularExpression("^[0-9\\.\\-\\_\\@\\(\\)\\~]+$").match(fileBaseName).hasMatch();
       fileInfo.suffix().toInt(&onlyNumberInExtension);
     }
     // Because '_' is considered as a word character (\w), \b
     // doesn't consider '_' as a word boundary.
-    QRegExp labelMapName("(\\b|_)([Ll]abel(s)?)(\\b|_)");
-    QRegExp segName("(\\b|_)([Ss]eg)(\\b|_)");
+    QRegularExpression labelMapName("(\\b|_)([Ll]abel(s)?)(\\b|_)");
+    QRegularExpression segName("(\\b|_)([Ss]eg)(\\b|_)");
     if (fileBaseName.contains(labelMapName) || //
         fileBaseName.contains(segName))
     {


### PR DESCRIPTION
To make the code compatible with Qt6:

Replace deprecated QRegExp usage with QRegularExpression for Qt >= 5.15

Replace deprecated filterRegExp usage with filterRegularExpression for Qt >= 5.12.

Replace deprecated QRegExp::Wildcard usage with QRegularExpression::fromWildcard for Qt >= 6.0. Although some wildcard support is available in Qt5, its syntax is more complex than in Qt6 and its behavior is slightly different across Qt5 versions.
