### PR TITLE
DOC: Fix spelling error in the word "supercede" -> "supersede"

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -194,6 +194,6 @@ PART C. MISCELLANEOUS
 
 This Agreement shall be governed by and construed in accordance with
 the laws of The Commonwealth of Massachusetts without regard to
-principles of conflicts of law. This Agreement shall supercede and
+principles of conflicts of law. This Agreement shall supersede and
 replace any license terms that you may have agreed to previously with
 respect to Slicer.


### PR DESCRIPTION
"Supercede" is a common misspelling of "supersede," the correct word meaning "to replace" or "to displace." Although the spelling "supercede" has existed for centuries and appears in some dictionaries as an archaic or colloquial variant, it is considered an error because the original comes from the Latin supersedere, meaning "to sit above," which also contains an "s" in the stem.

(I'm sorry for interrupting you again, but I just found this when installing the app and thought I have to fix this and I've learned a little bit because I know added "DOC:".)