### PR TITLE
BUG: Fix last used control point number not reset when list reset

### DIFF
--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.cxx
@@ -436,6 +436,7 @@ void vtkMRMLMarkupsNode::RemoveAllControlPoints()
     return;
   }
 
+  this->LastUsedControlPointNumber = 0;
   bool definedPointsExisted = false;
   bool missingPointsExisted = false;
   for (unsigned int i = 0; i < this->ControlPoints.size(); i++)


### PR DESCRIPTION
This functionality appears to have been lost during the rework of https://github.com/Slicer/Slicer/commit/23d076495be731efe23cfa1ffdd8a920524a489e. This restores the functionality described in the header for LastUsedControlPointNumber.

https://github.com/Slicer/Slicer/blob/2a98cba2d474d42aaef66cb5786a708a5f8a1a8e/Libs/MRML/Core/vtkMRMLMarkupsNode.h#L729-L731

`main`:

https://github.com/user-attachments/assets/066c9940-5407-45d8-a4e2-e95d8fe495ad


This PR:

https://github.com/user-attachments/assets/1cdcd8ea-f436-4dad-93ec-48df5d821390

