### PR TITLE
COMP: Fix LibFFI build error on macOS and Linux

### DIFF
--- a/SuperBuild/External_LibFFI.cmake
+++ b/SuperBuild/External_LibFFI.cmake
@@ -38,7 +38,7 @@ if((NOT DEFINED LibFFI_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "46b9adc9f8391c31d15028766e6c6a04b5d78092" # libffi-cmake-buildsystem-v3.5.2-2025-12-26-2263d60
+    "90704ad36f27b65b78573172127e7bea4ccd82bb" # libffi-cmake-buildsystem-v3.5.2-2025-12-26-2263d60
     QUIET
     )
 


### PR DESCRIPTION
This is a follow-up to https://github.com/Slicer/Slicer/commit/ae061acd0f40570dcc1332920a2f6e370f1bd69d. It address a reported build error on Linux (see [here](https://slicer.cdash.org/viewBuildError.php?buildid=4052061)) and macOS (see [here](https://slicer.cdash.org/viewBuildError.php?buildid=4052062)).
```
libffi:
$ git shortlog 46b9adc..90704ad
James Butler (1):
      COMP: LibFFI version defines not set causing macOS and Linux build error
```

I have successfully built locally on macOS with this change as well as have built successfully on Windows.