### PR TITLE
DOC: fix inconsistencies between documentation and code

### DIFF
--- a/Docs/developer_guide/script_repository/dicom.md
+++ b/Docs/developer_guide/script_repository/dicom.md
@@ -128,7 +128,7 @@ fileList = db.filesForSeries(seriesList[0])
 # Use pydicom to access the full header, which requires
 # re-reading the dataset instead of using the database cache
 import pydicom
-pydicom.dcmread(fileList[0])
+ds = pydicom.dcmread(fileList[0])
 ds.CTExposureSequence[0].ExposureModulationType
 ```
 
@@ -183,12 +183,12 @@ def pathFromNode(node):
     filepath = storageNode.GetFullNameFromFileName()
   else: # Loaded via DICOM browser
     instanceUIDs = node.GetAttribute("DICOM.instanceUIDs").split()
-    filepath = slicer.dicomDatabase.fileForInstance(instUids[0])
+    filepath = slicer.dicomDatabase.fileForInstance(instanceUIDs[0])
   return filepath
 
 # Example:
 node = slicer.util.getNode("volume1")
-path = self.pathFromNode(node)
+path = pathFromNode(node)
 print("DICOM path=%s" % path)
 ```
 

--- a/Docs/developer_guide/script_repository/markups.md
+++ b/Docs/developer_guide/script_repository/markups.md
@@ -35,7 +35,7 @@ slicer.modules.markups.logic().ImportControlPointsFromCSV(markupsNode, "/path/to
 Markups point list can be loaded from legacy [fcsv file format](/developer_guide/modules/markups.md#markups-fiducial-point-list-file-format-fcsv). Note that this file format is no longer recommended, as it is not a standard csv file format and can only store a small fraction of information that is in a markups node.
 
 ```python
-slicer.util.loadMarkupsFiducialList("/path/to/list/F.fcsv")
+slicer.util.loadMarkups("/path/to/list/F.fcsv")
 ```
 
 ### Adding control points Programmatically

--- a/Docs/developer_guide/script_repository/models.md
+++ b/Docs/developer_guide/script_repository/models.md
@@ -198,7 +198,7 @@ def onPointsModified(observer=None, eventid=None):
 # Initial update
 onPointsModified()
 # Automatic update each time when a markup point is modified
-pointListNodeObserverTag = markupsNode.AddObserver(slicer.vtkMRMLMarkupsFiducialNode.PointModifiedEvent, onPointsModified)
+pointListNodeObserverTag = pointListNode.AddObserver(slicer.vtkMRMLMarkupsNode.PointModifiedEvent, onPointsModified)
 
 # To stop updating selection, run this:
 # pointListNode.RemoveObserver(pointListNodeObserverTag)

--- a/Docs/developer_guide/script_repository/plots.md
+++ b/Docs/developer_guide/script_repository/plots.md
@@ -11,7 +11,7 @@ Create histogram plot of a volume and show it embedded in the view layout. More 
 import SampleData
 import numpy as np
 volumeNode = SampleData.SampleDataLogic().downloadMRHead()
-histogram = np.histogram(arrayFromVolume(volumeNode), bins=50)
+histogram = np.histogram(slicer.util.arrayFromVolume(volumeNode), bins=50)
 
 chartNode = slicer.util.plot(histogram, xColumnIndex = 1)
 chartNode.SetYAxisRangeAuto(False)
@@ -29,11 +29,11 @@ volumeNode = SampleData.SampleDataLogic().downloadMRHead()
 
 # Compute histogram values
 import numpy as np
-histogram = np.histogram(arrayFromVolume(volumeNode), bins=50)
+histogram = np.histogram(slicer.util.arrayFromVolume(volumeNode), bins=50)
 
 # Save results to a new table node
 tableNode=slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode")
-updateTableFromArray(tableNode, histogram)
+slicer.util.updateTableFromArray(tableNode, histogram)
 tableNode.GetTable().GetColumn(0).SetName("Count")
 tableNode.GetTable().GetColumn(1).SetName("Intensity")
 
@@ -116,7 +116,7 @@ import JupyterNotebooksLib as slicernb
 try:
   import matplotlib
 except ModuleNotFoundError:
-  pip_install("matplotlib")
+  slicer.util.pip_install("matplotlib")
   import matplotlib
 
 matplotlib.use("Agg")
@@ -159,14 +159,14 @@ try:
   import matplotlib
   import wx
 except ModuleNotFoundError:
-  pip_install("matplotlib wxPython")
+  slicer.util.pip_install("matplotlib wxPython")
   import matplotlib
 
 # Get a volume from SampleData and compute its histogram
 import SampleData
 import numpy as np
 volumeNode = SampleData.SampleDataLogic().downloadMRHead()
-histogram = np.histogram(arrayFromVolume(volumeNode), bins=50)
+histogram = np.histogram(slicer.util.arrayFromVolume(volumeNode), bins=50)
 
 # Set matplotlib to use WXAgg backend
 import matplotlib

--- a/Docs/developer_guide/script_repository/registration.md
+++ b/Docs/developer_guide/script_repository/registration.md
@@ -27,7 +27,7 @@ cliBrainsFitRigidNode = slicer.cli.run(slicer.modules.brainsfit, None, parameter
 
 # Display fused result. Computed transformNode is automatically applied to the movingVolumeNode.
 # Ctrl + left-click-and-drag up/down to change opacity in slice views.
-slicer.util.setSliceViewerLayers(fixedVolumeNode, movingVolumeNode, foregroundOpacity=0.5)
+slicer.util.setSliceViewerLayers(background=fixedVolumeNode, foreground=movingVolumeNode, foregroundOpacity=0.5)
 ```
 
 All parameters for BRAINSFit can be found [here](https://github.com/BRAINSia/BRAINSTools/blob/main/BRAINSFit/BRAINSFit.xml).

--- a/Docs/developer_guide/script_repository/segmentations.md
+++ b/Docs/developer_guide/script_repository/segmentations.md
@@ -188,7 +188,7 @@ hollowModeler.SetAttribute("ShellThickness", "2.5")  # grow outside
 hollowModeler.SetContinuousUpdate(True)  # auto-update output model if input parameters are changed
 
 # Hide inputs, show output
-segmentation.GetDisplayNode().SetVisibility(False)
+segmentationNode.GetDisplayNode().SetVisibility(False)
 modelNode.GetDisplayNode().SetVisibility(False)
 hollowedModelNode.GetDisplayNode().SetOpacity(0.5)
 ```
@@ -430,7 +430,7 @@ segmentId = "Segment_1"
 
 # Get array voxel coordinates
 import numpy as np
-seg=arrayFromSegment(segmentation_node, segmentId)
+seg = slicer.util.arrayFromSegmentBinaryLabelmap(segmentationNode, segmentId)
 # numpy array has voxel coordinates in reverse order (KJI instead of IJK)
 # and the array is cropped to minimum size in the segmentation
 mean_KjiCropped = [coords.mean() for coords in np.nonzero(seg)]
@@ -525,7 +525,7 @@ def printSegmentNames(unused1=None, unused2=None):
     print("Segment found at position {0}: {1}".format(ras, segment.GetName()))
 
 # Observe markup node changes
-pointListNode.AddObserver(slicer.vtkMRMLMarkupsPlaneNode.PointModifiedEvent, printSegmentNames)
+pointListNode.AddObserver(slicer.vtkMRMLMarkupsNode.PointModifiedEvent, printSegmentNames)
 printSegmentNames()
 ```
 
@@ -734,7 +734,7 @@ pointListNode.CreateDefaultDisplayNodes()
 for segmentId in stats["SegmentIDs"]:
   centroid_ras = stats[segmentId,"LabelmapSegmentStatisticsPlugin.centroid_ras"]
   segmentName = segmentationNode.GetSegmentation().GetSegment(segmentId).GetName()
-  pointListNode.AddFiducialFromArray(centroid_ras, segmentName)
+  pointListNode.AddControlPoint(centroid_ras, segmentName)
 ```
 
 #### Get size, position, and orientation of each segment

--- a/Docs/developer_guide/script_repository/sequences.md
+++ b/Docs/developer_guide/script_repository/sequences.md
@@ -138,10 +138,10 @@ for segmentIdIndex in range(visibleSegmentIds.GetNumberOfValues()):
 
 Warp a segmentation with a sequence of transforms and write each transformed segmentation to a ply file. It can be used on sequence registration results created as shown in this [tutorial video](https://youtu.be/qVgXdXEEVFU).
 
-```
+```python
 # Inputs
-transformSequenceNode = getNode("OutputTransforms")
-segmentationNode = getNode("Segmentation")
+transformSequenceNode = slicer.util.getNode("OutputTransforms")
+segmentationNode = slicer.util.getNode("Segmentation")
 segmentIndex = 0
 outputFilePrefix = r"c:/tmp/20220312/seg"
 

--- a/Docs/developer_guide/script_repository/volumes.md
+++ b/Docs/developer_guide/script_repository/volumes.md
@@ -67,7 +67,7 @@ volumeNode=slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode")
 volumeNode.SetAndObserveImageData(imageData)
 volumeNode.SetSpacing(spacing)
 volumeNode.SetOrigin(origin)
-slicer.util.setSliceViewerLayers(volumeNode, fit=True)
+slicer.util.setSliceViewerLayers(background=volumeNode, fit=True)
 ```
 
 ### Load volume from a remote server
@@ -794,7 +794,7 @@ c = b - a
 
 volumeNode = slicer.modules.volumes.logic().CloneVolume(input1Volume, "Difference")
 slicer.util.updateVolumeFromArray(volumeNode, c)
-setSliceViewerLayers(background=volumeNode)
+slicer.util.setSliceViewerLayers(background=volumeNode)
 ```
 
 ### Add noise to image
@@ -837,7 +837,7 @@ maskedVoxels[mask==0] = 0
 # Write masked volume to volume node and show it
 maskedVolumeNode = slicer.modules.volumes.logic().CloneVolume(volumeNode, "Masked")
 slicer.util.updateVolumeFromArray(maskedVolumeNode, maskedVoxels)
-slicer.util.setSliceViewerLayers(maskedVolumeNode)
+slicer.util.setSliceViewerLayers(background=maskedVolumeNode)
 ```
 
 ### Apply random deformations to image


### PR DESCRIPTION
Co-authored by Claude Code. Summary of the findings by Claude Code follows.

---

# Documentation vs Code Inconsistency Analysis - 3D Slicer

## Executive Summary

This analysis identifies inconsistencies between the 3D Slicer documentation (in `/Docs/`) and the actual codebase. The documentation is generally well-maintained, but several issues were found that could mislead developers or cause runtime errors.

---

## Category 1: Deprecated Functions Used in Documentation

### Issue 1.1: `loadMarkupsFiducialList()` - Deprecated

**Location**: [markups.md:38](Docs/developer_guide/script_repository/markups.md#L38)

**Documentation shows**:
```python
slicer.util.loadMarkupsFiducialList("/path/to/list/F.fcsv")
```

**Problem**: This function is deprecated since Slicer 4.13.0 (see [util.py:868-870](Base/Python/slicer/util.py#L868-L870))

**Recommendation**: Update documentation to use:
```python
slicer.util.loadMarkups("/path/to/list/F.fcsv")
```

---

### Issue 1.2: `AddFiducialFromArray()` - Deprecated

**Location**: [segmentations.md:737](Docs/developer_guide/script_repository/segmentations.md#L737)

**Documentation shows**:
```python
pointListNode.AddFiducialFromArray(centroid_ras, segmentName)
```

**Problem**: This method is deprecated (see [vtkMRMLMarkupsFiducialNode.h:111-114](Libs/MRML/Core/vtkMRMLMarkupsFiducialNode.h#L111-L114)):
```cpp
vtkWarningMacro("vtkMRMLMarkupsFiducialNode::AddFiducialFromArray method is deprecated, please use AddControlPoint instead");
```

**Recommendation**: Update to:
```python
pointListNode.AddControlPoint(centroid_ras, segmentName)
```

---

### Issue 1.3: `arrayFromSegment()` - Deprecated

**Location**: [segmentations.md:433](Docs/developer_guide/script_repository/segmentations.md#L433)

**Documentation shows**:
```python
seg=arrayFromSegment(segmentation_node, segmentId)
```

**Problem**: This function is deprecated since Slicer 4.13.0 (see [util.py:2111-2118](Base/Python/slicer/util.py#L2111-L2118))

**Recommendation**: Update to:
```python
seg = slicer.util.arrayFromSegmentBinaryLabelmap(segmentationNode, segmentId)
```

---

## Category 2: Inconsistent Function Prefix Usage

### Issue 2.1: Bare `getNode()` vs `slicer.util.getNode()`

**Problem**: Many documentation examples use `getNode()` without the `slicer.util.` prefix. While this works in the interactive Python console (where `slicer.util` functions are imported to global namespace), it will fail in scripts or modules.

**Locations** (partial list - over 80 occurrences):
- [volumes.md](Docs/developer_guide/script_repository/volumes.md): lines 422, 481, 482, 511, 512, 585, 823, 824
- [segmentations.md](Docs/developer_guide/script_repository/segmentations.md): lines 20, 51, 59, 67, 134, 146, 157, 170, 201, 233, 302, 332, 375, 393, 394, 428, 574, 657, 671, 672, 700, 721, 747
- [markups.md](Docs/developer_guide/script_repository/markups.md): lines 119, 258, 276, 358, 359, 384, 385, 409, 410, 501, 551, 569
- [transforms.md](Docs/developer_guide/script_repository/transforms.md): lines 27, 29, 31, 68, 70, 72
- [models.md](Docs/developer_guide/script_repository/models.md): lines 28, 29, 107, 140, 237
- [gui.md](Docs/developer_guide/script_repository/gui.md): lines 90, 136, 444, 501, 575, 582, 788, 789

**Clarification**: The documentation at [gui.md:106](Docs/developer_guide/script_repository/gui.md#L106) states:
> `slicer.util.getNode()` is recommended **only for interactive debugging** in the Python console/Jupyter notebook

**Recommendation**:
1. Add a clear note at the top of each script_repository file explaining that bare `getNode()` only works in interactive mode
2. Consider updating examples to use `slicer.util.getNode()` for clarity, or use `slicer.mrmlScene.GetFirstNodeByName()` for production code

---

## Category 3: Variable Name Inconsistencies

### Issue 3.1: `segmentation` vs `segmentationNode` Mismatch

**Location**: [segmentations.md:191](Docs/developer_guide/script_repository/segmentations.md#L191)

**Documentation shows**:
```python
segmentation.GetDisplayNode().SetVisibility(False)
```

**Problem**: The variable `segmentationNode` is defined on line 170, but line 191 uses `segmentation` (undefined variable)

**Recommendation**: Change to `segmentationNode.GetDisplayNode().SetVisibility(False)`

---

### Issue 3.2: Inconsistent Naming Throughout

The documentation mixes `segmentation` and `segmentationNode` variable names across examples. While not technically incorrect, this inconsistency can confuse readers.

**Examples**:
- Line 233: `segmentation = getNode('Segmentation')`
- Line 302: `segmentation = getNode("Segmentation").GetSegmentation()`
- Most other places: `segmentationNode = getNode("Segmentation")`

**Recommendation**: Standardize on `segmentationNode` for the MRML node, and `segmentation` for the `vtkSegmentation` object obtained via `.GetSegmentation()`

---

## Category 4: Observer Event Type Confusion

### Issue 4.1: Using PlaneNode Event for FiducialNode

**Location**: [segmentations.md:528](Docs/developer_guide/script_repository/segmentations.md#L528)

**Documentation shows**:
```python
pointListNode.AddObserver(slicer.vtkMRMLMarkupsPlaneNode.PointModifiedEvent, printSegmentNames)
```

**Problem**: The `pointListNode` is created as `vtkMRMLMarkupsFiducialNode` (line 511), but the event type references `vtkMRMLMarkupsPlaneNode`. While this works due to inheritance (both inherit from `vtkMRMLMarkupsNode`), it's confusing.

**Recommendation**: Use the base class event:
```python
pointListNode.AddObserver(slicer.vtkMRMLMarkupsNode.PointModifiedEvent, printSegmentNames)
```

---

## Category 5: Documentation Clarity Issues

### Issue 5.1: Missing Import Statement in Examples

**Location**: [segmentations.md:433](Docs/developer_guide/script_repository/segmentations.md#L433)

The example uses `arrayFromSegment()` without showing the import. The function should be called as `slicer.util.arrayFromSegment()` or imported first.

### Issue 5.2: Outdated Terminology

Several documentation files still reference old "fiducial" terminology alongside newer "control point" terminology:
- "fiducial lists" should be "point lists" or "markup point lists"
- "AddFiducial" should be "AddControlPoint"

**Locations**: Throughout markups.md and other files

---

## Category 6: Internal Documentation Inconsistencies

### Issue 6.1: Incomplete Example Code

**Location**: [segmentations.md:647](Docs/developer_guide/script_repository/segmentations.md#L647)

**Documentation shows**:
```python
extracted_voxels, extracted_header = slicerio.extract_segments(voxels, header, segmentation_info, segment_names_to_labels)
```

**Problem**: The variable `segmentation_info` is never defined in the example.

**Recommendation**: Either define `segmentation_info` or remove it from the function call if not needed.

---

## Category 7: Potential API Changes Not Reflected

### Issue 7.1: returnNode Parameter Still Documented

While the `returnNode` parameter is marked as deprecated in the code ([util.py:700](Base/Python/slicer/util.py#L700)), some documentation examples may still use patterns that rely on the old return style.

---

## Summary Statistics

| Issue Category | Count | Severity |
|---------------|-------|----------|
| Deprecated functions | 3 | High |
| Inconsistent prefixes | 80+ | Medium |
| Variable name issues | 2+ | Low |
| Event type confusion | 1 | Low |
| Incomplete examples | 2 | Medium |

---

## Recommendations for Improvement

### Immediate Actions (High Priority)
1. Replace `loadMarkupsFiducialList()` with `loadMarkups()` in markups.md
2. Replace `AddFiducialFromArray()` with `AddControlPoint()` in segmentations.md
3. Replace `arrayFromSegment()` with `arrayFromSegmentBinaryLabelmap()` in segmentations.md
4. Fix undefined variable `segmentation` -> `segmentationNode` in segmentations.md:191

### Medium-Term Actions
1. Add a prominent note at the top of script_repository files explaining that bare function names (like `getNode()`) only work in interactive mode
2. Standardize variable naming conventions across documentation
3. Complete incomplete code examples with missing variable definitions

### Long-Term Actions
1. Consider a documentation linter that checks code examples against the actual API
2. Update old fiducial terminology to control point terminology consistently
3. Add deprecation notes to documentation when API functions are deprecated

---

## Category 8: Script Repository - Code Errors and API Inconsistencies

This section provides a detailed analysis of specific script_repository files, identifying code that will produce runtime errors or doesn't match the current API.

### 8.1 models.md - Undefined Variable

**Location**: [models.md:201](Docs/developer_guide/script_repository/models.md#L201)

**Documentation shows**:
```python
pointListNodeObserverTag = markupsNode.AddObserver(slicer.vtkMRMLMarkupsFiducialNode.PointModifiedEvent, onPointsModified)
```

**Problem**: Variable `markupsNode` is never defined. The variable is `pointListNode` (defined on line 160).

**Fix**: Change `markupsNode` to `pointListNode`

---

### 8.2 dicom.md - Missing Variable Assignment

**Location**: [dicom.md:131-132](Docs/developer_guide/script_repository/dicom.md#L131-L132)

**Documentation shows**:
```python
pydicom.dcmread(fileList[0])
ds.CTExposureSequence[0].ExposureModulationType
```

**Problem**: The result of `pydicom.dcmread()` is not assigned to `ds`. The second line will fail with `NameError: name 'ds' is not defined`.

**Fix**:
```python
ds = pydicom.dcmread(fileList[0])
ds.CTExposureSequence[0].ExposureModulationType
```

---

### 8.3 dicom.md - Variable Name Mismatch

**Location**: [dicom.md:186](Docs/developer_guide/script_repository/dicom.md#L186)

**Documentation shows**:
```python
instanceUIDs = node.GetAttribute("DICOM.instanceUIDs").split()
filepath = slicer.dicomDatabase.fileForInstance(instUids[0])
```

**Problem**: Variable is defined as `instanceUIDs` (uppercase) but used as `instUids` (camelCase).

**Fix**: Change `instUids` to `instanceUIDs`

---

### 8.4 dicom.md - Incorrect Self Reference

**Location**: [dicom.md:191](Docs/developer_guide/script_repository/dicom.md#L191)

**Documentation shows**:
```python
node = slicer.util.getNode("volume1")
path = self.pathFromNode(node)
```

**Problem**: Uses `self.pathFromNode()` but this code is not inside a class. Should be just `pathFromNode()`.

**Fix**: Remove `self.` prefix

---

### 8.5 volumes.md - Incorrect Function Call (Positional vs Keyword)

**Location**: [volumes.md:70](Docs/developer_guide/script_repository/volumes.md#L70)

**Documentation shows**:
```python
slicer.util.setSliceViewerLayers(volumeNode, fit=True)
```

**Problem**: `setSliceViewerLayers()` expects keyword arguments. The first positional argument is being passed where `background=` is expected. The actual signature is:
```python
def setSliceViewerLayers(background="keep-current", foreground="keep-current", ...)
```

**Fix**:
```python
slicer.util.setSliceViewerLayers(background=volumeNode, fit=True)
```

---

### 8.6 volumes.md - Same Issue as 8.5

**Location**: [volumes.md:840](Docs/developer_guide/script_repository/volumes.md#L840)

**Documentation shows**:
```python
slicer.util.setSliceViewerLayers(maskedVolumeNode)
```

**Fix**:
```python
slicer.util.setSliceViewerLayers(background=maskedVolumeNode)
```

---

### 8.7 volumes.md - Missing slicer.util Prefix

**Location**: [volumes.md:797](Docs/developer_guide/script_repository/volumes.md#L797)

**Documentation shows**:
```python
setSliceViewerLayers(background=volumeNode)
```

**Problem**: Missing `slicer.util.` prefix.

**Fix**:
```python
slicer.util.setSliceViewerLayers(background=volumeNode)
```

---

### 8.8 plots.md - Multiple Missing Prefixes

**Locations**: [plots.md:14, 32, 36, 119, 162, 169](Docs/developer_guide/script_repository/plots.md)

**Issues**:
- Line 14: `arrayFromVolume(volumeNode)` - missing `slicer.util.`
- Line 32: `arrayFromVolume(volumeNode)` - missing `slicer.util.`
- Line 36: `updateTableFromArray(tableNode, histogram)` - missing `slicer.util.`
- Line 119: `pip_install("matplotlib")` - missing `slicer.util.`
- Line 162: `pip_install("matplotlib wxPython")` - missing `slicer.util.`
- Line 169: `arrayFromVolume(volumeNode)` - missing `slicer.util.`

**Note**: These work in interactive console but fail in scripts/modules.

---

### 8.9 sequences.md - Missing Python Language Tag

**Location**: [sequences.md:141-166](Docs/developer_guide/script_repository/sequences.md#L141-L166)

**Problem**: Code block starts with ` ``` ` instead of ` ```python `, and uses bare `getNode()` without prefix.

---

### 8.10 registration.md - Incorrect Function Call

**Location**: [registration.md:30](Docs/developer_guide/script_repository/registration.md#L30)

**Documentation shows**:
```python
slicer.util.setSliceViewerLayers(fixedVolumeNode, movingVolumeNode, foregroundOpacity=0.5)
```

**Problem**: Passing two positional arguments where keyword arguments are expected.

**Fix**:
```python
slicer.util.setSliceViewerLayers(background=fixedVolumeNode, foreground=movingVolumeNode, foregroundOpacity=0.5)
```

---

## Category 9: Potential Runtime Errors Summary

| File | Line | Issue Type | Severity |
|------|------|------------|----------|
| models.md | 201 | Undefined variable `markupsNode` | **Critical** |
| dicom.md | 131-132 | Missing assignment `ds = ...` | **Critical** |
| dicom.md | 186 | Variable name typo `instUids` vs `instanceUIDs` | **Critical** |
| dicom.md | 191 | Invalid `self.` reference | **High** |
| volumes.md | 70 | Wrong function call pattern | **High** |
| volumes.md | 797 | Missing `slicer.util.` prefix | **Medium** |
| volumes.md | 840 | Wrong function call pattern | **High** |
| registration.md | 30 | Wrong function call pattern | **High** |
| plots.md | 14,32,36,119,162,169 | Missing prefixes (6 instances) | **Medium** |

---

## Updated Summary Statistics

| Issue Category | Count | Severity |
|---------------|-------|----------|
| Deprecated functions | 3 | High |
| Undefined/wrong variables | 4 | Critical |
| Wrong function call patterns | 4 | High |
| Missing `slicer.util.` prefixes | 80+ | Medium |
| Variable name inconsistencies | 2+ | Low |
| Missing variable assignments | 1 | Critical |

---

## Verification Plan

To verify the documentation fixes are correct:
1. Run Python examples in Slicer's Python console to confirm they work
2. Check that deprecated function warnings are no longer triggered
3. Ensure examples work both in interactive mode and as scripts
4. For critical errors, test the exact code snippets to confirm they fail before fixing
