### PR TITLE
COMP: Fix sqlite linker failure

### DIFF
--- a/SuperBuild/External_sqlite.cmake
+++ b/SuperBuild/External_sqlite.cmake
@@ -58,10 +58,11 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       -DENABLE_DYNAMIC_EXTENSIONS:BOOL=OFF
       -DENABLE_SHARED:BOOL=OFF
       -DENABLE_STATIC:BOOL=ON
+      -DOMIT_DECLTYPE:BOOL=OFF
       -DSQLITE_BUILD_DOC:BOOL=OFF
       -DSQLITE_BUILD_EXAMPLES:BOOL=OFF
       -DSQLITE_BUILD_TESTS:BOOL=OFF
-       # recommended options would define SQLITE_OMIT_DEPRECATED and SQLITE_OMIT_DECLTYPE,
+       # recommended options would define SQLITE_OMIT_DEPRECATED
        # which would cause build errors in Python, so go with default options instead
       -DRECOMMENDED_OPTIONS:BOOL=OFF
       -DCMAKE_INSTALL_PREFIX:PATH=${EP_INSTALL_DIR}


### PR DESCRIPTION
As a follow-up to https://github.com/Slicer/Slicer/commit/21cf6a6522854c150d16cdbab39a721c85b549f1

This resolves build error such as:

cursor.obj : error LNK2019: unresolved external symbol sqlite3_column_decltype referenced in function pysqlite_build_row_cast_map [C:\S5R4\python-build\CMakeBuild\extensions\extension_sqlite3.vcxproj]


Although I was clearing out sqlite and python build directories during testing of this sqlite update, I must've missed a last change as I retried again and could replicate this build issue reported at https://github.com/Slicer/Slicer/commit/21cf6a6522854c150d16cdbab39a721c85b549f1#commitcomment-174837087.