### PR TITLE
COMP: Skip PIC flag passed to MSVC

### DIFF
--- a/Libs/vtkSegmentationCore/CMakeLists.txt
+++ b/Libs/vtkSegmentationCore/CMakeLists.txt
@@ -113,10 +113,7 @@ include_directories( ${vtkSegmentationCore_INCLUDE_DIRS} )
 add_library(${PROJECT_NAME} ${vtkSegmentationCore_SRCS})
 target_link_libraries( ${PROJECT_NAME} ${vtkSegmentationCore_LIBS} )
 
-if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND NOT WIN32)
-  set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-fPIC")
-endif()
-
+set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 # Apply user-defined properties to the library target.
 if(Slicer_LIBRARY_PROPERTIES)
   set_target_properties(${PROJECT_NAME} PROPERTIES ${Slicer_LIBRARY_PROPERTIES})

--- a/SuperBuild/External_LZMA.cmake
+++ b/SuperBuild/External_LZMA.cmake
@@ -43,11 +43,6 @@ if((NOT DEFINED ${proj}_INCLUDE_DIR
   set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
   set(EP_INSTALL_LIBDIR "lib")
 
-  set(${proj}_CMAKE_C_FLAGS ${ep_common_c_flags})
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8) # 64-bit
-    set(${proj}_CMAKE_C_FLAGS "${ep_common_c_flags} -fPIC")
-  endif()
-
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${Slicer_${proj}_GIT_REPOSITORY}"
@@ -59,7 +54,8 @@ if((NOT DEFINED ${proj}_INCLUDE_DIR
       -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
       -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
-      -DCMAKE_C_FLAGS:STRING=${${proj}_CMAKE_C_FLAGS}
+      -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
       -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
       -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
       -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}

--- a/SuperBuild/External_curl.cmake
+++ b/SuperBuild/External_curl.cmake
@@ -44,12 +44,6 @@ if((NOT DEFINED CURL_INCLUDE_DIR
     endif()
   endif()
 
-
-  set(${proj}_CMAKE_C_FLAGS ${ep_common_c_flags})
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8) # 64-bit
-    set(${proj}_CMAKE_C_FLAGS "${ep_common_c_flags} -fPIC")
-  endif()
-
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
     "${EP_GIT_PROTOCOL}://github.com/curl/curl.git"
@@ -83,7 +77,8 @@ if((NOT DEFINED CURL_INCLUDE_DIR
     #Not needed -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
     #Not needed -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
-      -DCMAKE_C_FLAGS:STRING=${${proj}_CMAKE_C_FLAGS}
+      -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
       -DCMAKE_DEBUG_POSTFIX:STRING=
       -DCMAKE_INSTALL_PREFIX:PATH=${EP_INSTALL_DIR}
       -DCMAKE_INSTALL_LIBDIR:STRING=lib  # Override value set in GNUInstallDirs CMake module

--- a/SuperBuild/External_sqlite.cmake
+++ b/SuperBuild/External_sqlite.cmake
@@ -37,11 +37,6 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
   set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
   set(EP_INSTALL_LIBDIR "lib")
 
-  set(${proj}_CMAKE_C_FLAGS ${ep_common_c_flags})
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8) # 64-bit
-    set(${proj}_CMAKE_C_FLAGS "${ep_common_c_flags} -fPIC")
-  endif()
-
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${Slicer_${proj}_GIT_REPOSITORY}"
@@ -53,7 +48,8 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
       -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
-      -DCMAKE_C_FLAGS:STRING=${${proj}_CMAKE_C_FLAGS}
+      -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
       -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
       -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
       -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}


### PR DESCRIPTION
The -fPIC flag is not available in the MSVC compiler. This commit avoids the warnings such as:

cl : command line warning D9002: ignoring unknown option '-fPIC'