### PR TITLE
COMP: Update cURL version to 8.17.0

### DIFF
--- a/Libs/RemoteIO/CMakeLists.txt
+++ b/Libs/RemoteIO/CMakeLists.txt
@@ -92,10 +92,22 @@ set(srcs ${RemoteIO_SRCS})
 
 add_library(${lib_name} ${srcs})
 
+# Define CURL_STATICLIB when linking against static curl on Windows
+if(WIN32)
+  target_compile_definitions(${lib_name} PRIVATE CURL_STATICLIB)
+endif()
+
 set(libs
   ${CURL_LIBRARIES}
   MRMLCore
   )
+if(WIN32)
+  list(APPEND libs
+    # For curl
+    iphlpapi  # for if_nametoindex
+    ws2_32  # for Windows sockets
+    )
+endif()
 if(Slicer_USE_PYTHONQT_WITH_OPENSSL)
   list(APPEND libs
     ${OPENSSL_LIBRARIES}

--- a/SuperBuild/External_curl.cmake
+++ b/SuperBuild/External_curl.cmake
@@ -52,13 +52,13 @@ if((NOT DEFINED CURL_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/Slicer/curl.git"
+    "${EP_GIT_PROTOCOL}://github.com/curl/curl.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "d73e360a78d97adda85364e6bd5c504a2eb1572a" # slicer-7.70.0-2020-04-29-53cdc2c
+    "curl-8_17_0"
     QUIET
     )
 
@@ -89,7 +89,7 @@ if((NOT DEFINED CURL_INCLUDE_DIR
       -DCMAKE_INSTALL_LIBDIR:STRING=lib  # Override value set in GNUInstallDirs CMake module
       -DBUILD_TESTING:BOOL=OFF
       -DBUILD_CURL_EXE:BOOL=OFF
-      -DBUILD_SHARED_LIBS:BOOL=OFF  # Before enabling this option, see https://github.com/Slicer/curl/commit/ca5fe8e63df7faea0bfb988ef3fe58f538e6950b
+      -DBUILD_SHARED_LIBS:BOOL=OFF  # Before enabling this option, review CURL_STATICLIB in CFLAGS where cURL is used
       -DENABLE_ARES:BOOL=OFF
       -DCURL_ZLIB:BOOL=ON
       -DZLIB_INCLUDE_DIR:PATH=${ZLIB_INCLUDE_DIR}
@@ -101,10 +101,11 @@ if((NOT DEFINED CURL_INCLUDE_DIR
       -DCURL_DISABLE_DICT:BOOL=ON
       -DCURL_DISABLE_FILE:BOOL=ON
       -DCURL_DISABLE_TFTP:BOOL=ON
-      -DHAVE_LIBIDN2:BOOL=FALSE
-      -DCMAKE_USE_LIBSSH:BOOL=OFF
-      -DCMAKE_USE_LIBSSH2:BOOL=OFF
-      -DCMAKE_USE_OPENSSL:BOOL=${CURL_ENABLE_SSL}
+      -DHAVE_LIBIDN2:BOOL=OFF
+      -DCURL_USE_LIBPSL:BOOL=OFF
+      -DCURL_USE_LIBSSH:BOOL=OFF
+      -DCURL_USE_LIBSSH2:BOOL=OFF
+      -DCURL_USE_OPENSSL:BOOL=${CURL_ENABLE_SSL}
     ${EXTERNAL_PROJECT_OPTIONAL_CMAKE_ARGS}
     DEPENDS
       ${${proj}_DEPENDENCIES}


### PR DESCRIPTION
This change is needed to support building against OpenSSL 3.

cURL 7.70.0 was originally released 2020-04-29. This commit updates to 8.17.0 released 2025-11-05. This update provides support for OpenSSL 3 which upon initial search appears to have been introduced/supported beginning in cURL 7.77.0.

Latest cURL 8.18.0 actually bumps  minimum OpenSSL version to 3, but since Slicer doesn't build OpenSSL 3 yet, we will move to this more recent version that supports both OpenSSL 1 and 3.

Note that many of the cURL build options switched from names like "CMAKE_USE_" to "CURL_USE_" based on the change in https://github.com/curl/curl/commit/9108da2c26d18e927b91e33d3729d9cf0f3eb8fa first included in cURL 7.81.0.


Testing results - builds were successful on both Windows and macOS platforms.