### PR TITLE
BUG: Fix typo in dicom thumbnail size label

### DIFF
--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -614,7 +614,7 @@ class _ui_DICOMSettingsPanel:
         thumbnailsSizeComboBox.addItem(_("Medium"), "medium")
         thumbnailsSizeComboBox.addItem(_("Large"), "large")
         thumbnailsSizeComboBox.currentIndex = 1
-        genericGroupBoxFormLayout.addRow(_("Thumbnails size:"), thumbnailsSizeComboBox)
+        genericGroupBoxFormLayout.addRow(_("Thumbnail size:"), thumbnailsSizeComboBox)
         parent.registerProperty(
             "DICOM/thumbnailsSize", thumbnailsSizeComboBox,
             "currentUserDataAsString", str(qt.SIGNAL("currentIndexChanged(int)")))


### PR DESCRIPTION
Not quite sure if "Thumbnail size" is correct.

Fixed typo in "Thumbnail size" label (changed to "Thumbnails' sizes", but not quite sure about this one, please correct me if I'm mistaken, thanks).