### PR TITLE
ENH: Get image data extent using accessor instead of direct member

### DIFF
--- a/Libs/vtkSegmentationCore/vtkOrientedImageData.cxx
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageData.cxx
@@ -298,7 +298,7 @@ void vtkOrientedImageData::ComputeBounds()
   }
 
   // Sanity check
-  const int* extent = this->Extent;
+  const int* extent = this->GetExtent();
   if (extent[0] > extent[1] || //
       extent[2] > extent[3] || //
       extent[4] > extent[5])
@@ -346,7 +346,8 @@ void vtkOrientedImageData::ComputeBounds()
 bool vtkOrientedImageData::IsEmpty()
 {
   // Empty if extent is uninitialized or otherwise invalid
-  if (this->Extent[0] > this->Extent[1] || this->Extent[2] > this->Extent[3] || this->Extent[4] > this->Extent[5])
+  const int* extent = this->GetExtent();
+  if (extent[0] > extent[1] || extent[2] > extent[3] || extent[4] > extent[5])
   {
     // empty
     return true;


### PR DESCRIPTION
This makes the code compatible with VTK 9.6, specifically https://github.com/Kitware/VTK/commit/1867881d95355ca8838289f88822f8d0ac6433cd, where vtkImageData is now an implementation of a new vtkCartesianGrid class where Extent is now a private member. To be compatible with VTK 9.6 and earlier versions, the GetExtent() accessor method is used instead.