### PR TITLE
ENH: Disable ITKv4 legacy classes and interfaces

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -69,9 +69,9 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
   list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
-    -DITK_LEGACY_REMOVE:BOOL=OFF   #<-- Allow LEGACY ITKv4 features for now.
-    -DITK_LEGACY_SILENT:BOOL=OFF   #<-- Use of legacy code will produce compiler warnings
-    -DModule_ITKDeprecated:BOOL=ON #<-- Needed for ITKv5 now. (itkMultiThreader.h and MutexLock backwards compatibility.)
+    -DITK_LEGACY_REMOVE:BOOL=ON     #<-- Disable LEGACY ITKv4 features in preparation for transition to ITKv6.
+    -DITK_LEGACY_SILENT:BOOL=OFF    #<-- Use of legacy code will produce compiler warnings
+    -DModule_ITKDeprecated:BOOL=OFF #<-- Needed for ITKv5 now. (itkMultiThreader.h and MutexLock backwards compatibility.)
     )
 
 


### PR DESCRIPTION
This disables support for interfaces and classes which existed in ITKv4. This leaves only ITKv5 code enabled. This is a first step towards transitioning to ITKv6, which is currently in beta testing.