### PR TITLE
COMP: Update DCMTK to 3.7.0+ commit with binary seg fix

### DIFF
--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -70,7 +70,7 @@ if(NOT DEFINED DCMTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "ccfd10b84ff3c9a40b7b331698aedf06d421fc43" # DCMTK-3.7.0
+    "3e85b37444107e93550167c2284e64b4881b0fcb" # DCMTK 3.7.0+ 2025-12-18
     QUIET
     )
 


### PR DESCRIPTION
Per https://github.com/Slicer/Slicer/pull/8946#issuecomment-3715986049 to sync up with the DCMTK version used by DCMQI. This is additional work for https://github.com/Slicer/Slicer/issues/8387.
```
DCMTK:
$ git shortlog ccfd10b..3e85b37
Joerg Riesmeier (6):
      Fixed versions numbers of external libraries.
      Fixed access rights.
      Added missing "see also" reference to json2dcm.
      Removed wrong reference to "dump2dcm(2)".
      Check pointer before calling setParent().
      Fixed typos in / formatting of API documentation.

Marco Eichelberg (2):
      Updated version information for 3.7.0+ development.
      Updated version information for 3.7.0+ development.

Michael Onken (2):
      Init Frame with number of pixels (not bytes).
      High Bit is 0 not 1 for binary segmentations.
```