### PR TITLE
COMP: Update CTK with Qt6 pythonqt wrapping fixes

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -78,7 +78,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "b9906abb3248506981ec1e1584cb7d9c69e47412"
+    "3811bcaf0d84e9b43777e6422b2330b84baf2e0b"
     QUIET
     )
 


### PR DESCRIPTION
This CTK update includes a fix that closes https://github.com/Slicer/Slicer/issues/8941.
```
List of changes:
$ git shortlog b9906ab..3811bca
James Butler (3):
      COMP: Update PythonQt with Qt 6.10 wrapping fixes
      BUG: Fix ctkPathLineEdit Filter enums unavailable to PythonQt with Qt6
      BUG: Fix Q_ENUM declarations for PythonQt compatibility with Qt5
```

This resolves issues discovered during automated testing while using Qt 6.10.1:
```
======================================================================
ERROR: test_downloadFromSource_downloadZipFile (SampleData.SampleDataTest.test_downloadFromSource_downloadZipFile)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:/S5R2/Slicer-build/lib/Slicer-5.11/qt-scripted-modules/SampleData.py", line 1266, in test_downloadFromSource_downloadZipFile
    filePaths = logic.downloadFromSource(SampleDataSource(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/S5R2/Slicer-build/lib/Slicer-5.11/qt-scripted-modules/SampleData.py", line 895, in downloadFromSource
    qt.QDir().mkpath(outputDir)
    ^^^^^^^^^^^^^^^^
AttributeError: QDir has no attribute named 'mkpath'. Did you mean: 'path'?
```
```
test_widgetRepresentation (qSlicerScreenCaptureModuleGenericTest.qSlicerScreenCaptureModuleGenericTest.test_widgetRepresentation) ... Traceback (most recent call last):
  File "C:/S5R2/Slicer-build/lib/Slicer-5.11/qt-scripted-modules/ScreenCapture.py", line 204, in setup
    self.outputDirSelector.filters = ctk.ctkPathLineEdit.Dirs
                                     ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: ctkPathLineEdit has no attribute named 'Dirs'
```
```
test_widgetRepresentation (qSlicerDICOMPatcherModuleGenericTest.qSlicerDICOMPatcherModuleGenericTest.test_widgetRepresentation) ... Traceback (most recent call last):
  File "C:/S5R2/Slicer-build/lib/Slicer-5.11/qt-scripted-modules/DICOMPatcher.py", line 60, in setup
    self.inputDirSelector.filters = ctk.ctkPathLineEdit.Dirs
                                    ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: ctkPathLineEdit has no attribute named 'Dirs'
```