### PR TITLE
BUG: Maintain selection in subject hierarchy after reparenting item

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
@@ -1031,6 +1031,18 @@ void qMRMLSubjectHierarchyModel::updateItemFromSubjectHierarchyItem(QStandardIte
         // Reparent items
         QList<QStandardItem*> children = parentItem->takeRow(item->row());
         newParentItem->insertRow(newIndex, children);
+
+        // Make sure the selection is maintained after reparenting
+        QList<vtkIdType> childItemIds;
+        for (QStandardItem* child : children)
+        {
+          vtkIdType childItemId = this->subjectHierarchyItemFromItem(child);
+          if (childItemId != vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID)
+          {
+            childItemIds.append(childItemId);
+          }
+        }
+        emit requestSelectItems(childItemIds);
       }
     }
   }


### PR DESCRIPTION
Re https://discourse.slicer.org/t/slicer-5-10-qmrmlsubjecthierarchycombobox-turned-to-none-but-no-issue-with-5-8-1/45203