### PR TITLE
ENH: Remove support for building against VTK <= 9.3

### DIFF
--- a/CMake/SlicerBlockInstallCMakeProjects.cmake
+++ b/CMake/SlicerBlockInstallCMakeProjects.cmake
@@ -4,13 +4,9 @@ include(${Slicer_CMAKE_DIR}/SlicerCheckModuleEnabled.cmake)  # For slicer_is_loa
 # Install VTK
 # -------------------------------------------------------------------------
 if(NOT "${VTK_DIR}" STREQUAL "" AND EXISTS "${VTK_DIR}/CMakeCache.txt")
-  if(${VTK_VERSION} VERSION_GREATER_EQUAL "8.90")
-    set(_runtime_component "runtime")
-  else()
-    set(_runtime_component "RuntimeLibraries")
-  endif()
+  set(_runtime_component "runtime")
   set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${VTK_DIR};VTK;${_runtime_component};/")
-  if(${VTK_VERSION} VERSION_GREATER_EQUAL "8.90" AND Slicer_USE_PYTHONQT)
+  if(Slicer_USE_PYTHONQT)
     set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${VTK_DIR};VTK;python;/")
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,14 +442,14 @@ endif()
 mark_as_superbuild(Slicer_VTK_VERSION_MAJOR)
 
 set(_default_vtk_minor_version "5")
-set(Slicer_VTK_VERSION_MINOR ${_default_vtk_minor_version} CACHE STRING "VTK minor version (2, 4 or 5)")
-set_property(CACHE Slicer_VTK_VERSION_MINOR PROPERTY STRINGS "2" "4" "5")
-if(NOT "${Slicer_VTK_VERSION_MINOR}" MATCHES "^(2|4|5)$")
-  message(FATAL_ERROR "error: Slicer_VTK_VERSION_MINOR must be 2, 4 or 5.")
+set(Slicer_VTK_VERSION_MINOR ${_default_vtk_minor_version} CACHE STRING "VTK minor version (4 or 5)")
+set_property(CACHE Slicer_VTK_VERSION_MINOR PROPERTY STRINGS "4" "5")
+if(NOT "${Slicer_VTK_VERSION_MINOR}" MATCHES "^(4|5)$")
+  message(FATAL_ERROR "error: Slicer_VTK_VERSION_MINOR must be 4 or 5.")
 endif()
 mark_as_superbuild(Slicer_VTK_VERSION_MINOR)
 
-set(Slicer_VTK_MINIMUM_SUPPORTED_VERSION "9.2")
+set(Slicer_VTK_MINIMUM_SUPPORTED_VERSION "9.4")
 
 #-----------------------------------------------------------------------------
 # Install no development files by default, but allow the user to get

--- a/Libs/MRML/Core/Testing/vtkMRMLTableNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTableNodeTest1.cxx
@@ -171,12 +171,7 @@ int vtkMRMLTableNodeTest1(int, char*[])
   checkDefaultArrayValue<vtkIntArray, int>(node3, "int", "some", 0);
 
   checkDefaultArrayValue<vtkUnsignedIntArray, unsigned int>(node3, "unsigned int", "3", 3);
-#if (VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 3, 20230902)) // Fix integrated through kitware/vtk@90adad9b4d
   checkDefaultArrayValue<vtkUnsignedIntArray, unsigned int>(node3, "unsigned int", "-5", 0);
-#else
-  // this is a bit odd (since an unsigned value accepts a negative value), but this is vtkVariant behavior:
-  checkDefaultArrayValue<vtkUnsignedIntArray, unsigned int>(node3, "unsigned int", "-5", -5);
-#endif
   checkDefaultArrayValue<vtkUnsignedIntArray, unsigned int>(node3, "unsigned int", "3.3", 0);
   checkDefaultArrayValue<vtkUnsignedIntArray, unsigned int>(node3, "unsigned int", "", 0);
   checkDefaultArrayValue<vtkUnsignedIntArray, unsigned int>(node3, "unsigned int", "some", 0);
@@ -188,12 +183,7 @@ int vtkMRMLTableNodeTest1(int, char*[])
   checkDefaultArrayValue<vtkShortArray, short>(node3, "short", "some", 0);
 
   checkDefaultArrayValue<vtkUnsignedShortArray, unsigned short>(node3, "unsigned short", "3", 3);
-#if (VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 3, 20230902)) // Fix integrated through kitware/vtk@90adad9b4d
   checkDefaultArrayValue<vtkUnsignedShortArray, unsigned short>(node3, "unsigned short", "-5", 0);
