### PR TITLE
PERF: Fixes performance issues for DICOM import in Qt6

### DIFF
--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -358,6 +358,15 @@ void qSlicerMainWindowPrivate::setupUi(QMainWindow* mainWindow)
 
   QObject::connect(this->ErrorLogToggleViewAction, SIGNAL(toggled(bool)), q, SLOT(onErrorLogToggled(bool)));
 
+  QIcon defaultIcon = q->style()->standardIcon(QStyle::SP_MessageBoxCritical);
+  this->ErrorLogIconHighlighted = defaultIcon;
+
+  QIcon disabledIcon;
+  disabledIcon.addPixmap(defaultIcon.pixmap(QSize(32, 32), QIcon::Disabled, QIcon::On), QIcon::Active, QIcon::On);
+  this->ErrorLogIconNormal = disabledIcon;
+
+  this->ErrorLogToggleViewAction->setIcon(this->ErrorLogIconNormal);
+
   this->ViewMenu->insertAction(this->ModuleHomeAction, this->ErrorLogToggleViewAction);
 
   // Change orientation depending on where the widget is docked
@@ -699,16 +708,13 @@ void qSlicerMainWindowPrivate::setupStatusBar()
 //-----------------------------------------------------------------------------
 void qSlicerMainWindowPrivate::setErrorLogIconHighlighted(bool highlighted)
 {
-  Q_Q(qSlicerMainWindow);
-  QIcon defaultIcon = q->style()->standardIcon(QStyle::SP_MessageBoxCritical);
-  QIcon icon = defaultIcon;
-  if (!highlighted)
+  if (this->ErrorLogIconIsHighlighted == highlighted)
   {
-    QIcon disabledIcon;
-    disabledIcon.addPixmap(defaultIcon.pixmap(QSize(32, 32), QIcon::Disabled, QIcon::On), QIcon::Active, QIcon::On);
-    icon = disabledIcon;
+    return;
   }
-  this->ErrorLogToggleViewAction->setIcon(icon);
+
+  this->ErrorLogIconIsHighlighted = highlighted;
+  this->ErrorLogToggleViewAction->setIcon(highlighted ? this->ErrorLogIconHighlighted : this->ErrorLogIconNormal);
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTApp/qSlicerMainWindow_p.h
+++ b/Base/QTApp/qSlicerMainWindow_p.h
@@ -80,6 +80,9 @@ public:
   QAction*                        ErrorLogToggleViewAction{ nullptr };
   ctkErrorLogWidget*              ErrorLogWidget{ nullptr };
   QToolButton*                    ErrorLogToolButton{ nullptr };
+  QIcon                           ErrorLogIconHighlighted;
+  QIcon                           ErrorLogIconNormal;
+  bool                            ErrorLogIconIsHighlighted{ false };
   QToolButton*                    LayoutButton{ nullptr };
   qSlicerModuleSelectorToolBar*   ModuleSelectorToolBar{ nullptr };
   QStringList                     FavoriteModules;

--- a/Modules/Scripted/DICOMLib/DICOMBrowser.py
+++ b/Modules/Scripted/DICOMLib/DICOMBrowser.py
@@ -65,6 +65,8 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
             self.dicomVisualBrowser.thumbnailSizePreset = ctk.ctkDICOMVisualBrowserWidget.ThumbnailSizePresetOption.Medium
         elif thumbnailsSize == "small":
             self.dicomVisualBrowser.thumbnailSizePreset = ctk.ctkDICOMVisualBrowserWidget.ThumbnailSizePresetOption.Small
+        elif thumbnailsSize == "hidden":
+            self.dicomVisualBrowser.thumbnailSizePreset = ctk.ctkDICOMVisualBrowserWidget.ThumbnailSizePresetOption.Hidden
 
         if settingsValue("DICOM/detailedLogging", False, converter=toBool):
             ctk.ctk.setDICOMLogLevel(ctk.ctkErrorLogLevel.Debug)

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -78,7 +78,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "e302aa773930b4f5d0720b004e098e54de66e2b7"
+    "fd37b874033c6589e28f5cefdd56a5f605d09960"
     QUIET
     )
 


### PR DESCRIPTION
when the copy file option is enabled.
ENH: Cache error log icons and track their state in qSlicerMainWindow to avoid regenerating icons on every log message. ENH: Skip icon updates if the error log state hasn't changed. 
ENH: Automatically disable detailed DICOM logging after 4 hours to avoid accidental performance degradation. 
ENH: Store a timestamp when detailed logging is enabled and check on startup to auto-disable if needed. 
ENH: Set the default thumbnail size to "small" in DICOM settings for better performance. 
ENH: Add a "hidden" option for thumbnail size in DICOM settings.

needs https://github.com/commontk/CTK/pull/1345