### PR TITLE
COMP: Update CTK to fix Qt6 errors

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -78,7 +78,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "bb28fad455f9bafca0fefa53e30bd862041837d1"
+    "c571aba4ced7b0d1f3c87e25714ccd3e0ac159fa"
     QUIET
     )
 


### PR DESCRIPTION
List of CTK changes:

```
$ git shortlog bb28fad455f9bafca0fefa53e30bd862041837d1..c571aba4ced7b0d1f3c87e25714ccd3e0ac159fa --no-merges
Andras Lasso (2):
      BUG: Fix crash in ctkSliderWidgetPrivate::synchronizeSiblingWidth
      BUG: Fix ctkMenuButton for Qt6

Bernhard Froehler (3):
      BUG: Fix Qt >= 6 updateSetting signal connection
      COMP: Fix Qt6 QComboBox changed signal
      COMP: Use QCheckBox checkStateChanged instead of stateChanged signal

Davide Punzo (1):
      BUG: Fix filter expression handling in DICOM object list widget for Qt5

Mathieu Albi (1):
      BUG: Fix out of range array access in ctkPythonConsole
```