### PR TITLE
BUG: Fix crash in ExportSegmentsToColorTableNode

### DIFF
--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -1120,6 +1120,12 @@ bool vtkSlicerSegmentationsModuleLogic::ExportSegmentsToColorTableNode(vtkMRMLSe
     }
   }
 
+  if (!colorTableNode->GetLookupTable())
+  {
+    vtkNew<vtkLookupTable> lookupTable;
+    colorTableNode->SetAndObserveLookupTable(lookupTable);
+  }
+
   colorTableNode->SetNumberOfColors(numberOfColors);
   colorTableNode->GetLookupTable()->SetRange(0, numberOfColors - 1);
   colorTableNode->GetLookupTable()->SetNumberOfTableValues(numberOfColors);


### PR DESCRIPTION
Make sure that ExportSegmentsToColorTableNode does not crash if color table is not set.