### PR TITLE
ENH: Make transform visualization 2D glyphs thickness and arrow tip length editable on GUI

### DIFF
--- a/Libs/MRML/Core/vtkMRMLTransformDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformDisplayNode.cxx
@@ -75,6 +75,7 @@ vtkMRMLTransformDisplayNode::vtkMRMLTransformDisplayNode()
   this->GlyphDiameterMm = 5.0;
   this->GlyphShaftDiameterPercent = 40;
   this->GlyphResolution = 6;
+  this->GlyphTipLengthPercent2D = 30;
 
   this->GridScalePercent = 100;
   this->GridSpacingMm = 15.0;
@@ -143,6 +144,7 @@ void vtkMRMLTransformDisplayNode::WriteXML(ostream& of, int nIndent)
   of << " GlyphDiameterMm=\"" << this->GlyphDiameterMm << "\"";
   of << " GlyphShaftDiameterPercent=\"" << this->GlyphShaftDiameterPercent << "\"";
   of << " GlyphResolution=\"" << this->GlyphResolution << "\"";
+  of << " GlyphTipLengthPercent2D=\"" << this->GlyphTipLengthPercent2D << "\"";
 
   of << " GridScalePercent=\"" << this->GridScalePercent << "\"";
   of << " GridSpacingMm=\"" << this->GridSpacingMm << "\"";
@@ -209,6 +211,7 @@ void vtkMRMLTransformDisplayNode::ReadXMLAttributes(const char** atts)
   READ_FROM_ATT(GlyphDiameterMm);
   READ_FROM_ATT(GlyphShaftDiameterPercent);
   READ_FROM_ATT(GlyphResolution);
+  READ_FROM_ATT(GlyphTipLengthPercent2D);
   READ_FROM_ATT(GridScalePercent);
   READ_FROM_ATT(GridSpacingMm);
   READ_FROM_ATT(GridLineDiameterMm);
@@ -314,6 +317,7 @@ void vtkMRMLTransformDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "GlyphDiameterMm = " << this->GlyphDiameterMm << "\n";
   os << indent << "GlyphShaftDiameterPercent = " << this->GlyphShaftDiameterPercent << "\n";
   os << indent << "GlyphResolution = " << this->GlyphResolution << "\n";
+  os << indent << "GlyphTipLengthPercent2D = " << this->GlyphTipLengthPercent2D << "\n";
 
   os << indent << "GridScalePercent = " << this->GridScalePercent << "\n";
   os << indent << "GridSpacingMm = " << this->GridSpacingMm << "\n";

--- a/Libs/MRML/Core/vtkMRMLTransformDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformDisplayNode.h
@@ -136,6 +136,9 @@ public:
   vtkGetMacro(GlyphShaftDiameterPercent, double);
   vtkSetMacro(GlyphResolution, int);
   vtkGetMacro(GlyphResolution, int);
+  // 2d parameters
+  vtkSetMacro(GlyphTipLengthPercent2D, double);
+  vtkGetMacro(GlyphTipLengthPercent2D, double);
 
   // Grid Parameters
   vtkSetMacro(GridScalePercent, double);
@@ -266,6 +269,8 @@ protected:
   double GlyphDiameterMm;
   double GlyphShaftDiameterPercent;
   int GlyphResolution;
+  // 2d parameters
+  double GlyphTipLengthPercent2D;
 
   // Grid Parameters
   double GridScalePercent;

