### PR TITLE
COMP: Fix TBB install not found during Linux build

### DIFF
--- a/SuperBuild/External_tbb.cmake
+++ b/SuperBuild/External_tbb.cmake
@@ -72,6 +72,7 @@ if((NOT DEFINED TBB_DIR
       -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
       # Install directories
       -DCMAKE_INSTALL_PREFIX:PATH=${EP_INSTALL_DIR}
+      -DCMAKE_INSTALL_LIBDIR:STRING=lib  # Override value set in GNUInstallDirs CMake module
       # Options
       -DBUILD_SHARED_LIBS:BOOL=ON
       -DTBB_TEST:BOOL=OFF
@@ -90,7 +91,7 @@ if((NOT DEFINED TBB_DIR
     set(tbb_bindir lib)
   endif()
 
-  set(TBB_DIR ${EP_INSTALL_DIR}/lib/cmake/TBB)
+  set(TBB_DIR ${EP_INSTALL_DIR}/${tbb_libdir}/cmake/TBB)
   set(TBB_BIN_DIR ${EP_INSTALL_DIR}/${tbb_bindir})
   set(TBB_LIB_DIR ${EP_INSTALL_DIR}/${tbb_libdir})
 


### PR DESCRIPTION
This is a follow-up to https://github.com/Slicer/Slicer/commit/ccc23152d551301f0889ba49871f93cb775dae4d which switched to build TBB from source.

This aims to resolve the following build error observed during the nightly build for Linux https://slicer.cdash.org/viewBuildError.php?buildid=4055590. 

This code change is based on the existing handling in other Slicer external projects:
https://github.com/Slicer/Slicer/blob/c3dcd368734227b25904946136a8197b31c7b7c0/SuperBuild/External_bzip2.cmake#L66
https://github.com/Slicer/Slicer/blob/c3dcd368734227b25904946136a8197b31c7b7c0/SuperBuild/External_zlib.cmake#L60
https://github.com/Slicer/Slicer/blob/c3dcd368734227b25904946136a8197b31c7b7c0/SuperBuild/External_VTK.cmake#L133