### PR TITLE
COMP: Update urllib3 version to latest 2.6.3 in doc requirement

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -12,5 +12,5 @@ sphinx-notfound-page
 sphinx-reredirects
 sphinx_rtd_theme>=0.5.2
 requests>=2.32.4 # not directly required, pinned by Snyk to avoid a vulnerability
-urllib3>=2.5.0 # not directly required, pinned by Snyk to avoid a vulnerability
+urllib3>=2.6.3 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
This is a follow-up to https://github.com/Slicer/Slicer/commit/c5365096306e9317cd0a1dbd47a485f64ab4d1ae as mentioned in https://github.com/Slicer/Slicer/pull/8966#issuecomment-3757619706.

This satisfies GitHub advisories warned in the Security section of the Slicer repository:
- https://github.com/advisories/GHSA-2xpw-w6gg-jr37
- https://github.com/advisories/GHSA-gm62-xv2j-4w53
- https://github.com/advisories/GHSA-38jv-5279-wg99