### PR TITLE
BUG: Fix Qt6 data dialog description shift-change

### DIFF
--- a/Base/QTGUI/qSlicerDataDialog.cxx
+++ b/Base/QTGUI/qSlicerDataDialog.cxx
@@ -251,7 +251,7 @@ void qSlicerDataDialogPrivate::addFile(const QFileInfo& file, const QString& rea
 #else
   QObject::connect(descriptionComboBox, SIGNAL(currentIndexChanged(QString)), this, SLOT(onFileTypeChanged(QString)));
 #endif
-  QObject::connect(descriptionComboBox, SIGNAL(activated(QString)), this, SLOT(onFileTypeActivated(QString)));
+  QObject::connect(descriptionComboBox, &QComboBox::textActivated, this, &qSlicerDataDialogPrivate::onFileTypeActivated);
   this->FileWidget->setCellWidget(row, TypeColumn, descriptionComboBox);
   descriptionComboBox->setCurrentIndex(0);
   if (!readerDescription.isEmpty() && ioProperties != nullptr)


### PR DESCRIPTION
When building with Qt6, opening the data dialog and adding any file, there is a message in the output:

```
QObject::connect: No such signal QComboBox::activated(QString) in C:\s\src\Base\QTGUI\qSlicerDataDialog.cxx:254
QObject::connect:  (receiver name: 'qSlicerDataDialog')
```
(beceause the `QString` version was removed with Qt6, there now is only an `int` version of that signal).

The result is that the "Description" ComboBox change with Shift clicked (which in previous builds, changed the type for all open datasets) does not work.

This pull request fixes the signal connection.