### PR TITLE
ENH: Show number of control points in SH tooltip of markup nodes

### DIFF
--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
@@ -441,6 +441,36 @@ const QString qSlicerSubjectHierarchyMarkupsPlugin::roleForPlugin() const
   return "Markup";
 }
 
+//-----------------------------------------------------------------------------
+QString qSlicerSubjectHierarchyMarkupsPlugin::tooltip(vtkIdType itemID) const
+{
+  if (itemID == vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID)
+  {
+    qCritical() << Q_FUNC_INFO << ": Invalid input item";
+    return tr("Invalid");
+  }
+  vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();
+  if (!shNode)
+  {
+    qCritical() << Q_FUNC_INFO << ": Failed to access subject hierarchy node";
+    return tr("Invalid");
+  }
+
+  // Get basic tooltip from abstract plugin
+  QString tooltipString = Superclass::tooltip(itemID);
+
+  vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(shNode->GetItemDataNode(itemID));
+  if (!markupsNode)
+  {
+    qCritical() << Q_FUNC_INFO << ": Subject hierarchy item not associated to valid markups node";
+    return tooltipString;
+  }
+
+  // Add number of control points info
+  tooltipString.append(tr(" (Number of control points: %1)").arg(markupsNode->GetNumberOfControlPoints()));
+  return tooltipString;
+}
+
 //---------------------------------------------------------------------------
 QIcon qSlicerSubjectHierarchyMarkupsPlugin::icon(vtkIdType itemID)
 {

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
@@ -62,6 +62,9 @@ public:
   ///   Each plugin should provide only one role.
   Q_INVOKABLE const QString roleForPlugin() const override;
 
+  /// Generate tooltip for a owned subject hierarchy item
+  QString tooltip(vtkIdType itemID) const override;
+
   /// Get icon of an owned subject hierarchy item
   /// \return Icon to set, empty icon if nothing to set
   QIcon icon(vtkIdType itemID) override;


### PR DESCRIPTION
Many times I'd find it useful to see the number of control points for a markups node in the Data module. This commit adds this.