### PR TITLE
ENH: Set application icon to SlicerApp-Real.exe executable

### DIFF
--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -451,6 +451,26 @@ macro(slicerMacroBuildApplication)
   endif()
   message(STATUS "Setting ${SLICERAPP_APPLICATION_NAME} executable name to '${executable_name}${CMAKE_EXECUTABLE_SUFFIX}'")
 
+  if(WIN32)
+    # Generate a minimal resource file so the icon is always embedded into the
+    # executable at link time without requiring custom apps to provide a .rc file.
+    # This allows for the ${executable_name}App-real (e.g. SlicerApp-real.exe) as shown in
+    # Windows task manager to be displayed with the application icon instead of a missing icon.
+    # On Windows there is both the AppLauncher executable as well as the main application
+    # executable (e.g. Slicer.exe and SlicerApp-real.exe) where we want to define an icon.
+    get_filename_component(_slicerapp_icon_name "${SLICERAPP_WIN_ICON_FILE}" NAME)
+    get_filename_component(_slicerapp_icon_dir "${SLICERAPP_WIN_ICON_FILE}" DIRECTORY)
+    set(_slicerapp_rc "${CMAKE_CURRENT_BINARY_DIR}/${SLICERAPP_NAME}.rc")
+    file(WRITE "${_slicerapp_rc}" "IDI_ICON1 ICON \"${_slicerapp_icon_name}\"\n")
+    # Override AdditionalIncludeDirectories for this source file to contain only
+    # the icon's directory, preventing propagation of all target include directories
+    # to rc.exe which would cause MSB6002 command-line length failures.
+    set_source_files_properties("${_slicerapp_rc}" PROPERTIES
+      VS_SETTINGS "AdditionalIncludeDirectories=${_slicerapp_icon_dir}"
+      )
+    list(APPEND SLICERAPP_SRCS "${_slicerapp_rc}")
+  endif()
+
   ctk_add_executable_utf8(${slicerapp_target}
     ${SLICERAPP_EXE_OPTIONS}
     ${SLICERAPP_SRCS}


### PR DESCRIPTION
On the Windows platform there is both the launcher application and SlicerApp-Real.exe application displayed in task manager as a bundle. Previously only the launcher had the application icon set to it, but this commit makes sure the main application executable also has an icon set.

Windows Task Manager: 

| `main` | This PR |
|--------|----------|
|<img width="329" height="213" alt="slicerapp-real-icon-original" src="https://github.com/user-attachments/assets/b283607f-8e2f-4483-9436-dae54b55f2e1" />|<img width="362" height="219" alt="slicerapp-real-icon" src="https://github.com/user-attachments/assets/a7e84e54-006b-47c6-9994-a512179f7f87" />|