--- a/Modules/Loadable/Transforms/Logic/vtkSlicerTransformLogic.cxx
+++ b/Modules/Loadable/Transforms/Logic/vtkSlicerTransformLogic.cxx
@@ -904,6 +904,7 @@ void vtkSlicerTransformLogic::GetGlyphVisualization2d(vtkPolyData* output,
   {
     case vtkMRMLTransformDisplayNode::GLYPH_TYPE_ARROW:
       glyph2DSource->SetGlyphTypeToArrow();
+      glyph2DSource->SetTipLength(displayNode->GetGlyphTipLengthPercent2D() / 100.0);
       glyphFilter->SetScaleModeToScaleByVector();
       // move the origin from the middle of the arrow to the base of the arrow
       rotateArrow->Translate(0.5, 0, 0);

--- a/Modules/Loadable/Transforms/Widgets/Resources/UI/qMRMLTransformDisplayNodeWidget.ui
+++ b/Modules/Loadable/Transforms/Widgets/Resources/UI/qMRMLTransformDisplayNodeWidget.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>499</width>
-    <height>969</height>
+    <height>1148</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -333,139 +333,6 @@
             <enum>QFrame::Raised</enum>
            </property>
            <layout class="QGridLayout" name="gridLayout_4">
-            <item row="1" column="0">
-             <widget class="QLabel" name="GlyphSpacingLabel">
-              <property name="toolTip">
-               <string>Distance between the glyph points</string>
-              </property>
-              <property name="text">
-               <string>Spacing:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label">
-              <property name="toolTip">
-               <string>Percentage of displacement usef for setting the glyph size. 100% means the glyph size equals the actual displacement.</string>
-              </property>
-              <property name="text">
-               <string>Scale factor:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="label_10">
-              <property name="toolTip">
-               <string>Glyphs are shown if the displacement magnitude is within this range</string>
-              </property>
-              <property name="text">
-               <string>Visible range:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1" colspan="2">
-             <widget class="qMRMLSliderWidget" name="GlyphSpacingMm">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>Distance between the glyph points</string>
-              </property>
-              <property name="decimals">
-               <number>0</number>
-              </property>
-              <property name="singleStep">
-               <double>1.000000000000000</double>
-              </property>
-              <property name="pageStep">
-               <double>25.000000000000000</double>
-              </property>
-              <property name="minimum">
-               <double>1.000000000000000</double>
-              </property>
-              <property name="maximum">
-               <double>100.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>10.000000000000000</double>
-              </property>
-              <property name="quantity">
-               <string notr="true">length</string>
-              </property>
-              <property name="unitAwareProperties">
-               <set>qMRMLSliderWidget::Precision|qMRMLSliderWidget::Prefix|qMRMLSliderWidget::Scaling|qMRMLSliderWidget::Suffix</set>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1" colspan="2">
-             <widget class="qMRMLRangeWidget" name="GlyphDisplayRangeMm">
-              <property name="toolTip">
-               <string>Only those glyphs are shown that have displacement magnitude within this range</string>
-              </property>
-              <property name="singleStep">
-               <double>0.100000000000000</double>
-              </property>
-              <property name="maximum">
-               <double>100.000000000000000</double>
-              </property>
-              <property name="maximumValue">
-               <double>100.000000000000000</double>
-              </property>
-              <property name="suffix">
-               <string/>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="0">
-             <widget class="QLabel" name="label_2">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>Choose a glyph type to use</string>
-              </property>
-              <property name="text">
-               <string>Glyph type:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="1" colspan="2">
-             <widget class="ctkComboBox" name="GlyphTypeComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>Choose a glyph type to use</string>
-              </property>
-              <property name="defaultText">
-               <string/>
-              </property>
-              <item>
-               <property name="text">
-                <string>Arrow</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Cone</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Sphere</string>
-               </property>
-              </item>
-             </widget>
-            </item>
             <item row="2" column="1" colspan="2">
              <widget class="qMRMLSliderWidget" name="GlyphScalePercent">
               <property name="sizePolicy">
@@ -497,8 +364,8 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="0" colspan="3">
-             <widget class="ctkCollapsibleGroupBox" name="GlyphSourceOptions">
+            <item row="6" column="0" colspan="3">
+             <widget class="ctkCollapsibleGroupBox" name="GlyphSourceOptions3D">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
                 <horstretch>0</horstretch>
@@ -586,6 +453,9 @@
                  <property name="toolTip">
                   <string>Diameter of the arrow shaft relative to the base diameter</string>
                  </property>
+                 <property name="decimals">
+                  <number>0</number>
+                 </property>
                  <property name="singleStep">
                   <double>1.000000000000000</double>
                  </property>
@@ -610,31 +480,6 @@
                  </property>
                  <property name="text">
                   <string>Tip length:</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="1">
-                <widget class="ctkSliderWidget" name="GlyphTipLengthPercent">
-                 <property name="toolTip">
-                  <string>Length of the arrow tip  as percentage of displacement</string>
-                 </property>
-                 <property name="decimals">
-                  <number>0</number>
-                 </property>
-                 <property name="singleStep">
-                  <double>1.000000000000000</double>
-                 </property>
-                 <property name="pageStep">
-                  <double>10.000000000000000</double>
-                 </property>
-                 <property name="maximum">
-                  <double>100.000000000000000</double>
-                 </property>
-                 <property name="value">
-                  <double>30.000000000000000</double>
-                 </property>
-                 <property name="suffix">
-                  <string>%</string>
                  </property>
                 </widget>
                </item>
@@ -673,7 +518,114 @@
                  </property>
                 </widget>
                </item>
+               <item row="2" column="1">
+                <widget class="ctkSliderWidget" name="GlyphTipLengthPercent">
+                 <property name="toolTip">
+                  <string>Length of the arrow tip  as percentage of displacement</string>
+                 </property>
+                 <property name="decimals">
+                  <number>0</number>
+                 </property>
+                 <property name="singleStep">
+                  <double>1.000000000000000</double>
+                 </property>
+                 <property name="pageStep">
+                  <double>10.000000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>100.000000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>30.000000000000000</double>
+                 </property>
+                 <property name="suffix">
+                  <string>%</string>
+                 </property>
+                </widget>
+               </item>
               </layout>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_10">
+              <property name="toolTip">
+               <string>Glyphs are shown if the displacement magnitude is within this range</string>
+              </property>
+              <property name="text">
+               <string>Visible range:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1" colspan="2">
+             <widget class="qMRMLSliderWidget" name="GlyphSpacingMm">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Distance between the glyph points</string>
+              </property>
+              <property name="decimals">
+               <number>0</number>
+              </property>
+              <property name="singleStep">
+               <double>1.000000000000000</double>
+              </property>
+              <property name="pageStep">
+               <double>25.000000000000000</double>
+              </property>
+              <property name="minimum">
+               <double>1.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>100.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>10.000000000000000</double>
+              </property>
+              <property name="quantity">
+               <string notr="true">length</string>
+              </property>
+              <property name="unitAwareProperties">
+               <set>qMRMLSliderWidget::Precision|qMRMLSliderWidget::Prefix|qMRMLSliderWidget::Scaling|qMRMLSliderWidget::Suffix</set>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1" colspan="2">
+             <widget class="qMRMLRangeWidget" name="GlyphDisplayRangeMm">
+              <property name="toolTip">
+               <string>Only those glyphs are shown that have displacement magnitude within this range</string>
+              </property>
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>100.000000000000000</double>
+              </property>
+              <property name="maximumValue">
+               <double>100.000000000000000</double>
+              </property>
+              <property name="suffix">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_2">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Choose a glyph type to use</string>
+              </property>
+              <property name="text">
+               <string>Glyph type:</string>
+              </property>
              </widget>
             </item>
             <item row="0" column="0">
@@ -705,6 +657,157 @@
               <property name="noneDisplay">
                <string>Entire region</string>
               </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="GlyphSpacingLabel">
+              <property name="toolTip">
+               <string>Distance between the glyph points</string>
+              </property>
+              <property name="text">
+               <string>Spacing:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1" colspan="2">
+             <widget class="ctkComboBox" name="GlyphTypeComboBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Choose a glyph type to use</string>
+              </property>
+              <property name="defaultText">
+               <string/>
+              </property>
+              <item>
+               <property name="text">
+                <string>Arrow</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Cone</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Sphere</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label">
+              <property name="toolTip">
+               <string>Percentage of displacement usef for setting the glyph size. 100% means the glyph size equals the actual displacement.</string>
+              </property>
+              <property name="text">
+               <string>Scale factor:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="0" colspan="3">
+             <widget class="ctkCollapsibleGroupBox" name="GlyphSourceOptions2D">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="title">
+               <string>2D glyph settings</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+              <property name="collapsed">
+               <bool>true</bool>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_10">
+               <property name="leftMargin">
+                <number>4</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>4</number>
+               </property>
+               <property name="bottomMargin">
+                <number>4</number>
+               </property>
+               <property name="spacing">
+                <number>4</number>
+               </property>
+               <item row="1" column="1">
+                <widget class="ctkSliderWidget" name="GlyphTipLengthPercent2D">
+                 <property name="toolTip">
+                  <string>Length of the arrow tip  as percentage of displacement</string>
+                 </property>
+                 <property name="decimals">
+                  <number>0</number>
+                 </property>
+                 <property name="singleStep">
+                  <double>1.000000000000000</double>
+                 </property>
+                 <property name="pageStep">
+                  <double>10.000000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>100.000000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>30.000000000000000</double>
+                 </property>
+                 <property name="suffix">
+                  <string>%</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="GlyphDiameterMmLabel_2">
+                 <property name="toolTip">
+                  <string>Adjust radius of base of arrow tip</string>
+                 </property>
+                 <property name="text">
+                  <string>Line width:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="GlyphTipLengthLabel_2">
+                 <property name="toolTip">
+                  <string>Adjust how much of the tip the arrow will consist of as a decimal percentage</string>
+                 </property>
+                 <property name="text">
+                  <string>Tip length:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QSpinBox" name="SliceIntersectionThicknessSpinBox">
+                 <property name="suffix">
+                  <string> px</string>
+                 </property>
+                 <property name="minimum">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <number>6</number>
+                 </property>
+                 <property name="singleStep">
+                  <number>1</number>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </widget>
             </item>
            </layout>

--- a/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.cxx
@@ -182,6 +182,10 @@ void qMRMLTransformDisplayNodeWidgetPrivate::init()
   QObject::connect(this->GlyphShaftDiameterPercent, SIGNAL(valueChanged(double)), q, SLOT(setGlyphShaftDiameterPercent(double)));
   QObject::connect(this->GlyphResolution, SIGNAL(valueChanged(double)), q, SLOT(setGlyphResolution(double)));
 
+  // 2D Glyph Parameters
+  QObject::connect(this->SliceIntersectionThicknessSpinBox, SIGNAL(valueChanged(int)), q, SLOT(setSliceIntersectionThickness(int)));
+  QObject::connect(this->GlyphTipLengthPercent2D, SIGNAL(valueChanged(double)), q, SLOT(setGlyphTipLengthPercent2D(double)));
+
   // Grid Parameters
   QObject::connect(this->GridScalePercent, SIGNAL(valueChanged(double)), q, SLOT(setGridScalePercent(double)));
   QObject::connect(this->GridSpacingMm, SIGNAL(valueChanged(double)), q, SLOT(setGridSpacingMm(double)));
@@ -280,6 +284,9 @@ void qMRMLTransformDisplayNodeWidget::updateWidgetFromDisplayNode()
   d->GlyphTipLengthPercent->setValue(d->TransformDisplayNode->GetGlyphTipLengthPercent());
   d->GlyphShaftDiameterPercent->setValue(d->TransformDisplayNode->GetGlyphShaftDiameterPercent());
   d->GlyphResolution->setValue(d->TransformDisplayNode->GetGlyphResolution());
+
+  // 2D Glyph Parameters
+  d->SliceIntersectionThicknessSpinBox->setValue(d->TransformDisplayNode->GetSliceIntersectionThickness());
 
   // Grid Parameters
   d->GridScalePercent->setValue(d->TransformDisplayNode->GetGridScalePercent());
@@ -559,6 +566,7 @@ void qMRMLTransformDisplayNodeWidget::updateGlyphSourceOptions(int glyphType)
     d->GlyphShaftDiameterPercent->setVisible(true);
     d->GlyphTipLengthLabel->setVisible(true);
     d->GlyphTipLengthPercent->setVisible(true);
+    d->GlyphTipLengthPercent2D->setVisible(true);
   }
   else if (glyphType == vtkMRMLTransformDisplayNode::GLYPH_TYPE_CONE)
   {
@@ -568,6 +576,7 @@ void qMRMLTransformDisplayNodeWidget::updateGlyphSourceOptions(int glyphType)
     d->GlyphShaftDiameterPercent->setVisible(false);
     d->GlyphTipLengthLabel->setVisible(false);
     d->GlyphTipLengthPercent->setVisible(false);
+    d->GlyphTipLengthPercent2D->setVisible(false);
   }
   else if (glyphType == vtkMRMLTransformDisplayNode::GLYPH_TYPE_SPHERE)
   {
@@ -577,6 +586,7 @@ void qMRMLTransformDisplayNodeWidget::updateGlyphSourceOptions(int glyphType)
     d->GlyphShaftDiameterPercent->setVisible(false);
     d->GlyphTipLengthLabel->setVisible(false);
     d->GlyphTipLengthPercent->setVisible(false);
+    d->GlyphTipLengthPercent2D->setVisible(false);
   }
 }
 
