### PR TITLE
ENH: Allow volume rendering of non-linearly transformed volumes

### DIFF
--- a/Docs/user_guide/modules/volumerendering.md
+++ b/Docs/user_guide/modules/volumerendering.md
@@ -28,6 +28,8 @@ To adjust volume rendering settings:
 
 ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_volumerendering_basic.png)
 
+Note that if the volume is under a non-linear warping transformation then internally the entire volume is resampled at its native resolution. To better control image quality and computation time, `Crop volume` module can be used to resample at a different resolution or resample only a certain part of the volume.
+
 ### Render different volumes in two views
 
 Switch to a layout with multiple 3D views (for example "Dual 3D") using the toolbar and then use one of the two options below.
@@ -121,7 +123,6 @@ See [video demo/tutorial of these steps](https://youtu.be/xZwyW6SaoM4?t=12) for 
   - RGB volume rendering is not supported (volume does not appear)
   - Only "Composite with shading" rendering technique is supported (volume does not appear if "Maximum Intensity Projection" or "Minimum Intensity Projection" technique is selected)
 - To reduce staircase artifacts during rendering, choose enable "Surface smoothing" in Advanced/Techniques/Advanced rendering properties section, or choose "Normal" or "Maximum" as quality.
-- The volume must not be under a warping (affine or non-linear) transformation. To render a warped volume, the transform must be hardened on the volume. (see [related issue](https://github.com/Slicer/Slicer/issues/6648))
 - If the application crashes when rotating or zooming a volume: This indicates that you get a TDR error, i.e., the operating system shuts down applications that keep the graphics card busy for too long. This happens because the size of the volume is too large for your GPU to comfortably handle. There are several ways to work around this:
   - Option A: Run the code snippet in the Python console (<kbd>Ctrl</kbd>-<kbd>3</kbd>) to split the volume to smaller chunks (that way you have a better chance that the graphics card will not be unresponsive for too long).
     ```python

--- a/Libs/MRML/Core/vtkMRMLVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeNode.h
@@ -256,6 +256,15 @@ public:
   /// by inverting the K axis direction. The physical location of voxels do not change.
   static void ReverseSliceOrder(vtkImageData* imageData, vtkMatrix4x4* ijkToRasMatrix);
 
+  /// Resample a volume with a transform.
+  /// This method can be used to bake a non-linear transform into a volume.
+  /// The parent transform of the volume is ignored to make it easy to apply any transform to the volume, regardless
+  /// of the current transform.
+  /// transform: the modeling transform to apply, from the volume's RAS coordinate system to world coordinates.
+  /// outputImage and outputIJKToWorld are the resampled image data and its matrix to transform IJK to world coordinates.
+  /// \return true on success, false on failure.
+  static bool GetTransformedImageData(vtkMRMLVolumeNode* volumeNode, vtkAbstractTransform* transform, vtkImageData* outputImage, vtkMatrix4x4* outputIJKToWorld);
+
 protected:
   vtkMRMLVolumeNode();
   ~vtkMRMLVolumeNode() override;


### PR DESCRIPTION
When a volume under a non-linear transform is volume-rendered then the volume is transformed in vtkMRMLVolumeRenderingDisplayableManager and the transformed volume is displayed.

fixes #6648

@mauigna06 