### PR TITLE
COMP: Update LibFFI to v3.5.2 based version

### DIFF
--- a/SuperBuild/External_LibFFI.cmake
+++ b/SuperBuild/External_LibFFI.cmake
@@ -38,7 +38,7 @@ if((NOT DEFINED LibFFI_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "e8599d9d5a50841c11a5ff8e3438dd12f080b096" # libffi-cmake-buildsystem-v3.4.2-2021-06-28-f9ea416
+    "46b9adc9f8391c31d15028766e6c6a04b5d78092" # libffi-cmake-buildsystem-v3.5.2-2025-12-26-2263d60
     QUIET
     )
 

--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -142,7 +142,7 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "f807c34cee2eccc434bad9f363915a5eeff7a2b8"
+    "ddb8a5cbbab0eff407d46125a1944a023b304eb5"
     QUIET
     )
 


### PR DESCRIPTION
This is work for #5944.

- [x] https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/pull/438 should be integrated first
- [x] Update final git hash of python-cmake-buildsystem once the above is integrated and restore repo to python-cmake-buildsystem instead of my personal repo.
- [x] Libffi repository used should be updated from my personal fork (jamesobutler/libffi) to a more permanent fork version such as by pushing my [`libffi-cmake-buildsystem-v3.5.2-2025-12-26-2263d60`](https://github.com/jamesobutler/libffi/tree/libffi-cmake-buildsystem-v3.5.2-2025-12-26-2263d60) branch to the existing used fork at python-cmake-buildsystem/libffi or a new fork. I do not currently have access to push a branch to python-cmake-buildsystem/libffi (cc: @jcfr)

Currently my Slicer build on Windows has successfully passed building LibFFI and python and is continuing.