### PR TITLE
Switch to official XZ project repository and update to v5.8.2

### DIFF
--- a/SuperBuild/External_LZMA.cmake
+++ b/SuperBuild/External_LZMA.cmake
@@ -34,7 +34,7 @@ if((NOT DEFINED ${proj}_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "v5.2.5"
+    "v5.8.2"
     QUIET
     )
 
@@ -73,7 +73,7 @@ if((NOT DEFINED ${proj}_INCLUDE_DIR
 
   set(${proj}_INCLUDE_DIR ${EP_INSTALL_DIR}/include)
   if(WIN32)
-    set(${proj}_LIBRARY ${EP_INSTALL_DIR}/lib/liblzma.lib)
+    set(${proj}_LIBRARY ${EP_INSTALL_DIR}/lib/lzma.lib)
   else()
     set(${proj}_LIBRARY ${EP_INSTALL_DIR}/lib/liblzma.a)
   endif()


### PR DESCRIPTION
`COMP: Switch to official XZ project repository`
https://github.com/xz-mirror/xz was archived on August 28th 2023 and listed https://github.com/tukaani-project/xz as the official repository.


`COMP: Update XZ version to v5.8.2`
v5.2.5 was originally released 2020-03-17. This commit updates to v5.8.2 released 2025-12-17. This includes various fixes and support for ARM64 platforms.
See https://github.com/tukaani-project/xz/blob/v5.8.2/NEWS for more release notes.

I have successfully built and tested on both Windows and macOS.