### PR TITLE
COMP: Update DCMTK version to 3.7.0

### DIFF
--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -64,13 +64,13 @@ if(NOT DEFINED DCMTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/commontk/DCMTK.git"
+    "${EP_GIT_PROTOCOL}://github.com/DCMTK/DCMTK.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "f390821c469c0897c1b5437164c8826e080a2581" # patched-DCMTK-3.6.8_20241024
+    "ccfd10b84ff3c9a40b7b331698aedf06d421fc43" # DCMTK-3.7.0
     QUIET
     )
 


### PR DESCRIPTION
DCMTK was last updated in 3D Slicer a little over a year ago in https://github.com/Slicer/Slicer/commit/75555c9f1043450ad04a85f8e758a56d3629bb32 and has been using a 3.6.8 based version. Special commits in the existing Slicer DCMTK fork branch had been integrated to the upstream allowing for direct use of the upstream repo.

This PR updates the DCMTK library to version 3.7.0., incorporating numerous enhancements, bug fixes, and compatibility improvements. Notable updates include:

- Added support for recent DICOM standards (2024e through 2025e)
- Added support for creating, writing and reading Labelmap Segmentation Storage objects to the "dcmseg" module. https://github.com/DCMTK/dcmtk/commit/71567ae8418e0066f71c9ce46423e272c98e1c09. (This PR is work for https://github.com/Slicer/Slicer/issues/8387)
- Added support for IPv6 in DCMTK's association acceptors.  The support for DICOM network connections over IPv6 is now considered complete. https://github.com/DCMTK/dcmtk/commit/4215154c9ddb39ffb03784331afdc45dadeb8dc6

Local Testing Results:
Windows:
- Build ✔️ 
- Package ✔️ 
- Test ✔️ (no new failing tests)
 
macOS:
- Build ✔️ 
- Package ✔️ 
- Test ✔️ (no new failing tests)

