### PR TITLE
COMP: Remove deprecated vtkVectorOperators

### DIFF
--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationROINode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationROINode.cxx
@@ -16,7 +16,6 @@
 #include <vtkMath.h>
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
-#include <vtkVectorOperators.h>
 #include <vtkPlanes.h>
 #include <vtkPolyData.h>
 #include <vtkSmartPointer.h>


### PR DESCRIPTION
vtkVectorOperators was deprecated in VTK 9.4 as of https://github.com/Kitware/VTK/commit/7ad26cf26413d67021179d26d7f4b741ff7f573c. It was subsequently removed in VTK 9.6 as of https://github.com/Kitware/VTK/commit/7a134cad65c3a0a408f7c32d5c86726f58769406.

vtkMRMLAnnotationROINode doesn't appear to use any vtkVector types so the include can be removed.