### PR TITLE
ENH: Add view node flag to disable Markups occlusion checking

### DIFF
--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -61,6 +61,7 @@ vtkMRMLAbstractViewNode::vtkMRMLAbstractViewNode()
   }
 
   this->MappedInLayout = false;
+  this->MarkupsOcclusionEnabled = true;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
@@ -298,6 +298,17 @@ public:
   vtkSetMacro(ScreenScaleFactor, double);
   //@}
 
+  //@{
+  /// Get/Set whether or not markup occlusion is enabled in this view.
+  /// If enabled, markup labels that are occluded by other objects are not shown and cannot be picked.
+  /// Otherwise all markup labels are shown and points can be picked regardless of occlusion.
+  /// This option is useful, since occlusion detection is a performance intensive operation, and can
+  /// cause slowdowns in some views (ex. virtual reality views).
+  /// Enabled by default.
+  vtkGetMacro(MarkupsOcclusionEnabled, bool);
+  vtkSetMacro(MarkupsOcclusionEnabled, bool);
+  //@}
+
 protected:
   vtkMRMLAbstractViewNode();
   ~vtkMRMLAbstractViewNode() override;
@@ -362,6 +373,8 @@ protected:
 
   static const char* ParentLayoutNodeReferenceRole;
   static const char* InteractionNodeReferenceRole;
+
+  bool MarkupsOcclusionEnabled;
 };
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -695,7 +695,7 @@ int vtkSlicerMarkupsWidgetRepresentation3D::RenderOverlay(vtkViewport* viewport)
     ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[i]);
     if (controlPoints->ControlPoints->GetNumberOfPoints() > 0)
     {
-      if (!this->MarkupsDisplayNode->GetOccludedVisibility())
+      if (!this->MarkupsDisplayNode->GetOccludedVisibility() && this->ViewNode && this->ViewNode->GetMarkupsOcclusionEnabled())
       {
         if (!zBuffer)
         {


### PR DESCRIPTION
Markups 3D representation checks control point occlusion each frame to decide label visibility and pickability. This requires reading the Z-buffer back to CPU memory via vtkFastSelectVisiblePoints, which can cause significant performance loss in some views (e.g. VR).

This commit addS a view node flag to skip occlusion checking and assume all points are visible. Occlusion checking remains enabled by default.