@@ -589,6 +599,28 @@ void qMRMLTransformDisplayNodeWidget::regionNodeChanged(vtkMRMLNode* node)
     return;
   }
   d->TransformDisplayNode->SetAndObserveRegionNode(node);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLTransformDisplayNodeWidget::setSliceIntersectionThickness(int thickness)
+{
+  Q_D(qMRMLTransformDisplayNodeWidget);
+  if (!d->TransformDisplayNode)
+  {
+    return;
+  }
+  d->TransformDisplayNode->SetSliceIntersectionThickness(thickness);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLTransformDisplayNodeWidget::setGlyphTipLengthPercent2D(double lengthPercent)
+{
+  Q_D(qMRMLTransformDisplayNodeWidget);
+  if (!d->TransformDisplayNode)
+  {
+    return;
+  }
+  d->TransformDisplayNode->SetGlyphTipLengthPercent2D(lengthPercent);
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.h
+++ b/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.h
@@ -75,6 +75,8 @@ public slots:
   void setGlyphDiameterMm(double diameterMm);
   void setGlyphShaftDiameterPercent(double diameterPercent);
   void setGlyphResolution(double resolution);
+  void setSliceIntersectionThickness(int thickness);
+  void setGlyphTipLengthPercent2D(double lengthPercent);
   void setGridScalePercent(double scale);
   void setGridSpacingMm(double spacing);
   void setGridLineDiameterMm(double diameterMm);


### PR DESCRIPTION
This PR makes "line thickness" and "arrow tip length" parameters editable in the transforms module GUI. Larger thickness value makes the 2D glyphs thicker, which can be useful for example for creating screenshots that are scaled to smaller size. Shorter arrow tips can help with making the visualization a bit less busy.

<img width="2388" height="1009" alt="image" src="https://github.com/user-attachments/assets/c6f981d6-40ed-4cfe-b37d-24b57ce1cdce" />
