### PR TITLE
COMP: Include the iostream header where cout/cerr used

### DIFF
--- a/Applications/SlicerApp/Testing/Cpp/qSlicerModuleFactoryManagerTest1.cxx
+++ b/Applications/SlicerApp/Testing/Cpp/qSlicerModuleFactoryManagerTest1.cxx
@@ -29,6 +29,9 @@
 // VTK includes
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 int qSlicerModuleFactoryManagerTest1(int argc, char* argv[])
 {
   qSlicerCoreApplication app(argc, argv);

--- a/Base/CLI/itkPluginFilterWatcher.h
+++ b/Base/CLI/itkPluginFilterWatcher.h
@@ -24,6 +24,9 @@
 // ITK includes
 #include <itkSimpleFilterWatcher.h>
 
+// STD includes
+#include <iostream>
+
 namespace itk
 {
 

--- a/Base/CLI/vtkPluginFilterWatcher.cxx
+++ b/Base/CLI/vtkPluginFilterWatcher.cxx
@@ -3,6 +3,9 @@
 
 // VTK includes
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 class vtkPluginWatcherStart : public vtkCommand
 {

--- a/Base/CLI/vtkPluginFilterWatcher.h
+++ b/Base/CLI/vtkPluginFilterWatcher.h
@@ -11,6 +11,7 @@
 #include "vtkSlicerBaseCLIExport.h"
 
 // STD includes
+#include <iostream>
 #include <string>
 
 /** \class vtkPluginFilterWatcher

--- a/Base/Logic/Testing/vtkDataIOManagerLogicTest1.cxx
+++ b/Base/Logic/Testing/vtkDataIOManagerLogicTest1.cxx
@@ -14,6 +14,9 @@
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkDataIOManagerLogic.h"
 
+// STD includes
+#include <iostream>
+
 int vtkDataIOManagerLogicTest1(int, char*[])
 {
   vtkNew<vtkDataIOManagerLogic> logic;

--- a/Base/Logic/Testing/vtkSlicerApplicationLogicTest1.cxx
+++ b/Base/Logic/Testing/vtkSlicerApplicationLogicTest1.cxx
@@ -30,6 +30,9 @@
 // VTK includes
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 int vtkSlicerApplicationLogicTest1(int, char*[])
 {

--- a/Base/Logic/vtkSlicerApplicationLogic.cxx
+++ b/Base/Logic/vtkSlicerApplicationLogic.cxx
@@ -37,6 +37,7 @@
 
 // STD includes
 #include <algorithm>
+#include <iostream>
 
 #ifdef VTK_USE_PTHREADS
 # include <unistd.h>

--- a/Base/Logic/vtkSlicerCLIModuleLogic.cxx
+++ b/Base/Logic/vtkSlicerCLIModuleLogic.cxx
@@ -51,6 +51,7 @@
 #include <algorithm>
 #include <cassert>
 #include <ctime>
+#include <iostream>
 #include <mutex>
 #include <random>
 #include <set>

--- a/Base/Logic/vtkSlicerScriptedLoadableModuleLogic.cxx
+++ b/Base/Logic/vtkSlicerScriptedLoadableModuleLogic.cxx
@@ -32,6 +32,7 @@
 
 // STD includes
 #include <cstdlib>
+#include <iostream>
 
 //----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkSlicerScriptedLoadableModuleLogic);

--- a/Base/QTApp/qSlicerApplicationHelper.hxx
+++ b/Base/QTApp/qSlicerApplicationHelper.hxx
@@ -44,6 +44,9 @@
 #include "qSlicerModuleFactoryManager.h"
 #include "qSlicerModuleManager.h"
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 

--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -90,6 +90,9 @@
 // VTK includes
 #include <vtkCollection.h>
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 

--- a/Base/QTCLI/Testing/CLIModule4Test.cxx
+++ b/Base/QTCLI/Testing/CLIModule4Test.cxx
@@ -24,6 +24,7 @@
 
 // STD includes
 #include <fstream>
+#include <iostream>
 
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every

--- a/Base/QTCLI/Testing/qSlicerCLIExecutableModuleFactoryTest1.cxx
+++ b/Base/QTCLI/Testing/qSlicerCLIExecutableModuleFactoryTest1.cxx
@@ -24,6 +24,7 @@
 #include <qSlicerCLIExecutableModuleFactory.h>
 
 // STD includes
+#include <iostream>
 
 #include "vtkMRMLCoreTestingMacros.h"
 

--- a/Base/QTCLI/Testing/qSlicerCLILoadableModuleFactoryTest1.cxx
+++ b/Base/QTCLI/Testing/qSlicerCLILoadableModuleFactoryTest1.cxx
@@ -24,6 +24,7 @@
 #include <qSlicerCLILoadableModuleFactory.h>
 
 // STD includes
+#include <iostream>
 
 #include "vtkMRMLCoreTestingMacros.h"
 

--- a/Base/QTCLI/Testing/qSlicerCLIModuleTest1.cxx
+++ b/Base/QTCLI/Testing/qSlicerCLIModuleTest1.cxx
@@ -39,6 +39,7 @@
 #include <vtkSlicerCLIModuleLogic.h>
 
 // STD includes
+#include <iostream>
 
 namespace
 {

--- a/Base/QTCLI/Testing/qSlicerPyCLIModuleTest1.cxx
+++ b/Base/QTCLI/Testing/qSlicerPyCLIModuleTest1.cxx
@@ -40,6 +40,7 @@
 #include <vtkSlicerCLIModuleLogic.h>
 
 // STD includes
+#include <iostream>
 
 namespace
 {

--- a/Base/QTCore/Testing/Cxx/qSlicerCoreApplicationTest1.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerCoreApplicationTest1.cxx
@@ -36,6 +36,7 @@
 // VTK includes
 
 // STD includes
+#include <iostream>
 
 // namespace{
 // class qSlicerCoreApplicationTest : public qSlicerCoreApplication

--- a/Base/QTCore/Testing/Cxx/qSlicerCoreIOManagerTest1.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerCoreIOManagerTest1.cxx
@@ -33,6 +33,9 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 int TestLongNodeNameSaving(const char* temporaryDirectory)
 {
   vtkNew<vtkMRMLScene> scene;

--- a/Base/QTCore/Testing/Cxx/qSlicerLoadableModuleFactoryTest1.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerLoadableModuleFactoryTest1.cxx
@@ -24,6 +24,7 @@
 #include <qSlicerLoadableModuleFactory.h>
 
 // STD includes
+#include <iostream>
 
 #include "vtkMRMLCoreTestingMacros.h"
 

--- a/Base/QTCore/Testing/Cxx/qSlicerScriptedUtilsTest1.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerScriptedUtilsTest1.cxx
@@ -6,6 +6,9 @@
 // PythonQt includes
 #include <PythonQt.h>
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 bool setModuleAttribute(int line, const QString& moduleName, const QString& attributeName, PyObject* expectedAttributeValue, bool expectedResult)
 {

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -20,6 +20,7 @@
 
 // STD includes
 #include <clocale>
+#include <iostream>
 #include <stdexcept>
 
 // Qt includes

--- a/Base/QTGUI/Testing/Cxx/CMakeLists.txt
+++ b/Base/QTGUI/Testing/Cxx/CMakeLists.txt
@@ -34,7 +34,7 @@ if(BUILD_TESTING)
     TESTING_OUTPUT_ASSERT_WARNINGS_ERRORS(0);
     ")
 
-  set(EXTRA_INCLUDE "vtkMRMLDebugLeaksMacro.h\"\n\#include <itkConfigure.h>\n\#include <itkFactoryRegistration.h>\n\#include \"vtkTestingOutputWindow.h")
+  set(EXTRA_INCLUDE "vtkMRMLDebugLeaksMacro.h\"\n\#include <itkConfigure.h>\n\#include <itkFactoryRegistration.h>\n\#include <iostream>\n\#include \"vtkTestingOutputWindow.h")
 
   include_directories(${CMAKE_CURRENT_BINARY_DIR})
   set(KIT_TEST_SRCS

--- a/Base/QTGUI/Testing/Cxx/qSlicerApplicationTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerApplicationTest1.cxx
@@ -27,6 +27,7 @@
 #include "qSlicerIOManager.h"
 
 // STD includes
+#include <iostream>
 
 int qSlicerApplicationTest1(int argc, char* argv[])
 {

--- a/Base/QTGUI/Testing/Cxx/qSlicerModuleGenericTest.cxx.in
+++ b/Base/QTGUI/Testing/Cxx/qSlicerModuleGenericTest.cxx.in
@@ -55,6 +55,9 @@
 // VTK includes
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 int qSlicer@MODULENAME@ModuleGenericTest(int argc, char* argv[])
 {

--- a/Base/QTGUI/Testing/Cxx/qSlicerModulePanelTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerModulePanelTest1.cxx
@@ -26,6 +26,7 @@
 #include "qSlicerModulePanel.h"
 
 // STD includes
+#include <iostream>
 
 int qSlicerModulePanelTest1(int argc, char* argv[])
 {

--- a/Base/QTGUI/Testing/Cxx/qSlicerModuleWidgetGenericTest.cxx.in
+++ b/Base/QTGUI/Testing/Cxx/qSlicerModuleWidgetGenericTest.cxx.in
@@ -62,6 +62,7 @@
 
 // STD includes
 #include <algorithm>
+#include <iostream>
 
 const int allowedWidgetWidthPixel = 500; // no matter how large the screen is, up to 500px widget width is allowed
 const int allowedWidgetWidthScreenPercentage = 30; // about 1/3 of the screen width is allowed

--- a/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
@@ -20,6 +20,7 @@
 // VTK includes
 
 // STD includes
+#include <iostream>
 
 #define CHECK_PLACE_ACTION_TEXT(expected, mouseToolBar)                                                                                                              \
   {                                                                                                                                                                  \

--- a/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest1.cxx
@@ -34,6 +34,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qSlicerWidgetTest1(int argc, char* argv[])
 {

--- a/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest2.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest2.cxx
@@ -51,6 +51,7 @@
 #include <vtkVersion.h>
 
 // STD includes
+#include <iostream>
 
 #define WINDOW_WIDTH 600
 #define WINDOW_HEIGHT 900

--- a/CMake/SlicerMacroConfigureModuleCxxTestDriver.cmake
+++ b/CMake/SlicerMacroConfigureModuleCxxTestDriver.cmake
@@ -55,7 +55,7 @@ macro(SlicerMacroConfigureModuleCxxTestDriver)
     set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN "")
     set(CMAKE_TESTDRIVER_AFTER_TESTMAIN "")
 
-    set(EXTRA_INCLUDE "vtkWin32OutputWindow.h\"\n\#include \"vtkVersionMacros.h")
+    set(EXTRA_INCLUDE "vtkWin32OutputWindow.h\"\n\#include <iostream>\n\#include \"vtkVersionMacros.h")
 
     if(SLICER_TEST_DRIVER_WITH_VTK_ERROR_OUTPUT_CHECK)
       set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN

--- a/Extensions/Testing/CLIExtensionTemplate/CLIModuleTemplate/CLIModuleTemplate.cxx
+++ b/Extensions/Testing/CLIExtensionTemplate/CLIModuleTemplate/CLIModuleTemplate.cxx
@@ -6,6 +6,9 @@
 
 #include "CLIModuleTemplateCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Extensions/Testing/SuperBuildExtensionTemplate/SuperCLIModuleTemplate/SuperCLIModuleTemplate.cxx
+++ b/Extensions/Testing/SuperBuildExtensionTemplate/SuperCLIModuleTemplate/SuperCLIModuleTemplate.cxx
@@ -6,6 +6,9 @@
 
 #include "SuperCLIModuleTemplateCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Libs/MRML/Core/Testing/CMakeLists.txt
+++ b/Libs/MRML/Core/Testing/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(KIT ${PROJECT_NAME})
 
-set(EXTRA_INCLUDE "vtkMRMLDebugLeaksMacro.h\"\n\#include \"vtkTestingOutputWindow.h")
+set(EXTRA_INCLUDE "vtkMRMLDebugLeaksMacro.h\"\n\#include <iostream>\n\#include \"vtkTestingOutputWindow.h")
 set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN "DEBUG_LEAKS_ENABLE_EXIT_ERROR();\nTESTING_OUTPUT_ASSERT_WARNINGS_ERRORS(0);" )
 set(CMAKE_TESTDRIVER_AFTER_TESTMAIN "TESTING_OUTPUT_ASSERT_WARNINGS_ERRORS(0);" )
 

--- a/Libs/MRML/Core/Testing/vtkArchiveTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkArchiveTest1.cxx
@@ -20,6 +20,7 @@
 #include <vtksys/Directory.hxx>
 
 // STD includes
+#include <iostream>
 
 #include "vtkMRMLCoreTestingMacros.h"
 

--- a/Libs/MRML/Core/Testing/vtkCodedEntryTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkCodedEntryTest1.cxx
@@ -17,6 +17,9 @@
 // VTK includes
 #include "vtkNew.h"
 
+// STD includes
+#include <iostream>
+
 //----------------------------------------------------------------------------
 int vtkCodedEntryTest1(int, char*[])
 {

--- a/Libs/MRML/Core/Testing/vtkMRMLColorNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLColorNodeTest1.cxx
@@ -19,6 +19,9 @@
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <iostream>
+
 /// \brief Concrete implementation of vtkMRMLColorNode
 class vtkMRMLColorNodeTestHelper1 : public vtkMRMLColorNode
 {

--- a/Libs/MRML/Core/Testing/vtkMRMLColorTableNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLColorTableNodeTest1.cxx
@@ -23,6 +23,9 @@
 #include <vtkSmartPointer.h>
 #include <vtkLookupTable.h>
 
+// STD includes
+#include <iostream>
+
 using namespace vtkMRMLCoreTestingUtilities;
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/Core/Testing/vtkMRMLDisplayNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDisplayNodeTest1.cxx
@@ -17,6 +17,9 @@
 // VTK includes
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <iostream>
+
 //----------------------------------------------------------------------------
 class vtkMRMLDisplayNodeTestHelper1 : public vtkMRMLDisplayNode
 {

--- a/Libs/MRML/Core/Testing/vtkMRMLDisplayableHierarchyNodeDisplayPropertiesTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDisplayableHierarchyNodeDisplayPropertiesTest.cxx
@@ -32,6 +32,7 @@
 
 // STD includes
 #include <cassert>
+#include <iostream>
 #include <sstream>
 
 namespace

--- a/Libs/MRML/Core/Testing/vtkMRMLDisplayableHierarchyNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDisplayableHierarchyNodeTest1.cxx
@@ -23,6 +23,9 @@
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <iostream>
+
 //----------------------------------------------------------------------------
 class vtkMRMLDisplayableHierarchyNodeTestHelper1;
 

--- a/Libs/MRML/Core/Testing/vtkMRMLDisplayableHierarchyNodeTest2.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDisplayableHierarchyNodeTest2.cxx
@@ -22,6 +22,9 @@
 // VTK includes
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 // test more general hierarchy uses, with different displayable node types
 int vtkMRMLDisplayableHierarchyNodeTest2(int, char*[])
 {

--- a/Libs/MRML/Core/Testing/vtkMRMLDisplayableHierarchyNodeTest3.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDisplayableHierarchyNodeTest3.cxx
@@ -21,6 +21,7 @@
 #include <vtkNew.h>
 
 // STD includes
+#include <iostream>
 #include <sstream>
 
 // helper methods to check children ordering

--- a/Libs/MRML/Core/Testing/vtkMRMLDisplayableNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDisplayableNodeTest1.cxx
@@ -23,6 +23,9 @@
 #include <vtkObjectFactory.h>
 #include <vtkSmartPointer.h>
 
+// STD includes
+#include <iostream>
+
 //----------------------------------------------------------------------------
 class vtkMRMLDisplayableNodeTestHelper1 : public vtkMRMLDisplayableNode
 {

--- a/Libs/MRML/Core/Testing/vtkMRMLHierarchyNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLHierarchyNodeTest1.cxx
@@ -17,6 +17,9 @@
 // VTK includes
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <iostream>
+
 //---------------------------------------------------------------------------
 class vtkMRMLHierarchyNodeTestHelper1 : public vtkMRMLHierarchyNode
 {

--- a/Libs/MRML/Core/Testing/vtkMRMLHierarchyNodeTest3.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLHierarchyNodeTest3.cxx
@@ -21,6 +21,7 @@
 #include <vtkNew.h>
 
 // STD includes
+#include <iostream>
 #include <sstream>
 
 // helper methods to check children ordering

--- a/Libs/MRML/Core/Testing/vtkMRMLInteractionNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLInteractionNodeTest1.cxx
@@ -14,6 +14,9 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLInteractionNodeTest1(int, char*[])
 {
   vtkNew<vtkMRMLInteractionNode> node1;

--- a/Libs/MRML/Core/Testing/vtkMRMLLinearTransformNodeEventsTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLLinearTransformNodeEventsTest.cxx
@@ -18,6 +18,9 @@
 #include <vtkGeneralTransform.h>
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 //---------------------------------------------------------------------------
 int vtkMRMLLinearTransformNodeEventsTest(int, char*[])
 {

--- a/Libs/MRML/Core/Testing/vtkMRMLModelDisplayNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLModelDisplayNodeTest1.cxx
@@ -26,6 +26,9 @@
 #include <vtkUnstructuredGrid.h>
 #include <vtkVoxel.h>
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 const char* VOXEL_ARRAY_NAME = "ids";

--- a/Libs/MRML/Core/Testing/vtkMRMLModelHierarchyNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLModelHierarchyNodeTest1.cxx
@@ -21,6 +21,9 @@
 #include <vtkCollection.h>
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLModelHierarchyNodeTest1(int, char*[])
 {
   vtkNew<vtkMRMLModelHierarchyNode> node1;

--- a/Libs/MRML/Core/Testing/vtkMRMLModelNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLModelNodeTest1.cxx
@@ -21,6 +21,9 @@
 #include <vtkSphereSource.h>
 #include <vtkUnstructuredGrid.h>
 
+// STD includes
+#include <iostream>
+
 //---------------------------------------------------------------------------
 int ExerciseBasicMethods();
 int TestActiveScalars();

--- a/Libs/MRML/Core/Testing/vtkMRMLModelStorageNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLModelStorageNodeTest1.cxx
@@ -24,6 +24,9 @@ Program:   3D Slicer
 
 #include <array>
 
+// STD includes
+#include <iostream>
+
 //---------------------------------------------------------------------------
 int TestReadWriteData(vtkMRMLScene* scene, const char* extension, vtkPointSet* mesh, int coordinateSystem, bool cellsMayBeSubdivided = false);
 void CreateVoxelMeshes(vtkUnstructuredGrid* ug, vtkPolyData* poly);

--- a/Libs/MRML/Core/Testing/vtkMRMLNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLNodeTest1.cxx
@@ -31,6 +31,7 @@
 #include "vtkAddonSetGet.h"
 
 // STD includes
+#include <iostream>
 #include <sstream>
 
 using namespace vtkAddonTestingUtilities;

--- a/Libs/MRML/Core/Testing/vtkMRMLNonlinearTransformNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLNonlinearTransformNodeTest1.cxx
@@ -30,6 +30,9 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 int TestBSplineTransform(const char* filename);
 int TestGridTransform(const char* filename);
 int TestThinPlateSplineTransform(const char* filename);

--- a/Libs/MRML/Core/Testing/vtkMRMLPlotChartNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLPlotChartNodeTest1.cxx
@@ -29,6 +29,9 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLPlotChartNodeTest1(int, char*[])
 {
   // Create a PlotChart node

--- a/Libs/MRML/Core/Testing/vtkMRMLPlotSeriesNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLPlotSeriesNodeTest1.cxx
@@ -28,6 +28,9 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLPlotSeriesNodeTest1(int, char*[])
 {
   vtkNew<vtkMRMLScene> scene;

--- a/Libs/MRML/Core/Testing/vtkMRMLPlotViewNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLPlotViewNodeTest1.cxx
@@ -23,6 +23,9 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLPlotViewNodeTest1(int, char*[])
 {
   vtkNew<vtkMRMLPlotViewNode> node1;

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneImportIDConflictTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneImportIDConflictTest.cxx
@@ -28,6 +28,7 @@
 #include <vtkPolyData.h>
 
 // STD includes
+#include <iostream>
 #include <vtkNew.h>
 
 using namespace vtkMRMLCoreTestingUtilities;

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneImportIDModelHierarchyConflictTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneImportIDModelHierarchyConflictTest.cxx
@@ -23,6 +23,7 @@
 #include "vtkMRMLScene.h"
 
 // STD includes
+#include <iostream>
 #include <vtkNew.h>
 #include <vtkPolyData.h>
 

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneImportIDModelHierarchyParentIDConflictTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneImportIDModelHierarchyParentIDConflictTest.cxx
@@ -21,6 +21,7 @@
 #include "vtkMRMLScene.h"
 
 // STD includes
+#include <iostream>
 #include <sstream>
 #include <vector>
 

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneImportTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneImportTest.cxx
@@ -26,6 +26,9 @@
 #include <vtkNew.h>
 #include <vtksys/SystemTools.hxx>
 
+// STD includes
+#include <iostream>
+
 //---------------------------------------------------------------------------
 int vtkMRMLSceneImportTest(int argc, char* argv[])
 {

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneTest1.cxx
@@ -18,6 +18,9 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 //------------------------------------------------------------------------------
 class vtkMRMLCustomNode : public vtkMRMLNode
 {

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneTest2.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneTest2.cxx
@@ -24,6 +24,7 @@
 
 // STD includes
 #include <algorithm>
+#include <iostream>
 #include <iterator>
 #include <set>
 #include <sstream>

--- a/Libs/MRML/Core/Testing/vtkMRMLScriptedModuleNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLScriptedModuleNodeTest1.cxx
@@ -14,6 +14,9 @@
 #include "vtkMRMLScene.h"
 #include "vtkMRMLScriptedModuleNode.h"
 
+// STD includes
+#include <iostream>
+
 int TestScriptedModuleParameterSaveLoadSpecialCharacters();
 
 int vtkMRMLScriptedModuleNodeTest1(int, char*[])

--- a/Libs/MRML/Core/Testing/vtkMRMLSegmentationStorageNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSegmentationStorageNodeTest1.cxx
@@ -33,6 +33,9 @@ Care Ontario.
 #include "vtkFractionalLabelmapToClosedSurfaceConversionRule.h"
 #include "vtkClosedSurfaceToFractionalLabelmapConversionRule.h"
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLSegmentationStorageNodeTest1(int argc, char* argv[])
 {
   vtkNew<vtkMRMLSegmentationStorageNode> node1;

--- a/Libs/MRML/Core/Testing/vtkMRMLSelectionNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSelectionNodeTest1.cxx
@@ -14,6 +14,9 @@
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLSelectionNode.h"
 
+// STD includes
+#include <iostream>
+
 // ---------------------------------------------------------------------------
 int TestUnit(vtkMRMLSelectionNode* node1);
 

--- a/Libs/MRML/Core/Testing/vtkMRMLSequenceNodeAttributesTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSequenceNodeAttributesTest.cxx
@@ -27,6 +27,9 @@
 #include <vtkOrientedGridTransform.h>
 #include "vtkMRMLGridTransformNode.h"
 
+// STD includes
+#include <iostream>
+
 /// Test that node attributes of volume nodes and transform nodes in sequences can be stored
 /// in volume sequence and transform sequence files.
 

--- a/Libs/MRML/Core/Testing/vtkMRMLStorageNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLStorageNodeTest1.cxx
@@ -21,6 +21,9 @@
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 enum TestReadReferenceType

--- a/Libs/MRML/Core/Testing/vtkMRMLTableNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTableNodeTest1.cxx
@@ -45,6 +45,9 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 template <class ArrayType, typename ValueType>

--- a/Libs/MRML/Core/Testing/vtkMRMLTableSQLiteStorageNodeTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTableSQLiteStorageNodeTest.cxx
@@ -30,6 +30,7 @@
 
 // ITKSYS includes
 #include <itksys/SystemTools.hxx>
+#include <iostream>
 
 #include "vtkMRMLCoreTestingMacros.h"
 

--- a/Libs/MRML/Core/Testing/vtkMRMLTableStorageNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTableStorageNodeTest1.cxx
@@ -30,6 +30,9 @@
 
 #include <vtksys/SystemTools.hxx>
 
+// STD includes
+#include <iostream>
+
 //---------------------------------------------------------------------------
 int TestReadWriteWithoutSchema(vtkMRMLScene* scene);
 int TestReadWriteWithSchema(vtkMRMLScene* scene);

--- a/Libs/MRML/Core/Testing/vtkMRMLTableViewNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTableViewNodeTest1.cxx
@@ -26,6 +26,9 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLTableViewNodeTest1(int, char*[])
 {
   vtkNew<vtkMRMLTableViewNode> node1;

--- a/Libs/MRML/Core/Testing/vtkMRMLTextStorageNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTextStorageNodeTest1.cxx
@@ -25,6 +25,9 @@
 
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 //---------------------------------------------------------------------------
 int TestReadWriteData(vtkMRMLScene* scene, const char* extension, std::string text, int encoding);
 

--- a/Libs/MRML/Core/Testing/vtkMRMLTransformNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTransformNodeTest1.cxx
@@ -23,6 +23,9 @@
 #include <vtkTransform.h>
 #include <vtkAddonMathUtilities.h>
 
+// STD includes
+#include <iostream>
+
 vtkMatrix4x4* CreateTransformMatrix(double translateX, double translateY, double translateZ, double rotateX, double rotateY, double rotateZ)
 {
   vtkNew<vtkTransform> tr;

--- a/Libs/MRML/Core/Testing/vtkMRMLTransformSequenceStorageNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTransformSequenceStorageNodeTest1.cxx
@@ -26,6 +26,9 @@
 #include <sstream>
 #include <iomanip>
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 std::string tempFilename(std::string tempDir, std::string suffix, std::string fileExtension, bool remove = false)

--- a/Libs/MRML/Core/Testing/vtkMRMLTransformStorageNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTransformStorageNodeTest1.cxx
@@ -23,6 +23,9 @@
 #include "vtkMRMLTransformStorageNode.h"
 #include "vtkMRMLScene.h"
 
+// STD includes
+#include <iostream>
+
 int TestSaveAndRead(std::string filename, vtkMRMLScene* scene, vtkMatrix4x4* matrix, double centerOfTransformation[3])
 {
   std::cout << std::endl << "|||||||||||||" << std::endl << filename << std::endl << std::endl;

--- a/Libs/MRML/Core/Testing/vtkMRMLTransformStorageNodeTest2.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTransformStorageNodeTest2.cxx
@@ -26,6 +26,7 @@
 #include <vtkGeneralTransform.h>
 #include <sstream>
 #include <iomanip>
+#include <iostream>
 #include <chrono>
 
 namespace

--- a/Libs/MRML/Core/Testing/vtkMRMLTransformableNodeOnNodeReferenceAddTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTransformableNodeOnNodeReferenceAddTest.cxx
@@ -32,6 +32,9 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 

--- a/Libs/MRML/Core/Testing/vtkMRMLTransformableNodeReferenceSaveImportTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTransformableNodeReferenceSaveImportTest.cxx
@@ -28,6 +28,9 @@
 // VTK includes
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 

--- a/Libs/MRML/Core/Testing/vtkMRMLTransformableNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTransformableNodeTest1.cxx
@@ -21,6 +21,9 @@
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <iostream>
+
 //---------------------------------------------------------------------------
 class vtkMRMLTransformableNodeTestHelper1 : public vtkMRMLTransformableNode
 {

--- a/Libs/MRML/Core/Testing/vtkMRMLUnitNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLUnitNodeTest1.cxx
@@ -28,6 +28,7 @@
 
 // STD includes
 #include <vector>
+#include <iostream>
 
 const size_t NUMBER_OF_UNITS = 5;
 const char* UNITS[NUMBER_OF_UNITS][2] = { { "length", "m" }, { "length", "km" }, { "energy", "J" }, { "luminous_intensity", "cd" }, { "energy", "eV" } };

--- a/Libs/MRML/Core/Testing/vtkMRMLVolumeArchetypeStorageNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLVolumeArchetypeStorageNodeTest1.cxx
@@ -22,6 +22,7 @@
 #include "vtkPointData.h"
 #include <vtksys/SystemTools.hxx>
 #include <vtkTransform.h>
+#include <iostream>
 
 std::string tempFilename(std::string tempDir, std::string suffix, std::string fileExtension, bool remove = false)
 {

--- a/Libs/MRML/Core/Testing/vtkMRMLVolumeDisplayNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLVolumeDisplayNodeTest1.cxx
@@ -17,6 +17,9 @@
 // VTK includes
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <iostream>
+
 //---------------------------------------------------------------------------
 class vtkMRMLVolumeDisplayNodeTestHelper1 : public vtkMRMLVolumeDisplayNode
 {

--- a/Libs/MRML/Core/Testing/vtkMRMLVolumeNodeEventsTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLVolumeNodeEventsTest.cxx
@@ -27,6 +27,9 @@
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <iostream>
+
 //---------------------------------------------------------------------------
 class vtkMRMLTestVolumeNode : public vtkMRMLVolumeNode
 {

--- a/Libs/MRML/Core/Testing/vtkMRMLVolumeNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLVolumeNodeTest1.cxx
@@ -23,6 +23,7 @@
 
 // STD includes
 #include <list>
+#include <iostream>
 
 //----------------------------------------------------------------------------
 class vtkMRMLVolumeNodeTestHelper1 : public vtkMRMLVolumeNode

--- a/Libs/MRML/Core/Testing/vtkMRMLVolumeSequenceStorageNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLVolumeSequenceStorageNodeTest1.cxx
@@ -23,6 +23,7 @@
 #include <vtkPointData.h>
 #include <vtksys/SystemTools.hxx>
 #include <vtkTransform.h>
+#include <iostream>
 
 namespace
 {

--- a/Libs/MRML/Core/Testing/vtkObserverManagerTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkObserverManagerTest1.cxx
@@ -20,6 +20,9 @@
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
 
+// STD includes
+#include <iostream>
+
 struct callBackDataStruct
 {
   std::string testString;

--- a/Libs/MRML/Core/Testing/vtkOrientedBSplineTransformTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkOrientedBSplineTransformTest1.cxx
@@ -23,6 +23,9 @@
 #include "vtkMatrix4x4.h"
 #include "vtkNew.h"
 
+// STD includes
+#include <iostream>
+
 typedef itk::BSplineDeformableTransform<double, 3, 3> itkBSplineType;
 
 double DisplacementScale = 0.63;

--- a/Libs/MRML/Core/Testing/vtkOrientedGridTransformTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkOrientedGridTransformTest1.cxx
@@ -23,6 +23,9 @@
 #include "vtkMatrix4x4.h"
 #include "vtkNew.h"
 
+// STD includes
+#include <iostream>
+
 typedef double itkVectorComponentType;
 typedef itk::Vector<itkVectorComponentType, 3> itkVectorPixelType;
 typedef itk::Image<itkVectorPixelType, 3> itkDisplacementFieldType;

--- a/Libs/MRML/Core/Testing/vtkThinPlateSplineTransformTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkThinPlateSplineTransformTest1.cxx
@@ -22,6 +22,9 @@
 #include "vtkPoints.h"
 #include "vtkThinPlateSplineTransform.h"
 
+// STD includes
+#include <iostream>
+
 typedef itk::ThinPlateSplineKernelTransform<double, 3> itkThinPlateSplineType;
 typedef itkThinPlateSplineType::PointSetType PointSetType;
 

--- a/Libs/MRML/Core/vtkEventBroker.cxx
+++ b/Libs/MRML/Core/vtkEventBroker.cxx
@@ -22,6 +22,9 @@
 #include <vtkObjectFactory.h>
 #include <vtkTimerLog.h>
 
+// STD includes
+#include <iostream>
+
 vtkCxxSetObjectMacro(vtkEventBroker, TimerLog, vtkTimerLog);
 vtkCxxSetObjectMacro(vtkEventBroker, RequestModifiedCallback, vtkCallbackCommand);
 

--- a/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
@@ -30,6 +30,7 @@ Version:   $Revision: 1.6 $
 #include <vtkTable.h>
 
 // STD includes
+#include <iostream>
 #include <sstream>
 
 const std::vector<std::string> TERMINOLOGY_COLUMN_NAMES = { "Category_CodingScheme",       "Category_CodeValue",       "Category_CodeMeaning",
@@ -793,7 +794,7 @@ int vtkMRMLColorTableStorageNode::WriteCtblFile(std::string fullFileName, vtkMRM
       of << rgba[0] * 255.0 << " ";
       of << rgba[1] * 255.0 << " ";
       of << rgba[2] * 255.0 << " ";
-      of << rgba[3] * 255.0 << endl;
+      of << rgba[3] * 255.0 << std::endl;
     }
   }
 

--- a/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h
+++ b/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h
@@ -16,6 +16,9 @@
 // VTK includes
 #include <vtkMath.h>
 
+// STD includes
+#include <iostream>
+
 /// Convenience macros for unit tests.
 ///
 /// The macro returns from the current method with EXIT_FAILURE if the check fails.

--- a/Libs/MRML/Core/vtkMRMLCoreTestingUtilities.cxx
+++ b/Libs/MRML/Core/vtkMRMLCoreTestingUtilities.cxx
@@ -43,6 +43,9 @@
 #include <vtkURIHandler.h>
 #include <vtkXMLDataParser.h>
 
+// STD includes
+#include <iostream>
+
 namespace vtkMRMLCoreTestingUtilities
 {
 

--- a/Libs/MRML/Core/vtkMRMLHierarchyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLHierarchyNode.cxx
@@ -23,6 +23,7 @@ Version:   $Revision: 1.14 $
 
 // STD includes
 #include <algorithm>
+#include <iostream>
 #include <sstream>
 
 vtkCxxSetReferenceStringMacro(vtkMRMLHierarchyNode, ParentNodeIDReference);

--- a/Libs/MRML/Core/vtkMRMLHierarchyStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLHierarchyStorageNode.cxx
@@ -133,7 +133,7 @@ int vtkMRMLHierarchyStorageNode::WriteDataInternal(vtkMRMLNode* refNode)
   }
 
   // put down a header
-  of << "# hierarchy file " << (this->GetFileName() != nullptr ? this->GetFileName() : "null") << endl;
+  of << "# hierarchy file " << (this->GetFileName() != nullptr ? this->GetFileName() : "null") << std::endl;
 
   of.close();
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -755,8 +755,8 @@ int vtkMRMLMarkupsFiducialStorageNode::WriteDataInternal(vtkMRMLNode* refNode)
   }
 
   // put down a header
-  of << "# Markups fiducial file version = " << Slicer_VERSION << endl;
-  of << "# CoordinateSystem = " << vtkMRMLMarkupsStorageNode::GetCoordinateSystemAsString(this->GetCoordinateSystem()) << endl;
+  of << "# Markups fiducial file version = " << Slicer_VERSION << std::endl;
+  of << "# CoordinateSystem = " << vtkMRMLMarkupsStorageNode::GetCoordinateSystemAsString(this->GetCoordinateSystem()) << std::endl;
 
   // label the columns
   // id,x,y,z,ow,ox,oy,oz,vis,sel,lock,label,desc,associatedNodeID
@@ -771,11 +771,11 @@ int vtkMRMLMarkupsFiducialStorageNode::WriteDataInternal(vtkMRMLNode* refNode)
     separator = this->FieldDelimiterCharacters[0];
   }
   of << "# columns = id" << separator << "x" << separator << "y" << separator << "z" << separator << "ow" << separator << "ox" << separator << "oy" << separator << "oz"
-     << separator << "vis" << separator << "sel" << separator << "lock" << separator << "label" << separator << "desc" << separator << "associatedNodeID" << endl;
+     << separator << "vis" << separator << "sel" << separator << "lock" << separator << "label" << separator << "desc" << separator << "associatedNodeID" << std::endl;
   for (int i = 0; i < markupsNode->GetNumberOfControlPoints(); i++)
   {
     of << this->GetPointAsString(markupsNode, i);
-    of << endl;
+    of << std::endl;
   }
 
   of.close();

--- a/Libs/MRML/Core/vtkMRMLPETProceduralColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLPETProceduralColorNode.cxx
@@ -63,7 +63,7 @@ void vtkMRMLPETProceduralColorNode::PrintSelf(ostream& os, vtkIndent indent)
   Superclass::PrintSelf(os, indent);
   if (this->ColorTransferFunction != nullptr)
   {
-    os << indent << "ColorTransferFunction:" << endl;
+    os << indent << "ColorTransferFunction:" << std::endl;
     this->ColorTransferFunction->PrintSelf(os, indent.GetNextIndent());
   }
 }

--- a/Libs/MRML/Core/vtkMRMLProceduralColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLProceduralColorNode.cxx
@@ -103,7 +103,7 @@ void vtkMRMLProceduralColorNode::PrintSelf(ostream& os, vtkIndent indent)
   Superclass::PrintSelf(os, indent);
   if (this->ColorTransferFunction != nullptr)
   {
-    os << indent << "ColorTransferFunction:" << endl;
+    os << indent << "ColorTransferFunction:" << std::endl;
     this->ColorTransferFunction->PrintSelf(os, indent.GetNextIndent());
   }
 }

--- a/Libs/MRML/Core/vtkMRMLProceduralColorStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLProceduralColorStorageNode.cxx
@@ -184,10 +184,10 @@ int vtkMRMLProceduralColorStorageNode::WriteDataInternal(vtkMRMLNode* refNode)
     }
 
     // put down a header
-    of << "# Color procedural file " << (this->GetFileName() != nullptr ? this->GetFileName() : "null") << endl;
+    of << "# Color procedural file " << (this->GetFileName() != nullptr ? this->GetFileName() : "null") << std::endl;
     int numPoints = ctf->GetSize();
-    of << "# " << numPoints << " points" << endl;
-    of << "# position R G B" << endl;
+    of << "# " << numPoints << " points" << std::endl;
+    of << "# position R G B" << std::endl;
     for (int i = 0; i < numPoints; ++i)
     {
       double val[6];
@@ -200,7 +200,7 @@ int vtkMRMLProceduralColorStorageNode::WriteDataInternal(vtkMRMLNode* refNode)
       of << val[2];
       of << " ";
       of << val[3];
-      of << endl;
+      of << std::endl;
     }
     of.close();
   }

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -121,6 +121,7 @@ Version:   $Revision: 1.18 $
 
 // STD includes
 #include <algorithm>
+#include <iostream>
 #include <numeric>
 
 // #define MRMLSCENE_VERBOSE

--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyLegacyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyLegacyNode.cxx
@@ -34,6 +34,7 @@
 #include <vtkSmartPointer.h>
 
 // STD includes
+#include <iostream>
 #include <sstream>
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.cxx
@@ -41,6 +41,9 @@
 
 #include <vtksys/SystemTools.hxx>
 
+// STD includes
+#include <iostream>
+
 //------------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLTableSQLiteStorageNode);
 
@@ -228,7 +231,7 @@ int vtkMRMLTableSQLiteStorageNode::WriteDataInternal(vtkMRMLNode* refNode)
   vtkSQLiteQuery* query = static_cast<vtkSQLiteQuery*>(database->GetQueryInstance());
 
   query->SetQuery(createTableQuery.c_str());
-  cout << "creating the table" << endl;
+  std::cout << "creating the table" << std::endl;
   if (!query->Execute())
   {
     vtkErrorMacro(<< "Error performing 'create table' query");

--- a/Libs/MRML/Core/vtkMRMLdGEMRICProceduralColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLdGEMRICProceduralColorNode.cxx
@@ -75,7 +75,7 @@ void vtkMRMLdGEMRICProceduralColorNode::PrintSelf(ostream& os, vtkIndent indent)
   Superclass::PrintSelf(os, indent);
   if (this->ColorTransferFunction != nullptr)
   {
-    os << indent << "ColorTransferFunction:" << endl;
+    os << indent << "ColorTransferFunction:" << std::endl;
     this->ColorTransferFunction->PrintSelf(os, indent.GetNextIndent());
   }
 }

--- a/Libs/MRML/Core/vtkURIHandler.cxx
+++ b/Libs/MRML/Core/vtkURIHandler.cxx
@@ -5,6 +5,9 @@
 // VTK includes
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <iostream>
+
 vtkStandardNewMacro(vtkURIHandler);
 vtkCxxSetObjectMacro(vtkURIHandler, PermissionPrompter, vtkPermissionPrompter);
 //----------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLCameraDisplayableManagerTest1.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLCameraDisplayableManagerTest1.cxx
@@ -43,6 +43,7 @@
 #include <vtkWindowToImageFilter.h>
 
 // STD includes
+#include <iostream>
 #include <string>
 
 #include "vtkMRMLCoreTestingMacros.h"
@@ -456,7 +457,7 @@ bool readFileIntoString(const char* filename, std::string& output)
   std::ifstream istream(filename);
   if (!istream)
   {
-    cerr << "Could not open input file:" << filename << endl;
+    std::cerr << "Could not open input file:" << filename << std::endl;
     return false;
   }
 

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLDisplayableManagerFactoriesTest1.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLDisplayableManagerFactoriesTest1.cxx
@@ -26,6 +26,7 @@
 #include <vtkTesting.h>
 
 // STD includes
+#include <iostream>
 
 //----------------------------------------------------------------------------
 int vtkMRMLDisplayableManagerFactoriesTest1(int argc, char* argv[])

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLModelDisplayableManagerTest.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLModelDisplayableManagerTest.cxx
@@ -47,6 +47,7 @@
 #include <vtkWindowToImageFilter.h>
 
 // STD includes
+#include <iostream>
 #include <string>
 
 const char vtkMRMLModelDisplayableManagerTest1EventLog[] = //

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLSliceViewDisplayableManagerFactoryTest.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLSliceViewDisplayableManagerFactoryTest.cxx
@@ -37,6 +37,9 @@
 #include <vtkRenderWindowInteractor.h>
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 //----------------------------------------------------------------------------
 int vtkMRMLSliceViewDisplayableManagerFactoryTest(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
 {

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLTestCustomDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLTestCustomDisplayableManager.cxx
@@ -31,6 +31,7 @@
 
 // STD includes
 #include <cassert>
+#include <iostream>
 
 //---------------------------------------------------------------------------
 vtkStandardNewMacro(vtkMRMLTestCustomDisplayableManager);

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLTestSliceViewDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLTestSliceViewDisplayableManager.cxx
@@ -29,6 +29,7 @@
 
 // STD includes
 #include <cassert>
+#include <iostream>
 
 //---------------------------------------------------------------------------
 vtkStandardNewMacro(vtkMRMLTestSliceViewDisplayableManager);

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLTestThreeDViewDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLTestThreeDViewDisplayableManager.cxx
@@ -29,6 +29,7 @@
 
 // STD includes
 #include <cassert>
+#include <iostream>
 
 //---------------------------------------------------------------------------
 vtkStandardNewMacro(vtkMRMLTestThreeDViewDisplayableManager);

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLThreeDReformatDisplayableManagerTest1.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLThreeDReformatDisplayableManagerTest1.cxx
@@ -47,6 +47,7 @@
 #include <vtkWindowToImageFilter.h>
 
 // STD includes
+#include <iostream>
 #include <string>
 
 #include "vtkMRMLCoreTestingMacros.h"

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLThreeDViewDisplayableManagerFactoryTest1.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLThreeDViewDisplayableManagerFactoryTest1.cxx
@@ -36,6 +36,9 @@
 #include <vtkRenderer.h>
 #include <vtkSmartPointer.h>
 
+// STD includes
+#include <iostream>
+
 // Initialize object factory
 #define MRMLDisplayableManagerCxxTests_AUTOINIT 1(MRMLDisplayableManagerCxxTests)
 #include <vtkAutoInit.h>

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractDisplayableManager.cxx
@@ -46,6 +46,7 @@
 #include <cassert>
 #include <algorithm>
 #include <functional>
+#include <iostream>
 
 #if (_MSC_VER >= 1700 && _MSC_VER < 1800)
 // Visual Studio 2012 moves bind1st to <functional>

--- a/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.cxx
@@ -36,6 +36,7 @@
 #include <vtkSmartPointer.h>
 
 // STD includes
+#include <iostream>
 
 //---------------------------------------------------------------------------
 vtkStandardNewMacro(vtkMRMLScriptedDisplayableManager);

--- a/Libs/MRML/DisplayableManager/vtkMRMLVolumeGlyphSliceDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLVolumeGlyphSliceDisplayableManager.cxx
@@ -42,6 +42,7 @@
 // STD includes
 #include <algorithm>
 #include <cassert>
+#include <iostream>
 
 //---------------------------------------------------------------------------
 vtkStandardNewMacro(vtkMRMLVolumeGlyphSliceDisplayableManager);

--- a/Libs/MRML/IDImageIO/itkMRMLIDImageIO.cxx
+++ b/Libs/MRML/IDImageIO/itkMRMLIDImageIO.cxx
@@ -28,6 +28,9 @@ Version:   $Revision: 1.18 $
 #include <vtkMatrix4x4.h>
 #include <vtkPointData.h>
 
+// STD includes
+#include <iostream>
+
 namespace itk
 {
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Logic/Testing/Cxx/CMakeLists.txt
+++ b/Libs/MRML/Logic/Testing/Cxx/CMakeLists.txt
@@ -19,7 +19,7 @@ list(APPEND ITK_INCLUDE_DIRS
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------
-set(EXTRA_INCLUDE "vtkMRMLDebugLeaksMacro.h\"\n\#include \"vtkTestingOutputWindow.h")
+set(EXTRA_INCLUDE "vtkMRMLDebugLeaksMacro.h\"\n\#include <iostream>\n\#include \"vtkTestingOutputWindow.h")
 set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN "DEBUG_LEAKS_ENABLE_EXIT_ERROR();\nTESTING_OUTPUT_ASSERT_WARNINGS_ERRORS(0);" )
 set(CMAKE_TESTDRIVER_AFTER_TESTMAIN "TESTING_OUTPUT_ASSERT_WARNINGS_ERRORS(0);" )
 create_test_sourcelist(Tests ${KIT}CxxTests.cxx

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLApplicationLogicTest1.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLApplicationLogicTest1.cxx
@@ -30,6 +30,7 @@
 #include <vtksys/SystemTools.hxx>
 
 // STD includes
+#include <iostream>
 #include <sstream>
 #include <string>
 

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLColorLogicTest1.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLColorLogicTest1.cxx
@@ -35,6 +35,7 @@
 #include <vtkTimerLog.h>
 
 // STD includes
+#include <iostream>
 
 #include "vtkMRMLCoreTestingMacros.h"
 

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLDisplayableHierarchyLogicTest1.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLDisplayableHierarchyLogicTest1.cxx
@@ -23,6 +23,9 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLDisplayableHierarchyLogicTest1(int, char*[])
 {
   vtkNew<vtkMRMLScene> scene;

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLLayoutLogicCompareTest.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLLayoutLogicCompareTest.cxx
@@ -13,6 +13,7 @@
 #include <vtkNew.h>
 
 // STD includes
+#include <iostream>
 
 bool TestSetSlicerLayoutCompareGridView();
 bool TestSetSlicerLayoutCompareGridViewEvents();

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLLayoutLogicTest1.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLLayoutLogicTest1.cxx
@@ -12,6 +12,9 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLLayoutLogicTest1(int, char*[])
 {
   vtkNew<vtkMRMLScene> scene;

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLLayoutLogicTest2.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLLayoutLogicTest2.cxx
@@ -12,6 +12,9 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLLayoutLogicTest2(int, char*[])
 {
   vtkNew<vtkMRMLLayoutLogic> logic;

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLayerLogicTest.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLayerLogicTest.cxx
@@ -36,6 +36,9 @@
 #include <vtkPointData.h>
 #include <vtkTrivialProducer.h>
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 bool testDTIPipeline();

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest1.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest1.cxx
@@ -27,6 +27,9 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLSliceLogicTest1(int, char*[])
 {
   vtkNew<vtkMRMLSliceLogic> logic;

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest2.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest2.cxx
@@ -50,6 +50,9 @@
 #include <itkConfigure.h>
 #include <itkFactoryRegistration.h>
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 int vtkMRMLSliceLogicTest2(int argc, char* argv[])
 {

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest3.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest3.cxx
@@ -42,6 +42,9 @@
 #include <itkConfigure.h>
 #include <itkFactoryRegistration.h>
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 vtkMRMLScalarVolumeNode* loadVolume(const char* volume, vtkMRMLScene* scene)
 {

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest4.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest4.cxx
@@ -39,6 +39,9 @@
 #include <itkConfigure.h>
 #include <itkFactoryRegistration.h>
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 vtkMRMLScalarVolumeNode* loadVolume2(const char* volume, vtkMRMLScene* scene)
 {

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest5.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest5.cxx
@@ -43,6 +43,9 @@
 #include <itkConfigure.h>
 #include <itkFactoryRegistration.h>
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 vtkMRMLScalarVolumeNode* vtkMRMLSliceLogicTest5_loadVolume(const char* volume, vtkMRMLScene* scene)
 {

--- a/Libs/MRML/Logic/vtkImageNeighborhoodFilter.cxx
+++ b/Libs/MRML/Logic/vtkImageNeighborhoodFilter.cxx
@@ -14,6 +14,7 @@
 #include "vtkImageNeighborhoodFilter.h"
 
 #include "vtkObjectFactory.h"
+#include <iostream>
 
 //------------------------------------------------------------------------------
 vtkStandardNewMacro(vtkImageNeighborhoodFilter);

--- a/Libs/MRML/Logic/vtkMRMLDisplayableHierarchyLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLDisplayableHierarchyLogic.cxx
@@ -25,6 +25,9 @@
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <iostream>
+
 vtkStandardNewMacro(vtkMRMLDisplayableHierarchyLogic);
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Logic/vtkMRMLLayoutLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLLayoutLogic.cxx
@@ -40,6 +40,7 @@
 
 // STD includes
 #include <cassert>
+#include <iostream>
 #include <sstream>
 
 // Standard layouts definitions

--- a/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
@@ -50,6 +50,7 @@
 
 // STD includes
 #include <algorithm>
+#include <iostream>
 
 //----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkMRMLSliceLayerLogic);

--- a/Libs/MRML/Logic/vtkMRMLSliceLinkLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLinkLogic.cxx
@@ -35,6 +35,7 @@
 
 // STD includes
 #include <cassert>
+#include <iostream>
 
 //----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkMRMLSliceLinkLogic);

--- a/Libs/MRML/Widgets/Testing/CMakeLists.txt
+++ b/Libs/MRML/Widgets/Testing/CMakeLists.txt
@@ -29,6 +29,8 @@ set(CMAKE_TESTDRIVER_AFTER_TESTMAIN  "
   DEBUG_LEAKS_ENABLE_EXIT_ERROR();
   ")
 
+set(EXTRA_INCLUDE "vtkMRMLDebugLeaksMacro.h\"\n\#include <itkConfigure.h>\n\#include <itkFactoryRegistration.h>\n\#include <iostream>\n\#include \"vtkTestingOutputWindow.h")
+
 set(TEST_SOURCES
   qMRMLCheckableNodeComboBoxTest.cxx
   qMRMLCheckableNodeComboBoxTest1.cxx
@@ -127,6 +129,7 @@ endif()
 
 create_test_sourcelist(Tests ${KIT}CppTests.cxx
   ${TEST_SOURCES}
+  EXTRA_INCLUDE ${EXTRA_INCLUDE}
   )
 
 set(Tests_UtilityFiles

--- a/Libs/MRML/Widgets/Testing/qMRMLCheckableNodeComboBoxTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLCheckableNodeComboBoxTest1.cxx
@@ -35,6 +35,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLCheckableNodeComboBoxTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLClipNodeWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLClipNodeWidgetTest1.cxx
@@ -38,6 +38,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLClipNodeWidgetTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLColorTableComboBoxTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorTableComboBoxTest1.cxx
@@ -34,6 +34,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLColorTableComboBoxTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLDisplayNodeWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLDisplayNodeWidgetTest1.cxx
@@ -36,6 +36,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLDisplayNodeWidgetTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest1.cxx
@@ -48,6 +48,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 //------------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest2.cxx
@@ -37,6 +37,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 // Common test driver includes
 #include "qMRMLWidgetCxxTests.h"
 #include "qMRMLLayoutManagerTestHelper.cxx"

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest3.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest3.cxx
@@ -42,6 +42,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 // Common test driver includes
 #include "qMRMLWidgetCxxTests.h"
 

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTestHelper.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTestHelper.cxx
@@ -6,6 +6,9 @@
 #include <vtkMRMLLayoutNode.h>
 #include <qMRMLLayoutManager.h>
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerVisibilityTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerVisibilityTest.cxx
@@ -45,6 +45,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 // --------------------------------------------------------------------------
 bool checkNodeVisibility(int line, vtkMRMLAbstractViewNode* viewNode, bool expectedNodeVisibility)
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerWithCustomFactoryTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerWithCustomFactoryTest.cxx
@@ -51,6 +51,9 @@
 #include <vtkWeakPointer.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 //------------------------------------------------------------------------------
 class qSlicerLayoutCustomSliceViewFactory : public qMRMLLayoutSliceViewFactory
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLMatrixWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLMatrixWidgetTest1.cxx
@@ -13,6 +13,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 int qMRMLMatrixWidgetTest1(int argc, char* argv[])
 {
   qMRMLWidget::preInitializeApplication();

--- a/Libs/MRML/Widgets/Testing/qMRMLModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLModelTest1.cxx
@@ -35,6 +35,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLModelTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeAttributeTableViewTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeAttributeTableViewTest.cxx
@@ -23,6 +23,9 @@
 #include <QApplication>
 #include <QItemSelectionModel>
 
+// STD includes
+#include <iostream>
+
 // CTK includes
 #include "ctkTest.h"
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxLazyUpdateTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxLazyUpdateTest1.cxx
@@ -41,6 +41,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLNodeComboBoxLazyUpdateTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest1.cxx
@@ -36,6 +36,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLNodeComboBoxTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest2.cxx
@@ -36,6 +36,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLNodeComboBoxTest2(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest3.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest3.cxx
@@ -35,6 +35,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 // Common test driver includes
 #include "qMRMLWidgetCxxTests.h"
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest4.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest4.cxx
@@ -36,6 +36,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 int qMRMLNodeComboBoxTest4(int argc, char* argv[])
 {
   qMRMLWidget::preInitializeApplication();

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest5.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest5.cxx
@@ -37,6 +37,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 int qMRMLNodeComboBoxTest5(int argc, char* argv[])
 {
   qMRMLWidget::preInitializeApplication();

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest7.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest7.cxx
@@ -33,6 +33,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 // test the filtering with many cases
 int qMRMLNodeComboBoxTest7(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest8.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest8.cxx
@@ -36,6 +36,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest9.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest9.cxx
@@ -37,6 +37,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 // test the filtering with many cases
 int qMRMLNodeComboBoxTest9(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeFactoryTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeFactoryTest1.cxx
@@ -37,6 +37,7 @@
 
 // STD includes
 #include <cstdlib>
+#include <iostream>
 
 int qMRMLNodeFactoryTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLScalarInvariantComboBoxTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLScalarInvariantComboBoxTest1.cxx
@@ -36,6 +36,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLScalarInvariantComboBoxTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneCategoryModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneCategoryModelTest1.cxx
@@ -40,6 +40,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLSceneCategoryModelTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneDisplayableModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneDisplayableModelTest1.cxx
@@ -37,6 +37,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 // MRML includes
 #include <vtkMRMLDisplayableHierarchyNode.h>

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneDisplayableModelTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneDisplayableModelTest2.cxx
@@ -36,6 +36,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 int qMRMLSceneDisplayableModelTest2(int argc, char* argv[])
 {
   qMRMLWidget::preInitializeApplication();

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneFactoryWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneFactoryWidgetTest1.cxx
@@ -34,6 +34,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLSceneFactoryWidgetTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneHierarchyModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneHierarchyModelTest1.cxx
@@ -41,6 +41,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLSceneHierarchyModelTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneTransformModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneTransformModelTest1.cxx
@@ -37,6 +37,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLSceneTransformModelTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneTransformModelTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneTransformModelTest2.cxx
@@ -36,6 +36,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 int qMRMLSceneTransformModelTest2(int argc, char* argv[])
 {
   qMRMLWidget::preInitializeApplication();

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest1.cxx
@@ -44,6 +44,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 int qMRMLSliceWidgetTest1(int argc, char* argv[])
 {
   qMRMLWidget::preInitializeApplication();

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest2.cxx
@@ -48,6 +48,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 vtkMRMLScalarVolumeNode* loadVolume(const char* volume, vtkMRMLScene* scene)
 {
   vtkNew<vtkMRMLScalarVolumeDisplayNode> displayNode;

--- a/Libs/MRML/Widgets/Testing/qMRMLThreeDViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLThreeDViewTest1.cxx
@@ -36,6 +36,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLThreeDViewTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLTransformSlidersTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLTransformSlidersTest1.cxx
@@ -11,6 +11,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLTransformSlidersTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLTreeViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLTreeViewTest1.cxx
@@ -33,6 +33,7 @@
 #include <vtkTimerLog.h>
 
 // STD includes
+#include <iostream>
 
 int qMRMLTreeViewTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest1.cxx
@@ -40,6 +40,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLVolumeThresholdWidgetTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest2.cxx
@@ -46,6 +46,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLVolumeThresholdWidgetTest2(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetTest1.cxx
@@ -40,6 +40,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLWindowLevelWidgetTest1(int argc, char* argv[])
 {

--- a/Libs/MRML/Widgets/qMRMLEventLogger.cxx
+++ b/Libs/MRML/Widgets/qMRMLEventLogger.cxx
@@ -24,6 +24,9 @@
 // MRML includes
 #include <vtkMRMLScene.h>
 
+// STD includes
+#include <iostream>
+
 //------------------------------------------------------------------------------
 // qMRMLEventLoggerPrivate methods
 

--- a/Libs/MRML/Widgets/qMRMLSceneHierarchyModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSceneHierarchyModel.cxx
@@ -33,6 +33,9 @@
 #include <vtkCollection.h>
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 //------------------------------------------------------------------------------
 qMRMLSceneHierarchyModelPrivate::qMRMLSceneHierarchyModelPrivate(qMRMLSceneHierarchyModel& object)
   : Superclass(object)

--- a/Libs/MRML/Widgets/qMRMLSortFilterProxyModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSortFilterProxyModel.cxx
@@ -28,6 +28,9 @@
 #include <vtkMRMLNode.h>
 #include <vtkMRMLScene.h>
 
+// STD includes
+#include <iostream>
+
 // -----------------------------------------------------------------------------
 // qMRMLSortFilterProxyModelPrivate
 

--- a/Libs/RemoteIO/vtkHTTPHandler.cxx
+++ b/Libs/RemoteIO/vtkHTTPHandler.cxx
@@ -8,6 +8,9 @@
 // CURL includes
 #include <curl/curl.h>
 
+// STD includes
+#include <iostream>
+
 #if defined(_MSC_VER)
 # pragma warning(disable : 4786)
 #endif

--- a/Libs/vtkITK/Testing/VTKITKVectorReader.cxx
+++ b/Libs/vtkITK/Testing/VTKITKVectorReader.cxx
@@ -8,6 +8,9 @@
 #include <itkConfigure.h>
 #include <itkFactoryRegistration.h>
 
+// STD includes
+#include <iostream>
+
 int main(int argc, char* argv[])
 {
   itk::itkFactoryRegistration();

--- a/Libs/vtkITK/vtkITKImageSequenceReader.cxx
+++ b/Libs/vtkITK/vtkITKImageSequenceReader.cxx
@@ -37,6 +37,7 @@
 #include "itkVectorIndexSelectionCastImageFilter.h"
 
 // STD includes
+#include <iostream>
 #include <sstream>
 #include <iomanip> // for std::setw and std::setfill
 

--- a/Libs/vtkITK/vtkITKImageSequenceWriter.cxx
+++ b/Libs/vtkITK/vtkITKImageSequenceWriter.cxx
@@ -43,6 +43,9 @@
 #include <itkMetaDataObject.h>
 #include <itkVTKImageImport.h>
 
+// STD includes
+#include <iostream>
+
 #define NRRD_DIM_MAX 16
 
 class AttributeMapType : public std::map<std::string, std::string>

--- a/Libs/vtkITK/vtkITKImageToImageFilter.h
+++ b/Libs/vtkITK/vtkITKImageToImageFilter.h
@@ -30,6 +30,9 @@
 #include <vtkImageImport.h>
 #include <vtkVersion.h>
 
+// STD includes
+#include <iostream>
+
 #undef itkExceptionMacro
 #define itkExceptionMacro(x)                                                     \
   {                                                                              \

--- a/Libs/vtkITK/vtkITKImageToImageFilterF2F2.h
+++ b/Libs/vtkITK/vtkITKImageToImageFilterF2F2.h
@@ -26,6 +26,9 @@
 #include "vtkITKUtility.h"
 #include <vtkVersion.h>
 
+// STD includes
+#include <iostream>
+
 class VTK_ITK_EXPORT vtkITKImageToImageFilterF2F2 : public vtkITKImageToImageFilter
 {
 public:

--- a/Libs/vtkITK/vtkITKImageWriter.cxx
+++ b/Libs/vtkITK/vtkITKImageWriter.cxx
@@ -27,6 +27,9 @@
 #include <vtkStreamingDemandDrivenPipeline.h>
 #include <vtkVersion.h>
 
+// STD includes
+#include <iostream>
+
 // VTKsys includes
 #include <vtksys/SystemTools.hxx>
 

--- a/Libs/vtkSegmentationCore/Testing/vtkClosedSurfaceToFractionalLabelMapConversionTest1.cxx
+++ b/Libs/vtkSegmentationCore/Testing/vtkClosedSurfaceToFractionalLabelMapConversionTest1.cxx
@@ -33,6 +33,9 @@
 #include <vtkSegmentationConverter.h>
 #include <vtkSegmentationConverterFactory.h>
 
+// STD includes
+#include <iostream>
+
 void CreateSpherePolyData(vtkPolyData* polyData);
 
 //----------------------------------------------------------------------------

--- a/Libs/vtkSegmentationCore/Testing/vtkSegmentationConverterTest1.cxx
+++ b/Libs/vtkSegmentationCore/Testing/vtkSegmentationConverterTest1.cxx
@@ -22,6 +22,9 @@
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <iostream>
+
 // SegmentationCore includes
 #include <vtkSegmentationConverter.h>
 #include <vtkSegmentationConverterFactory.h>

--- a/Libs/vtkSegmentationCore/Testing/vtkSegmentationHistoryTest1.cxx
+++ b/Libs/vtkSegmentationCore/Testing/vtkSegmentationHistoryTest1.cxx
@@ -28,6 +28,9 @@
 #include <vtkSphereSource.h>
 #include <vtkVersion.h>
 
+// STD includes
+#include <iostream>
+
 // Get CHECK_INT from vtkAddonTestingMacros.h to avoid dependency on vtkAddon
 namespace
 {

--- a/Libs/vtkSegmentationCore/Testing/vtkSegmentationTest1.cxx
+++ b/Libs/vtkSegmentationCore/Testing/vtkSegmentationTest1.cxx
@@ -35,6 +35,9 @@
 #include "vtkBinaryLabelmapToClosedSurfaceConversionRule.h"
 #include "vtkClosedSurfaceToBinaryLabelmapConversionRule.h"
 
+// STD includes
+#include <iostream>
+
 void CreateSpherePolyData(vtkPolyData* polyData);
 void CreateCubeLabelmap(vtkOrientedImageData* imageData);
 

--- a/Libs/vtkSegmentationCore/Testing/vtkSegmentationTest2.cxx
+++ b/Libs/vtkSegmentationCore/Testing/vtkSegmentationTest2.cxx
@@ -27,6 +27,9 @@
 #include <vtkMatrix4x4.h>
 #include <vtkImageAccumulate.h>
 
+// STD includes
+#include <iostream>
+
 // SegmentationCore includes
 #include "vtkSegmentation.h"
 #include "vtkSegment.h"

--- a/Libs/vtkTeem/Testing/vtkDiffusionTensorMathematicsTest1.cxx
+++ b/Libs/vtkTeem/Testing/vtkDiffusionTensorMathematicsTest1.cxx
@@ -29,6 +29,9 @@
 #include <vtkPointData.h>
 #include <vtkVersion.h>
 
+// STD includes
+#include <iostream>
+
 //----------------------------------------------------------------------------
 int vtkDiffusionTensorMathematicsTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
 {

--- a/Libs/vtkTeem/vtkDiffusionTensorGlyph.cxx
+++ b/Libs/vtkTeem/vtkDiffusionTensorGlyph.cxx
@@ -754,7 +754,7 @@ void vtkDiffusionTensorGlyph::PrintSelf(ostream& os, vtkIndent indent)
 
   os << indent << "Color Glyphs by Scalar Invariant: " << this->ScalarInvariant << "\n";
   os << indent << "Mask Glyphs: " << (this->MaskGlyphs ? "On\n" : "Off\n");
-  os << indent << "Resolution: " << this->Resolution << endl;
+  os << indent << "Resolution: " << this->Resolution << std::endl;
 
   // print objects
   if (this->VolumePositionMatrix)

--- a/Modules/CLI/AddScalarVolumes/AddScalarVolumes.cxx
+++ b/Modules/CLI/AddScalarVolumes/AddScalarVolumes.cxx
@@ -22,6 +22,9 @@
 #include "itkPluginUtilities.h"
 #include "AddScalarVolumesCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/CastScalarVolume/CastScalarVolume.cxx
+++ b/Modules/CLI/CastScalarVolume/CastScalarVolume.cxx
@@ -15,6 +15,9 @@
 #include "itkPluginUtilities.h"
 #include "CastScalarVolumeCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/CheckerBoardFilter/CheckerBoardFilter.cxx
+++ b/Modules/CLI/CheckerBoardFilter/CheckerBoardFilter.cxx
@@ -22,6 +22,9 @@
 
 #include "CheckerBoardFilterCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/CreateDICOMSeries/CreateDICOMSeries.cxx
+++ b/Modules/CLI/CreateDICOMSeries/CreateDICOMSeries.cxx
@@ -20,6 +20,9 @@ command line processing and additional features have been added.
 
 #include "CreateDICOMSeriesCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/CurvatureAnisotropicDiffusion/CurvatureAnisotropicDiffusion.cxx
+++ b/Modules/CLI/CurvatureAnisotropicDiffusion/CurvatureAnisotropicDiffusion.cxx
@@ -22,6 +22,9 @@
 #include "itkPluginUtilities.h"
 #include "CurvatureAnisotropicDiffusionCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/DiffusionTensorTest/DiffusionTensorTest.cxx
+++ b/Modules/CLI/DiffusionTensorTest/DiffusionTensorTest.cxx
@@ -6,6 +6,9 @@
 
 #include "DiffusionTensorTestCLP.h"
 
+// STD includes
+#include <iostream>
+
 int main(int argc, char* argv[])
 {
   typedef itk::DiffusionTensor3D<float> TensorType;

--- a/Modules/CLI/ExecutionModelTour/ExecutionModelTour.cxx
+++ b/Modules/CLI/ExecutionModelTour/ExecutionModelTour.cxx
@@ -14,6 +14,9 @@
 #include <vtkMRMLMarkupsFiducialNode.h>
 #include <vtkMRMLMarkupsFiducialStorageNode.h>
 
+// STD includes
+#include <iostream>
+
 int main(int argc, char* argv[])
 {
   PARSE_ARGS;

--- a/Modules/CLI/ExtractSkeleton/ExtractSkeleton.cxx
+++ b/Modules/CLI/ExtractSkeleton/ExtractSkeleton.cxx
@@ -29,6 +29,9 @@
 #include <vtkMRMLMarkupsCurveNode.h>
 #include <vtkMRMLMarkupsJsonStorageNode.h>
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/FiducialRegistration/FiducialRegistration.cxx
+++ b/Modules/CLI/FiducialRegistration/FiducialRegistration.cxx
@@ -10,6 +10,7 @@
 #include <itkVersorRigid3DTransform.h>
 
 // STD includes
+#include <iostream>
 #include <numeric>
 
 namespace

--- a/Modules/CLI/GaussianBlurImageFilter/GaussianBlurImageFilter.cxx
+++ b/Modules/CLI/GaussianBlurImageFilter/GaussianBlurImageFilter.cxx
@@ -6,6 +6,9 @@
 
 #include "GaussianBlurImageFilterCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/GradientAnisotropicDiffusion/GradientAnisotropicDiffusion.cxx
+++ b/Modules/CLI/GradientAnisotropicDiffusion/GradientAnisotropicDiffusion.cxx
@@ -22,6 +22,9 @@
 #include "itkPluginUtilities.h"
 #include "GradientAnisotropicDiffusionCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/GrayscaleFillHoleImageFilter/GrayscaleFillHoleImageFilter.cxx
+++ b/Modules/CLI/GrayscaleFillHoleImageFilter/GrayscaleFillHoleImageFilter.cxx
@@ -22,6 +22,9 @@
 
 #include "GrayscaleFillHoleImageFilterCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/GrayscaleGrindPeakImageFilter/GrayscaleGrindPeakImageFilter.cxx
+++ b/Modules/CLI/GrayscaleGrindPeakImageFilter/GrayscaleGrindPeakImageFilter.cxx
@@ -22,6 +22,9 @@
 
 #include "GrayscaleGrindPeakImageFilterCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/GrayscaleModelMaker/GrayscaleModelMaker.cxx
+++ b/Modules/CLI/GrayscaleModelMaker/GrayscaleModelMaker.cxx
@@ -33,6 +33,9 @@ Version:   $Revision$
 #include "ModuleDescriptionParser.h"
 #include "ModuleDescription.h"
 
+// STD includes
+#include <iostream>
+
 int main(int argc, char* argv[])
 {
   PARSE_ARGS;

--- a/Modules/CLI/HistogramMatching/HistogramMatching.cxx
+++ b/Modules/CLI/HistogramMatching/HistogramMatching.cxx
@@ -27,6 +27,9 @@
 
 #include "HistogramMatchingCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/ImageLabelCombine/ImageLabelCombine.cxx
+++ b/Modules/CLI/ImageLabelCombine/ImageLabelCombine.cxx
@@ -11,6 +11,9 @@
 
 #include "ImageLabelCombineCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/LabelMapSmoothing/LabelMapSmoothing.cxx
+++ b/Modules/CLI/LabelMapSmoothing/LabelMapSmoothing.cxx
@@ -20,6 +20,9 @@
 
 #include "LabelMapSmoothingCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/MaskScalarVolume/MaskScalarVolume.cxx
+++ b/Modules/CLI/MaskScalarVolume/MaskScalarVolume.cxx
@@ -19,6 +19,9 @@
 #include "itkPluginUtilities.h"
 #include "MaskScalarVolumeCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/MedianImageFilter/MedianImageFilter.cxx
+++ b/Modules/CLI/MedianImageFilter/MedianImageFilter.cxx
@@ -20,6 +20,9 @@
 
 #include "MedianImageFilterCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/MergeModels/MergeModels.cxx
+++ b/Modules/CLI/MergeModels/MergeModels.cxx
@@ -21,6 +21,9 @@
 #include "vtkMRMLModelNode.h"
 #include "vtkMRMLModelStorageNode.h"
 
+// STD includes
+#include <iostream>
+
 int main(int argc, char* argv[])
 {
   PARSE_ARGS;

--- a/Modules/CLI/ModelMaker/ModelMaker.cxx
+++ b/Modules/CLI/ModelMaker/ModelMaker.cxx
@@ -59,6 +59,9 @@ Version:   $Revision$
 #include <vtkUnstructuredGrid.h>
 #include <vtkWindowedSincPolyDataFilter.h>
 
+// STD includes
+#include <iostream>
+
 // VTKsys includes
 #include <vtksys/SystemTools.hxx>
 
@@ -328,7 +331,7 @@ int main(int argc, char* argv[])
       labelsMax = Labels[Labels.size() - 1];
       if (debug)
       {
-        cout << "Set labels min to " << labelsMin << ", labels max = " << labelsMax << ", labels vector size = " << Labels.size() << endl;
+        std::cout << "Set labels min to " << labelsMin << ", labels max = " << labelsMax << ", labels vector size = " << Labels.size() << std::endl;
       }
     }
   }
@@ -1801,7 +1804,7 @@ int main(int argc, char* argv[])
   {
     if (debug)
     {
-      cout << "Deleting threshold" << endl;
+      std::cout << "Deleting threshold" << std::endl;
     }
     threshold->SetInputData(nullptr);
     threshold = nullptr;
@@ -1819,7 +1822,7 @@ int main(int argc, char* argv[])
   {
     if (debug)
     {
-      cout << "Deleting geometry filter" << endl;
+      std::cout << "Deleting geometry filter" << std::endl;
     }
     geometryFilter->SetInputData(nullptr);
     geometryFilter = nullptr;

--- a/Modules/CLI/ModelToLabelMap/ModelToLabelMap.cxx
+++ b/Modules/CLI/ModelToLabelMap/ModelToLabelMap.cxx
@@ -33,6 +33,9 @@
 #include "vtkMRMLVolumeArchetypeStorageNode.h"
 #include "vtkOrientedImageData.h"
 
+// STD includes
+#include <iostream>
+
 int main(int argc, char* argv[])
 {
   PARSE_ARGS;

--- a/Modules/CLI/MultiplyScalarVolumes/MultiplyScalarVolumes.cxx
+++ b/Modules/CLI/MultiplyScalarVolumes/MultiplyScalarVolumes.cxx
@@ -17,6 +17,9 @@
 #include "itkPluginUtilities.h"
 #include "MultiplyScalarVolumesCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
+++ b/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
@@ -8,6 +8,9 @@
 #include "N4ITKBiasFieldCorrectionCLP.h"
 #include "itkPluginUtilities.h"
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 

--- a/Modules/CLI/OrientScalarVolume/OrientScalarVolume.cxx
+++ b/Modules/CLI/OrientScalarVolume/OrientScalarVolume.cxx
@@ -22,6 +22,9 @@
 #include "itkPluginUtilities.h"
 #include "OrientScalarVolumeCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/PETStandardUptakeValueComputation/PETStandardUptakeValueComputation.cxx
+++ b/Modules/CLI/PETStandardUptakeValueComputation/PETStandardUptakeValueComputation.cxx
@@ -32,6 +32,9 @@
 #include <itkMetaDataDictionary.h>
 #include <itkNumericSeriesFileNames.h>
 
+// STD includes
+#include <iostream>
+
 #undef HAVE_SSTREAM // stupid DCMTK Header issue
 #include "itkDCMTKFileReader.h"
 

--- a/Modules/CLI/ProbeVolumeWithModel/ProbeVolumeWithModel.cxx
+++ b/Modules/CLI/ProbeVolumeWithModel/ProbeVolumeWithModel.cxx
@@ -18,6 +18,9 @@
 
 #include <vtksys/SystemTools.hxx>
 
+// STD includes
+#include <iostream>
+
 int main(int argc, char* argv[])
 {
   PARSE_ARGS;

--- a/Modules/CLI/ROITest/CLIROITest.cxx
+++ b/Modules/CLI/ROITest/CLIROITest.cxx
@@ -11,6 +11,9 @@
 // VTK includes
 #include <vtkMath.h>
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx
+++ b/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx
@@ -34,6 +34,9 @@
 #include <itkThinPlateSplineKernelTransform.h>
 #include <itkTransformFactory.h>
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DRead.hxx
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DRead.hxx
@@ -16,6 +16,9 @@
 
 #include "itkDiffusionTensor3DRead.h"
 
+// STD includes
+#include <iostream>
+
 namespace itk
 {
 

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.hxx
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.hxx
@@ -20,6 +20,9 @@
 # include <NrrdIO.h>
 #endif
 
+// STD includes
+#include <iostream>
+
 namespace itk
 {
 

--- a/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
+++ b/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
@@ -38,6 +38,7 @@
 #include "itkWarpTransform3D.h"
 
 // STD includes
+#include <iostream>
 
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every

--- a/Modules/CLI/ResampleScalarVolume/ResampleScalarVolume.cxx
+++ b/Modules/CLI/ResampleScalarVolume/ResampleScalarVolume.cxx
@@ -54,6 +54,9 @@
 
 #include "ResampleScalarVolumeCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/RobustStatisticsSegmenter/SFLSRobustStatSegmentor3DLabelMap_single.hxx
+++ b/Modules/CLI/RobustStatisticsSegmenter/SFLSRobustStatSegmentor3DLabelMap_single.hxx
@@ -11,6 +11,7 @@
 // //debug//
 // #include "cArrayOp.h"
 #include <fstream>
+#include <iostream>
 // //DEBUG//
 
 #include "itkImageRegionConstIteratorWithIndex.h"

--- a/Modules/CLI/RobustStatisticsSegmenter/SFLSSegmentor3D.hxx
+++ b/Modules/CLI/RobustStatisticsSegmenter/SFLSSegmentor3D.hxx
@@ -9,6 +9,7 @@
 #include <csignal>
 
 #include <fstream>
+#include <iostream>
 
 #include "itkImageRegionIteratorWithIndex.h"
 

--- a/Modules/CLI/RobustStatisticsSegmenter/Testing/SFLSRobustStat3DTestConsole.cxx
+++ b/Modules/CLI/RobustStatisticsSegmenter/Testing/SFLSRobustStat3DTestConsole.cxx
@@ -10,6 +10,9 @@
 #include <itkConfigure.h>
 #include <itkFactoryRegistration.h>
 
+// STD includes
+#include <iostream>
+
 #include "labelMapPreprocessor.h"
 
 template <typename TPixel>

--- a/Modules/CLI/RobustStatisticsSegmenter/labelMapPreprocessor.h
+++ b/Modules/CLI/RobustStatisticsSegmenter/labelMapPreprocessor.h
@@ -5,6 +5,7 @@
 #include "itkImageRegionIterator.h"
 
 #include <algorithm>
+#include <iostream>
 
 template <typename pixel_t>
 typename itk::Image<pixel_t, 3>::Pointer preprocessLabelMap(typename itk::Image<pixel_t, 3>::Pointer originalLabelMap, pixel_t desiredLabel)

--- a/Modules/CLI/SimpleRegionGrowingSegmentation/SimpleRegionGrowingSegmentation.cxx
+++ b/Modules/CLI/SimpleRegionGrowingSegmentation/SimpleRegionGrowingSegmentation.cxx
@@ -21,6 +21,9 @@
 
 #include "SimpleRegionGrowingSegmentationCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/SubtractScalarVolumes/SubtractScalarVolumes.cxx
+++ b/Modules/CLI/SubtractScalarVolumes/SubtractScalarVolumes.cxx
@@ -24,6 +24,9 @@
 #include "itkPluginUtilities.h"
 #include "SubtractScalarVolumesCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/TestGridTransformRegistration/TestGridTransformRegistration.cxx
+++ b/Modules/CLI/TestGridTransformRegistration/TestGridTransformRegistration.cxx
@@ -29,6 +29,9 @@
 
 #include "itkTimeProbesCollectorBase.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/CLI/ThresholdScalarVolume/ThresholdScalarVolume.cxx
+++ b/Modules/CLI/ThresholdScalarVolume/ThresholdScalarVolume.cxx
@@ -18,6 +18,9 @@
 #include "itkPluginUtilities.h"
 #include "ThresholdScalarVolumeCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module

--- a/Modules/Core/Testing/qSlicerCoreModuleFactoryTest1.cxx
+++ b/Modules/Core/Testing/qSlicerCoreModuleFactoryTest1.cxx
@@ -24,6 +24,7 @@
 #include <qSlicerCoreModuleFactory.h>
 
 // STD includes
+#include <iostream>
 
 #include "vtkMRMLCoreTestingMacros.h"
 

--- a/Modules/Core/Testing/qSlicerModulePanelTest2.cxx
+++ b/Modules/Core/Testing/qSlicerModulePanelTest2.cxx
@@ -31,6 +31,7 @@
 #include <qSlicerStyle.h>
 
 // STD includes
+#include <iostream>
 
 int qSlicerModulePanelTest2(int argc, char* argv[])
 {

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationControlPointsNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationControlPointsNode.cxx
@@ -12,6 +12,7 @@
 // STD includes
 #include <algorithm>
 #include <cassert>
+#include <iostream>
 #include <sstream>
 
 #define NUMERIC_ZERO 1.0e-6

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLinesNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLinesNode.cxx
@@ -1,5 +1,6 @@
 #include <sstream>
 #include <algorithm>
+#include <iostream>
 
 #include "vtkObjectFactory.h"
 #include "vtkMRMLAnnotationLinesStorageNode.h"

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationNode.cxx
@@ -15,6 +15,7 @@
 #include <vtkStringArray.h>
 
 // STD includes
+#include <iostream>
 #include <sstream>
 
 // KPs Todos

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationROINode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationROINode.cxx
@@ -22,6 +22,7 @@
 #include <vtkSmartPointer.h>
 
 // STD includes
+#include <iostream>
 #include <sstream>
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerNode.cxx
@@ -13,6 +13,7 @@
 #include <vtkMatrix4x4.h>
 
 // STD includes
+#include <iostream>
 #include <sstream>
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerStorageNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerStorageNode.cxx
@@ -6,6 +6,9 @@
 #include "vtkMRMLScene.h"
 #include "vtkStringArray.h"
 
+// STD includes
+#include <iostream>
+
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLAnnotationRulerStorageNode);
 

--- a/Modules/Loadable/Cameras/Testing/Cxx/qSlicerCamerasModuleWidgetTest1.cxx
+++ b/Modules/Loadable/Cameras/Testing/Cxx/qSlicerCamerasModuleWidgetTest1.cxx
@@ -21,6 +21,9 @@
 #include "qSlicerCoreApplication.h"
 #include "qSlicerCamerasModuleWidget.h"
 
+// STD includes
+#include <iostream>
+
 int qSlicerCamerasModuleWidgetTest1(int argc, char* argv[])
 {
   qSlicerCoreApplication app(argc, argv);

--- a/Modules/Loadable/Cameras/Testing/Cxx/vtkSlicerCamerasModuleLogicCopyImportedCamerasTest.cxx
+++ b/Modules/Loadable/Cameras/Testing/Cxx/vtkSlicerCamerasModuleLogicCopyImportedCamerasTest.cxx
@@ -31,6 +31,7 @@
 
 // STD includes
 #include <cassert>
+#include <iostream>
 
 //----------------------------------------------------------------------------
 bool TestCopyImportedCameras(bool clear, bool legacy);

--- a/Modules/Loadable/Colors/Logic/Testing/Cxx/vtkSlicerColorLogicTest1.cxx
+++ b/Modules/Loadable/Colors/Logic/Testing/Cxx/vtkSlicerColorLogicTest1.cxx
@@ -35,6 +35,7 @@
 #include <vtkTimerLog.h>
 
 // STD includes
+#include <iostream>
 
 using namespace vtkAddonTestingUtilities;
 

--- a/Modules/Loadable/Colors/Widgets/Testing/qMRMLColorListViewTest1.cxx
+++ b/Modules/Loadable/Colors/Widgets/Testing/qMRMLColorListViewTest1.cxx
@@ -34,6 +34,9 @@
 #include <vtkMRMLColorTableNode.h>
 #include <vtkMRMLPETProceduralColorNode.h>
 
+// STD includes
+#include <iostream>
+
 // VTK includes
 #include <vtkNew.h>
 

--- a/Modules/Loadable/Colors/Widgets/Testing/qMRMLColorTableViewTest1.cxx
+++ b/Modules/Loadable/Colors/Widgets/Testing/qMRMLColorTableViewTest1.cxx
@@ -41,6 +41,9 @@
 #include <vtkSmartPointer.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 int qMRMLColorTableViewTest1(int argc, char* argv[])
 {
   qMRMLWidget::preInitializeApplication();

--- a/Modules/Loadable/Data/Testing/Cxx/vtkSlicerDataLogicAutoRemoveTest.cxx
+++ b/Modules/Loadable/Data/Testing/Cxx/vtkSlicerDataLogicAutoRemoveTest.cxx
@@ -30,6 +30,9 @@
 // VTK includes
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 bool testAutoRemoveModelFirst();
 bool testAutoRemoveDisplayFirst();
 

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsDisplayNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsDisplayNodeTest1.cxx
@@ -19,6 +19,9 @@
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLMarkupsDisplayNode.h"
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLMarkupsDisplayNodeTest1(int, char*[])
 {
   vtkNew<vtkMRMLMarkupsDisplayNode> node1;

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialNodeTest1.cxx
@@ -26,6 +26,9 @@
 #include <vtkNew.h>
 #include <vtkPolyData.h>
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLMarkupsFiducialNodeTest1(int, char*[])
 {
   vtkNew<vtkMRMLMarkupsFiducialNode> node1;

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest2.cxx
@@ -28,6 +28,9 @@
 #include <vtkNew.h>
 #include <vtkTestingOutputWindow.h>
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLMarkupsFiducialStorageNodeTest2(int argc, char* argv[])
 {
   // Test reading in a Slicer3 .fcsv file

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest3.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest3.cxx
@@ -27,6 +27,9 @@
 // VTK includes
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 int vtkMRMLMarkupsFiducialStorageNodeTest3(int argc, char* argv[])
 {
   // Test reading in a Slicer4 Annotation fiducial .acsv file

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
@@ -31,6 +31,7 @@
 
 // STL includes
 #include <sstream>
+#include <iostream>
 
 int vtkMRMLMarkupsNodeTest1(int, char*[])
 {

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest2.cxx
@@ -22,6 +22,9 @@
 #include <vtkNew.h>
 #include <vtkTestingOutputWindow.h>
 
+// STD includes
+#include <iostream>
+
 // test copy and swap
 int vtkMRMLMarkupsNodeTest2(int, char*[])
 {

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest3.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest3.cxx
@@ -31,6 +31,7 @@
 
 // STL includes
 #include <sstream>
+#include <iostream>
 
 // Test markups measurements
 

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest4.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest4.cxx
@@ -32,6 +32,7 @@
 
 // STL includes
 #include <sstream>
+#include <iostream>
 
 static const double EPSILON = 1e-5;
 

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest5.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest5.cxx
@@ -34,6 +34,9 @@
 #include <vtkTestingOutputWindow.h>
 #include <vtkTransform.h>
 
+// STD includes
+#include <iostream>
+
 // STL includes
 #include <sstream>
 

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest6.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest6.cxx
@@ -33,6 +33,7 @@
 #include <vtkTransform.h>
 
 // STL includes
+#include <iostream>
 #include <sstream>
 
 static const double TOLERANCE = 1e-4;

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest1.cxx
@@ -29,6 +29,9 @@
 // VTK includes
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 int TestMarkupsStorageNode(vtkMRMLMarkupsStorageNode* node1)

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest2.cxx
@@ -44,6 +44,7 @@
 
 // STD includes
 #include <algorithm>
+#include <iostream>
 
 namespace
 {

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMarkupsAnnotationSceneTest.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMarkupsAnnotationSceneTest.cxx
@@ -34,6 +34,9 @@
 #include <vtkNew.h>
 #include "vtkPolyData.h"
 
+// STD includes
+#include <iostream>
+
 int vtkMarkupsAnnotationSceneTest(int argc, char* argv[])
 {
   // Test reading in a Slicer4 MRML scene with legacy annotation nodes (created using Slicer-4.1.1):

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest1.cxx
@@ -27,6 +27,9 @@
 #include <vtkNew.h>
 #include <vtkTestingOutputWindow.h>
 
+// STD includes
+#include <iostream>
+
 int vtkSlicerMarkupsLogicTest1(int, char*[])
 {
   vtkSmartPointer<vtkMRMLScene> scene = vtkSmartPointer<vtkMRMLScene>::New();

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest2.cxx
@@ -25,6 +25,9 @@
 #include <vtkNew.h>
 #include <vtkTestingOutputWindow.h>
 
+// STD includes
+#include <iostream>
+
 static void PrintLabels(vtkMRMLMarkupsNode* m)
 {
   if (!m)

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest3.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest3.cxx
@@ -34,6 +34,9 @@
 // VTK includes
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 int vtkSlicerMarkupsLogicTest3(int, char*[])
 {
   vtkNew<vtkSlicerMarkupsLogic> logic1;

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest4.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest4.cxx
@@ -42,6 +42,9 @@
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
 
+// STD includes
+#include <iostream>
+
 //------------------------------------------------------------------------------
 void RegisteredEventDetectionCallback(vtkObject* caller, unsigned long, void*, void*);
 void UnregisteredEventDetectionCallback(vtkObject* caller, unsigned long, void*, void*);

--- a/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTest.cxx
+++ b/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTest.cxx
@@ -20,6 +20,9 @@
 
 // Qt includes
 
+// STD includes
+#include <iostream>
+
 // CTK includes
 #include <ctkTest.h>
 

--- a/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTest1.cxx
+++ b/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTest1.cxx
@@ -48,6 +48,9 @@
 #include <vtkNew.h>
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 int qSlicerModelsModuleWidgetTest1(int argc, char* argv[])
 {

--- a/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTestScene.cxx
+++ b/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTestScene.cxx
@@ -34,6 +34,9 @@
 #include "qSlicerModelsModule.h"
 #include "vtkSlicerModelsLogic.h"
 
+// STD includes
+#include <iostream>
+
 // MRML includes
 #include <vtkMRMLModelHierarchyNode.h>
 #include <vtkMRMLScene.h>

--- a/Modules/Loadable/Models/Widgets/Testing/Cxx/qMRMLModelDisplayNodeWidgetTest2.cxx
+++ b/Modules/Loadable/Models/Widgets/Testing/Cxx/qMRMLModelDisplayNodeWidgetTest2.cxx
@@ -38,6 +38,7 @@
 #include "qMRMLWidget.h"
 
 // STD includes
+#include <iostream>
 
 int qMRMLModelDisplayNodeWidgetTest2(int argc, char* argv[])
 {

--- a/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
+++ b/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
@@ -45,6 +45,9 @@
 #include <vtkNew.h>
 #include <vtkTransform.h>
 
+// STD includes
+#include <iostream>
+
 //------------------------------------------------------------------------------
 class qSlicerReformatModuleWidgetPrivate : public Ui_qSlicerReformatModuleWidget
 {

--- a/Modules/Loadable/SceneViews/Testing/Cxx/vtkSceneViewImportSceneTest.cxx
+++ b/Modules/Loadable/SceneViews/Testing/Cxx/vtkSceneViewImportSceneTest.cxx
@@ -33,6 +33,9 @@
 #include <vtkPolyData.h>
 #include <vtkSmartPointer.h>
 
+// STD includes
+#include <iostream>
+
 // Sequences logic includes
 #include <vtkSlicerSequencesLogic.h>
 

--- a/Modules/Loadable/SceneViews/Testing/Cxx/vtkSceneViewStoreSceneTest.cxx
+++ b/Modules/Loadable/SceneViews/Testing/Cxx/vtkSceneViewStoreSceneTest.cxx
@@ -33,6 +33,9 @@
 // Sequences logic includes
 #include <vtkSlicerSequencesLogic.h>
 
+// STD includes
+#include <iostream>
+
 // SceneView logic includes
 #include <vtkSlicerSceneViewsModuleLogic.h>
 

--- a/Modules/Loadable/SceneViews/Testing/Cxx/vtkSceneViewTest1.cxx
+++ b/Modules/Loadable/SceneViews/Testing/Cxx/vtkSceneViewTest1.cxx
@@ -20,6 +20,9 @@
 #include <vtkImageData.h>
 #include <vtkNew.h>
 
+// STD includes
+#include <iostream>
+
 int vtkSceneViewTest1(int, char*[])
 {
   vtkNew<vtkMRMLSceneViewNode> node1;

--- a/Modules/Loadable/Segmentations/Logic/FibHeap.cxx
+++ b/Modules/Loadable/Segmentations/Logic/FibHeap.cxx
@@ -259,24 +259,24 @@ void FibHeap::Print(FibHeapNode* tree, FibHeapNode* theParent)
   {
     if (temp->m_Left == FibHeapNode::NullNodeIndex)
     {
-      cout << "(m_Left is nullptr)";
+      std::cout << "(m_Left is nullptr)";
     }
     temp->Print();
     if (temp->m_Parent != theParent->m_Index)
     {
-      cout << "(m_Parent is incorrect)";
+      std::cout << "(m_Parent is incorrect)";
     }
     if (temp->m_Right == FibHeapNode::NullNodeIndex)
     {
-      cout << "(m_Right is nullptr)";
+      std::cout << "(m_Right is nullptr)";
     }
     else if (m_HeapNodes[temp->m_Right].m_Left != temp->m_Index)
     {
-      cout << "(Error in left link left) ->";
+      std::cout << "(Error in left link left) ->";
     }
     else
     {
-      cout << " <-> ";
+      std::cout << " <-> ";
     }
 
     temp = HeapNodeFromIndex(temp->m_Right);
@@ -289,17 +289,17 @@ void FibHeap::Print(FibHeapNode* tree, FibHeapNode* theParent)
     }
     */
   } while (temp != nullptr && temp != tree);
-  cout << '\n';
+  std::cout << '\n';
 
   temp = tree;
   do
   {
-    cout << "Children of ";
+    std::cout << "Children of ";
     temp->Print();
-    cout << ": ";
+    std::cout << ": ";
     if (temp->m_Child == FibHeapNode::NullNodeIndex)
     {
-      cout << "NONE\n";
+      std::cout << "NONE\n";
     }
     else
     {

--- a/Modules/Loadable/Sequences/Testing/Cxx/vtkMRMLSequenceNodeTest1.cxx
+++ b/Modules/Loadable/Sequences/Testing/Cxx/vtkMRMLSequenceNodeTest1.cxx
@@ -32,6 +32,9 @@
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkTestingOutputWindow.h"
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 bool testAddInvalidFile(const char* filePath);
 bool testAddFile(const char* filePath);

--- a/Modules/Loadable/Sequences/Testing/Cxx/vtkMRMLSequenceStorageNodeTest1.cxx
+++ b/Modules/Loadable/Sequences/Testing/Cxx/vtkMRMLSequenceStorageNodeTest1.cxx
@@ -43,6 +43,9 @@
 #include <itkConfigure.h>
 #include <itkFactoryRegistration.h>
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 int TestWriteReadSequence(const std::string& tempDir, vtkMRMLSequenceNode* sequenceNode, vtkMRMLStorageNode* storageNode, std::string fileName)
 {

--- a/Modules/Loadable/SubjectHierarchy/Testing/Cxx/vtkSlicerSubjectHierarchyModuleLogicTest.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Cxx/vtkSlicerSubjectHierarchyModuleLogicTest.cxx
@@ -42,6 +42,7 @@
 
 // STD includes
 #include <cassert>
+#include <iostream>
 #include <sstream>
 
 namespace

--- a/Modules/Loadable/Tables/Testing/Cxx/vtkSlicerTablesLogicAddFileTest.cxx
+++ b/Modules/Loadable/Tables/Testing/Cxx/vtkSlicerTablesLogicAddFileTest.cxx
@@ -36,6 +36,9 @@
 #include "vtkTestingOutputWindow.h"
 #include "vtkMRMLCoreTestingMacros.h"
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 int testAddInvalidFile(const char* filePath);
 int testAddFile(const char* filePath);

--- a/Modules/Loadable/Transforms/Logic/Testing/Cxx/vtkSlicerTransformLogicTest1.cxx
+++ b/Modules/Loadable/Transforms/Logic/Testing/Cxx/vtkSlicerTransformLogicTest1.cxx
@@ -19,6 +19,9 @@
 #include <itkConfigure.h>
 #include <itkFactoryRegistration.h>
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 int vtkSlicerTransformLogicTest1(int argc, char* argv[])
 {

--- a/Modules/Loadable/Transforms/Logic/Testing/Cxx/vtkSlicerTransformLogicTest2.cxx
+++ b/Modules/Loadable/Transforms/Logic/Testing/Cxx/vtkSlicerTransformLogicTest2.cxx
@@ -21,6 +21,9 @@
 #include <vtkNew.h>
 #include <vtkPolyDataReader.h>
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Transforms/Logic/Testing/Cxx/vtkSlicerTransformLogicTest3.cxx
+++ b/Modules/Loadable/Transforms/Logic/Testing/Cxx/vtkSlicerTransformLogicTest3.cxx
@@ -21,6 +21,9 @@
 #include <vtkNew.h>
 #include <vtkPolyDataReader.h>
 
+// STD includes
+#include <iostream>
+
 namespace
 {
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Units/Testing/Cxx/vtkSlicerUnitsLogicTest1.cxx
+++ b/Modules/Loadable/Units/Testing/Cxx/vtkSlicerUnitsLogicTest1.cxx
@@ -32,6 +32,7 @@
 
 // STD includes
 #include <algorithm>
+#include <iostream>
 
 namespace
 {

--- a/Modules/Loadable/VolumeRendering/Logic/Testing/Cxx/vtkSlicerVolumeRenderingLogicAddFromFileTest.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/Testing/Cxx/vtkSlicerVolumeRenderingLogicAddFromFileTest.cxx
@@ -33,6 +33,9 @@
 #include <vtksys/SystemTools.hxx>
 #include <vtkTestingOutputWindow.h>
 
+// STD includes
+#include <iostream>
+
 //----------------------------------------------------------------------------
 int testAddVolumePropertyFromFile(const std::string& temporaryDirectory);
 

--- a/Modules/Loadable/VolumeRendering/Logic/Testing/Cxx/vtkSlicerVolumeRenderingLogicTest.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/Testing/Cxx/vtkSlicerVolumeRenderingLogicTest.cxx
@@ -34,6 +34,9 @@
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
 
+// STD includes
+#include <iostream>
+
 //----------------------------------------------------------------------------
 int testDefaultRenderingMethod(const std::string& moduleShareDirectory);
 int testPresets(const std::string& moduleShareDirectory);

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/qSlicerVolumeRenderingModuleWidgetTest2.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/qSlicerVolumeRenderingModuleWidgetTest2.cxx
@@ -42,6 +42,9 @@
 #include <itkConfigure.h>
 #include <itkFactoryRegistration.h>
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 int qSlicerVolumeRenderingModuleWidgetTest2(int argc, char* argv[])
 {

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLShaderPropertyStorageNodeTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLShaderPropertyStorageNodeTest1.cxx
@@ -29,6 +29,9 @@
 
 #include <vtksys/SystemTools.hxx>
 
+// STD includes
+#include <iostream>
+
 //---------------------------------------------------------------------------
 void BuildShaderProperty(vtkMRMLShaderPropertyNode* psNode);
 int TestReadWriteData(vtkMRMLScene* scene, const char* extension, vtkMRMLShaderPropertyNode* sp);

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumePropertyJsonStorageNodeTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumePropertyJsonStorageNodeTest1.cxx
@@ -28,6 +28,9 @@
 #include <vtkPiecewiseFunction.h>
 #include <vtkVolumeProperty.h>
 
+// STD includes
+#include <iostream>
+
 //---------------------------------------------------------------------------
 const double DOUBLE_TOLERANCE = 1e-6;
 

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumePropertyNodeTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumePropertyNodeTest1.cxx
@@ -27,6 +27,7 @@
 
 // STD includes
 #include <limits>
+#include <iostream>
 
 namespace
 {

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumeRenderingDisplayableManagerTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumeRenderingDisplayableManagerTest1.cxx
@@ -56,6 +56,7 @@
 #include <vtkWindowToImageFilter.h>
 
 // STD includes
+#include <iostream>
 #include <string>
 
 const char vtkMRMLVolumeRenderingDisplayableManagerTest1EventLog[] = //

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumeRenderingMultiVolumeTest.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumeRenderingMultiVolumeTest.cxx
@@ -51,6 +51,7 @@
 
 // STD includes
 #include <cassert>
+#include <iostream>
 
 //----------------------------------------------------------------------------
 void SetupRenderer(vtkRenderWindow* renderWindow, vtkRenderer* renderer)

--- a/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesIOOptionsWidgetTest1.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesIOOptionsWidgetTest1.cxx
@@ -38,6 +38,9 @@
 // VTK includes
 #include "qMRMLWidget.h"
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 int qSlicerVolumesIOOptionsWidgetTest1(int argc, char* argv[])
 {

--- a/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesModuleWidgetTest1.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesModuleWidgetTest1.cxx
@@ -33,6 +33,9 @@
 #include "qSlicerVolumesModule.h"
 #include "vtkSlicerVolumesLogic.h"
 
+// STD includes
+#include <iostream>
+
 // VTK includes
 #include <vtkNew.h>
 #include "qMRMLWidget.h"

--- a/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest1.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest1.cxx
@@ -45,6 +45,9 @@
 #include <itkConfigure.h>
 #include <itkFactoryRegistration.h>
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 bool isImageDataValid(int line, vtkAlgorithmOutput* imageDataConnection);
 vtkMRMLScalarVolumeNode* TestScalarVolumeLoading(const char* volumeName, vtkSlicerVolumesLogic* logic);

--- a/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest2.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest2.cxx
@@ -49,6 +49,9 @@
 #include <itkConfigure.h>
 #include <itkFactoryRegistration.h>
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 bool isImageDataValid(vtkAlgorithmOutput* imageDataConnection)
 {

--- a/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDTISliceDisplayWidgetTest2.cxx
+++ b/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDTISliceDisplayWidgetTest2.cxx
@@ -46,6 +46,9 @@
 #include <itkConfigure.h>
 #include <itkFactoryRegistration.h>
 
+// STD includes
+#include <iostream>
+
 //-----------------------------------------------------------------------------
 int qSlicerDTISliceDisplayWidgetTest2(int argc, char* argv[])
 {

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -200,7 +200,7 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG 5cee466fd3d653bd9633dd1fc47bffae7f56b32a
+  GIT_TAG 2ed3e2226cf25958b4dbf8bf917b2f7793ecd6a2
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_vtkAddon Slicer_REMOTE_DEPENDENCIES vtkAddon)

--- a/Utilities/Templates/Modules/CLI/TemplateKey.cxx
+++ b/Utilities/Templates/Modules/CLI/TemplateKey.cxx
@@ -6,6 +6,9 @@
 
 #include "TemplateKeyCLP.h"
 
+// STD includes
+#include <iostream>
+
 // Use an anonymous namespace to keep class types and function names
 // from colliding when module is used as shared object module.  Every
 // thing should be in an anonymous namespace except for the module


### PR DESCRIPTION
This change is necessary to be compatible with VTK 9.6 code as iostream was removed from a core header file as seen in https://github.com/Kitware/VTK/commit/a95326aef076dd9fc6d7329d5fb54f1015ca59b9. See release note https://github.com/Kitware/VTK/commit/7462a8b1411a78f470ca459a34cf1ef2e7c353a8.

See the announcement made on the VTK discourse about this update https://discourse.vtk.org/t/important-update-standard-iostream-availability-from-vtk/16171.

Marking this PR initially as draft until the corresponding vtkAddon PR is integrated:
- [x] https://github.com/Slicer/vtkAddon/pull/66 should be integrated first
- [x] Update git hash for vtkAddon once the above is integrated