### PR TITLE
Crash closing application after fill between slices

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/AbstractScriptedSegmentEditorAutoCompleteEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/AbstractScriptedSegmentEditorAutoCompleteEffect.py
@@ -410,7 +410,7 @@ class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEdi
         effectiveGeometryImage = slicer.vtkOrientedImageData()
         effectiveGeometryString = segmentationNode.GetSegmentation().DetermineCommonLabelmapGeometry(
             vtkSegmentationCore.vtkSegmentation.EXTENT_UNION_OF_EFFECTIVE_SEGMENTS, self.selectedSegmentIds)
-        if effectiveGeometryString is None:
+        if not effectiveGeometryString:
             return True
         vtkSegmentationCore.vtkSegmentationConverter.DeserializeImageGeometry(effectiveGeometryString, effectiveGeometryImage)
 


### PR DESCRIPTION
Launch in the terminal Slicer 5.10 (or 5.8), load a volume and go to Segment Editor.
Add a segment and Paint 2 separated slices.
Use Fill between slices, Initialize, Apply.
Close the application and look in the terminal, an exception occurred :
Traceback (most recent call last):
  File "/Slicer-5.10.0-linux-amd64/lib/Slicer-5.10/qt-scripted-modules/SegmentEditorEffects/AbstractScriptedSegmentEditorAutoCompleteEffect.py", line 67, in __del__
  File "/Slicer-5.10.0-linux-amd64/lib/Slicer-5.10/qt-scripted-modules/SegmentEditorEffects/AbstractScriptedSegmentEditorAutoCompleteEffect.py", line 210, in observeSegmentation
ImportError: sys.meta_path is None, Python is likely shutting down

If we just deal with the "import" issue in observeSegmentation, there will be another one:
ValueError: Trying to call 'parameterSetNode' on a destroyed qSlicerSegmentEditorScriptedEffect object


The second commit is produced if instead of closing the application, you click the Undo button until there is nothing left, there will be an error in the terminal:
DeserializeImageGeometry: Failed to de-serialize geometry string 