### PR TITLE
COMP: Update CTK with fix to build with Qt 6.10

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -78,7 +78,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "c571aba4ced7b0d1f3c87e25714ccd3e0ac159fa"
+    "b9906abb3248506981ec1e1584cb7d9c69e47412"
     QUIET
     )
 


### PR DESCRIPTION
This resolves build compatibility issues when using Qt 6.10. I've successfully built Slicer with Qt 6.10.1 with this fix.

- [x] https://github.com/commontk/CTK/pull/1333 should be integrated first
- [x] Restore upstream CTK specification and update latest git hash following integration of the above
```
CTK:
$ git shortlog c571aba..TBD
Andras Lasso (1):
      BUG: Fix crash in ctkRangeWidgetPrivate::synchronizeSiblingSpinBox

James Butler (1):
      COMP: Update PythonQt with Qt 6.10 compatibility fix
```