### PR TITLE
COMP: Update urllib3 version to latest 2.6.3

### DIFF
--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -56,7 +56,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
                             --hash=sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f
   # [/charset-normalizer]
   # [urllib3]
-  urllib3==2.5.0 --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
+  urllib3==2.6.3 --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
   # [/urllib3]
   # [requests]
   requests==2.32.5 --hash=sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6


### PR DESCRIPTION
This satisfies GitHub advisories warned in the Security section of the Slicer repository:
- https://github.com/advisories/GHSA-2xpw-w6gg-jr37
- https://github.com/advisories/GHSA-gm62-xv2j-4w53
- https://github.com/advisories/GHSA-38jv-5279-wg99

This will boost the Slicer OpenSSF Scorecard report which is currently getting docked a few points for these warned advisories.