### PR TITLE
BUG: Remove orphan points from ROI and plane cut tools of Dynamic Modeler

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -335,7 +335,7 @@ list_conditional_append(Slicer_BUILD_LandmarkRegistration Slicer_REMOTE_DEPENDEN
 
 Slicer_Remote_Add(SurfaceToolbox
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/SlicerSurfaceToolbox"
-  GIT_TAG 1e3a3633ef090ec2df83cc48d447ba1ae66265b6
+  GIT_TAG 172483af41cf22c39ac77c07485d5f7ef8b4ffdc
   OPTION_NAME Slicer_BUILD_SurfaceToolbox
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
Update SurfaceToolbox to get the Dynamic Modeler fix.

```
$ git shortlog 1e3a3633ef090ec2df83cc48d447ba1ae66265b6..172483af41cf22c39ac77c07485d5f7ef8b4ffdc --no-merges
Andras Lasso (1):
      Remove orphan points from Dynamic Modeler ROI Cut and Plane Cut outputs
```

fixes #8777