```
DCMTK:
$ git shortlog f390821..ccfd10b
Joerg Riesmeier (151):
      Fixed issue with rendering MONOCHROME1 images.
      Improved performance of DcmVR::setVR().
      Fixed indentation of comment.
      Fixed API documentation and identation.
      Introduced new enum type for invalid VRs.
      Slightly changed implementation of DcmVR::setVR().
      Fixed comment.
      Added support for new Storage SOP Classes.
      Added support for new segmentation SOP Classes.
      Added two new DICONDE Storage SOP Classes.
      Re-added support for surface segmentations.
      Added LUTData (0028,3006) to unhandled attributes.
      Updated data dictionary for DICOM 2024e.
      Updated code definitions for DICOM 2024e.
      Added document on how to contribute to the DCMTK.
      Removed empty line at the end of the file.
      Added reference to new "CONTRIBUTING.md" file.
      Fixed line breaks.
      Updated information on latest CMake version.
      Fixed line breaks and added contributors.
      Minor fixes to comments.
      Removed extra space.
      Extended and revised announcement file.
      Various minor fixes to installation description.
      Removed empty line at end of verbatim environment.
      Updated Makefile dependencies.
      Removed space character after "if" statement.
      Updated information on latest CMake version.
      Updated documentation on predefined CMake targets.
      Added CONTRIBUTING.md file to HTML documentation.
      No longer obfuscate email address for bug reports.
      Updated name and date after recent change.
      Moved recently added item to the correct place.
      Rebuilt Makefile dependencies.
      Added missing package date.
      Replaced call of delete by delete[].
      Replaced call of delete also in destructor.
      Fixed source code formatting.
      Avoided warning on unchecked option --write-auto.
      Added check to make sure: HighBit < BitsAllocated.
      Revised handling of --write-auto option.
      Fixed wrong capitalization of acronym "JSON".
      Fixed issue with Doxygen grouping markup.
      Replaced call of delete by delete[].
      Enhanced check for invalid NULL parameter.
      Fixed issue rendering invalid monochrome image.
      Enhanced dcm2xml's support for DICOMDIR files.
      Restructured code of method convertString().
      Made a minor change to the API documentation.
      Improved performance of DcmList::seek_to().
      Replaced call of DcmList::seek_to() by seek().
      Further optimizations of DcmList:seek_to().
      Do not exceed the maximum size of DcmList.
      Made sure that memory is always cleaned up.
      Fixed another issue with invalid mono images.
      Removed further outdated Autoconf tests.
      Don't call getAbsMinimum() in a for-loop.
      Fixed another issue with invalid DICOM images.
      Made sure all member variables are initialized.
      Added support for the Context Group Keyword.
      Avoid warning on unused variable.
      Added the usual note for development versions.
      Removed space between CMake command and "(".
      Reverted accidentally committed changes.
      Fixed minor documentation errors.
      Fixed source code formatting.
      Added missing newline to "FILES" section.
      Added line break for 80-characters-per-line limit.
      Replaced spaces by tab character for indendation.
      Fixed calculation of no. of TLS 1.3 cipher suites.
      Added "datadir" and "docdir" to CMake config.
      Fixed issue with icon image of IMAGE content item.
      Added missing virtual functions to base class.
      Added putAndInsertXXX() methods for 64-bit VRs.
      Used "@note" in Doxgen's API documentation.
      Fixed wrong Doxygen subsection labels.
      Increased precision of float/double output to XML.
      Report warning on unexpected Verifying Observers.
      Report warning on incorrect Mapping Resource UID.
      Made sure float/double values use a decimal point.
      Avoid possible output of "-nan" in XML format.
      Updated data dictionary for DICOM 2025a.
      Updated code definitions for DICOM 2025a.
      Updated Context Group classes for DICOM 2025a.
      Added SOP Class to "DICOM Conformance" section.
      Always return unknown PDU type with two digits.
      Use non-throwing new operator to avoid crash.
      Use non-throwing new operator.
      Added initial support for new transfer syntax.
      Added support for new Storage SOP Classes.
      Added support for new Presentation States.
      Added quotation marks to CMake variables.
      Added support for new Directory Record Type.
      Updated list of multi-frame Storage SOP Classes.
      Added note on the potential misuse of options.
      Updated data dictionary for DICOM 2025b.
      Updated code definitions for DICOM 2025b.
      Updated Context Group classes for DICOM 2025b.
      Added support for new DICONDE Storage SOP Class.
      Indicated retired attributes in documentation.
      Added missing GNU Autoconf support to "tests".
      Made output of warning messages more consistent.
      Enhanced log output for incorrect pixel data.
      Updated documentation of parameter "jsonfile-in".
      Added "json2dcm" to module's documentation page.
      Added new command line tool "json2dcm".
      Fixed wrong sub-group title.
      Various minor fixes, mainly related to json2dcm.
      Changed log level and text of some log messages.
      Minor fixes to manpage and syntax usage.
      Fixed indentation of source header.
      Fixed minor issues in manpage.
      Fixed formatting and replaced wrong term.
      Do not warn on "Undefind Length" for some VRs.
      Made some functions virtual to allow overriding.
      Fixed various spelling and formatting issues.
      Replaced wrong term in manpage.
      Replaced tab characters by spaces.
      Updated data dictionary for DICOM 2025c.
      Updated code definitions for DICOM 2025c.
      Updated Context Group classes for DICOM 2025c.
      Fixed issue with invalid "YBR_FULL" DICOM images.
      Fixed issue with commit 7ad81d69b.
      Fixed off-by-one error when processing an image.
      Fixed warning reported by Visual Studio.
      Reduced number of warnings (gcc -Wconversion).
      Slightly enhanced new functionality of LUT class.
      Added support for Patient's Age to "dcmsr"
      Converted array index to unsigned integer value.
      Added check of "writeMode" to write() method.
      Fixed typo in comment.
      Updated data dictionary for DICOM 2025d.
      Updated code definitions for DICOM 2025d.
      Warn if Photometric Interpretation is missing.
      Removed last (empty) entry from UID name map.
      Made sure not to use incompatible options.
      Made DcmItem::updateSpecificCharacterSet() public.
      Added new tools dcmdecap and dcmencap.
      Fixed issues with new command line tool dcmdecap.
      Fixed source code formatting.
      Fixed issue with VR scanner for "DateTime" values.
      Moved new regression tests to another file.
      Made use of getDestinationEncoding().
      Updated data dictionary for DICOM 2025e.
      Updated code definitions for DICOM 2025e.
      Updated Context Group classes for DICOM 2025e.
      Updated copyright date.
      Fixed wrong use of ESC in "LO" and "SH" test case.
      Updated information on latest CMake version.
      Fixed issue when charset conversion is disabled.
      Avoid wrong warning message on private pixel data.

Marco Eichelberg (156):
      Added OFStandard::isspace().
      Replaced mutex in OFGlobal by read/write lock.
      Fixed minor warning.
      Added template specializaton for OFGlobal<OFBool>.
      Fixed segmentation fault when decoding invalid RLE.
      Fixed compilation on NetBSD.
      Added command line options --list-profiles.
      Disabled outdated backwards compatibility code.
      Updated documentation for upcoming release.
      Updated manpages for upcoming release.
      Fixed data directory macros.
      Fixed compilation with older CMake versions.
      Updated CMake version requirements.
      Fixed CMake file for dcmqrdb library.
      Fixed minor warning.
      Updated configure files for upcoming release.
      Updated copyright date.
      Updated version information for DCMTK release 3.6.9.
      Updated man pages for DCMTK release 3.6.9.
      Created CHANGES.369 for DCMTK release 3.6.9.
      Updated configure files for upcoming release.
      Updated PACKAGE version settings.
      Updated Github workflow config.
      Updated version information for 3.6.9+ development.
      Updated version information for 3.6.9+ development.
      Removed duplicate library dependencies.
      Fixed padding of compressed JPEG-LS bitstream.
      Removed duplicate library dependencies (part 2).
      Simplified DcmQuantColorTable::computeHistogram().
      Properly handle unknown "localhost" in DVPSIPCClient.
      Added option that allows to relax GSPS validation.
      Fixed TIFF export on Windows.
      Fixed frame size calculation for special cases.
      Fixed thread issues in oficonv code.
      Fixed data corruption in iconv passthrough mode.
      Added logger warnings when converting invalid IS/DS.
      Added OFString/std::string conversion helpers.
      Fixed minor warning on MSVC.
      Fixed two memory leaks in oficonv.
      Fixed a few memory leaks in unit tests.
      Fixed HAVE_PROTOTYPE_FEENABLEEXCEPT configure test.
      Fixed handling of SpecificCharacterSet in sequences.
      Further clean-up of outdated configure tests.
      Fixed debug build on Win32.
      Fixed character set conversion in dcm2json.
      Further clean-up of outdated configure tests.
      Fixed access rights.
      Fixed issue with invalid RLE compressed DICOM images.
      Improved diagnostic log output.
      Improved handling of JPEG image files.
      Fixed minor warnings.
      Stop cmake with error message if C++ standard is 98.
      Updated INSTALL for previous commit.
      Silently remove trailing zero bytes in strings.
      Added class that computes SHA-256 checksums.
      Removed conditional code for very old MSVC versions.
      Fixed precision when converting double to text.
      Refuse compilation on platforms without 64-bit int.
      Fixed minor inconsistency in macro definition.
      Updated some comments.
      Added support for "-nan" in OFStandard::atof().
      Fixed Solaris/OpenIndiana build.
      Warn when decoding frame into odd-length buffer.
      Fixed byte order when decoding JPEG-LS on big endian.
      Fixed STL file size validation on big-endian CPUs.
      Fixed BMP to DICOM conversion on big-endian CPUs.
      Fixed bug in RLE decoder.
      Fixed segfault in JPEG-LS decoder.
      Fixed ANNOUNCE.369.
      Fixed error message on Windows.
      Removed unused variable.
      Improved description of support lib compile flags.
      Disable Borland workarounds when using bcc64x.
      Added TLS support for C-MOVE in dcmqrscp.
      Added TLS support to movescu.
      Fixed C++98 build.
      Fixed linker warning on MacOS.
      Added support for BulkDataURI in JSON export.
      Fixed compilation of dcm2json on Windows.
      Minor fixes in dcm2json.
      Fixed JSON conversion of compressed images.
      Fixed bug in dcm2json.
      Encode special characters in file: URLs.
      Fixed shared library build.
      Minor fix in jsmn API definition.
      Fixed URL encoding of path separators.
      Replaced C-style casts with C++ casts.
      Fixed memory leaks and segfault in json2dcm.
      Added support for reading from stdin.
      Updated documentation parameter "dcmfile-out".
      Apply bit mask when passing pixel data to CharLS.
      Fixed minor MSVC warning.
      Reworded comment on HP color transform.
      Fixed generation of 32-bit BMP on Big Endian CPUs.
      Added a note that json2dcm accepts trailing commas.
      Added note on bulk data export.
      Improved json2dcm performance.
      Added --ignore-bulkdata-uri option to json2dcm.
      Added options for handling JSON arrays of datasets.
      Removed unneccessary parameter.
      Fixed warnings from gcc on MacOS 15.
      Refactored DICOM JSON parser into reusable class.
      Added default for bulk data size in help output.
      Added error code for unsupported URI type.
      Fixed OFStandard API documentation.
      Added support for file BulkDataURIs in json2dcm.
      Added missing include on Windows.
      Added method for activating the list of ciphersuites.
      Moved pragma to separate include file.
      Initialize dataset transfer syntax when reading file.
      Improved documentation of initializeXfer() method.
      Added note on character set conversion.
      Fixed metaheader generation in dcmodify and dcmconv.
      Link libnsl and libsocket only when required.
      Fixed sample code.
      Improved CMake code for static builds.
      Added method for accessing a DICOM file preamble.
      Set implementation information at runtime.
      Added new tool dcmencap that encapsulates documents.
      Added consistency check for --series-from option.
      Minor improvements for dcmencap.
      Made depreciation warnings more prominent.
      Updated man pages for deprecated tools.
      Fixed minor warnings.
      Fixed inconsistencies in command line options.
      Fixed off-by-one buffer overrun.
      Added JPEG decoder option for preserving BitsStored.
      Enabled the use of TLS for sub-associations.
      Fixed minor warning.
      Fixed dcmAcceptOddAttributeLength implementation.
      Added new tool dcmdecap that extracts encapsulated documents.
      Added dcmdecap and dcmencap to module documentation.
      Fix TCP initialization error message.
      DcmJSONReader::clear() now prevents double delete.
      Fixed minor warnings.
      Switch stdout to binary on Windows.
      Added missing includes.
      Added IPv6 support to DCMTK's association acceptors.
      Fixed man page on Windows.
      Fixed man page on Windows.
      Added callback parameter to "request fork" function.
      Added storescp option --max-associations.
      Fixed minor warning on C++20 build.
      Fixed strlcpy related issue in oficonv.
      Fixed errors when compiling with C++98.
      Fixed two possible segfaults in dcmqrscp.
      Fixed bug in handling of odd-length data elements.
      Fixed documentation.
      Fixed warnings reported on Android.
      Updated documentation for upcoming release.
      Updated URL for Windows support libs.
      Updated autoconf files for upcoming release.
      Updated copyright date.
      Updated version information for DCMTK release 3.7.0.
      Updated man pages for DCMTK release 3.7.0.
      Created CHANGES.370 for DCMTK release 3.7.0.

Mathieu Malaterre (3):
      Provide a hook to setup iconv path at runtime.
      Reworked JSON writeBulkData API.
      Access JSON bulk data URI prefix through API.

Michael Onken (44):
      Move test for putOFstringAtPos into separate file.
      Added documentation, changed method name.
      Simplify header includes.
      Use DcmItem instead of DcmDataset for references.
      Use synchronization instead of synchronisation.
      Added missing libdir for dcmtkcharls to linker.
      Updated Makefile dependencies.
      CMake debug postfix options for libs/executables.
      Fix binary segmentations with certain dimensions.
      Fixed compiler warnings introduced in 6245f9.
      Added segmentation bugfix to notable changes.
      Added Ubuntu 24.10 to list of tested systems.
      Different integer type to avoid compiler warning.
      Use OFrand_r instead of rand().
      Don't check for libsndfile in default build.
      Handle NULL values appropriately.
      Added "component" to debug dump.
      Use temp filename.
      Fix writing of Tractography Results Series.
      Fixed compiler error/warning in test.
      Make DCMTK clients build w/o __cplusplus setting.
      Fixed test failing due to new ftoa implementation.
      Made destructor virtual.
      Added Labelmap Segmentation Support.
      Fix some compiler warnings.
      Remove override specificier.
      Fix debug output.
      Remove test app.
      Use space between template angle brackets.
      Restore old GitHub actions rules.
      Remove superfluous comment line.
      Fix more compiler warnings from 71567a
      Fix another data type size warning.
      Fix linker errors with dupl. method definitions.
      Replace old-style casts to avoid compiler warnings.
      Fixed leak in SCP Pool class, re-use threads.
      Fix reusability of SCP threads in pool.
      Fix potential crashes and endless loop.
      Updated copyright date.
      OverlapUtil and some segmentation enhancements.
      Re-add dcmsign to the Makefile.
      Fix compiler warnings/errors from 74bba5.
      Avoid compiler warning for VS 2022 on Windows 10.
      Fix compiler warning on unreachable code.

Nikolas Goldhammer (1):
      Updated CMake files for Android API 35.

Sergey Fedorov (1):
      Fix environ for Apple.

Tingyan Xu (5):
      Added JSON parser to module ofstd.
      Initial release of the json2dcm command line tool.
      Changes to JSON2DCM: Moved Exitcodes to JSON2DCM to ensure fixed codes. Removed some DEBUG testing output.
      Merge branch 'testing' of ssh://caesar.offis.uni-oldenburg.de:10022/share/dicom/git-depot/dcmtk into testing
      Fixed bug in json2dcm concerning empty PN
```