### PR TITLE
BUG: Fix a test assuming that the extension manager is enabled

### DIFF
--- a/Base/Logic/Testing/vtkSlicerApplicationLogicTest1.cxx
+++ b/Base/Logic/Testing/vtkSlicerApplicationLogicTest1.cxx
@@ -241,7 +241,13 @@ int vtkSlicerApplicationLogicTest1(int, char*[])
       std::string isEmbeddedExpectedAsStr(data.at(rowIdx).at(3));
       bool isEmbeddedExpected = (isEmbeddedExpectedAsStr == "1");
 
-      bool isEmbedded = vtkSlicerApplicationLogic::IsEmbeddedModule(filePath, applicationHomeDir, slicerRevision, Slicer_EXTENSIONS_DIRBASENAME);
+#ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
+      std::string extensionsDirBase = Slicer_EXTENSIONS_DIRBASENAME;
+#else
+      std::string extensionsDirBase;
+      // empty string will be interpreted by IsEmbeddedModule to mean that Slicer was built without extension manager support
+#endif
+      bool isEmbedded = vtkSlicerApplicationLogic::IsEmbeddedModule(filePath, applicationHomeDir, slicerRevision, extensionsDirBase);
       if (isEmbeddedExpected != isEmbedded)
       {
         std::cerr << "Line " << __LINE__ << " - Problem with isEmbedded ! - Row:" << rowIdx << "\n"


### PR DESCRIPTION
The test assumed that `Slicer_EXTENSIONS_DIRBASENAME` is defined, but it wouldn't be defined if extension manager support were disabled.

This caused problems when trying to build a custom application with

```txt
Slicer_BUILD_EXTENSIONMANAGER_SUPPORT OFF
BUILD_TESTING ON
```

The issue was introduced in 2803638e40fdf3fe7b478277247d097ce264d4e5 which did guard with `#ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT` in core code, but probably just forgot to do it in this test.