### PR TITLE
COMP: Update DCMTK to 3.7.0++ commit with additional binary seg fix

### DIFF
--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -70,7 +70,7 @@ if(NOT DEFINED DCMTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "3e85b37444107e93550167c2284e64b4881b0fcb" # DCMTK 3.7.0+ 2025-12-18
+    "a7369385d91f40e19a9b2d4ef922c61370dfc5b1" # DCMTK 3.7.0++ 2026-01-22
     QUIET
     )
 


### PR DESCRIPTION
This should fix the dashboard linker errors for the dcmqi extension identified while testing the new functionality added in DCMTK (see https://github.com/Slicer/Slicer/pull/8948#issuecomment-3763790260). The actual fix is in this commit: https://github.com/DCMTK/dcmtk/commit/a7369385d91f40e19a9b2d4ef922c61370dfc5b1.

cc: @michaelonken 

```text
$ git shortlog 3e85b37..a736938
Harald Roesen (8):
      Reworked struct OFUUID.
      Added dependencies for reworked OFFUUID struct.
      Removed unnecessary include(s).
      Added few 'negated' tests.
      Finalization of OFUUID class.
      Replaced the old OFUUID implementation with a new one. The old OFUUID represented an UUID version 1, while the new one is an UUID version 7. It offers monotonicity, and improved unguessability. In addition it mitigates security issues because it does not use a Media Access Control (MAC) address as is the case with version 1.
      Check pointer before calling setParent().
      Replaced friend operators with member operators.

Joerg Riesmeier (12):
      Fixed issue with delimiters in Chinese encodings.
      Also test Japanese character sets with "oficonv".
      Updated libiconv version number.
      Added test case with a backslash-like byte.
      Link dcmimage privately to libtiff and libpng.
      Added new DcmSCU loggers to sample config file.
      Minor fixes to comments
      Minor fixes to comments.
      Removed empty lines at the end of the file.
      Replaced leading spaces by a tab character.
      Added OFUUID to list of further classes/utilities.
      Fixed outdated reference to conversion flags.

Marco Eichelberg (6):
      Added dependency check between command line options.
      Added DcmJsonFormat::getMinBulkSize().
      Fixed possible segfault in dcmpschk application.
      Fixed minor gcc -Wextra warning.
      Fixed minor memory leak in oficonv.
      Silently convert path separators in dump2dcm.

Michael Onken (5):
      Added some optional return keys.
      Make SCU dataset logging configurable.
      Updated copyright dates.
      Make new DcmSCU logger names consistent.
      Export symbols of OverlapUtil for shared builds.
```