-#else
-  // this is a bit odd (since an unsigned value accepts a negative value), but this is vtkVariant behavior:
-  checkDefaultArrayValue<vtkUnsignedShortArray, unsigned short>(node3, "unsigned short", "-5", -5);
-#endif
   checkDefaultArrayValue<vtkUnsignedShortArray, unsigned short>(node3, "unsigned short", "3.3", 0);
   checkDefaultArrayValue<vtkUnsignedShortArray, unsigned short>(node3, "unsigned short", "", 0);
   checkDefaultArrayValue<vtkUnsignedShortArray, unsigned short>(node3, "unsigned short", "some", 0);
@@ -205,12 +195,7 @@ int vtkMRMLTableNodeTest1(int, char*[])
   checkDefaultArrayValue<vtkLongArray, long>(node3, "long", "some", 0);
 
   checkDefaultArrayValue<vtkUnsignedLongArray, unsigned long>(node3, "unsigned long", "3", 3);
-#if (VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 3, 20230902)) // Fix integrated through kitware/vtk@90adad9b4d
   checkDefaultArrayValue<vtkUnsignedLongArray, unsigned long>(node3, "unsigned long", "-5", 0);
-#else
-  // this is a bit odd (since an unsigned value accepts a negative value), but this is vtkVariant behavior:
-  checkDefaultArrayValue<vtkUnsignedLongArray, unsigned long>(node3, "unsigned long", "-5", -5);
-#endif
   checkDefaultArrayValue<vtkUnsignedLongArray, unsigned long>(node3, "unsigned long", "3.3", 0);
   checkDefaultArrayValue<vtkUnsignedLongArray, unsigned long>(node3, "unsigned long", "", 0);
   checkDefaultArrayValue<vtkUnsignedLongArray, unsigned long>(node3, "unsigned long", "some", 0);
@@ -222,12 +207,7 @@ int vtkMRMLTableNodeTest1(int, char*[])
   checkDefaultArrayValue<vtkLongLongArray, long long>(node3, "long long", "some", 0);
 
   checkDefaultArrayValue<vtkUnsignedLongLongArray, unsigned long long>(node3, "unsigned long long", "3", 3);
-#if (VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 3, 20230902)) // Fix integrated through kitware/vtk@90adad9b4d
   checkDefaultArrayValue<vtkUnsignedLongLongArray, unsigned long long>(node3, "unsigned long long", "-5", 0);
-#else
-  // this is a bit odd (since an unsigned value accepts a negative value), but this is vtkVariant behavior:
-  checkDefaultArrayValue<vtkUnsignedLongLongArray, unsigned long long>(node3, "unsigned long long", "-5", -5);
-#endif
   checkDefaultArrayValue<vtkUnsignedLongLongArray, unsigned long long>(node3, "unsigned long long", "3.3", 0);
   checkDefaultArrayValue<vtkUnsignedLongLongArray, unsigned long long>(node3, "unsigned long long", "", 0);
   checkDefaultArrayValue<vtkUnsignedLongLongArray, unsigned long long>(node3, "unsigned long long", "some", 0);

--- a/Libs/vtkSegmentationCore/vtkPolyDataToFractionalLabelmapFilter.cxx
+++ b/Libs/vtkSegmentationCore/vtkPolyDataToFractionalLabelmapFilter.cxx
@@ -41,7 +41,6 @@
 #include <vtkStripper.h>
 #include <vtkImageStencil.h>
 #include <vtkImageCast.h>
-#include <vtkVersion.h> // For VTK_VERSION_*
 
 // std includes
 #include <map>
@@ -588,12 +587,8 @@ void vtkPolyDataToFractionalLabelmapFilter::FillImageStencilData(vtkImageStencil
       else
       {
         // if no polys, select polylines instead
-#if (VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 2, 20230212))
         vtkSMPThreadLocalObject<vtkIdList> storage;
         this->PolyDataSelector(input, slice, storage.Local(), z, spacing[2]);
-#else
-        this->PolyDataSelector(input, slice, z, spacing[2]);
-#endif
       }
 
       if (!slice->GetNumberOfLines())

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -141,10 +141,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     )
 
   set(_git_tag)
-  if("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.2")
-    set(_git_tag "59ec450206012e86d4855bc669800499254bfc77") # slicer-v9.2.20230607-1ff325c54-2
-    set(vtk_dist_info_version "9.2.20230607")
-  elseif("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.4")
+  if("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.4")
     set(_git_tag "454bb391dff78c6ff463298a5143ab5b4f0aa083") # slicer-v9.4.2-2025-03-26-13acb1a5d
     set(vtk_dist_info_version "9.4.2")
   elseif("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.5")


### PR DESCRIPTION
This anticipates upcoming support for VTK 9.6.0 at which there will be support for VTK 9.4, 9.5 and 9.6.

This is a follow-up to https://github.com/Slicer/Slicer/commit/dfde1cfc68f2d8d6da6678fb0a22fa4dd184288c where the VTK minimum version was last updated to 9.2.