### PR TITLE
Improve python package installation utilities

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -320,6 +320,18 @@ slicer_add_python_unittest(
   )
 
 slicer_add_python_unittest(
+  SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_util_pip.py
+  SLICER_ARGS --no-main-window --testing --disable-modules
+  TESTNAME_PREFIX nomainwindow_
+  )
+
+slicer_add_python_unittest(
+  SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_packaging.py
+  SLICER_ARGS --no-main-window --testing --disable-modules
+  TESTNAME_PREFIX nomainwindow_
+  )
+
+slicer_add_python_unittest(
   SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
   SLICER_ARGS --no-main-window --disable-cli-modules --disable-scripted-loadable-modules
   TESTNAME_PREFIX nomainwindow_

--- a/Applications/SlicerApp/Testing/Python/SlicerStartupPreserveSysPathTestHelperScript.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerStartupPreserveSysPathTestHelperScript.py
@@ -1,6 +1,8 @@
 import sys
 import os
 
+from slicer.util import EXIT_SUCCESS
+
 SENTINEL = "/test/slicer-start-preserve-sys-path/directory"
 if SENTINEL not in sys.path:
     raise RuntimeError(f"{SENTINEL} not in sys.path as expected")

--- a/Base/Python/CMakeLists.txt
+++ b/Base/Python/CMakeLists.txt
@@ -17,9 +17,9 @@ set(Slicer_PYTHON_SCRIPTS
   slicer/parameterNodeWrapper/wrapper
   slicer/packaging
   slicer/ScriptedLoadableModule
-  slicer/slicerqt
   slicer/testing
   slicer/util
+  slicerqt
   mrml
   vtkAddon
   vtkITK

--- a/Base/Python/CMakeLists.txt
+++ b/Base/Python/CMakeLists.txt
@@ -15,6 +15,7 @@ set(Slicer_PYTHON_SCRIPTS
   slicer/parameterNodeWrapper/util
   slicer/parameterNodeWrapper/validators
   slicer/parameterNodeWrapper/wrapper
+  slicer/packaging
   slicer/ScriptedLoadableModule
   slicer/slicerqt
   slicer/testing

--- a/Base/Python/slicer/i18n.py
+++ b/Base/Python/slicer/i18n.py
@@ -11,9 +11,11 @@ def translate(context, text):
     This `translate(context, message)` function is recognized by Qt's lupdate tool.
     See example use in DICOM module.
     """
-    from slicer import app
-
-    return app.translate(context, text)
+    try:
+        from slicer import app
+        return app.translate(context, text)
+    except ImportError:
+        return text
 
 
 def getContext(sourceFile):

--- a/Base/Python/slicer/packaging.py
+++ b/Base/Python/slicer/packaging.py
@@ -1,0 +1,1283 @@
+"""Utilities for managing Python package dependencies in 3D Slicer.
+
+This module provides functions for checking, installing, and managing Python
+packages in the Slicer environment. It is the canonical home for all pip-related
+functionality.
+
+**Key functions:**
+
+- :func:`load_requirements` / :func:`load_pyproject_dependencies` -- parse dependency files
+- :func:`pip_check` -- check if requirements are satisfied (pure Python, no subprocess)
+- :func:`pip_ensure` -- high-level: check, prompt, install, restart detection
+- :func:`pip_install` / :func:`pip_uninstall` -- install/uninstall packages
+
+For backward compatibility, :func:`pip_install` and :func:`pip_uninstall` are also
+available as ``slicer.util.pip_install`` and ``slicer.util.pip_uninstall``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import logging
+import os
+import shlex
+import shutil
+import sys
+import tomllib
+from pathlib import Path
+from subprocess import CalledProcessError
+from typing import TYPE_CHECKING
+
+from packaging.markers import default_environment
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+
+from slicer.i18n import tr as _
+from slicer.util import launchConsoleProcess, logProcessOutput
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import qt
+
+
+def _executePythonModule(
+    module: str,
+    args: list[str],
+    blocking: bool = True,
+    logCallback: Callable[[str], None] | None = None,
+    completedCallback: Callable[[int], None] | None = None,
+) -> None:
+    """Execute a Python module as a script in Slicer's Python environment.
+
+    Internally python -m is called with the module name and additional arguments.
+
+    :param module: Python module name to execute (e.g., "pip")
+    :param args: command-line arguments to pass to the module
+    :param blocking: If True (default), block until completion. If False, return immediately.
+    :param logCallback: When blocking=False, called with each line of output.
+    :param completedCallback: When blocking=False, called when process completes.
+    :raises RuntimeError: if PythonSlicer executable not found
+    :raises CalledProcessError: in blocking mode, if process fails
+    """
+    # Determine pythonSlicerExecutablePath
+    try:
+        from slicer import app  # noqa: F401
+
+        # If we get to this line then import from "app" is succeeded,
+        # which means that we run this function from Slicer Python interpreter.
+        # PythonSlicer is added to PATH environment variable in Slicer
+        # therefore shutil.which will be able to find it.
+        pythonSlicerExecutablePath = shutil.which("PythonSlicer")
+        if not pythonSlicerExecutablePath:
+            raise RuntimeError("PythonSlicer executable not found")
+    except ImportError:
+        # Running from console
+        pythonSlicerExecutablePath = os.path.dirname(sys.executable) + "/PythonSlicer"
+        if os.name == "nt":
+            pythonSlicerExecutablePath += ".exe"
+
+    commandLine = [pythonSlicerExecutablePath, "-m", module, *args]
+
+    if blocking:
+        proc = launchConsoleProcess(commandLine, useStartupEnvironment=False)
+        logProcessOutput(proc, logCallback=logCallback)
+    else:
+        launchConsoleProcess(
+            commandLine,
+            useStartupEnvironment=False,
+            blocking=False,
+            logCallback=logCallback,
+            completedCallback=completedCallback,
+        )
+
+
+def load_requirements(path: str | Path) -> list[Requirement]:
+    """Load requirements from a requirements.txt file.
+
+    Parses a requirements file and returns a list of Requirement objects
+    that can be used with :func:`pip_check` and :func:`pip_ensure`.
+
+    :param path: Path to the requirements.txt file. Can be a string or Path object.
+
+    :returns: List of :class:`packaging.requirements.Requirement` objects.
+
+    Lines starting with ``#`` (comments), empty lines, and lines starting with
+    ``-`` (pip options like ``-r``, ``-c``, ``--index-url``) are skipped.
+
+    Example:
+
+    .. code-block:: python
+
+      from pathlib import Path
+      reqs = slicer.packaging.load_requirements(Path(__file__).parent / "requirements.txt")
+      slicer.packaging.pip_ensure(reqs, requester="MyExtension")
+
+    """
+    reqs = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            # Skip comments, empty lines, and pip options (-r, -c, --index-url, etc.)
+            if line and not line.startswith("#") and not line.startswith("-"):
+                reqs.append(Requirement(line))
+    return reqs
+
+
+def load_pyproject_dependencies(path: str | Path) -> list[Requirement]:
+    """Load dependencies from a pyproject.toml file.
+
+    Reads the ``[project.dependencies]`` list (`PEP 621
+    <https://peps.python.org/pep-0621/>`_) and returns
+    :class:`~packaging.requirements.Requirement` objects that can be used
+    with :func:`pip_check` and :func:`pip_ensure`.
+
+    Only the ``dependencies`` list inside the ``[project]`` table is read.
+    Other fields in the table (``name``, ``version``, etc.) are not read or
+    validated.
+
+    :param path: Path to the pyproject.toml file. Can be a string or Path object.
+
+    :returns: List of :class:`packaging.requirements.Requirement` objects.
+        Returns an empty list if ``[project]`` exists but has no
+        ``dependencies`` key.
+
+    :raises KeyError: If the file has no ``[project]`` table.
+
+    Example pyproject.toml::
+
+      [project]
+      dependencies = [
+          "numpy>=1.20",
+          "scikit-image>=0.20",
+      ]
+
+    Example:
+
+    .. code-block:: python
+
+      from pathlib import Path
+      reqs = slicer.packaging.load_pyproject_dependencies(
+          Path(__file__).parent / "pyproject.toml"
+      )
+      slicer.packaging.pip_ensure(reqs, requester="MyExtension")
+
+    """
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+
+    if "project" not in data:
+        msg = f"pyproject.toml has no [project] table: {path}"
+        raise KeyError(msg)
+
+    return [Requirement(dep) for dep in data["project"].get("dependencies", [])]
+
+
+def _to_requirements(
+    reqs: str | Requirement | list[str | Requirement],
+) -> list[Requirement]:
+    """Normalize flexible input into a list of Requirement objects.
+
+    Accepts a single string (one requirement, possibly with a marker; or
+    multiple simple requirements separated by whitespace), a single
+    Requirement, or a list of strings/Requirements. For multiple
+    requirements that include markers, use a list to avoid ambiguity.
+    """
+    if isinstance(reqs, str):
+        # Try the whole string as a single requirement first. This is what
+        # makes "foo; sys_platform == 'win32'" work -- markers contain
+        # whitespace and would be mangled by the split path below.
+        try:
+            return [Requirement(reqs)]
+        except InvalidRequirement:
+            pass
+        # Otherwise treat the string as multiple simple requirements
+        # separated by whitespace, e.g. "numpy>=1.0 scipy>=1.0".
+        return [Requirement(s) for s in reqs.split()]
+    if isinstance(reqs, Requirement):
+        return [reqs]
+    if isinstance(reqs, list):
+        return [Requirement(r) if isinstance(r, str) else r for r in reqs]
+    msg = f"Expected str, Requirement, or list, got {type(reqs).__name__}"
+    raise TypeError(msg)
+
+
+def pip_check(
+    req: str | Requirement | list[str | Requirement],
+    _seen: set[tuple[str, frozenset[str]]] | None = None,
+) -> bool:
+    """Check if requirement(s) are satisfied.
+
+    For requirements with extras like ``package[extra1,extra2]>=1.0``, this:
+
+    1. Checks if the base package is installed at an acceptable version
+    2. Finds which dependencies are activated by the requested extras
+    3. Recursively verifies those dependencies are satisfied
+
+    Markers (e.g., ``; sys_platform == 'win32'``) are evaluated - if a marker
+    doesn't apply to the current environment, the requirement is considered
+    satisfied (since it doesn't need to be installed).
+
+    :param req: Requirement(s) to check. Accepts a space-separated string
+        (e.g., ``"numpy>=1.20 scipy"``), a single
+        :class:`~packaging.requirements.Requirement`, or a list of strings
+        and/or Requirement objects.
+    :param _seen: Internal parameter for tracking circular dependencies.
+        Do not pass this parameter.
+
+    :returns: True if all requirements are satisfied, False otherwise.
+
+    Example:
+
+    .. code-block:: python
+
+      if slicer.packaging.pip_check("numpy>=1.20"):
+          print("numpy is satisfied")
+
+    """
+    from importlib.metadata import PackageNotFoundError, requires, version
+
+    if _seen is None:
+        _seen = set()
+        # Normalize flexible input types at the public entry point
+        reqs = _to_requirements(req)
+        return all(pip_check(r, _seen) for r in reqs)
+
+    # From here, req is a single Requirement (internal recursive call)
+
+    # Check if requirement's marker applies to current environment
+    # If not, consider it satisfied (doesn't need to be installed here)
+    if req.marker is not None:
+        env = default_environment()
+        if not req.marker.evaluate(env):
+            return True
+
+    # Avoid rechecking the same requirement
+    key = (req.name.lower(), frozenset(req.extras))
+    if key in _seen:
+        return True
+    _seen.add(key)
+
+    # Check if base package is installed at acceptable version
+    try:
+        installed = version(req.name)
+    except PackageNotFoundError:
+        return False
+    if installed not in req.specifier:
+        return False
+
+    # If no extras then we are done
+    if not req.extras:
+        return True
+
+    # Find dependencies activated by the requested extras
+    dep_strings = requires(req.name) or []
+    env = default_environment()
+    activated = []
+
+    for dep_str in dep_strings:
+        dep = Requirement(dep_str)
+        if dep.marker is None:
+            continue
+
+        # Check if any requested extra activates this dependency
+        for extra in req.extras:
+            if dep.marker.evaluate({**env, "extra": extra}):
+                # Strip marker before recursive check - we've already determined it applies
+                dep_str_no_marker = str(dep).split(";")[0].strip()
+                activated.append(Requirement(dep_str_no_marker))
+                break  # Don't check other extras for same dep
+
+    # Recursively verify all activated dependencies
+    return all(pip_check(dep, _seen) for dep in activated)
+
+
+# Module-level flag to track whether a non-blocking pip install is in progress.
+# Used to prevent concurrent non-blocking pip operations which could corrupt
+# the Python environment.
+_pip_install_in_progress: bool = False
+
+
+def isPipInstallInProgress() -> bool:
+    """Check if a non-blocking pip install is currently in progress.
+
+    Use this to check before starting an operation that might conflict with
+    an ongoing pip installation.
+
+    :returns: True if a non-blocking pip install is in progress, False otherwise.
+
+    Example:
+
+    .. code-block:: python
+
+      if slicer.packaging.isPipInstallInProgress():
+          slicer.util.warningDisplay(
+              "Package installation is in progress. Please wait."
+          )
+      else:
+          slicer.packaging.pip_install("scipy", blocking=False)
+
+    """
+    return _pip_install_in_progress
+
+
+def _get_installed_versions() -> dict[str, str]:
+    """Return ``{canonical_distribution_name: version}`` for all installed packages.
+
+    Calls :func:`importlib.invalidate_caches` first so that metadata changes made by
+    a pip subprocess are visible to this process.
+    """
+    importlib.invalidate_caches()
+    return {
+        canonicalize_name(dist.metadata["Name"]): dist.metadata["Version"]
+        for dist in importlib.metadata.distributions()
+    }
+
+
+def _find_updated_imported_packages(
+    before_versions: dict[str, str],
+    after_versions: dict[str, str],
+) -> list[tuple[str, str | None, str]]:
+    """Find packages that were updated AND had modules already imported.
+
+    Compares *before_versions* and *after_versions* (both returned by
+    :func:`_get_installed_versions`) and checks whether any changed distribution
+    has top-level import names present in :data:`sys.modules`.
+
+    :param before_versions: ``{canonical_dist_name: version}`` before installation.
+    :param after_versions: ``{canonical_dist_name: version}`` after installation.
+    :returns: List of ``(dist_name, old_version, new_version)`` tuples for packages
+        that have import names present in ``sys.modules`` and either changed version
+        or were freshly installed (``old_version`` is ``None`` in that case).
+    """
+    # Reverse mapping: canonical dist name -> set of top-level import names
+    dist_to_imports: dict[str, set[str]] = {}
+    for import_name, dist_names in importlib.metadata.packages_distributions().items():
+        for dn in dist_names:
+            dist_to_imports.setdefault(canonicalize_name(dn), set()).add(import_name)
+
+    result = []
+    for name, old_ver in before_versions.items():
+        new_ver = after_versions.get(name)
+        if new_ver is None or old_ver == new_ver:
+            continue
+        import_names = dist_to_imports.get(name, set())
+        if any(imp in sys.modules for imp in import_names):
+            result.append((name, old_ver, new_ver))
+
+    # Also check packages that were freshly installed (not in before_versions).
+    # If their import names are already in sys.modules, that means they were
+    # previously installed and imported, then uninstalled, then reinstalled.
+    # The old module objects are still in memory.
+    for name, new_ver in after_versions.items():
+        if name in before_versions:
+            continue  # Already handled above
+        import_names = dist_to_imports.get(name, set())
+        if any(imp in sys.modules for imp in import_names):
+            result.append((name, None, new_ver))
+
+    return result
+
+
+def pip_ensure(
+    requirements: str | Requirement | list[str | Requirement],
+    constraints: str | Path | None = None,
+    skip_packages: list[str] | None = None,
+    prompt_install: bool = True,
+    prompt_restart: bool = True,
+    requester: str | None = None,
+    skip_in_testing: bool = True,
+    show_progress: bool = True,
+) -> list[str] | None:
+    """Ensure requirements are satisfied, installing if needed.
+
+    Call at the point where dependencies are actually needed (e.g., in an
+    ``onApplyButton`` method). This function checks which requirements are
+    missing and installs them, optionally showing a confirmation dialog first.
+
+    After installation, if any updated packages were already imported in the
+    current session, a restart prompt is shown (the old versions remain loaded
+    in memory and may not work correctly until Slicer is restarted).
+
+    :param requirements: Requirement(s) to ensure. Accepts a space-separated
+        string (e.g., ``"flywheel-sdk>=1.0 numpy"``), a single
+        :class:`~packaging.requirements.Requirement`, or a list of strings
+        and/or Requirement objects. Can also be obtained from
+        :func:`load_requirements` or :func:`load_pyproject_dependencies`.
+    :param constraints: Path to a constraints file (string or Path object), or None.
+        When provided, passed to pip as ``-c constraints.txt`` during installation.
+        Constraints files use the same format as requirements files but only constrain
+        versions without triggering installation. Useful for ensuring compatible
+        versions across multiple extensions.
+    :param skip_packages: Discouraged workaround for transitive dependency conflicts;
+        see the script repository for guidance. Forwarded to :func:`pip_install`.
+    :param prompt_install: If True (default), show confirmation dialog before installing.
+    :param prompt_restart: If True (default), check whether any updated packages were
+        already imported and, if so, show a dialog recommending a restart. The user
+        can choose to restart immediately or continue without restarting.
+    :param requester: Name shown in dialog to identify who is requesting the packages
+        (e.g., "TotalSegmentator", "MyFilter", "MyExtension").
+    :param skip_in_testing: If True (default), skip installation when Slicer is running
+        in testing mode (``slicer.app.testingEnabled()``). This prevents tests from
+        modifying the Python environment. Set to False if your test explicitly
+        needs to verify installation behavior.
+    :param show_progress: If True (default), show progress dialog during installation
+        with status updates and collapsible log details. If False, show only
+        a busy cursor during installation.
+
+    :returns: When ``skip_packages`` is provided, a list of skipped requirement strings
+        (forwarded from :func:`pip_install`). Otherwise ``None``.
+
+    :raises RuntimeError: If user declines installation.
+    :raises subprocess.CalledProcessError: If installation fails.
+
+    Example:
+
+    .. code-block:: python
+
+      class MyFilterWidget(ScriptedLoadableModuleWidget):
+
+          def onApplyButton(self):
+              slicer.packaging.pip_ensure("scikit-image>=0.20", requester="MyFilter")
+              import skimage
+
+              # Now safe to use skimage
+              filtered = skimage.filters.gaussian(array, sigma=2.0)
+
+    For loading from a requirements file, use :func:`load_requirements`::
+
+      reqs = slicer.packaging.load_requirements(self.resourcePath("requirements.txt"))
+      slicer.packaging.pip_ensure(reqs, requester="MyFilter")
+
+    For more examples (constraints, skip_packages), see
+    :doc:`/developer_guide/script_repository` (Python package management section).
+
+    """
+    requirements = _to_requirements(requirements)
+    missing = [req for req in requirements if not pip_check(req)]
+
+    if not missing:
+        return None  # All satisfied
+
+    # Check if we're in full Slicer or PythonSlicer
+    if not _isSlicerAppAvailable():
+        # Running in PythonSlicer - just do simple install (prompt not available)
+        return pip_install(
+            [str(req) for req in missing],
+            constraints=constraints,
+            skip_packages=skip_packages,
+        )
+
+    import slicer
+
+    # Skip installation in testing mode to avoid modifying the environment
+    if skip_in_testing and slicer.app.testingEnabled():
+        missing_str = ", ".join(str(req) for req in missing)
+        logging.info(f"Testing mode is enabled: skipping pip_ensure for [{missing_str}]")
+        return None
+
+    if prompt_install:
+        package_list = "\n".join(f"- {req}" for req in missing)
+        if requester:
+            title = _("{requester} - Install Python Packages").format(requester=requester)
+        else:
+            title = _("Install Python Packages")
+        count = len(missing)
+        if count == 1:
+            message = _(
+                "1 Python package needs to be installed.\n\n"
+                "This will modify Slicer's Python environment. Continue?",
+            )
+        else:
+            message = _(
+                "{count} Python packages need to be installed.\n\n"
+                "This will modify Slicer's Python environment. Continue?",
+            ).format(count=count)
+        if not slicer.util.confirmOkCancelDisplay(message, title, detailedText=package_list):
+            raise RuntimeError("User declined package installation")
+
+    # Snapshot installed versions before installation
+    before_versions = _get_installed_versions() if prompt_restart else None
+
+    # Install missing packages with optional progress display
+    skipped = pip_install(
+        [str(req) for req in missing],
+        constraints=constraints,
+        skip_packages=skip_packages,
+        blocking=True,
+        show_progress=show_progress,
+        requester=requester,
+    )
+
+    if not prompt_restart:
+        return skipped
+
+    # Check if any updated packages were already imported
+    after_versions = _get_installed_versions()
+    updated_imported = _find_updated_imported_packages(before_versions, after_versions)
+
+    if updated_imported:
+        detail_lines = [
+            f"- {name}: {old_ver} -> {new_ver}" if old_ver else f"- {name}: (reinstalled) -> {new_ver}"
+            for name, old_ver, new_ver in updated_imported
+        ]
+        detail_text = "\n".join(detail_lines)
+        logging.info(
+            f"Updated packages already imported (restart recommended): {detail_text}",
+        )
+
+        # confirmYesNoDisplay auto-returns True in testing mode, which would
+        # trigger an unwanted restart. Guard with testingEnabled() check and
+        # rely on the log message above for test verification.
+        if not slicer.app.testingEnabled():
+            count = len(updated_imported)
+            if requester:
+                title = _("{requester} - Restart Recommended").format(requester=requester)
+            else:
+                title = _("Restart Recommended")
+            if count == 1:
+                message = _(
+                    "1 updated package was already loaded in memory "
+                    "and may not work correctly until Slicer is restarted.\n\n"
+                    "Would you like to restart now?",
+                )
+            else:
+                message = _(
+                    "{count} updated packages were already loaded in memory "
+                    "and may not work correctly until Slicer is restarted.\n\n"
+                    "Would you like to restart now?",
+                ).format(count=count)
+            if slicer.util.confirmYesNoDisplay(
+                message, title, detailedText=detail_text,
+            ):
+                slicer.util.restart()
+
+    return skipped
+
+
+def _isSlicerAppAvailable() -> bool:
+    """Check if slicer.app is available (running in full Slicer, not PythonSlicer).
+
+    :returns: True if slicer.app is available, False if running in PythonSlicer console.
+    """
+    try:
+        from slicer import app
+        return app is not None
+    except ImportError:
+        return False
+
+
+def pip_install(
+    requirements: str | list[str],
+    constraints: str | Path | None = None,
+    no_deps_requirements: str | list[str] | None = None,
+    skip_packages: list[str] | None = None,
+    blocking: bool = True,
+    show_progress: bool = True,
+    requester: str | None = None,
+    parent: qt.QWidget | None = None,
+    logCallback: Callable[[str], None] | None = None,
+    completedCallback: Callable[[int], None] | None = None,
+) -> list[str] | None:
+    """Install python packages.
+
+    Currently, the method simply calls ``python -m pip install`` but in the future further checks, optimizations,
+    user confirmation may be implemented, therefore it is recommended to use this method call instead of calling
+    pip install directly.
+
+    :param requirements: requirement specifier in the same format as used by pip (https://docs.python.org/3/installing/index.html).
+      It can be either a single string or a list of command-line arguments. In general, passing all arguments as a single string is
+      the simplest. The only case when using a list may be easier is when there are arguments that may contain spaces, because
+      each list item is automatically quoted (it is not necessary to put quotes around each string argument that may contain spaces).
+    :param constraints: Path to a constraints file (string or Path object), or None.
+        When provided, passed to pip as ``-c constraints.txt``. Constraints files use the
+        same format as requirements files but only constrain versions without triggering
+        installation. Useful for ensuring compatible versions across multiple extensions.
+    :param no_deps_requirements: Packages to install with ``--no-deps`` flag, installed before
+        ``requirements``. Use this when a package has overly strict dependency requirements
+        that conflict with other packages. Can be a string or list, same format as ``requirements``.
+        When provided, installation happens in two steps: first ``no_deps_requirements`` are
+        installed with ``--no-deps``, then ``requirements`` are installed normally.
+        Mutually exclusive with ``skip_packages``.
+    :param skip_packages: Discouraged workaround for transitive dependency conflicts;
+        see the script repository for guidance. Package names to exclude from the
+        dependency tree: installs each requirement with ``--no-deps``, walks its
+        dependencies recursively, and skips any package in this list. Metadata is
+        scrubbed so pip won't try to install them later. Name matching is
+        case-insensitive and normalizes hyphens/underscores. Returns a list of the
+        skipped requirement strings. Requires ``blocking=True``. Mutually exclusive
+        with ``no_deps_requirements``.
+    :param blocking: If True (default), block until installation completes and raise
+        CalledProcessError on failure. If False, return immediately and use callbacks.
+        Note: When running in PythonSlicer (without the full application), blocking mode
+        is always used regardless of this setting.
+    :param show_progress: If True (default), show visual feedback during installation. When
+        blocking=True, shows a modal progress dialog with status updates and collapsible log
+        details. When blocking=False, shows pip output lines in the status bar as installation
+        progresses. Note: When running in PythonSlicer or in testing mode, progress display
+        is skipped and simple blocking mode is used.
+    :param requester: Name shown in dialog/status bar to identify who is requesting the packages
+        (e.g., "MyExtension"). Only used when show_progress=True.
+    :param parent: Parent widget for the progress dialog. Only used when show_progress=True
+        and blocking=True.
+    :param logCallback: When blocking=False, called with each line of pip output.
+        If None, output is printed to Python console as usual.
+        Signature: ``logCallback(line: str) -> None``
+    :param completedCallback: When blocking=False, called when pip completes.
+        Receives return code (0 = success). Recommended when blocking=False to know
+        when installation finished.
+        Signature: ``completedCallback(returnCode: int) -> None``
+
+    :returns: When ``skip_packages`` is provided, a list of skipped requirement strings
+        (e.g., ``["torch>=2.0", "SimpleITK>=2.0.2"]``). Otherwise ``None``.
+
+    :raises subprocess.CalledProcessError: In blocking mode, if pip installation fails.
+        When show_progress=True, an error dialog with the full log is shown before raising.
+    :raises ValueError: If ``skip_packages`` is combined with ``no_deps_requirements``
+        or with ``blocking=False``.
+
+    .. warning::
+
+        When using ``blocking=False``, the user can interact with the application
+        while installation is in progress. Consider disabling relevant UI elements
+        to prevent conflicts.
+
+    Example:
+
+    .. code-block:: python
+
+      pip_install("pandas scipy scikit-learn")
+
+    For more examples (constraints, non-blocking mode, skip_packages, no_deps_requirements),
+    see :doc:`/developer_guide/script_repository` (Python package management section).
+
+    """
+    # Validate skip_packages constraints
+    if skip_packages is not None:
+        if no_deps_requirements is not None:
+            raise ValueError(
+                "skip_packages and no_deps_requirements are mutually exclusive. "
+                "skip_packages installs each package with --no-deps internally.",
+            )
+        if not blocking:
+            raise ValueError(
+                "skip_packages requires blocking=True. "
+                "The recursive dependency walk cannot run in non-blocking mode.",
+            )
+
+    # Check if we're running in full Slicer or PythonSlicer
+    if not _isSlicerAppAvailable():
+        # Running in PythonSlicer - use simple blocking mode
+        if skip_packages is not None:
+            return _pip_install_with_skips(requirements, skip_packages, constraints)
+        _pip_install_simple(requirements, constraints, no_deps_requirements)
+        return None
+
+    import slicer
+
+    # In testing mode, skip UI and use simple blocking install
+    if slicer.app.testingEnabled():
+        logging.info("Testing mode is enabled: skipping progress UI for pip_install")
+        if skip_packages is not None:
+            return _pip_install_with_skips(requirements, skip_packages, constraints)
+        _pip_install_simple(requirements, constraints, no_deps_requirements)
+        return None
+
+    # Check for concurrent non-blocking installs
+    if not blocking and _pip_install_in_progress:
+        raise RuntimeError(
+            "A non-blocking pip_install is already in progress. "
+            "Wait for it to complete or use blocking=True.",
+        )
+
+    # skip_packages dispatch (blocking only)
+    if skip_packages is not None:
+        if show_progress:
+            return _pip_install_with_skips_dialog(
+                requirements, skip_packages, constraints, requester, parent,
+            )
+        else:
+            return _pip_install_with_skips_busy_cursor(
+                requirements, skip_packages, constraints,
+            )
+
+    # Determine which mode to use based on show_progress and blocking
+    if show_progress and blocking:
+        # Modal progress dialog (blocking from user's perspective, but UI responsive)
+        _pip_install_with_dialog(
+            requirements, constraints, no_deps_requirements, requester, parent,
+        )
+    elif show_progress and not blocking:
+        # Status bar progress (non-blocking)
+        _pip_install_with_statusbar(
+            requirements, constraints, no_deps_requirements, requester,
+            logCallback, completedCallback,
+        )
+    elif not show_progress and blocking:
+        # Busy cursor only
+        _pip_install_with_busy_cursor(requirements, constraints, no_deps_requirements)
+    else:
+        # Non-blocking, no progress (existing behavior)
+        _pip_install_nonblocking(
+            requirements, constraints, no_deps_requirements,
+            logCallback, completedCallback,
+        )
+    return None
+
+
+def _pip_install_simple(
+    requirements: str | list[str],
+    constraints: str | Path | None = None,
+    no_deps_requirements: str | list[str] | None = None,
+) -> None:
+    """Simple blocking pip install without any UI (for PythonSlicer and testing mode).
+
+    :raises subprocess.CalledProcessError: If pip installation fails.
+    """
+    # Handle no_deps_requirements first
+    if no_deps_requirements is not None:
+        args = _build_pip_args(no_deps_requirements, constraints, no_deps=True)
+        _executePythonModule("pip", args, blocking=True)
+
+    # Then install regular requirements
+    args = _build_pip_args(requirements, constraints, no_deps=False)
+    _executePythonModule("pip", args, blocking=True)
+
+
+def _pip_install_with_busy_cursor(
+    requirements: str | list[str],
+    constraints: str | Path | None = None,
+    no_deps_requirements: str | list[str] | None = None,
+) -> None:
+    """Blocking pip install with busy cursor.
+
+    :raises subprocess.CalledProcessError: If pip installation fails.
+    """
+    import qt
+
+    qt.QApplication.setOverrideCursor(qt.Qt.BusyCursor)
+    try:
+        _pip_install_simple(requirements, constraints, no_deps_requirements)
+    finally:
+        qt.QApplication.restoreOverrideCursor()
+
+
+def _pip_install_with_dialog(
+    requirements: str | list[str],
+    constraints: str | Path | None = None,
+    no_deps_requirements: str | list[str] | None = None,
+    requester: str | None = None,
+    parent: qt.QWidget | None = None,
+) -> None:
+    """Blocking pip install with modal progress dialog.
+
+    :raises subprocess.CalledProcessError: If pip installation fails.
+    """
+    import threading
+
+    import qt
+    import slicer
+
+    # Create the progress dialog
+    dialog = _PipProgressDialog(requester=requester, parent=parent)
+    dialog.show()
+    slicer.app.processEvents()  # Ensure dialog is displayed
+
+    completed = threading.Event()
+    result = {"returnCode": None, "log": ""}
+
+    def onLog(line):
+        dialog.appendLog(line)
+        print(line)  # Still log to console
+
+    def onComplete(returnCode):
+        result["returnCode"] = returnCode
+        result["log"] = dialog.getFullLog()
+        completed.set()
+
+    # Run the installation (uses internal non-blocking path)
+    _pip_install_nonblocking(
+        requirements, constraints, no_deps_requirements,
+        logCallback=onLog, completedCallback=onComplete,
+    )
+
+    # Wait for completion while keeping UI responsive
+    while not completed.is_set():
+        slicer.app.processEvents()
+        qt.QThread.msleep(10)  # Reduce CPU usage
+
+    dialog.close()
+
+    if result["returnCode"] != 0:
+        slicer.util.errorDisplay(
+            _("Package installation failed."),
+            windowTitle=_("{requester} - Installation Failed").format(requester=requester) if requester else _("Installation Failed"),
+            detailedText=result["log"],
+        )
+        raise CalledProcessError(result["returnCode"], "pip install")
+
+
+def _pip_install_with_statusbar(
+    requirements: str | list[str],
+    constraints: str | Path | None = None,
+    no_deps_requirements: str | list[str] | None = None,
+    requester: str | None = None,
+    logCallback: Callable[[str], None] | None = None,
+    completedCallback: Callable[[int], None] | None = None,
+) -> None:
+    """Non-blocking pip install with status bar messages.
+
+    Shows pip output lines in the status bar as installation progresses.
+    """
+    import qt
+    import slicer
+
+    prefix = f"{requester}: " if requester else ""
+
+    # Set busy cursor
+    qt.QApplication.setOverrideCursor(qt.Qt.BusyCursor)
+
+    def wrappedLogCallback(line):
+        # Show pip output in status bar (no timeout so it stays until next update)
+        slicer.util.showStatusMessage(f"{prefix}{line}", 0)
+        if logCallback:
+            logCallback(line)
+        else:
+            print(line)
+
+    def wrappedCompletedCallback(returnCode):
+        # Clean up cursor and clear status message
+        qt.QApplication.restoreOverrideCursor()
+        slicer.util.showStatusMessage("", 0)  # Clear status bar
+
+        if completedCallback:
+            completedCallback(returnCode)
+        elif returnCode != 0:
+            logging.error(f"pip install failed with return code {returnCode}")
+
+    try:
+        _pip_install_nonblocking(
+            requirements, constraints, no_deps_requirements,
+            logCallback=wrappedLogCallback, completedCallback=wrappedCompletedCallback,
+        )
+    except Exception:
+        # Not `finally` - on success, cursor stays busy until wrappedCompletedCallback fires
+        qt.QApplication.restoreOverrideCursor()
+        slicer.util.showStatusMessage("", 0)
+        raise
+
+
+def _pip_install_nonblocking(
+    requirements: str | list[str],
+    constraints: str | Path | None = None,
+    no_deps_requirements: str | list[str] | None = None,
+    logCallback: Callable[[str], None] | None = None,
+    completedCallback: Callable[[int], None] | None = None,
+) -> None:
+    """Non-blocking pip install.
+
+    Handles no_deps_requirements by chaining the two pip calls.
+    Sets the _pip_install_in_progress flag to prevent concurrent operations.
+    """
+    global _pip_install_in_progress
+    _pip_install_in_progress = True
+
+    # Wrapper to clear the flag when the operation completes
+    def wrappedCompletedCallback(returnCode):
+        global _pip_install_in_progress
+        _pip_install_in_progress = False
+        if completedCallback:
+            completedCallback(returnCode)
+
+    try:
+        if no_deps_requirements is None:
+            # Simple case - single install
+            args = _build_pip_args(requirements, constraints, no_deps=False)
+            _executePythonModule("pip", args, blocking=False,
+                                 logCallback=logCallback, completedCallback=wrappedCompletedCallback)
+            return
+
+        # Two-step installation: first no_deps, then regular
+        def onNoDepsComplete(returnCode):
+            if returnCode != 0:
+                # First step failed - abort, clear flag, and notify caller
+                global _pip_install_in_progress
+                _pip_install_in_progress = False
+                if completedCallback:
+                    completedCallback(returnCode)
+                return
+            # Success - proceed to regular install (flag stays set until final completion)
+            args = _build_pip_args(requirements, constraints, no_deps=False)
+            _executePythonModule("pip", args, blocking=False,
+                                 logCallback=logCallback, completedCallback=wrappedCompletedCallback)
+
+        no_deps_args = _build_pip_args(no_deps_requirements, constraints, no_deps=True)
+        _executePythonModule("pip", no_deps_args, blocking=False,
+                             logCallback=logCallback, completedCallback=onNoDepsComplete)
+    except Exception:
+        _pip_install_in_progress = False
+        raise
+
+
+def _pip_install_with_skips_dialog(
+    requirements: str | list[str],
+    skip_packages: list[str],
+    constraints: str | Path | None = None,
+    requester: str | None = None,
+    parent: qt.QWidget | None = None,
+) -> list[str]:
+    """Recursive skip-packages install with modal progress dialog."""
+    import slicer
+
+    dialog = _PipProgressDialog(requester=requester, parent=parent)
+    dialog.show()
+    slicer.app.processEvents()
+
+    try:
+        skipped = _pip_install_with_skips(
+            requirements, skip_packages, constraints, log_fn=dialog.appendLog,
+        )
+    finally:
+        dialog.close()
+
+    return skipped
+
+
+def _pip_install_with_skips_busy_cursor(
+    requirements: str | list[str],
+    skip_packages: list[str],
+    constraints: str | Path | None = None,
+) -> list[str]:
+    """Recursive skip-packages install with busy cursor only."""
+    import qt
+
+    qt.QApplication.setOverrideCursor(qt.Qt.BusyCursor)
+    try:
+        return _pip_install_with_skips(requirements, skip_packages, constraints)
+    finally:
+        qt.QApplication.restoreOverrideCursor()
+
+
+def _build_pip_args(
+    requirements: str | list[str],
+    constraints: str | Path | None = None,
+    no_deps: bool = False,
+) -> list[str]:
+    """Build pip install command-line arguments.
+
+    :param requirements: Package requirements (string or list).
+    :param constraints: Path to constraints file, or None.
+    :param no_deps: If True, add --no-deps flag.
+    :returns: List of arguments for pip install command.
+    """
+    if type(requirements) == str:
+        args = ["install", *(shlex.split(requirements))]
+    elif type(requirements) == list:
+        args = ["install", *requirements]
+    else:
+        raise ValueError("pip_install requirement input must be string or list")
+
+    if no_deps:
+        args.append("--no-deps")
+
+    if constraints is not None:
+        args.extend(["-c", str(constraints)])
+
+    return args
+
+
+def _pip_install_with_skips(
+    requirements: str | list[str],
+    skip_packages: list[str],
+    constraints: str | Path | None = None,
+    log_fn: Callable[[str], None] | None = None,
+) -> list[str]:
+    """Install packages while skipping named packages from the dependency tree.
+
+    Each package is installed with ``--no-deps``, and its dependencies (and
+    their dependencies, recursively) are also installed -- except for packages
+    in *skip_packages*. Package metadata is updated after each install so that
+    pip does not later try to install the skipped packages.
+
+    This function is always blocking.
+
+    :param requirements: Package requirements (string or list).
+    :param skip_packages: Package names to exclude from installation.
+    :param constraints: Path to constraints file, or None.
+    :param log_fn: Optional callback for status and pip output lines.
+    :returns: List of skipped requirement strings (e.g. ``["torch>=2.0"]``).
+    """
+    # Parse requirements
+    if isinstance(requirements, str):
+        req_strings = shlex.split(requirements)
+    else:
+        req_strings = list(requirements)
+
+    skip_set = {canonicalize_name(name) for name in skip_packages}
+    seen: set[str] = set()
+    skipped: list[str] = []
+
+    def _log(msg):
+        if log_fn:
+            log_fn(msg)
+        # Keep UI responsive between pip calls
+        try:
+            from slicer import app
+            app.processEvents()
+        except ImportError:
+            pass
+
+    def _install_one(req):
+        """Recursively install a single requirement, skipping packages in skip_set."""
+        canonical = canonicalize_name(req.name)
+
+        # Cycle / duplicate detection
+        if canonical in seen:
+            return
+        seen.add(canonical)
+
+        # Check skip list
+        if canonical in skip_set:
+            skipped.append(str(req))
+            _log(f"Skipping {req.name} (in skip list)")
+            return
+
+        # Evaluate environment markers
+        if req.marker is not None and not req.marker.evaluate():
+            return
+
+        # Check if already satisfied
+        if pip_check(req):
+            _log(f"{req.name} already satisfied")
+            return
+
+        # Install with --no-deps
+        _log(f"Installing {req.name}...")
+        # Strip the marker -- we already evaluated it above, and passing it
+        # through as a string would be mangled by shlex.split in _build_pip_args.
+        extras_str = f"[{','.join(req.extras)}]" if req.extras else ""
+        install_str = f"{req.name}{extras_str}{req.specifier}"
+        args = _build_pip_args(install_str, constraints, no_deps=True)
+        _executePythonModule("pip", args, blocking=True, logCallback=log_fn)
+
+        # Read sub-dependencies from installed metadata
+        importlib.invalidate_caches()
+        try:
+            sub_deps = importlib.metadata.requires(req.name) or []
+        except importlib.metadata.PackageNotFoundError:
+            sub_deps = []
+
+        # Scrub METADATA before recursing -- if the walk is interrupted,
+        # the METADATA for already-installed packages is still cleaned.
+        if skip_set:
+            _scrub_metadata(canonical, skip_set)
+
+        # Recurse on each sub-dependency
+        for dep_str in sub_deps:
+            try:
+                dep_req = Requirement(dep_str)
+            except Exception:
+                continue  # skip malformed dependency strings
+
+            # Skip extras-gated dependencies (optional, not required)
+            if dep_req.marker is not None and "extra" in str(dep_req.marker):
+                continue
+
+            try:
+                _install_one(dep_req)
+            except CalledProcessError:
+                logging.warning("Failed to install %s, continuing with remaining dependencies", dep_req.name)
+                _log(f"WARNING: Failed to install {dep_req.name}")
+
+    # Process each top-level requirement
+    for req_str in req_strings:
+        try:
+            req = Requirement(req_str)
+        except Exception:
+            logging.warning("Could not parse requirement: %s", req_str)
+            continue
+        _install_one(req)
+
+    return skipped
+
+
+def _scrub_metadata(package_name: str, skip_set: set[str]) -> None:
+    """Remove Requires-Dist lines for skipped packages from installed METADATA.
+
+    After installing a package with ``--no-deps``, its METADATA file still
+    declares all original dependencies. This function removes the
+    ``Requires-Dist`` entries for packages in *skip_set* so that future
+    ``pip check`` or ``pip install --upgrade`` operations do not attempt to
+    install them.
+
+    :param package_name: Name of the installed package whose METADATA to modify.
+    :param skip_set: Set of **canonicalized** package names to remove.
+    """
+    try:
+        dist = importlib.metadata.distribution(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        logging.warning("_scrub_metadata: distribution not found for %s", package_name)
+        return
+
+    # Locate the METADATA file within the distribution
+    meta_path = None
+    if dist.files:
+        for p in dist.files:
+            if p.name == "METADATA":
+                meta_path = p.locate()
+                break
+
+    if meta_path is None:
+        logging.warning("_scrub_metadata: METADATA file not found for %s", package_name)
+        return
+
+    # Use latin-1 encoding because some packages have non-UTF-8 metadata
+    with open(meta_path, "r+", encoding="latin-1") as f:
+        lines = f.readlines()
+        f.seek(0)
+        for line in lines:
+            if line.startswith("Requires-Dist: "):
+                req_str = line[len("Requires-Dist: "):].strip()
+                try:
+                    req = Requirement(req_str)
+                    if canonicalize_name(req.name) in skip_set:
+                        continue  # drop this line
+                except Exception:
+                    pass  # keep malformed lines
+            f.write(line)
+        f.truncate()
+
+
+def pip_uninstall(
+    requirements: str | list[str],
+    blocking: bool = True,
+    logCallback: Callable[[str], None] | None = None,
+    completedCallback: Callable[[int], None] | None = None,
+) -> None:
+    """Uninstall python packages.
+
+    Currently, the method simply calls ``python -m pip uninstall`` but in the future further checks, optimizations,
+    user confirmation may be implemented, therefore it is recommended to use this method call instead of a plain
+    pip uninstall.
+
+    :param requirements: requirement specifier in the same format as used by pip (https://docs.python.org/3/installing/index.html).
+      It can be either a single string or a list of command-line arguments. It may be simpler to pass command-line arguments as a list
+      if the arguments may contain spaces (because no escaping of the strings with quotes is necessary).
+    :param blocking: If True (default), block until uninstall completes. If False, return immediately.
+        Note: When running in PythonSlicer (without the full application), blocking mode
+        is always used regardless of this setting.
+    :param logCallback: When blocking=False, called with each line of pip output.
+    :param completedCallback: When blocking=False, called when pip completes with return code.
+
+    Example: calling from Slicer GUI
+
+    .. code-block:: python
+
+      pip_uninstall("tensorflow keras scikit-learn ipywidgets")
+
+    Example: calling from PythonSlicer console
+
+    .. code-block:: python
+
+      from slicer.packaging import pip_uninstall
+      pip_uninstall("tensorflow")
+
+    """
+    if type(requirements) == str:
+        # shlex.split splits string the same way as the shell (keeping quoted string as a single argument)
+        args = ["uninstall", *(shlex.split(requirements)), "--yes"]
+    elif type(requirements) == list:
+        args = ["uninstall", *requirements, "--yes"]
+    else:
+        raise ValueError("pip_uninstall requirement input must be string or list")
+
+    # In PythonSlicer, always use blocking mode
+    if not _isSlicerAppAvailable():
+        _executePythonModule("pip", args, blocking=True)
+        return
+
+    _executePythonModule("pip", args, blocking=blocking,
+                         logCallback=logCallback, completedCallback=completedCallback)
+
+
+class _PipProgressDialog:
+    """Modal dialog showing pip installation progress with collapsible log details.
+
+    Internal class used by :func:`pip_install` when show_progress=True and blocking=True.
+    """
+
+    def __init__(self, requester: str | None = None, parent: qt.QWidget | None = None) -> None:
+        import ctk
+        import qt
+        import slicer
+
+        self._dialog = qt.QDialog(parent or slicer.util.mainWindow())
+        self._dialog.setModal(True)
+        if requester:
+            self._dialog.setWindowTitle(
+                _("{requester} - Installing Python Packages").format(requester=requester),
+            )
+        else:
+            self._dialog.setWindowTitle(_("Installing Python Packages"))
+        # Prevent closing via X button
+        self._dialog.setWindowFlags(self._dialog.windowFlags() & ~qt.Qt.WindowCloseButtonHint)
+
+        # Prevent closing via Escape key by capturing it with a shortcut that does nothing
+        self._escapeShortcut = qt.QShortcut(qt.QKeySequence(qt.Qt.Key_Escape), self._dialog)
+        self._escapeShortcut.setContext(qt.Qt.WidgetWithChildrenShortcut)
+
+        layout = qt.QVBoxLayout(self._dialog)
+
+        # Status label
+        self.statusLabel = qt.QLabel(_("Installing packages..."))
+        layout.addWidget(self.statusLabel)
+
+        # Indeterminate progress bar
+        self.progressBar = qt.QProgressBar()
+        self.progressBar.setRange(0, 0)  # Indeterminate mode
+        layout.addWidget(self.progressBar)
+
+        # Collapsible details section
+        self.detailsButton = ctk.ctkCollapsibleButton()
+        self.detailsButton.text = _("Details")
+        self.detailsButton.collapsed = True
+        detailsLayout = qt.QVBoxLayout(self.detailsButton)
+
+        self.logText = qt.QPlainTextEdit()
+        self.logText.setReadOnly(True)
+        self.logText.setMinimumHeight(150)
+        self.logText.setMaximumHeight(300)
+        # Use monospace font for log output
+        font = qt.QFont("Monospace")
+        font.setStyleHint(qt.QFont.TypeWriter)
+        self.logText.setFont(font)
+        detailsLayout.addWidget(self.logText)
+
+        layout.addWidget(self.detailsButton)
+
+        # Set reasonable default size
+        self._dialog.resize(500, 120)
+
+        # Store log lines for retrieval
+        self._logLines = []
+
+    def show(self) -> None:
+        """Show the dialog."""
+        self._dialog.show()
+
+    def close(self) -> None:
+        """Close the dialog."""
+        self._dialog.close()
+
+    def appendLog(self, line: str) -> None:
+        """Append a line to the log display."""
+        self._logLines.append(line)
+        self.logText.appendPlainText(line)
+        # Auto-scroll to bottom
+        scrollBar = self.logText.verticalScrollBar()
+        scrollBar.setValue(scrollBar.maximum)
+
+    def getFullLog(self) -> str:
+        """Return the complete log as a string."""
+        return "\n".join(self._logLines)

--- a/Base/Python/slicer/tests/test_slicer_packaging.py
+++ b/Base/Python/slicer/tests/test_slicer_packaging.py
@@ -1,0 +1,1565 @@
+"""Unit tests for slicer.packaging module.
+
+Tests for: load_requirements, load_pyproject_dependencies, pip_check, pip_ensure,
+pip_install (with progress, non-blocking, and skip_packages modes),
+_scrub_metadata, and _PipProgressDialog.
+"""
+
+import importlib.metadata
+import os
+import tempfile
+import threading
+import tomllib
+import unittest
+import unittest.mock
+
+from packaging.requirements import Requirement
+
+import slicer
+import slicer.util
+import slicer.packaging
+
+
+class LoadRequirementsTest(unittest.TestCase):
+    """Tests for slicer.packaging.load_requirements."""
+
+    def test_simple_requirements(self):
+        """Test loading simple requirements."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("numpy>=1.20\n")
+            f.write("scipy>=1.0\n")
+            temp_path = f.name
+
+        try:
+            reqs = slicer.packaging.load_requirements(temp_path)
+            self.assertEqual(len(reqs), 2)
+            self.assertEqual(reqs[0].name, "numpy")
+            self.assertEqual(reqs[1].name, "scipy")
+        finally:
+            os.unlink(temp_path)
+
+    def test_skip_comments(self):
+        """Test that comments are skipped."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("# This is a comment\n")
+            f.write("numpy>=1.0\n")
+            f.write("# Another comment\n")
+            temp_path = f.name
+
+        try:
+            reqs = slicer.packaging.load_requirements(temp_path)
+            self.assertEqual(len(reqs), 1)
+            self.assertEqual(reqs[0].name, "numpy")
+        finally:
+            os.unlink(temp_path)
+
+    def test_skip_empty_lines(self):
+        """Test that empty lines are skipped."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("numpy>=1.0\n")
+            f.write("\n")
+            f.write("   \n")
+            f.write("scipy>=1.0\n")
+            temp_path = f.name
+
+        try:
+            reqs = slicer.packaging.load_requirements(temp_path)
+            self.assertEqual(len(reqs), 2)
+        finally:
+            os.unlink(temp_path)
+
+    def test_skip_pip_options(self):
+        """Test that pip options (-r, -c, --index-url) are skipped."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("numpy>=1.0\n")
+            f.write("-r other_requirements.txt\n")
+            f.write("-c constraints.txt\n")
+            f.write("--index-url https://example.com\n")
+            f.write("scipy>=1.0\n")
+            temp_path = f.name
+
+        try:
+            reqs = slicer.packaging.load_requirements(temp_path)
+            self.assertEqual(len(reqs), 2)
+            names = [r.name for r in reqs]
+            self.assertEqual(names, ["numpy", "scipy"])
+        finally:
+            os.unlink(temp_path)
+
+    def test_returns_requirement_objects(self):
+        """Test that returned objects are Requirement instances."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("numpy>=1.20,<2.0\n")
+            temp_path = f.name
+
+        try:
+            reqs = slicer.packaging.load_requirements(temp_path)
+            self.assertEqual(len(reqs), 1)
+            self.assertIsInstance(reqs[0], Requirement)
+            # Check specifier contains expected constraints (order may vary)
+            self.assertTrue(reqs[0].specifier.contains("1.25"))
+            self.assertFalse(reqs[0].specifier.contains("1.19"))
+            self.assertFalse(reqs[0].specifier.contains("2.1"))
+        finally:
+            os.unlink(temp_path)
+
+
+class LoadPyprojectDependenciesTest(unittest.TestCase):
+    """Tests for slicer.packaging.load_pyproject_dependencies."""
+
+    def test_simple_dependencies(self):
+        """Test loading simple dependencies from pyproject.toml."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write("[project]\n")
+            f.write('dependencies = [\n    "numpy>=1.20",\n    "scipy>=1.0",\n]\n')
+            temp_path = f.name
+
+        try:
+            reqs = slicer.packaging.load_pyproject_dependencies(temp_path)
+            self.assertEqual(len(reqs), 2)
+            self.assertEqual(reqs[0].name, "numpy")
+            self.assertEqual(reqs[1].name, "scipy")
+        finally:
+            os.unlink(temp_path)
+
+    def test_empty_dependencies(self):
+        """Test that empty dependencies list returns empty list."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write("[project]\ndependencies = []\n")
+            temp_path = f.name
+
+        try:
+            reqs = slicer.packaging.load_pyproject_dependencies(temp_path)
+            self.assertEqual(reqs, [])
+        finally:
+            os.unlink(temp_path)
+
+    def test_missing_dependencies_key(self):
+        """Test that missing dependencies key returns empty list (valid per PEP 621)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write("[project]\n")
+            temp_path = f.name
+
+        try:
+            reqs = slicer.packaging.load_pyproject_dependencies(temp_path)
+            self.assertEqual(reqs, [])
+        finally:
+            os.unlink(temp_path)
+
+    def test_missing_project_table(self):
+        """Test that missing [project] table raises KeyError with file path."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write('[build-system]\nrequires = ["setuptools"]\n')
+            temp_path = f.name
+
+        try:
+            with self.assertRaises(KeyError) as ctx:
+                slicer.packaging.load_pyproject_dependencies(temp_path)
+            self.assertIn(temp_path, str(ctx.exception))
+        finally:
+            os.unlink(temp_path)
+
+    def test_returns_requirement_objects(self):
+        """Test that returned objects are Requirement instances with correct specifiers."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write("[project]\n")
+            f.write('dependencies = ["numpy>=1.20,<2.0"]\n')
+            temp_path = f.name
+
+        try:
+            reqs = slicer.packaging.load_pyproject_dependencies(temp_path)
+            self.assertEqual(len(reqs), 1)
+            self.assertIsInstance(reqs[0], Requirement)
+            self.assertTrue(reqs[0].specifier.contains("1.25"))
+            self.assertFalse(reqs[0].specifier.contains("1.19"))
+            self.assertFalse(reqs[0].specifier.contains("2.1"))
+        finally:
+            os.unlink(temp_path)
+
+    def test_extras_and_markers(self):
+        """Test dependencies with extras and environment markers."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write("[project]\n")
+            f.write("dependencies = [\n")
+            f.write('    "requests[socks]>=2.0",\n')
+            f.write("    'pywin32>=300; sys_platform == \"win32\"',\n")
+            f.write("]\n")
+            temp_path = f.name
+
+        try:
+            reqs = slicer.packaging.load_pyproject_dependencies(temp_path)
+            self.assertEqual(len(reqs), 2)
+            self.assertEqual(reqs[0].name, "requests")
+            self.assertIn("socks", reqs[0].extras)
+            self.assertEqual(reqs[1].name, "pywin32")
+            self.assertIsNotNone(reqs[1].marker)
+        finally:
+            os.unlink(temp_path)
+
+    def test_invalid_toml(self):
+        """Test that invalid TOML raises TOMLDecodeError."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write("[project\nthis is not valid toml\n")
+            temp_path = f.name
+
+        try:
+            with self.assertRaises(tomllib.TOMLDecodeError):
+                slicer.packaging.load_pyproject_dependencies(temp_path)
+        finally:
+            os.unlink(temp_path)
+
+
+class PipCheckTest(unittest.TestCase):
+    """Tests for slicer.packaging.pip_check."""
+
+    def test_satisfied_requirement(self):
+        """Test that installed package is detected as satisfied."""
+        # numpy is installed in Slicer
+        req = Requirement("numpy>=1.0")
+        self.assertTrue(slicer.packaging.pip_check(req))
+
+    def test_unsatisfied_version(self):
+        """Test that version too high is detected as unsatisfied."""
+        req = Requirement("numpy>=99999.0")
+        self.assertFalse(slicer.packaging.pip_check(req))
+
+    def test_missing_package(self):
+        """Test that missing package is detected."""
+        req = Requirement("nonexistent-package-xyz123>=1.0")
+        self.assertFalse(slicer.packaging.pip_check(req))
+
+    def test_list_all_satisfied(self):
+        """Test checking a list of requirements - all satisfied."""
+        reqs = [
+            Requirement("numpy>=1.0"),
+            Requirement("scipy>=1.0"),
+        ]
+        self.assertTrue(slicer.packaging.pip_check(reqs))
+
+    def test_list_one_missing(self):
+        """Test checking a list of requirements - one missing."""
+        reqs = [
+            Requirement("numpy>=1.0"),
+            Requirement("nonexistent-package-xyz123>=1.0"),
+        ]
+        self.assertFalse(slicer.packaging.pip_check(reqs))
+
+    def test_marker_not_applicable(self):
+        """Test that inapplicable marker is considered satisfied."""
+        # This marker will never apply
+        req = Requirement('somepackage>=1.0; sys_platform == "nonexistent_platform"')
+        self.assertTrue(slicer.packaging.pip_check(req))
+
+    def test_empty_list(self):
+        """Test that empty list returns True."""
+        self.assertTrue(slicer.packaging.pip_check([]))
+
+    def test_string_single(self):
+        """Test string input with a single requirement."""
+        self.assertTrue(slicer.packaging.pip_check("numpy>=1.0"))
+
+    def test_string_multiple(self):
+        """Test space-separated string with multiple requirements."""
+        self.assertTrue(slicer.packaging.pip_check("numpy>=1.0 scipy>=1.0"))
+
+    def test_string_with_marker(self):
+        """Test string input with an environment marker (whitespace inside)."""
+        # Inapplicable marker is treated as satisfied.
+        self.assertTrue(
+            slicer.packaging.pip_check("foo; sys_platform == 'nonexistent'"),
+        )
+        # Real package with an applicable marker.
+        self.assertTrue(
+            slicer.packaging.pip_check("numpy>=1.0; python_version >= '3.0'"),
+        )
+
+    def test_string_missing(self):
+        """Test string input for missing package."""
+        self.assertFalse(slicer.packaging.pip_check("nonexistent-package-xyz123"))
+
+    def test_list_of_strings(self):
+        """Test list of string requirements."""
+        self.assertTrue(slicer.packaging.pip_check(["numpy>=1.0", "scipy>=1.0"]))
+
+    def test_mixed_list(self):
+        """Test list mixing strings and Requirement objects."""
+        reqs = [Requirement("numpy>=1.0"), "scipy>=1.0"]
+        self.assertTrue(slicer.packaging.pip_check(reqs))
+
+
+class PipCheckMockedTest(unittest.TestCase):
+    """Tests for slicer.packaging.pip_check using mocks for isolation."""
+
+    def test_version_specifier_not_equal(self):
+        """Test != version specifier."""
+        with unittest.mock.patch("importlib.metadata.version", return_value="1.24.0"):
+            req = Requirement("numpy>=1.20,!=1.24.0")
+            self.assertFalse(slicer.packaging.pip_check(req))
+
+        with unittest.mock.patch("importlib.metadata.version", return_value="1.23.0"):
+            req = Requirement("numpy>=1.20,!=1.24.0")
+            self.assertTrue(slicer.packaging.pip_check(req))
+
+    def test_extras_satisfied(self):
+        """Test that extras dependencies are checked."""
+        def mock_version(name):
+            versions = {"requests": "2.28.0", "pysocks": "1.7.0"}
+            if name.lower() in versions:
+                return versions[name.lower()]
+            raise importlib.metadata.PackageNotFoundError()
+
+        def mock_requires(name):
+            if name.lower() == "requests":
+                return ['PySocks>=1.5.6; extra == "socks"']
+            return []
+
+        with unittest.mock.patch("importlib.metadata.version", side_effect=mock_version):
+            with unittest.mock.patch("importlib.metadata.requires", side_effect=mock_requires):
+                req = Requirement("requests[socks]>=2.0")
+                self.assertTrue(slicer.packaging.pip_check(req))
+
+    def test_extras_missing(self):
+        """Test that missing extras dependency is detected."""
+        def mock_version(name):
+            if name.lower() == "requests":
+                return "2.28.0"
+            raise importlib.metadata.PackageNotFoundError()
+
+        def mock_requires(name):
+            if name.lower() == "requests":
+                return ['PySocks>=1.5.6; extra == "socks"']
+            return []
+
+        with unittest.mock.patch("importlib.metadata.version", side_effect=mock_version):
+            with unittest.mock.patch("importlib.metadata.requires", side_effect=mock_requires):
+                req = Requirement("requests[socks]>=2.0")
+                self.assertFalse(slicer.packaging.pip_check(req))
+
+
+class PipEnsureTest(unittest.TestCase):
+    """Tests for slicer.packaging.pip_ensure."""
+
+    def test_all_satisfied_no_install(self):
+        """Test that no installation happens when all satisfied."""
+        reqs = [
+            Requirement("numpy>=1.0"),
+            Requirement("scipy>=1.0"),
+        ]
+        # Should return without error or calling pip_install
+        with unittest.mock.patch("slicer.packaging._pip_install_simple") as mock_install:
+            slicer.packaging.pip_ensure(reqs, prompt_install=False)
+            mock_install.assert_not_called()
+
+    def test_skip_in_testing_mode(self):
+        """Test that installation is skipped in testing mode."""
+        reqs = [Requirement("nonexistent-package-xyz123>=1.0")]
+
+        # Note: Can't mock slicer.app.testingEnabled() because it's a Qt slot
+        if slicer.app.testingEnabled():
+            with unittest.mock.patch("slicer.packaging._pip_install_simple") as mock_install:
+                # Should not raise, should not install
+                slicer.packaging.pip_ensure(reqs, prompt_install=False, skip_in_testing=True)
+                mock_install.assert_not_called()
+        else:
+            self.skipTest("Not in testing mode")
+
+    def test_calls_pip_install_for_missing(self):
+        """Test that pip_install is called for missing packages."""
+        reqs = [Requirement("nonexistent-package-xyz123>=1.0")]
+
+        # Force skip_in_testing=False to test the install path
+        if slicer.app.testingEnabled():
+            with unittest.mock.patch("slicer.packaging._pip_install_simple") as mock_install:
+                slicer.packaging.pip_ensure(reqs, prompt_install=False, skip_in_testing=False)
+                mock_install.assert_called_once()
+                # Check that the requirement string was passed
+                call_args = mock_install.call_args
+                self.assertIn("nonexistent-package-xyz123>=1.0", call_args[0][0])
+        else:
+            self.skipTest("Not in testing mode - would show dialog")
+
+    def test_string_input_all_satisfied(self):
+        """Test that string input works when all satisfied."""
+        with unittest.mock.patch("slicer.packaging._pip_install_simple") as mock_install:
+            slicer.packaging.pip_ensure("numpy>=1.0", prompt_install=False)
+            mock_install.assert_not_called()
+
+    def test_string_multiple_all_satisfied(self):
+        """Test that space-separated string works when all satisfied."""
+        with unittest.mock.patch("slicer.packaging._pip_install_simple") as mock_install:
+            slicer.packaging.pip_ensure("numpy>=1.0 scipy>=1.0", prompt_install=False)
+            mock_install.assert_not_called()
+
+
+class PipInstallNonBlockingTest(unittest.TestCase):
+    """Tests for slicer.packaging.pip_install non-blocking mode."""
+
+    def test_nonblocking_returns_immediately(self):
+        """Test that non-blocking mode returns immediately."""
+        import qt
+
+        completed = threading.Event()
+        log_lines = []
+
+        def on_log(line):
+            log_lines.append(line)
+
+        def on_complete(return_code):
+            completed.set()
+
+        # Use --version which is quick
+        slicer.packaging._executePythonModule(
+            "pip", ["--version"],
+            blocking=False,
+            logCallback=on_log,
+            completedCallback=on_complete,
+        )
+
+        # Wait for completion with processEvents
+        timeout_ms = 10000
+        start = qt.QTime.currentTime()
+        while not completed.is_set():
+            qt.QCoreApplication.processEvents()
+            if start.msecsTo(qt.QTime.currentTime()) > timeout_ms:
+                self.fail("Timeout waiting for non-blocking completion")
+            qt.QThread.msleep(50)
+
+        self.assertTrue(len(log_lines) > 0)
+
+    def test_blocking_mode_unchanged(self):
+        """Test that blocking mode still works (backward compatibility)."""
+        # pip --version should succeed without callbacks
+        try:
+            slicer.packaging._executePythonModule("pip", ["--version"])
+        except Exception as e:
+            self.fail(f"Blocking mode failed: {e}")
+
+
+class PipUninstallNonBlockingTest(unittest.TestCase):
+    """Tests for slicer.packaging.pip_uninstall non-blocking mode."""
+
+    def test_nonblocking_with_nonexistent_package(self):
+        """Test that non-blocking pip_uninstall works with callbacks.
+
+        Uses a nonexistent package to avoid actually uninstalling anything.
+        The command will fail (return code != 0) but callbacks should work.
+        """
+        import qt
+
+        completed = threading.Event()
+        log_lines = []
+        result = {"return_code": None}
+
+        def on_log(line):
+            log_lines.append(line)
+
+        def on_complete(return_code):
+            result["return_code"] = return_code
+            completed.set()
+
+        # Try to uninstall a nonexistent package
+        slicer.packaging.pip_uninstall(
+            "nonexistent-package-xyz123",
+            blocking=False,
+            logCallback=on_log,
+            completedCallback=on_complete,
+        )
+
+        # Wait for completion with processEvents
+        timeout_ms = 10000
+        start = qt.QTime.currentTime()
+        while not completed.is_set():
+            qt.QCoreApplication.processEvents()
+            if start.msecsTo(qt.QTime.currentTime()) > timeout_ms:
+                self.fail("Timeout waiting for non-blocking completion")
+            qt.QThread.msleep(50)
+
+        # Verify callbacks were called
+        self.assertIsNotNone(result["return_code"])
+        # Nonexistent package should produce some output
+        self.assertTrue(len(log_lines) > 0)
+
+
+class PipProgressDialogTest(unittest.TestCase):
+    """Tests for slicer.packaging._PipProgressDialog."""
+
+    def test_append_log(self):
+        """Test appendLog adds lines correctly."""
+        dialog = slicer.packaging._PipProgressDialog(requester="Test")
+        dialog.appendLog("Line 1")
+        dialog.appendLog("Line 2")
+
+        log = dialog.getFullLog()
+        self.assertIn("Line 1", log)
+        self.assertIn("Line 2", log)
+
+    def test_get_full_log(self):
+        """Test getFullLog returns all lines."""
+        dialog = slicer.packaging._PipProgressDialog(requester="Test")
+        dialog.appendLog("First")
+        dialog.appendLog("Second")
+        dialog.appendLog("Third")
+
+        log = dialog.getFullLog()
+        self.assertEqual(log, "First\nSecond\nThird")
+
+
+class IntegrationTest(unittest.TestCase):
+    """Integration tests combining multiple functions."""
+
+    def test_load_check_ensure_workflow(self):
+        """Test the complete workflow: load -> check -> ensure."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("numpy>=1.0\n")
+            f.write("scipy>=1.0\n")
+            temp_path = f.name
+
+        try:
+            # Load
+            reqs = slicer.packaging.load_requirements(temp_path)
+            self.assertEqual(len(reqs), 2)
+
+            # Check
+            satisfied = slicer.packaging.pip_check(reqs)
+            self.assertTrue(satisfied)
+
+            # Ensure (should be no-op since all satisfied)
+            with unittest.mock.patch("slicer.packaging._pip_install_simple") as mock_install:
+                slicer.packaging.pip_ensure(reqs, prompt_install=False)
+                mock_install.assert_not_called()
+        finally:
+            os.unlink(temp_path)
+
+    def test_load_pyproject_check_ensure_workflow(self):
+        """Test the complete workflow with pyproject.toml: load -> check -> ensure."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write("[project]\n")
+            f.write('dependencies = [\n    "numpy>=1.0",\n    "scipy>=1.0",\n]\n')
+            temp_path = f.name
+
+        try:
+            # Load
+            reqs = slicer.packaging.load_pyproject_dependencies(temp_path)
+            self.assertEqual(len(reqs), 2)
+
+            # Check
+            satisfied = slicer.packaging.pip_check(reqs)
+            self.assertTrue(satisfied)
+
+            # Ensure (should be no-op since all satisfied)
+            with unittest.mock.patch("slicer.packaging._pip_install_simple") as mock_install:
+                slicer.packaging.pip_ensure(reqs, prompt_install=False)
+                mock_install.assert_not_called()
+        finally:
+            os.unlink(temp_path)
+
+
+class ConstraintsTest(unittest.TestCase):
+    """Tests for constraints file support in pip functions."""
+
+    def test_pip_install_with_constraints_builds_correct_args(self):
+        """Test that pip_install passes -c flag when constraints provided."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("numpy<2.0\n")
+            constraints_path = f.name
+
+        try:
+            with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+                slicer.packaging.pip_install("scipy", constraints=constraints_path)
+
+                mock_exec.assert_called_once()
+                call_args = mock_exec.call_args
+                args = call_args[0][1]  # Second positional arg is the args list
+
+                self.assertIn("-c", args)
+                self.assertIn(constraints_path, args)
+                # -c should come after install and the package
+                c_index = args.index("-c")
+                self.assertGreater(c_index, 0)
+                self.assertEqual(args[c_index + 1], constraints_path)
+        finally:
+            os.unlink(constraints_path)
+
+    def test_pip_install_without_constraints_no_c_flag(self):
+        """Test that pip_install does not pass -c flag when constraints is None."""
+        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            slicer.packaging.pip_install("scipy")
+
+            mock_exec.assert_called_once()
+            call_args = mock_exec.call_args
+            args = call_args[0][1]
+
+            self.assertNotIn("-c", args)
+
+    def test_pip_ensure_passes_constraints(self):
+        """Test that pip_ensure passes constraints to pip_install."""
+        reqs = [Requirement("nonexistent-package-xyz123>=1.0")]
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("numpy<2.0\n")
+            constraints_path = f.name
+
+        try:
+            if slicer.app.testingEnabled():
+                with unittest.mock.patch("slicer.packaging._pip_install_simple") as mock_install:
+                    slicer.packaging.pip_ensure(
+                        reqs,
+                        constraints=constraints_path,
+                        prompt_install=False,
+                        skip_in_testing=False,
+                    )
+
+                    mock_install.assert_called_once()
+                    # Check that constraints was passed as second positional arg
+                    call_args = mock_install.call_args
+                    self.assertEqual(call_args[0][1], constraints_path)
+            else:
+                self.skipTest("Not in testing mode - would show dialog")
+        finally:
+            os.unlink(constraints_path)
+
+    def test_load_requirements_can_load_constraints_file(self):
+        """Test that load_requirements works with constraints file format."""
+        # Constraints files have the same format as requirements files
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("numpy<2.0\n")
+            f.write("scipy>=1.0,<2.0\n")
+            f.write("# This is a constraint comment\n")
+            temp_path = f.name
+
+        try:
+            reqs = slicer.packaging.load_requirements(temp_path)
+            self.assertEqual(len(reqs), 2)
+            self.assertEqual(reqs[0].name, "numpy")
+            self.assertEqual(reqs[1].name, "scipy")
+        finally:
+            os.unlink(temp_path)
+
+    def test_pip_install_constraints_with_pathlib_path(self):
+        """Test that pip_install accepts pathlib.Path for constraints."""
+        from pathlib import Path
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("numpy<2.0\n")
+            constraints_path = Path(f.name)
+
+        try:
+            with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+                slicer.packaging.pip_install("scipy", constraints=constraints_path)
+
+                mock_exec.assert_called_once()
+                call_args = mock_exec.call_args
+                args = call_args[0][1]
+
+                self.assertIn("-c", args)
+                # Path should be converted to string
+                self.assertIn(str(constraints_path), args)
+        finally:
+            constraints_path.unlink()
+
+
+class GetInstalledVersionsTest(unittest.TestCase):
+    """Tests for slicer.packaging._get_installed_versions."""
+
+    def test_returns_dict(self):
+        """Test that _get_installed_versions returns a dict."""
+        versions = slicer.packaging._get_installed_versions()
+        self.assertIsInstance(versions, dict)
+
+    def test_contains_known_packages(self):
+        """Test that known installed packages appear in the result."""
+        versions = slicer.packaging._get_installed_versions()
+        # numpy and scipy are always installed in Slicer
+        self.assertIn("numpy", versions)
+        self.assertIn("scipy", versions)
+
+    def test_names_are_canonical(self):
+        """Test that package names are canonicalized (lowercase, hyphens)."""
+        versions = slicer.packaging._get_installed_versions()
+        for name in versions:
+            self.assertEqual(name, name.lower(), f"Name not lowercase: {name}")
+            self.assertNotIn("_", name, f"Name contains underscore: {name}")
+
+
+class FindUpdatedImportedPackagesTest(unittest.TestCase):
+    """Tests for slicer.packaging._find_updated_imported_packages."""
+
+    def test_no_changes(self):
+        """Test that identical before/after returns empty list."""
+        versions = {"numpy": "1.24.0", "scipy": "1.11.0"}
+        result = slicer.packaging._find_updated_imported_packages(versions, versions.copy())
+        self.assertEqual(result, [])
+
+    def test_version_changed_but_not_imported(self):
+        """Test that changed but non-imported packages are not flagged."""
+        before = {"fakepkg-not-imported": "1.0.0"}
+        after = {"fakepkg-not-imported": "2.0.0"}
+
+        mock_pkg_dists = {"fakepkg_not_imported": ["fakepkg-not-imported"]}
+        with unittest.mock.patch(
+            "importlib.metadata.packages_distributions",
+            return_value=mock_pkg_dists,
+        ):
+            result = slicer.packaging._find_updated_imported_packages(before, after)
+
+        # fakepkg_not_imported is not in sys.modules
+        self.assertEqual(result, [])
+
+    def test_version_changed_and_imported(self):
+        """Test that changed AND imported packages are flagged."""
+        before = {"numpy": "1.24.0"}
+        after = {"numpy": "1.26.0"}
+
+        # numpy is already imported in sys.modules in Slicer
+        mock_pkg_dists = {"numpy": ["numpy"]}
+        with unittest.mock.patch(
+            "importlib.metadata.packages_distributions",
+            return_value=mock_pkg_dists,
+        ):
+            result = slicer.packaging._find_updated_imported_packages(before, after)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], ("numpy", "1.24.0", "1.26.0"))
+
+    def test_newly_installed_not_flagged(self):
+        """Test that packages absent before install are not flagged."""
+        before = {}  # Package was not installed before
+        after = {"newpkg": "1.0.0"}
+
+        result = slicer.packaging._find_updated_imported_packages(before, after)
+        self.assertEqual(result, [])
+
+    def test_reinstalled_package_flagged(self):
+        """Test that reinstalled packages with modules in sys.modules are flagged.
+
+        Scenario: package was imported, then uninstalled, then reinstalled.
+        It won't be in before_versions (uninstalled) but its modules are still
+        in sys.modules from the earlier import.
+        """
+        before = {}  # Package was uninstalled before pip_ensure ran
+        after = {"numpy": "1.26.0"}  # Now reinstalled
+
+        # numpy is already in sys.modules in Slicer
+        mock_pkg_dists = {"numpy": ["numpy"]}
+        with unittest.mock.patch(
+            "importlib.metadata.packages_distributions",
+            return_value=mock_pkg_dists,
+        ):
+            result = slicer.packaging._find_updated_imported_packages(before, after)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], ("numpy", None, "1.26.0"))
+
+
+class PipEnsureRestartPromptTest(unittest.TestCase):
+    """Tests for restart prompt logic in pip_ensure."""
+
+    def test_restart_check_called_after_install(self):
+        """Test that version snapshots are taken before and after install."""
+        reqs = [Requirement("nonexistent-package-xyz123>=1.0")]
+
+        if not slicer.app.testingEnabled():
+            self.skipTest("Not in testing mode")
+
+        call_order = []
+
+        def mock_get_versions():
+            call_order.append("get_versions")
+            return {"numpy": "1.24.0"}
+
+        with unittest.mock.patch("slicer.packaging._pip_install_simple"):
+            with unittest.mock.patch(
+                "slicer.packaging._get_installed_versions",
+                side_effect=mock_get_versions,
+            ):
+                with unittest.mock.patch(
+                    "slicer.packaging._find_updated_imported_packages",
+                    return_value=[],
+                ) as mock_check:
+                    slicer.packaging.pip_ensure(
+                        reqs, prompt_install=False, skip_in_testing=False,
+                    )
+
+        # _get_installed_versions should be called twice (before and after)
+        self.assertEqual(call_order.count("get_versions"), 2)
+        mock_check.assert_called_once()
+
+    def test_no_restart_when_no_updates(self):
+        """Test that restart() is not called when nothing was updated."""
+        reqs = [Requirement("nonexistent-package-xyz123>=1.0")]
+
+        if not slicer.app.testingEnabled():
+            self.skipTest("Not in testing mode")
+
+        with unittest.mock.patch("slicer.packaging._pip_install_simple"):
+            with unittest.mock.patch(
+                "slicer.packaging._get_installed_versions",
+                return_value={"numpy": "1.24.0"},
+            ):
+                with unittest.mock.patch(
+                    "slicer.packaging._find_updated_imported_packages",
+                    return_value=[],
+                ):
+                    with unittest.mock.patch("slicer.util.restart") as mock_restart:
+                        slicer.packaging.pip_ensure(
+                            reqs, prompt_install=False, skip_in_testing=False,
+                        )
+                        mock_restart.assert_not_called()
+
+    def test_restart_prompt_skipped_in_testing_mode(self):
+        """Test that restart dialog is skipped in testing mode (only logged)."""
+        reqs = [Requirement("nonexistent-package-xyz123>=1.0")]
+
+        if not slicer.app.testingEnabled():
+            self.skipTest("Not in testing mode")
+
+        updated = [("numpy", "1.24.0", "1.26.0")]
+
+        with unittest.mock.patch("slicer.packaging._pip_install_simple"):
+            with unittest.mock.patch(
+                "slicer.packaging._get_installed_versions",
+                return_value={"numpy": "1.24.0"},
+            ):
+                with unittest.mock.patch(
+                    "slicer.packaging._find_updated_imported_packages",
+                    return_value=updated,
+                ):
+                    with unittest.mock.patch("slicer.util.restart") as mock_restart:
+                        slicer.packaging.pip_ensure(
+                            reqs, prompt_install=False, skip_in_testing=False,
+                        )
+                        # In testing mode, restart should NOT be called
+                        # (dialog is skipped, only logged)
+                        mock_restart.assert_not_called()
+
+    def test_prompt_restart_false_skips_check(self):
+        """Test that prompt_restart=False skips the version check entirely."""
+        reqs = [Requirement("nonexistent-package-xyz123>=1.0")]
+
+        if not slicer.app.testingEnabled():
+            self.skipTest("Not in testing mode")
+
+        with unittest.mock.patch("slicer.packaging._pip_install_simple"):
+            with unittest.mock.patch(
+                "slicer.packaging._get_installed_versions",
+            ) as mock_get_versions:
+                slicer.packaging.pip_ensure(
+                    reqs,
+                    prompt_install=False,
+                    prompt_restart=False,
+                    skip_in_testing=False,
+                )
+                # Should not be called at all when prompt_restart=False
+                mock_get_versions.assert_not_called()
+
+
+class GetInstalledVersionsSubprocessTest(unittest.TestCase):
+    """Test that _get_installed_versions sees packages installed by a pip subprocess.
+
+    Uses pip-install-test -- a minimal stub package on PyPI specifically
+    designed for testing pip installs.
+    """
+
+    _TEST_PKG = "pip-install-test"
+
+    def test_get_installed_versions_sees_newly_installed_package(self):
+        """Verify _get_installed_versions reflects packages installed by pip subprocess."""
+        # Ensure the test package is not installed before we start
+        try:
+            slicer.packaging.pip_uninstall(self._TEST_PKG)
+        except Exception:
+            pass
+
+        versions_before = slicer.packaging._get_installed_versions()
+        self.assertNotIn(self._TEST_PKG, versions_before)
+
+        try:
+            # Install the test package via pip subprocess
+            slicer.packaging._pip_install_simple([self._TEST_PKG])
+
+            # _get_installed_versions must see the newly installed package
+            versions_after = slicer.packaging._get_installed_versions()
+            self.assertIn(
+                self._TEST_PKG, versions_after,
+                f"{self._TEST_PKG} not visible to importlib.metadata after pip install",
+            )
+        finally:
+            # Clean up regardless of test outcome
+            try:
+                slicer.packaging.pip_uninstall(self._TEST_PKG)
+            except Exception:
+                pass
+
+
+class ScrubMetadataTest(unittest.TestCase):
+    """Tests for slicer.packaging._scrub_metadata."""
+
+    def test_removes_matching_requires_dist(self):
+        """Test that Requires-Dist lines for skipped packages are removed."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("Metadata-Version: 2.1\n")
+            f.write("Name: my-package\n")
+            f.write("Version: 1.0.0\n")
+            f.write("Requires-Dist: numpy>=1.20\n")
+            f.write("Requires-Dist: torch>=2.0\n")
+            f.write("Requires-Dist: scipy>=1.0\n")
+            temp_path = f.name
+
+        try:
+            # Create a mock distribution that points to our temp file
+            mock_file = unittest.mock.MagicMock()
+            mock_file.name = "METADATA"
+            mock_file.locate.return_value = temp_path
+            mock_dist = unittest.mock.MagicMock()
+            mock_dist.files = [mock_file]
+
+            with unittest.mock.patch("importlib.metadata.distribution", return_value=mock_dist):
+                slicer.packaging._scrub_metadata("my-package", {"torch"})
+
+            with open(temp_path, encoding="latin-1") as f:
+                content = f.read()
+
+            self.assertIn("Requires-Dist: numpy>=1.20", content)
+            self.assertIn("Requires-Dist: scipy>=1.0", content)
+            self.assertNotIn("torch", content)
+        finally:
+            os.unlink(temp_path)
+
+    def test_canonicalizes_names(self):
+        """Test that package names are compared in canonicalized form."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("Metadata-Version: 2.1\n")
+            f.write("Requires-Dist: SimpleITK>=2.0\n")
+            f.write("Requires-Dist: numpy>=1.20\n")
+            temp_path = f.name
+
+        try:
+            mock_file = unittest.mock.MagicMock()
+            mock_file.name = "METADATA"
+            mock_file.locate.return_value = temp_path
+            mock_dist = unittest.mock.MagicMock()
+            mock_dist.files = [mock_file]
+
+            # Skip set uses canonicalized form (lowercase, hyphens)
+            with unittest.mock.patch("importlib.metadata.distribution", return_value=mock_dist):
+                slicer.packaging._scrub_metadata("my-package", {"simpleitk"})
+
+            with open(temp_path, encoding="latin-1") as f:
+                content = f.read()
+
+            self.assertNotIn("SimpleITK", content)
+            self.assertIn("numpy", content)
+        finally:
+            os.unlink(temp_path)
+
+    def test_preserves_non_requires_dist_lines(self):
+        """Test that non-Requires-Dist metadata lines are preserved."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("Metadata-Version: 2.1\n")
+            f.write("Name: my-package\n")
+            f.write("Version: 1.0.0\n")
+            f.write("Summary: A test package\n")
+            f.write("Requires-Dist: torch>=2.0\n")
+            temp_path = f.name
+
+        try:
+            mock_file = unittest.mock.MagicMock()
+            mock_file.name = "METADATA"
+            mock_file.locate.return_value = temp_path
+            mock_dist = unittest.mock.MagicMock()
+            mock_dist.files = [mock_file]
+
+            with unittest.mock.patch("importlib.metadata.distribution", return_value=mock_dist):
+                slicer.packaging._scrub_metadata("my-package", {"torch"})
+
+            with open(temp_path, encoding="latin-1") as f:
+                content = f.read()
+
+            self.assertIn("Metadata-Version: 2.1", content)
+            self.assertIn("Name: my-package", content)
+            self.assertIn("Version: 1.0.0", content)
+            self.assertIn("Summary: A test package", content)
+        finally:
+            os.unlink(temp_path)
+
+    def test_handles_missing_distribution(self):
+        """Test that missing distribution does not crash."""
+        with unittest.mock.patch(
+            "importlib.metadata.distribution",
+            side_effect=importlib.metadata.PackageNotFoundError("not-found"),
+        ):
+            # Should not raise
+            slicer.packaging._scrub_metadata("not-found", {"torch"})
+
+
+class PipInstallWithSkipsTest(unittest.TestCase):
+    """Tests for slicer.packaging._pip_install_with_skips."""
+
+    def _mock_dep_tree(self, tree, installed=None):
+        """Return patches for a simulated dependency tree.
+
+        :param tree: dict mapping package name -> list of dependency strings.
+        :param installed: set of package names already installed.
+        :returns: list of mock context managers to enter.
+        """
+        if installed is None:
+            installed = set()
+
+        def mock_version(name):
+            from packaging.utils import canonicalize_name
+            if canonicalize_name(name) in {canonicalize_name(n) for n in installed}:
+                return "1.0.0"
+            raise importlib.metadata.PackageNotFoundError(name)
+
+        def mock_requires(name):
+            from packaging.utils import canonicalize_name
+            canonical = canonicalize_name(name)
+            for key, deps in tree.items():
+                if canonicalize_name(key) == canonical:
+                    return deps
+            return []
+
+        return [
+            unittest.mock.patch("importlib.metadata.version", side_effect=mock_version),
+            unittest.mock.patch("importlib.metadata.requires", side_effect=mock_requires),
+            unittest.mock.patch("importlib.invalidate_caches"),
+            unittest.mock.patch("slicer.packaging._scrub_metadata"),
+        ]
+
+    def test_skips_named_packages(self):
+        """Test that packages in skip list are not installed."""
+        tree = {"top-pkg": ["torch>=2.0", "numpy>=1.0"]}
+        patches = self._mock_dep_tree(tree)
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            for p in patches:
+                p.start()
+            try:
+                skipped = slicer.packaging._pip_install_with_skips(
+                    "top-pkg", skip_packages=["torch"],
+                )
+            finally:
+                for p in patches:
+                    p.stop()
+
+        # torch should be skipped, not installed
+        self.assertEqual(len(skipped), 1)
+        self.assertIn("torch", skipped[0])
+
+        # top-pkg and numpy should have install calls (2 calls)
+        install_calls = [
+            c for c in mock_exec.call_args_list
+            if c[0][0] == "pip"
+        ]
+        installed_names = []
+        for call in install_calls:
+            args = call[0][1]  # pip args list
+            # Find the requirement string (comes after "install")
+            install_idx = args.index("install")
+            req_str = args[install_idx + 1]
+            installed_names.append(req_str)
+        self.assertIn("top-pkg", installed_names)
+        self.assertIn("numpy>=1.0", installed_names)
+        self.assertNotIn("torch>=2.0", installed_names)
+
+    def test_recursive_skip_at_depth(self):
+        """Test that skip applies to transitive dependencies."""
+        tree = {
+            "top-pkg": ["mid-pkg>=1.0"],
+            "mid-pkg": ["torch>=2.0", "scipy>=1.0"],
+        }
+        patches = self._mock_dep_tree(tree)
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            for p in patches:
+                p.start()
+            try:
+                skipped = slicer.packaging._pip_install_with_skips(
+                    "top-pkg", skip_packages=["torch"],
+                )
+            finally:
+                for p in patches:
+                    p.stop()
+
+        self.assertEqual(len(skipped), 1)
+        self.assertIn("torch", skipped[0])
+
+        # Should have installed: top-pkg, mid-pkg, scipy (3 calls)
+        self.assertEqual(mock_exec.call_count, 3)
+
+    def test_returns_skipped_requirement_strings(self):
+        """Test that return value contains full PEP 508 strings."""
+        tree = {"pkg": ["torch>=2.0.1", "SimpleITK>=2.0.2"]}
+        patches = self._mock_dep_tree(tree)
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule"):
+            for p in patches:
+                p.start()
+            try:
+                skipped = slicer.packaging._pip_install_with_skips(
+                    "pkg", skip_packages=["torch", "SimpleITK"],
+                )
+            finally:
+                for p in patches:
+                    p.stop()
+
+        self.assertEqual(len(skipped), 2)
+        # Should contain the full specifier strings
+        skipped_str = " ".join(skipped)
+        self.assertIn("torch>=2.0.1", skipped_str)
+        self.assertIn("SimpleITK>=2.0.2", skipped_str)
+
+    def test_cycle_detection(self):
+        """Test that circular dependencies don't cause infinite loops."""
+        tree = {
+            "pkg-a": ["pkg-b>=1.0"],
+            "pkg-b": ["pkg-a>=1.0"],
+        }
+        patches = self._mock_dep_tree(tree)
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule"):
+            for p in patches:
+                p.start()
+            try:
+                # Should complete without hanging
+                slicer.packaging._pip_install_with_skips("pkg-a", skip_packages=[])
+            finally:
+                for p in patches:
+                    p.stop()
+
+    def test_skips_extras_gated_deps(self):
+        """Test that extras-gated dependencies are not walked."""
+        tree = {"pkg": ['ruff>=0.1; extra == "dev"', "numpy>=1.0"]}
+        patches = self._mock_dep_tree(tree)
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            for p in patches:
+                p.start()
+            try:
+                slicer.packaging._pip_install_with_skips("pkg", skip_packages=[])
+            finally:
+                for p in patches:
+                    p.stop()
+
+        # Should install pkg and numpy, NOT ruff
+        installed_reqs = []
+        for call in mock_exec.call_args_list:
+            args = call[0][1]
+            install_idx = args.index("install")
+            installed_reqs.append(args[install_idx + 1])
+
+        self.assertIn("pkg", installed_reqs)
+        self.assertIn("numpy>=1.0", installed_reqs)
+        self.assertNotIn("ruff>=0.1", installed_reqs)
+
+    def test_evaluates_env_markers(self):
+        """Test that platform-inappropriate deps are skipped."""
+        tree = {"pkg": ['win-only>=1.0; sys_platform == "nonexistent"', "numpy>=1.0"]}
+        patches = self._mock_dep_tree(tree)
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            for p in patches:
+                p.start()
+            try:
+                slicer.packaging._pip_install_with_skips("pkg", skip_packages=[])
+            finally:
+                for p in patches:
+                    p.stop()
+
+        # Should install pkg and numpy, NOT win-only
+        installed_reqs = []
+        for call in mock_exec.call_args_list:
+            args = call[0][1]
+            install_idx = args.index("install")
+            installed_reqs.append(args[install_idx + 1])
+
+        self.assertNotIn("win-only>=1.0", installed_reqs)
+        self.assertIn("numpy>=1.0", installed_reqs)
+
+    def test_strips_markers_before_pip_call(self):
+        """Test that env markers are stripped from args passed to pip.
+
+        When a sub-dependency has a marker that evaluates to True,
+        the marker has served its purpose. Passing it through as a
+        string would be mangled by shlex.split, so only name+specifier
+        should reach pip.
+        """
+        import sys
+
+        current_platform = sys.platform
+        tree = {"pkg": [f'scipy>=1.0; sys_platform == "{current_platform}"']}
+        patches = self._mock_dep_tree(tree)
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            for p in patches:
+                p.start()
+            try:
+                slicer.packaging._pip_install_with_skips("pkg", skip_packages=[])
+            finally:
+                for p in patches:
+                    p.stop()
+
+        # Should install both pkg and scipy
+        self.assertEqual(mock_exec.call_count, 2)
+
+        # The scipy call should have just "scipy>=1.0", no marker text
+        scipy_call = mock_exec.call_args_list[1]
+        args = scipy_call[0][1]
+        install_idx = args.index("install")
+        req_arg = args[install_idx + 1]
+        self.assertEqual(req_arg, "scipy>=1.0")
+        self.assertNotIn("sys_platform", " ".join(args))
+
+    def test_preserves_extras_in_pip_call(self):
+        """Test that extras are preserved when constructing the pip argument.
+
+        The marker-stripping fix builds the install string from req.name and
+        req.specifier, but must also include req.extras so that
+        ``package[gpu]>=1.0`` reaches pip as ``package[gpu]>=1.0``, not
+        ``package>=1.0``.
+        """
+        tree = {"pkg[extra1]>=1.0": []}
+        patches = self._mock_dep_tree(tree)
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            for p in patches:
+                p.start()
+            try:
+                slicer.packaging._pip_install_with_skips("pkg[extra1]>=1.0", skip_packages=[])
+            finally:
+                for p in patches:
+                    p.stop()
+
+        self.assertEqual(mock_exec.call_count, 1)
+        args = mock_exec.call_args_list[0][0][1]
+        install_idx = args.index("install")
+        req_arg = args[install_idx + 1]
+        self.assertEqual(req_arg, "pkg[extra1]>=1.0")
+
+    def test_already_satisfied_not_reinstalled(self):
+        """Test that already-installed packages are not re-downloaded."""
+        tree = {"pkg": ["numpy>=1.0"]}
+        # numpy is marked as already installed
+        patches = self._mock_dep_tree(tree, installed={"numpy"})
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            for p in patches:
+                p.start()
+            try:
+                slicer.packaging._pip_install_with_skips("pkg", skip_packages=[])
+            finally:
+                for p in patches:
+                    p.stop()
+
+        # Only pkg should be installed (numpy is already satisfied)
+        self.assertEqual(mock_exec.call_count, 1)
+
+    def test_installs_with_constraints(self):
+        """Test that constraints are passed to each pip call."""
+        tree = {"pkg": ["numpy>=1.0"]}
+        patches = self._mock_dep_tree(tree)
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            for p in patches:
+                p.start()
+            try:
+                slicer.packaging._pip_install_with_skips(
+                    "pkg", skip_packages=[], constraints="/path/to/constraints.txt",
+                )
+            finally:
+                for p in patches:
+                    p.stop()
+
+        # Every pip call should include -c constraints
+        for call in mock_exec.call_args_list:
+            args = call[0][1]
+            self.assertIn("-c", args)
+            self.assertIn("/path/to/constraints.txt", args)
+
+
+    def test_top_level_failure_propagates(self):
+        """Test that a top-level install failure raises instead of being swallowed.
+
+        When the package the user explicitly asked for fails to install,
+        the exception should propagate to the caller rather than being
+        silently logged.
+        """
+        from subprocess import CalledProcessError
+
+        tree = {"pkg": []}
+        patches = self._mock_dep_tree(tree)
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            mock_exec.side_effect = CalledProcessError(1, "pip")
+            for p in patches:
+                p.start()
+            try:
+                with self.assertRaises(CalledProcessError):
+                    slicer.packaging._pip_install_with_skips("pkg", skip_packages=[])
+            finally:
+                for p in patches:
+                    p.stop()
+
+    def test_sub_dependency_failure_continues(self):
+        """Test that a sub-dependency failure is swallowed while other deps are still tried.
+
+        When a transitive dependency fails to install, the function should
+        log a warning and continue installing the remaining dependencies.
+        """
+        from subprocess import CalledProcessError
+
+        tree = {"pkg": ["dep-a>=1.0", "dep-b>=1.0"]}
+        patches = self._mock_dep_tree(tree)
+
+        def selective_fail(module, args, **kwargs):
+            # Find the requirement arg (first arg after "install")
+            install_idx = args.index("install")
+            req_arg = args[install_idx + 1]
+            if req_arg.startswith("dep-a"):
+                raise CalledProcessError(1, "pip")
+            # pkg and dep-b succeed
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            mock_exec.side_effect = selective_fail
+            for p in patches:
+                p.start()
+            try:
+                # Should NOT raise despite dep-a failing
+                slicer.packaging._pip_install_with_skips("pkg", skip_packages=[])
+            finally:
+                for p in patches:
+                    p.stop()
+
+        # Should have attempted all three: pkg, dep-a (fails), dep-b
+        self.assertEqual(mock_exec.call_count, 3)
+
+
+class SkipPackagesValidationTest(unittest.TestCase):
+    """Tests for skip_packages parameter validation in pip_install."""
+
+    def test_nonblocking_raises_valueerror(self):
+        """Test that blocking=False with skip_packages raises ValueError."""
+        with self.assertRaises(ValueError, msg="skip_packages requires blocking=True"):
+            slicer.packaging.pip_install(
+                "pkg", skip_packages=["torch"], blocking=False,
+            )
+
+    def test_mutual_exclusion_with_no_deps(self):
+        """Test that skip_packages with no_deps_requirements raises ValueError."""
+        with self.assertRaises(ValueError, msg="mutually exclusive"):
+            slicer.packaging.pip_install(
+                "pkg",
+                skip_packages=["torch"],
+                no_deps_requirements="other-pkg",
+            )
+
+
+class SkipPackagesEnsureTest(unittest.TestCase):
+    """Tests for skip_packages support in pip_ensure."""
+
+    def test_pip_ensure_forwards_skip_packages(self):
+        """Test that pip_ensure passes skip_packages to pip_install."""
+        reqs = [Requirement("nonexistent-package-xyz123>=1.0")]
+
+        if not slicer.app.testingEnabled():
+            self.skipTest("Not in testing mode")
+
+        with unittest.mock.patch("slicer.packaging.pip_install") as mock_install:
+            mock_install.return_value = ["torch>=2.0"]
+            result = slicer.packaging.pip_ensure(
+                reqs,
+                skip_packages=["torch"],
+                prompt_install=False,
+                skip_in_testing=False,
+            )
+
+            mock_install.assert_called_once()
+            call_kwargs = mock_install.call_args[1]
+            self.assertEqual(call_kwargs["skip_packages"], ["torch"])
+
+    def test_pip_ensure_returns_skipped_list(self):
+        """Test that pip_ensure returns the skipped list from pip_install."""
+        reqs = [Requirement("nonexistent-package-xyz123>=1.0")]
+
+        if not slicer.app.testingEnabled():
+            self.skipTest("Not in testing mode")
+
+        with unittest.mock.patch("slicer.packaging.pip_install") as mock_install:
+            mock_install.return_value = ["torch>=2.0", "SimpleITK>=2.0"]
+            result = slicer.packaging.pip_ensure(
+                reqs,
+                skip_packages=["torch", "SimpleITK"],
+                prompt_install=False,
+                prompt_restart=False,
+                skip_in_testing=False,
+            )
+
+            self.assertEqual(result, ["torch>=2.0", "SimpleITK>=2.0"])
+
+
+class NoDepsRequirementsTwoStepTest(unittest.TestCase):
+    """Tests for the two-step no_deps_requirements install path."""
+
+    def test_two_step_builds_correct_args(self):
+        """Test that _pip_install_simple makes two pip calls with correct flags.
+
+        First call should have --no-deps for the no_deps_requirements,
+        second call should install regular requirements without --no-deps.
+        """
+        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            slicer.packaging._pip_install_simple(
+                requirements="numpy scipy",
+                no_deps_requirements="problematic-pkg==1.0",
+            )
+
+            self.assertEqual(mock_exec.call_count, 2)
+
+            # First call: no_deps_requirements with --no-deps
+            first_args = mock_exec.call_args_list[0][0][1]
+            self.assertIn("--no-deps", first_args)
+            self.assertIn("problematic-pkg==1.0", first_args)
+
+            # Second call: regular requirements without --no-deps
+            second_args = mock_exec.call_args_list[1][0][1]
+            self.assertNotIn("--no-deps", second_args)
+            self.assertIn("numpy", second_args)
+            self.assertIn("scipy", second_args)
+
+    def test_two_step_passes_constraints_to_both(self):
+        """Test that constraints file is passed to both steps."""
+        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            slicer.packaging._pip_install_simple(
+                requirements="numpy",
+                constraints="/path/to/constraints.txt",
+                no_deps_requirements="problematic-pkg",
+            )
+
+            self.assertEqual(mock_exec.call_count, 2)
+            for call in mock_exec.call_args_list:
+                args = call[0][1]
+                self.assertIn("-c", args)
+                self.assertIn("/path/to/constraints.txt", args)
+
+    def test_without_no_deps_requirements_single_call(self):
+        """Test that omitting no_deps_requirements makes only one pip call."""
+        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            slicer.packaging._pip_install_simple(requirements="numpy scipy")
+
+            mock_exec.assert_called_once()
+            args = mock_exec.call_args[0][1]
+            self.assertNotIn("--no-deps", args)
+
+
+class IsPipInstallInProgressTest(unittest.TestCase):
+    """Tests for isPipInstallInProgress flag management."""
+
+    def setUp(self):
+        """Reset the flag before each test."""
+        slicer.packaging._pip_install_in_progress = False
+
+    def tearDown(self):
+        """Ensure flag is reset after each test."""
+        slicer.packaging._pip_install_in_progress = False
+
+    def test_flag_set_during_nonblocking_install(self):
+        """Test that _pip_install_nonblocking sets the flag during execution."""
+        flag_during_install = []
+
+        def fake_exec(module, args, blocking=True, logCallback=None, completedCallback=None):
+            flag_during_install.append(slicer.packaging.isPipInstallInProgress())
+            if completedCallback:
+                completedCallback(0)
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule", side_effect=fake_exec):
+            slicer.packaging._pip_install_nonblocking("numpy")
+
+        # Flag should have been True during execution
+        self.assertEqual(len(flag_during_install), 1)
+        self.assertTrue(flag_during_install[0])
+        # Flag should be False after completion
+        self.assertFalse(slicer.packaging.isPipInstallInProgress())
+
+    def test_flag_cleared_on_exception(self):
+        """Test that the flag is cleared if _executePythonModule raises."""
+        with unittest.mock.patch(
+            "slicer.packaging._executePythonModule",
+            side_effect=RuntimeError("test error"),
+        ):
+            with self.assertRaises(RuntimeError):
+                slicer.packaging._pip_install_nonblocking("numpy")
+
+        self.assertFalse(slicer.packaging.isPipInstallInProgress())
+
+class NonBlockingPipInstallCallbackTest(unittest.TestCase):
+    """Tests for _pip_install_nonblocking callback invocation."""
+
+    def setUp(self):
+        slicer.packaging._pip_install_in_progress = False
+
+    def tearDown(self):
+        slicer.packaging._pip_install_in_progress = False
+
+    def test_completed_callback_receives_return_code(self):
+        """Test that completedCallback is called with the process return code."""
+        result = {"return_code": None}
+
+        def on_complete(return_code):
+            result["return_code"] = return_code
+
+        def fake_exec(module, args, blocking=True, logCallback=None, completedCallback=None):
+            if completedCallback:
+                completedCallback(42)
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule", side_effect=fake_exec):
+            slicer.packaging._pip_install_nonblocking(
+                "numpy", completedCallback=on_complete,
+            )
+
+        self.assertEqual(result["return_code"], 42)
+        self.assertFalse(slicer.packaging.isPipInstallInProgress())
+
+    def test_two_step_nonblocking_chains_calls(self):
+        """Test that no_deps_requirements chains two non-blocking calls."""
+        call_args_list = []
+
+        def fake_exec(module, args, blocking=True, logCallback=None, completedCallback=None):
+            call_args_list.append(args)
+            if completedCallback:
+                completedCallback(0)
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule", side_effect=fake_exec):
+            slicer.packaging._pip_install_nonblocking(
+                "numpy", no_deps_requirements="problematic-pkg",
+            )
+
+        # Should have two calls: first with --no-deps, second without
+        self.assertEqual(len(call_args_list), 2)
+        self.assertIn("--no-deps", call_args_list[0])
+        self.assertNotIn("--no-deps", call_args_list[1])
+        self.assertFalse(slicer.packaging.isPipInstallInProgress())
+
+    def test_two_step_nonblocking_aborts_on_first_failure(self):
+        """Test that failure in no_deps step prevents regular install."""
+        call_count = [0]
+
+        def fake_exec(module, args, blocking=True, logCallback=None, completedCallback=None):
+            call_count[0] += 1
+            if completedCallback:
+                completedCallback(1)  # Failure
+
+        result = {"return_code": None}
+
+        def on_complete(return_code):
+            result["return_code"] = return_code
+
+        with unittest.mock.patch("slicer.packaging._executePythonModule", side_effect=fake_exec):
+            slicer.packaging._pip_install_nonblocking(
+                "numpy",
+                no_deps_requirements="problematic-pkg",
+                completedCallback=on_complete,
+            )
+
+        # Only the first call should happen (it failed, so second is skipped)
+        self.assertEqual(call_count[0], 1)
+        self.assertEqual(result["return_code"], 1)
+        self.assertFalse(slicer.packaging.isPipInstallInProgress())

--- a/Base/Python/slicer/tests/test_slicer_util_pip.py
+++ b/Base/Python/slicer/tests/test_slicer_util_pip.py
@@ -1,0 +1,46 @@
+"""Tests verifying slicer.util.pip_install/pip_uninstall wrappers delegate to slicer.packaging."""
+
+import unittest
+import unittest.mock
+
+import slicer
+import slicer.packaging
+import slicer.util
+
+
+class UtilPipInstallWrapperTest(unittest.TestCase):
+    """Tests that slicer.util.pip_install delegates to slicer.packaging.pip_install."""
+
+    def test_delegates_positional_arg(self):
+        """Test that a simple positional argument is forwarded."""
+        with unittest.mock.patch("slicer.packaging.pip_install") as mock:
+            slicer.util.pip_install("some-package")
+            mock.assert_called_once_with("some-package")
+
+    def test_delegates_kwargs(self):
+        """Test that keyword arguments are forwarded."""
+        with unittest.mock.patch("slicer.packaging.pip_install") as mock:
+            slicer.util.pip_install("pkg", constraints="/tmp/c.txt", show_progress=False)
+            mock.assert_called_once_with("pkg", constraints="/tmp/c.txt", show_progress=False)
+
+    def test_returns_value(self):
+        """Test that the return value is propagated."""
+        with unittest.mock.patch("slicer.packaging.pip_install", return_value=["skipped"]):
+            result = slicer.util.pip_install("pkg", skip_packages=["torch"])
+            self.assertEqual(result, ["skipped"])
+
+
+class UtilPipUninstallWrapperTest(unittest.TestCase):
+    """Tests that slicer.util.pip_uninstall delegates to slicer.packaging.pip_uninstall."""
+
+    def test_delegates_positional_arg(self):
+        """Test that a simple positional argument is forwarded."""
+        with unittest.mock.patch("slicer.packaging.pip_uninstall") as mock:
+            slicer.util.pip_uninstall("some-package")
+            mock.assert_called_once_with("some-package")
+
+    def test_delegates_kwargs(self):
+        """Test that keyword arguments are forwarded."""
+        with unittest.mock.patch("slicer.packaging.pip_uninstall") as mock:
+            slicer.util.pip_uninstall("pkg", blocking=False)
+            mock.assert_called_once_with("pkg", blocking=False)

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -1,6 +1,15 @@
+from __future__ import annotations
+
 #
 # General
 #
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from subprocess import Popen
+
 
 EXIT_SUCCESS = 0
 EXIT_FAILURE = 1
@@ -2650,7 +2659,7 @@ def dataframeFromTable(tableNode):
             warnings.simplefilter(action="ignore", category=UserWarning)
             import pandas as pd
     except ImportError:
-        raise ImportError("Failed to convert to pandas dataframe. Please install pandas by running `slicer.util.pip_install('pandas')`")
+        raise ImportError("Failed to convert to pandas dataframe. Please install pandas by running `slicer.packaging.pip_install('pandas')`")
     dataframe = pd.DataFrame()
     vtable = tableNode.GetTable()
     for columnIndex in range(vtable.GetNumberOfColumns()):
@@ -2688,7 +2697,7 @@ def dataframeFromMarkups(markupsNode):
             warnings.simplefilter(action="ignore", category=UserWarning)
             import pandas as pd
     except ImportError:
-        raise ImportError("Failed to convert to pandas dataframe. Please install pandas by running `slicer.util.pip_install('pandas')`")
+        raise ImportError("Failed to convert to pandas dataframe. Please install pandas by running `slicer.packaging.pip_install('pandas')`")
 
     label = []
     description = []
@@ -3244,7 +3253,7 @@ def displayPythonShell(display=True):
     .. code-block:: python
 
       with slicer.util.displayPythonShell():
-        slicer.util.pip_install('nibabel')
+        slicer.packaging.pip_install('nibabel')
 
     """
     import slicer
@@ -3876,7 +3885,15 @@ def plot(narray, xColumnIndex=-1, columnNames=None, title=None, show=True, nodes
     return chartNode
 
 
-def launchConsoleProcess(args, useStartupEnvironment=True, updateEnvironment=None, cwd=None):
+def launchConsoleProcess(
+    args: list[str],
+    useStartupEnvironment: bool = True,
+    updateEnvironment: dict[str, str] | None = None,
+    cwd: str | None = None,
+    blocking: bool = True,
+    logCallback: Callable[[str], None] | None = None,
+    completedCallback: Callable[[int], None] | None = None,
+) -> Popen[str]:
     """Launch a process. Hiding the console and captures the process output.
 
     The console window is hidden when running on Windows.
@@ -3885,18 +3902,50 @@ def launchConsoleProcess(args, useStartupEnvironment=True, updateEnvironment=Non
     :param useStartupEnvironment: launch the process in the original environment as the original Slicer process
     :param updateEnvironment: map containing optional additional environment variables (existing variables are overwritten)
     :param cwd: current working directory
+    :param blocking: If True (default), return the process object for use with
+        :py:meth:`logProcessOutput`. If False, process output asynchronously using
+        a background thread and QTimer polling. The main thread remains free and
+        the Qt event loop runs normally.
+    :param logCallback: When blocking=False, called with each line of output.
+        If None, output is printed to console (same as blocking mode).
+        Signature: ``logCallback(line: str) -> None``
+    :param completedCallback: When blocking=False, called when process completes.
+        Receives the return code as argument. If the process failed (non-zero return
+        code) and no completedCallback is provided, a CalledProcessError is logged.
+        Signature: ``completedCallback(returnCode: int) -> None``
     :return: process object.
 
-    This method is typically used together with :py:meth:`logProcessOutput` to wait for the execution to complete and display the process output in the application log:
+    Blocking mode example (this is the typical usage pattern):
 
     .. code-block:: python
 
       proc = slicer.util.launchConsoleProcess(args)
       slicer.util.logProcessOutput(proc)
 
+    Non-blocking mode example:
+
+    .. code-block:: python
+
+      def onLog(line):
+          print(f"[pip] {line}")
+
+      def onComplete(returnCode):
+          if returnCode == 0:
+              print("Done!")
+          else:
+              print(f"Failed with code {returnCode}")
+
+      slicer.util.launchConsoleProcess(
+          args,
+          blocking=False,
+          logCallback=onLog,
+          completedCallback=onComplete
+      )
+      # Returns immediately, UI stays responsive
+
     """
-    import subprocess
     import os
+    import subprocess
 
     if useStartupEnvironment:
         startupEnv = startupEnvironment()
@@ -3916,13 +3965,90 @@ def launchConsoleProcess(args, useStartupEnvironment=True, updateEnvironment=Non
         proc = subprocess.Popen(args, env=startupEnv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True, startupinfo=info, cwd=cwd)
     else:
         proc = subprocess.Popen(args, env=startupEnv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True, cwd=cwd)
+
+    if blocking:
+        return proc  # Caller will use logProcessOutput() as before
+
+    # Non-blocking mode: start background thread and QTimer polling
+    _startAsyncProcessHandling(proc, logCallback, completedCallback)
     return proc
 
 
-def logProcessOutput(proc):
+def _startAsyncProcessHandling(
+    proc: Popen[str],
+    logCallback: Callable[[str], None] | None = None,
+    completedCallback: Callable[[int], None] | None = None,
+) -> None:
+    """Start asynchronous handling of process output using a background thread and QTimer.
+
+    Internal function used by :py:meth:`launchConsoleProcess` when blocking=False.
+
+    :param proc: subprocess.Popen object
+    :param logCallback: Called with each line of output, or None for default console printing
+    :param completedCallback: Called when process completes with return code
+    """
+    import queue
+    import threading
+
+    import qt
+
+    outputQueue = queue.Queue()
+    CHECK_INTERVAL_MS = 100  # Poll every 100ms for responsive UI
+
+    def readOutputThread():
+        """Background thread: read stdout and put lines into queue."""
+        while True:
+            try:
+                line = proc.stdout.readline()
+                if not line:
+                    break
+                outputQueue.put(("line", line.rstrip()))
+            except UnicodeDecodeError:
+                # Same handling as logProcessOutput - ignore decode errors
+                pass
+        proc.wait()
+        outputQueue.put(("done", proc.returncode))
+
+    def checkOutput():
+        """Main thread: poll queue and process available output."""
+        while True:
+            try:
+                msgType, data = outputQueue.get_nowait()
+                if msgType == "line":
+                    if logCallback:
+                        logCallback(data)
+                    else:
+                        # Default behavior: print to console (matches blocking mode)
+                        print(data)
+                elif msgType == "done":
+                    returnCode = data
+                    if completedCallback:
+                        completedCallback(returnCode)
+                    elif returnCode != 0:
+                        # No callback provided and process failed - log the error
+                        import logging
+
+                        logging.error(f"Process failed with return code {returnCode}: {proc.args}")
+                    return  # Stop polling
+            except queue.Empty:
+                break
+
+        # Process still running or output still being read - reschedule
+        qt.QTimer.singleShot(CHECK_INTERVAL_MS, checkOutput)
+
+    # Start background thread
+    thread = threading.Thread(target=readOutputThread, daemon=True)
+    thread.start()
+
+    # Start polling from main thread
+    qt.QTimer.singleShot(0, checkOutput)
+
+
+def logProcessOutput(proc, logCallback=None):
     """Continuously write process output to the application log and the Python console.
 
     :param proc: process object.
+    :param logCallback: optional callback called with each output line (str).
     """
     from subprocess import CalledProcessError
 
@@ -3939,7 +4065,10 @@ def logProcessOutput(proc):
             line = proc.stdout.readline()
             if not line:
                 break
-            print(line.rstrip())
+            line = line.rstrip()
+            print(line)
+            if logCallback:
+                logCallback(line)
             if guiApp:
                 guiApp.processEvents()  # give a chance the application to refresh GUI
         except UnicodeDecodeError as e:
@@ -3954,121 +4083,28 @@ def logProcessOutput(proc):
         raise CalledProcessError(retcode, proc.args, output=proc.stdout, stderr=proc.stderr)
 
 
-def _executePythonModule(module, args):
-    """Execute a Python module as a script in Slicer's Python environment.
-
-    Internally python -m is called with the module name and additional arguments.
-
-    :raises RuntimeError: in case of failure
-    """
-    # Determine pythonSlicerExecutablePath
-    try:
-        from slicer import app  # noqa: F401
-
-        # If we get to this line then import from "app" is succeeded,
-        # which means that we run this function from Slicer Python interpreter.
-        # PythonSlicer is added to PATH environment variable in Slicer
-        # therefore shutil.which will be able to find it.
-        import shutil
-
-        pythonSlicerExecutablePath = shutil.which("PythonSlicer")
-        if not pythonSlicerExecutablePath:
-            raise RuntimeError("PythonSlicer executable not found")
-    except ImportError:
-        # Running from console
-        import os
-        import sys
-
-        pythonSlicerExecutablePath = os.path.dirname(sys.executable) + "/PythonSlicer"
-        if os.name == "nt":
-            pythonSlicerExecutablePath += ".exe"
-
-    commandLine = [pythonSlicerExecutablePath, "-m", module, *args]
-    proc = launchConsoleProcess(commandLine, useStartupEnvironment=False)
-    logProcessOutput(proc)
-
-
-def pip_install(requirements):
+def pip_install(requirements, **kwargs):
     """Install python packages.
 
-    Currently, the method simply calls ``python -m pip install`` but in the future further checks, optimizations,
-    user confirmation may be implemented, therefore it is recommended to use this method call instead of calling
-    pip install directly.
+    This is a convenience wrapper that delegates to :func:`slicer.packaging.pip_install`.
+    See that function for full documentation and parameter details.
 
-    :param requirements: requirement specifier in the same format as used by pip (https://docs.python.org/3/installing/index.html).
-      It can be either a single string or a list of command-line arguments. In general, passing all arguments as a single string is
-      the simplest. The only case when using a list may be easier is when there are arguments that may contain spaces, because
-      each list item is automatically quoted (it is not necessary to put quotes around each string argument that may contain spaces).
-
-    Example: calling from Slicer GUI
-
-    .. code-block:: python
-
-      pip_install("pandas scipy scikit-learn")
-
-    Example: calling from PythonSlicer console
-
-    .. code-block:: python
-
-      from slicer.util import pip_install
-      pip_install("pandas>2")
-
-    Example: upgrading to latest version of a package
-
-    .. code-block:: python
-
-      pip_install("--upgrade pandas")
-
+    :param requirements: requirement specifier (string or list), same format as used by pip.
     """
-
-    if type(requirements) == str:
-        # shlex.split splits string the same way as the shell (keeping quoted string as a single argument)
-        import shlex
-
-        args = "install", *(shlex.split(requirements))
-    elif type(requirements) == list:
-        args = "install", *requirements
-    else:
-        raise ValueError("pip_install requirement input must be string or list")
-
-    _executePythonModule("pip", args)
+    from slicer.packaging import pip_install as _pip_install
+    return _pip_install(requirements, **kwargs)
 
 
-def pip_uninstall(requirements):
+def pip_uninstall(requirements, **kwargs):
     """Uninstall python packages.
 
-    Currently, the method simply calls ``python -m pip uninstall`` but in the future further checks, optimizations,
-    user confirmation may be implemented, therefore it is recommended to use this method call instead of a plain
-    pip uninstall.
+    This is a convenience wrapper that delegates to :func:`slicer.packaging.pip_uninstall`.
+    See that function for full documentation and parameter details.
 
-    :param requirements: requirement specifier in the same format as used by pip (https://docs.python.org/3/installing/index.html).
-      It can be either a single string or a list of command-line arguments. It may be simpler to pass command-line arguments as a list
-      if the arguments may contain spaces (because no escaping of the strings with quotes is necessary).
-
-    Example: calling from Slicer GUI
-
-    .. code-block:: python
-
-      pip_uninstall("tensorflow keras scikit-learn ipywidgets")
-
-    Example: calling from PythonSlicer console
-
-    .. code-block:: python
-
-      from slicer.util import pip_uninstall
-      pip_uninstall("tensorflow")
-
+    :param requirements: requirement specifier (string or list), same format as used by pip.
     """
-    if type(requirements) == str:
-        # shlex.split splits string the same way as the shell (keeping quoted string as a single argument)
-        import shlex
-
-        args = "uninstall", *(shlex.split(requirements)), "--yes"
-    elif type(requirements) == list:
-        args = "uninstall", *requirements, "--yes"
-    else:
-        raise ValueError("pip_uninstall requirement input must be string or list")
-    _executePythonModule("pip", args)
+    from slicer.packaging import pip_uninstall as _pip_uninstall
+    return _pip_uninstall(requirements, **kwargs)
 
 
 def longPath(path):

--- a/Base/Python/slicerqt.py
+++ b/Base/Python/slicerqt.py
@@ -10,7 +10,14 @@ import qt
 import vtk  # noqa: F401
 
 import slicer
-from slicer.util import *
+
+from slicer.util import (  # noqa: F401
+    array,
+    exit,
+    getNode,
+    getNodesByClass,
+    mainWindow,
+)
 
 # HACK Ideally constant from vtkSlicerConfigure should be wrapped,
 #      that way the following try/except could be avoided.

--- a/Base/QTGUI/qSlicerPythonManager.cxx
+++ b/Base/QTGUI/qSlicerPythonManager.cxx
@@ -42,8 +42,9 @@ void qSlicerPythonManager::executeInitializationScripts()
     return;
   }
 
-  // Evaluate application script
-  this->executeFile(app->slicerHome() + "/bin/Python/slicer/slicerqt.py");
+  // slicerqt.py must live at bin/Python/ (not bin/Python/slicer/) so that CTK's
+  // executeFile sys.path.insert doesn't shadow PyPI packages with slicer/*.py.
+  this->executeFile(app->slicerHome() + "/bin/Python/slicerqt.py");
 }
 
 //-----------------------------------------------------------------------------

--- a/Docs/developer_guide/python_faq.md
+++ b/Docs/developer_guide/python_faq.md
@@ -25,7 +25,7 @@ modules, are not available.
 :::
 
 :::{tip}
-To install additional packages, you can use the {func}`slicer.util.pip_install()` function.
+To install additional packages, you can use the {func}`slicer.packaging.pip_install()` function.
 :::
 
 ## What is the Python Console?
@@ -50,7 +50,7 @@ For example, this applies to the [Segment Editor effects](/user_guide/modules/se
 :::
 
 :::{tip}
-To install additional packages, you can use the {func}`slicer.util.pip_install()` function.
+To install additional packages, you can use the {func}`slicer.packaging.pip_install()` function.
 :::
 
 :::{versionchanged} 5.2.0
@@ -350,14 +350,33 @@ In our example:
 
 You can install any Python package within Slicer's built-in Python environment.
 
-The convenience function {func}`slicer.util.pip_install` can be used to install packages into your Slicer module. To understand its usage, examine the [Install a Python package](/developer_guide/script_repository.md#install-a-python-package) example within the Script Repository.
+### Utility functions for dependency management
+
+:::{versionadded} 5.11
+The `slicer.packaging` module with `pip_ensure`, `pip_check`, `load_requirements`, and `load_pyproject_dependencies`.
+:::
+
+Slicer provides several utility functions to help manage Python dependencies:
+
+| Function | Purpose |
+|----------|---------|
+| `slicer.packaging.load_requirements` | Load a `requirements.txt` file |
+| `slicer.packaging.pip_check` | Check if requirements are already satisfied |
+| `slicer.packaging.pip_ensure` | Ensure requirements are installed, prompting the user if needed |
+| `slicer.packaging.pip_install` | Install packages |
+
+The recommended approach is to use {func}`slicer.packaging.pip_ensure`, which handles checking, user confirmation, and installation with progress display in one call. It also automatically skips installation when running in testing mode (`slicer.app.testingEnabled()`).
+
+For direct installation with visual feedback, use {func}`slicer.packaging.pip_install` with `show_progress=True`. This displays a modal progress dialog during installation.
+
+For detailed usage examples, see [Install a Python package](/developer_guide/script_repository.md#install-a-python-package) in the Script Repository.
 
 :::{warning}
 Since installing packages can have side effects on other extensions or the main application, here are some best practices to adhere to:
 
 **DO:**
-* ✅ Always include a confirmation dialog that clearly communicates the installation process, mirroring the approach in the linked example.
-* ✅ Document the dependencies your module relies upon.
+* ✅ Ask the user before installing. {func}`slicer.packaging.pip_ensure` does this for you; if you go through the lower-level {func}`slicer.packaging.pip_install`, write your own confirmation dialog as shown in the linked example.
+* ✅ Document the dependencies your module relies upon using a `requirements.txt` file.
 * ✅ Consider specifying version requirements using `>=X.Y` to avoid incompatible versions.
 * ✅ Verify that all Python packages are distributed as Python wheels. This is particularly important for dependencies including compiled code, as installing a wheel eliminates the need for users to install a compiler.
 

--- a/Docs/developer_guide/script_repository.md
+++ b/Docs/developer_guide/script_repository.md
@@ -20,6 +20,9 @@ The Slicer source code has Python [scripted modules](https://github.com/Slicer/S
 ```{include} script_repository/gui.md
 ```
 
+```{include} script_repository/packaging.md
+```
+
 ```{include} script_repository/dicom.md
 ```
 

--- a/Docs/developer_guide/script_repository/gui.md
+++ b/Docs/developer_guide/script_repository/gui.md
@@ -1271,11 +1271,60 @@ This [code snippet](https://gist.github.com/pieper/a9c0ba57de3833c9f5aea68247bda
 
 It is recommended to only install a package at runtime when it is actually needed (not at startup, not even when the user opens a module, but just before that Python package is used the first time), and ask the user about it. For more comprehensive guidelines, refer to the [best practices](/developer_guide/python_faq.md#can-i-use-any-python-package-in-a-slicer-module).
 
+#### Recommended approach using pip_ensure
+
+:::{versionadded} 5.11
+The `slicer.packaging` module and the `pip_ensure` workflow described below.
+:::
+
+The `slicer.packaging.pip_ensure()` function handles checking, prompting, and installing in one call with a progress dialog:
+
+```python
+import slicer.packaging
+
+class MyModuleWidget(ScriptedLoadableModuleWidget):
+
+    def onApplyButton(self):
+        # For a single package (or space-separated list):
+        slicer.packaging.pip_ensure("flywheel-sdk>=1.0", requester="MyModule")
+
+        # Or load requirements from file (recommended for multiple dependencies):
+        # reqs = slicer.packaging.load_requirements(self.resourcePath("requirements.txt"))
+        # slicer.packaging.pip_ensure(reqs, requester="MyModule")
+
+        import flywheel
+        # Now safe to use flywheel
+```
+
+Key features of `pip_ensure()`:
+- Shows a confirmation dialog before installing (controlled by `prompt_install`, default `True`)
+- Shows a progress dialog during installation with collapsible log details
+- Detects when an updated package was already imported in the current session and offers a restart prompt (controlled by `prompt_restart`, default `True`)
+- Automatically skips installation in testing mode (`slicer.app.testingEnabled()`)
+
+#### Alternative: pip_install with progress dialog
+
+For direct installation with visual feedback without using `pip_ensure`. Note that `pip_install`
+now shows a progress dialog by default:
+
 ```python
 try:
   import flywheel
 except ModuleNotFoundError:
   if slicer.util.confirmOkCancelDisplay("This module requires 'flywheel-sdk' Python package. Click OK to install it now."):
-    slicer.util.pip_install("flywheel-sdk")
+    slicer.packaging.pip_install("flywheel-sdk", requester="MyModule")
+    import flywheel
+```
+
+#### Simple approach (no progress dialog)
+
+For scripting or automation where no visual feedback is needed:
+
+```python
+try:
+  import flywheel
+except ModuleNotFoundError:
+  if slicer.util.confirmOkCancelDisplay("This module requires 'flywheel-sdk' Python package. Click OK to install it now."):
+    slicer.packaging.pip_install("flywheel-sdk", show_progress=False)
     import flywheel
 ```

--- a/Docs/developer_guide/script_repository/models.md
+++ b/Docs/developer_guide/script_repository/models.md
@@ -342,7 +342,7 @@ outputLabelmapVolumeArray = (slicer.util.arrayFromVolume(outputLabelmapVolumeNod
 try:
   import imageio
 except ModuleNotFoundError:
-  slicer.util.pip_install("imageio")
+  slicer.packaging.pip_install("imageio")
   import imageio
 
 # Write labelmap volume to series of TIFF files
@@ -351,5 +351,5 @@ for i in range(len(outputLabelmapVolumeArray)):
 ```
 
 :::{tip}
-To learn how to use {func}`slicer.util.pip_install` within a Slicer module, refer to the [](/developer_guide/script_repository.md#install-a-python-package) example in the Script Repository.
+To learn how to use {func}`slicer.packaging.pip_install` within a Slicer module, refer to the [](/developer_guide/script_repository.md#install-a-python-package) example in the Script Repository.
 :::

--- a/Docs/developer_guide/script_repository/packaging.md
+++ b/Docs/developer_guide/script_repository/packaging.md
@@ -1,0 +1,173 @@
+## Python package management
+
+The `slicer.packaging` module provides functions for checking, installing, and managing Python
+packages in the Slicer environment. For best practices on when and how to install packages,
+see [Can I use any Python package in a Slicer module?](/developer_guide/python_faq.md#can-i-use-any-python-package-in-a-slicer-module).
+
+:::{versionadded} 5.11
+The `slicer.packaging` module with `pip_ensure`, `pip_check`, `load_requirements`,
+and `load_pyproject_dependencies`.
+:::
+
+:::{tip}
+When writing a Slicer module, prefer {func}`slicer.packaging.pip_ensure` over
+{func}`slicer.packaging.pip_install`. `pip_ensure` checks whether each requirement is already
+satisfied (skipping the install if so), prompts the user before modifying the environment, and
+detects when an updated package was already imported in the current session and offers a restart
+prompt. `pip_install` is the lower-level building block and does none of those things on its own.
+:::
+
+### Check if packages are installed
+
+Use `pip_check` to test whether requirements are already satisfied without launching a
+subprocess:
+
+```python
+import slicer.packaging
+
+# Single requirement
+if slicer.packaging.pip_check("scipy>=1.0"):
+    print("scipy is available")
+
+# Multiple requirements (space-separated)
+if slicer.packaging.pip_check("scipy>=1.0 numpy>=1.20"):
+    print("All available")
+
+# Multiple requirements from a file
+reqs = slicer.packaging.load_requirements("/path/to/requirements.txt")
+if not slicer.packaging.pip_check(reqs):
+    print("Some requirements are missing")
+```
+
+### Load requirements from a file
+
+You can keep your dependencies in a `requirements.txt` file and load them with
+{func}`slicer.packaging.load_requirements`:
+
+```python
+reqs = slicer.packaging.load_requirements(self.resourcePath("requirements.txt"))
+slicer.packaging.pip_ensure(reqs, requester="MyExtension")
+```
+
+If your extension already has a `pyproject.toml`, you can read the `[project.dependencies]` list with {func}`slicer.packaging.load_pyproject_dependencies` instead. Both functions return the same `list[Requirement]` type, so the rest of the pipeline (`pip_check`, `pip_ensure`) works identically:
+
+```python
+reqs = slicer.packaging.load_pyproject_dependencies(self.resourcePath("pyproject.toml"))
+slicer.packaging.pip_ensure(reqs, requester="MyExtension")
+```
+
+### Install packages with a constraints file
+
+A constraints file limits which versions pip may install without triggering installation
+on its own. This is useful for ensuring compatible versions across multiple extensions.
+
+```python
+import slicer.packaging
+
+# Via pip_ensure (recommended)
+reqs = slicer.packaging.load_requirements("/path/to/requirements.txt")
+slicer.packaging.pip_ensure(
+    reqs,
+    constraints="/path/to/constraints.txt",
+    requester="MyExtension",
+)
+```
+
+```python
+# Via pip_install (lower level)
+slicer.packaging.pip_install("pandas scipy", constraints="/path/to/constraints.txt")
+```
+
+### Install packages with broken dependency declarations
+
+When a package declares overly strict dependencies that conflict with other packages,
+use `no_deps_requirements` to install it without its declared dependencies, then
+install the actual dependencies you need separately:
+
+```python
+slicer.packaging.pip_install(
+    requirements="numpy scipy",
+    no_deps_requirements="problematic-pkg==1.0",
+)
+```
+
+### Excluding specific transitive dependencies (`skip_packages`)
+
+`skip_packages` installs each requirement with `--no-deps`, walks its dependency
+tree recursively, and excludes any package matching the skip list. Package METADATA
+is scrubbed afterward so pip will not flag the skipped packages as missing.
+
+It exists for the specific case where a package pulls in a transitive dependency
+that Slicer already provides differently, such as `SimpleITK` (Slicer bundles a
+custom build) or `torch` (must come from SlicerPyTorch for the correct CUDA/CPU
+combination). Without `skip_packages`, installing such a package would overwrite
+or conflict with Slicer's bundled version.
+
+```python
+import slicer.packaging
+
+skipped = slicer.packaging.pip_ensure(
+    "nnunetv2>=2.3",
+    skip_packages=["SimpleITK", "torch", "requests"],
+    requester="SlicerNNUNet",
+)
+# skipped contains the requirement strings that were excluded,
+# e.g. ["torch>=2.0", "SimpleITK>=2.0.2", "requests"]
+```
+
+:::{warning}
+`skip_packages` is a workaround, not a recommended pattern. It hides
+unwanted requirements from pip, which means real conflicts are no longer
+reported and `pip show` no longer reflects the true dependency graph.
+Skip lists also drift over time as Slicer's bundled packages change.
+
+Where possible, consider asking the upstream maintainer to relax the
+unnecessary requirement, or use `no_deps_requirements` if the dependency
+tree is small enough to enumerate yourself. For packages with deep
+transitive dependency trees that conflict with Slicer's bundled libraries
+(e.g. nnUNet pulling in `torch` and `SimpleITK`), `skip_packages` is
+often the only practical option short of forking the package -- which is
+why it exists.
+
+`skip_packages` and `no_deps_requirements` are mutually exclusive.
+:::
+
+### Non-blocking package installation
+
+Use `blocking=False` to install packages without blocking the UI. Pip output
+appears in the status bar by default, and you can provide callbacks for custom handling:
+
+```python
+def onComplete(returnCode):
+    if returnCode == 0:
+        import pandas  # Now safe to import
+    else:
+        slicer.util.errorDisplay("Failed to install packages")
+
+slicer.packaging.pip_install(
+    "pandas scipy",
+    blocking=False,
+    completedCallback=onComplete,
+)
+# Returns immediately — UI stays responsive
+```
+
+:::{warning}
+When using `blocking=False`, the user can interact with the application while
+installation is in progress. Consider showing a modal dialog or disabling
+relevant UI elements during installation to prevent conflicts.
+:::
+
+### Check if installation is in progress
+
+Before starting an operation that might conflict with an ongoing pip installation,
+check the in-progress flag:
+
+```python
+import slicer.packaging
+
+if slicer.packaging.isPipInstallInProgress():
+    slicer.util.warningDisplay("Package installation is in progress. Please wait.")
+else:
+    slicer.packaging.pip_install("scipy", blocking=False, requester="MyExtension")
+```

--- a/Docs/developer_guide/script_repository/plots.md
+++ b/Docs/developer_guide/script_repository/plots.md
@@ -72,7 +72,7 @@ Matplotlib may be used from within Slicer, but the default Tk backend locks up a
 try:
   import matplotlib
 except ModuleNotFoundError:
-  slicer.util.pip_install("matplotlib")
+  slicer.packaging.pip_install("matplotlib")
   import matplotlib
 
 matplotlib.use("Agg")
@@ -104,7 +104,7 @@ imageWidget.show()
 ```
 
 :::{tip}
-To learn how to use {func}`slicer.util.pip_install` within a Slicer module, refer to the [](/developer_guide/script_repository.md#install-a-python-package) example in the Script Repository.
+To learn how to use {func}`slicer.packaging.pip_install` within a Slicer module, refer to the [](/developer_guide/script_repository.md#install-a-python-package) example in the Script Repository.
 :::
 
 ![Matplotlib example](https://www.slicer.org/w/img_auth.php/a/ab/MatplotlibExample.png)
@@ -116,7 +116,7 @@ import JupyterNotebooksLib as slicernb
 try:
   import matplotlib
 except ModuleNotFoundError:
-  slicer.util.pip_install("matplotlib")
+  slicer.packaging.pip_install("matplotlib")
   import matplotlib
 
 matplotlib.use("Agg")
@@ -159,7 +159,7 @@ try:
   import matplotlib
   import wx
 except ModuleNotFoundError:
-  slicer.util.pip_install("matplotlib wxPython")
+  slicer.packaging.pip_install("matplotlib wxPython")
   import matplotlib
 
 # Get a volume from SampleData and compute its histogram
@@ -182,7 +182,7 @@ plt.show(block=False)
 ```
 
 :::{tip}
-To learn how to use {func}`slicer.util.pip_install` within a Slicer module, refer to the [](/developer_guide/script_repository.md#install-a-python-package) example in the Script Repository.
+To learn how to use {func}`slicer.packaging.pip_install` within a Slicer module, refer to the [](/developer_guide/script_repository.md#install-a-python-package) example in the Script Repository.
 :::
 
 ![Interactive Matplotlib Example](https://www.slicer.org/w/img_auth.php/d/d2/InteractiveMatplotlibExample.png)

--- a/Docs/developer_guide/slicer.md
+++ b/Docs/developer_guide/slicer.md
@@ -25,6 +25,15 @@
     :show-inheritance:
 ```
 
+## slicer.packaging
+
+```{eval-rst}
+.. automodule:: slicer.packaging
+    :members:
+    :undoc-members:
+    :show-inheritance:
+```
+
 ## slicer.ScriptedLoadableModule
 
 ```{eval-rst}

--- a/Utilities/Scripts/SlicerWizard/TemplateManager.py
+++ b/Utilities/Scripts/SlicerWizard/TemplateManager.py
@@ -19,6 +19,7 @@ _sourcePatterns = [
     "*.png",
     "*.dox",
     "*.sha256",
+    "requirements.txt",
 ]
 
 _templateCategories = [

--- a/Utilities/Templates/Modules/Scripted/CMakeLists.txt
+++ b/Utilities/Templates/Modules/Scripted/CMakeLists.txt
@@ -9,6 +9,7 @@ set(MODULE_PYTHON_SCRIPTS
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
   Resources/UI/${MODULE_NAME}.ui
+  Resources/requirements.txt
   )
 
 #-----------------------------------------------------------------------------

--- a/Utilities/Templates/Modules/Scripted/Resources/requirements.txt
+++ b/Utilities/Templates/Modules/Scripted/Resources/requirements.txt
@@ -1,0 +1,2 @@
+# Add Python package dependencies here, one per line.
+# Example: scikit-image>=0.20

--- a/Utilities/Templates/Modules/Scripted/TemplateKey.py
+++ b/Utilities/Templates/Modules/Scripted/TemplateKey.py
@@ -243,6 +243,15 @@ class TemplateKeyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def onApplyButton(self) -> None:
         """Run processing when user clicks "Apply" button."""
+        # TODO: If your module requires additional Python packages, uncomment
+        # the following lines and add your dependencies to the
+        # Resources/requirements.txt file (one per line, e.g. "scikit-image>=0.20").
+        # import slicer.packaging
+        # slicer.packaging.pip_ensure(
+        #     slicer.packaging.load_requirements(self.resourcePath("requirements.txt")),
+        #     requester="TemplateKey",
+        # )
+
         with slicer.util.tryWithErrorDisplay(_("Failed to compute results."), waitCursor=True):
             # Compute output
             self.logic.process(self.ui.inputSelector.currentNode(), self.ui.outputSelector.currentNode(),


### PR DESCRIPTION
# Python Dependency Handling Improvements

## Summary

This PR introduces a new `slicer.packaging` module for managing Python dependencies in Slicer extensions. The goal is to provide a standardized, user-friendly way to check, prompt for, and install Python packages. The existing `slicer.util.pip_install` and `slicer.util.pip_uninstall` functions are retained as backward-compatible wrappers that delegate to `slicer.packaging`.

**New/updated functions:**

| Function | Purpose |
|----------|---------|
| `slicer.packaging.load_requirements(path)` | Load a `requirements.txt` file into `Requirement` objects |
| `slicer.packaging.load_pyproject_dependencies(path)` | Load `[project.dependencies]` from a `pyproject.toml` file into `Requirement` objects |
| `slicer.packaging.pip_check(reqs)` | Check if requirements are satisfied (pure Python, no subprocess). Accepts a string, a list of strings, a `Requirement`, or a list of `Requirement`s. |
| `slicer.packaging.pip_install(...)` | Canonical home; extended with modal progress dialog, non-blocking mode, status bar feedback, `--no-deps` support, and a discouraged `skip_packages` workaround for transitive dependency conflicts. Also available as `slicer.util.pip_install` (backward-compatible wrapper) |
| `slicer.packaging.pip_ensure(reqs, requester="...")` | High-level: checks, prompts, installs with progress, and offers restart if updated packages were already imported. Accepts the same flexible input as `pip_check`. |

All install functions support optional `constraints` (constraints file), `no_deps_requirements` (packages to install with `--no-deps`), and `skip_packages` (packages to exclude from the transitive dependency tree) parameters.

**Typical usage in an extension:**

```python
import slicer.packaging

reqs = slicer.packaging.load_requirements(self.resourcePath("requirements.txt"))
slicer.packaging.pip_ensure(reqs, requester="MyExtension")
import my_dependency  # Now safe
```

Or, with `pyproject.toml`:

```python
import slicer.packaging

reqs = slicer.packaging.load_pyproject_dependencies(self.resourcePath("pyproject.toml"))
slicer.packaging.pip_ensure(reqs, requester="MyExtension")
import my_dependency  # Now safe
```

With `skip_packages` (for extensions that need to exclude certain transitive dependencies; **discouraged workaround**, see [the script repository](https://github.com/Slicer/Slicer/blob/main/Docs/developer_guide/script_repository/packaging.md) for guidance):

```python
import slicer.packaging

skipped = slicer.packaging.pip_ensure(
    "nnunetv2>=2.3",
    skip_packages=["SimpleITK", "torch", "requests"],
    requester="SlicerNNUNet",
)
# skipped contains the requirement strings that were excluded
```

**Behavior of `pip_install`:**

Four operating modes:

- `show_progress=True, blocking=True` : Modal progress dialog (new default behavior)
- `show_progress=True, blocking=False`: Status bar messages
- `show_progress=False, blocking=True`: Busy cursor only (the previous default behavior, except with a busy cursor now added)
- `show_progress=False, blocking=False`: No visual indication that anything is happening (without looking at python console); specify callbacks to create more reasonable custom behaviors.

## Changes

The PR is organized as 5 commits, each a self-contained change:

1. **`ENH: Add slicer.packaging module for managing Python dependencies`**
   - `Base/Python/slicer/packaging.py` (new) — `load_requirements`, `load_pyproject_dependencies`, `pip_check`, `pip_ensure`, `pip_install`, `pip_uninstall`, the non-blocking infrastructure, the modal progress dialog, the restart prompt, and the `skip_packages` workaround
   - `Base/Python/slicer/util.py` — backward-compatible `pip_install` / `pip_uninstall` wrappers that delegate to `slicer.packaging`; updated error messages to point at the canonical name
   - `Base/Python/slicer/tests/test_slicer_packaging.py` (new) — full unit test suite for the new module
   - `Base/Python/slicer/tests/test_slicer_util_pip.py` (new) — focused tests for the back-compat wrappers
   - `Base/Python/CMakeLists.txt` — register the new module
   - `Applications/SlicerApp/Testing/Python/CMakeLists.txt` — register the test files

2. **`DOC: Document slicer.packaging in the developer guide`**
   - `Docs/developer_guide/script_repository/packaging.md` (new) — full "Python package management" section in the script repository
   - `Docs/developer_guide/script_repository.md` — include directive
   - `Docs/developer_guide/python_faq.md` — point developers at `slicer.packaging`, recommend `pip_ensure` as the high-level workflow, refresh the best-practices list to reflect that `pip_ensure` handles confirmation on its own
   - `Docs/developer_guide/script_repository/gui.md`, `models.md`, `plots.md` — sweep existing examples to use the canonical name
   - `Docs/developer_guide/slicer.md` — wire `slicer.packaging` into the auto-generated API reference

3. **`ENH: Show slicer.packaging usage in the new scripted module template`**
   - `Utilities/Templates/Modules/Scripted/TemplateKey.py` — commented-out `pip_ensure` example at the top of `onApplyButton`
   - `Utilities/Templates/Modules/Scripted/Resources/requirements.txt` (new) — blank scaffold
   - `Utilities/Templates/Modules/Scripted/CMakeLists.txt` — list the requirements file as a module resource
   - `Utilities/Scripts/SlicerWizard/TemplateManager.py` — recognize `requirements.txt` as a template file so it actually rides along when the wizard generates a new module

4. **`BUG: Clean up Python interactor startup`**
   - `Base/Python/slicerqt.py` (renamed from `Base/Python/slicer/slicerqt.py`) — moved out of the `slicer/` package directory so that CTK's `executeFile` no longer puts `bin/Python/slicer/` on `sys.path[0]` (which silently shadowed any same-named PyPI package, including the one we wanted for this PR). The wildcard `from slicer.util import *` is replaced with an explicit 5-name list (`array`, `exit`, `getNode`, `getNodesByClass`, `mainWindow`).
   - `Base/QTGUI/qSlicerPythonManager.cxx` — updated path
   - `Base/Python/CMakeLists.txt` — register the new location

5. **`BUG: Allow i18n translation functions to work without Qt`**
   - `Base/Python/slicer/i18n.py` — `translate()` no longer crashes when `slicer.app` is unavailable; it returns the untranslated text instead. This is what made it possible to wrap user-facing strings in `slicer.packaging` with `_()` while keeping the module headless-safe.

---

<details>
<summary><strong>Testing Snippets (click to expand)</strong></summary>

Convenient snippets to quickly try things. First, run this once in the Python console:

```python
import slicer.packaging
```

### load_requirements

```python
import tempfile, os
with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
    f.write("numpy>=1.20\npandas>=2.0\nscipy\n")
    path = f.name
reqs = slicer.packaging.load_requirements(path)
print([f"{r.name}: {r.specifier}" for r in reqs])
os.unlink(path)
```

### load_pyproject_dependencies

```python
import tempfile, os
with tempfile.NamedTemporaryFile(mode='w', suffix='.toml', delete=False) as f:
    f.write("[project]\ndependencies = [\n")
    f.write('    "numpy>=1.20",\n    "pandas>=2.0",\n    "scipy",\n]\n')
    path = f.name
reqs = slicer.packaging.load_pyproject_dependencies(path)
print([f"{r.name}: {r.specifier}" for r in reqs])
os.unlink(path)
```

### pip_check

```python
# Simple string syntax
slicer.packaging.pip_check("numpy>=1.0")          # True
slicer.packaging.pip_check("numpy>=99999.0")       # False
slicer.packaging.pip_check("nonexistent-package-xyz")  # False

# Multiple requirements in a single space-separated string
slicer.packaging.pip_check("numpy>=1.0 scipy>=1.0")  # True

# Markers that don't apply are considered satisfied
slicer.packaging.pip_check("foo; sys_platform == 'nonexistent'")  # True

# A list of strings also works
slicer.packaging.pip_check(["numpy>=1.0", "scipy>=1.0"])  # True

# Or a packaging.requirements.Requirement object, if you already have one
from packaging.requirements import Requirement
slicer.packaging.pip_check(Requirement("numpy>=1.0"))  # True
```

### pip_install with progress dialog (default)

```python
# Default: shows modal progress dialog, blocks until complete
# (If already installed, completes quickly with "already satisfied")
slicer.packaging.pip_install("scikit-image", requester="ReviewTest")
```

To see the full installation flow, uninstall first:
```python
slicer.packaging.pip_uninstall("scikit-image")
slicer.packaging.pip_install("scikit-image", requester="ReviewTest")
```

If it's still too fast, try putting "torch" as the package :)

### pip_install without progress dialog

```python
# Busy cursor only, no dialog
slicer.packaging.pip_install("scikit-image", show_progress=False)
```

### Non-blocking pip_install with status bar messages

```python
slicer.packaging.pip_install("scikit-image", blocking=False, requester="ReviewTest")
```

### Non-blocking pip_install with custom callbacks

```python
def onLog(line):
    print(f"[pip] {line}")

def onComplete(code):
    print(f"Done! Return code: {code}")

# Using --help to see callbacks firing with lots of output
slicer.packaging.pip_install("--help", blocking=False, show_progress=False, logCallback=onLog, completedCallback=onComplete)
```

### Backward-compat wrappers in slicer.util

The old `slicer.util.pip_install` and `slicer.util.pip_uninstall` still work; they delegate to `slicer.packaging`. Quick sanity check:

```python
slicer.util.pip_install("charset-normalizer")
slicer.util.pip_uninstall("charset-normalizer")
```

### Check if pip install is in progress

```python
slicer.packaging.pip_install("scikit-image", blocking=False, requester="ReviewTest")
print(slicer.packaging.isPipInstallInProgress())  # probably True
```

versus just this:

```python
print(slicer.packaging.isPipInstallInProgress())  # False
```

### pip_ensure

```python
# With prompt dialog (default). Does nothing if already installed --
# uninstall first if you want to see the full install flow:
#   slicer.packaging.pip_uninstall("charset-normalizer")
slicer.packaging.pip_ensure("charset-normalizer>=3.0", requester="ReviewTest")

# Without install prompt
slicer.packaging.pip_ensure("charset-normalizer>=3.0", prompt_install=False, requester="ReviewTest")
```

### pip_ensure restart prompt

After installation, `pip_ensure` checks if any updated packages were already imported in the current session. If so, it shows a "Restart Recommended" dialog with details (old → new versions). The user can restart immediately or continue.

```python
import numpy  # Ensure numpy is in sys.modules

# Reinstall numpy (already imported) -- should trigger restart prompt
slicer.packaging.pip_uninstall("numpy")
slicer.packaging.pip_ensure("numpy>=1.0", requester="ReviewTest")
# A "Restart Recommended" dialog should appear because numpy was already imported
```

To disable the restart prompt: `slicer.packaging.pip_ensure("numpy>=1.0", prompt_restart=False)`

### With constraints file

```python
import tempfile, os

# Create a constraints file that pins charset-normalizer
with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
    f.write("charset-normalizer==3.3.2\n")
    constraints_path = f.name

# Install requests (which depends on charset-normalizer) with the constraint
slicer.packaging.pip_install("requests", constraints=constraints_path)
os.unlink(constraints_path)
```

### With skip_packages (selective dependency installation)

> **Note:** `skip_packages` is a discouraged workaround for transitive dependency conflicts; see the script repository's "Python package management" section for guidance.

```python
# Install scikit-image but skip imageio (one of its dependencies)
skipped = slicer.packaging.pip_install(
    "scikit-image",
    skip_packages=["imageio"],
    requester="ReviewTest",
)
print(f"Skipped: {skipped}")

# Or via pip_ensure:
skipped = slicer.packaging.pip_ensure(
    "scikit-image>=0.20",
    skip_packages=["imageio"],
    requester="ReviewTest",
)
```

### PythonSlicer (command-line) usage

Run this from a terminal using Slicer's PythonSlicer executable (not the Slicer Python console):

```bash
/path/to/PythonSlicer -c "import slicer.packaging; slicer.packaging.pip_install('charset-normalizer')"
```

This verifies that `pip_install` works in the PythonSlicer environment where `slicer.app` and Qt are not available. The function automatically falls back to simple blocking mode.

</details>

---

<details>
<summary><strong>Design Rationale (click to expand)</strong></summary>

### Why requirements.txt? And why also pyproject.toml?

`requirements.txt` is the primary recommended format. Slicer extensions aren't Python packages — they just need "install these things into this environment," which is exactly what `requirements.txt` is for. It's pip's native input format, every Python developer knows it, and it requires no boilerplate beyond the dependency list itself.

That said, `pyproject.toml` is the modern standard in the Python ecosystem (PEP 621). It offers structured parsing via `tomllib` (stdlib) with no ad-hoc text handling, and extensions that already have a `pyproject.toml` for other tooling (ruff, pytest, etc.) can keep dependencies in one file. So we provide `load_pyproject_dependencies` as an alternative for extensions that prefer it.

Both formats boil down to PEP 508 dependency strings. Both loader functions return the same `list[Requirement]` type, so the downstream API (`pip_check`, `pip_ensure`, `pip_install`) works identically regardless of which one you use.

`load_pyproject_dependencies` reads only the `[project.dependencies]` list. Other fields in the `[project]` table (`name`, `version`, etc.) are not read or validated — extensions aren't Python packages and shouldn't need to provide them.

### Why pure-Python pip_check instead of pip --dry-run?

Installing is not done frequently, but _checking_ may be called frequently. A pure-Python implementation using `importlib.metadata` avoids the overhead of a subprocess. If we used `pip --dry-run` it would have to be a subprocess.

### Why explicit pip_ensure instead of lazy import magic?

We considered [LazyImportGroup](https://github.com/Slicer/Slicer/issues/7707) which intercepts first use of imports to trigger installation. It is elegant, but it reduces transparency and makes debugging harder for extension developers. For now we get this pattern which has more boilerplate but is more transparent and simple to debug:

```python
slicer.packaging.pip_ensure(reqs, requester="MyExtension")
import my_dependency  # Explicit, debuggable
```

IDE support works via `TYPE_CHECKING`:
```python
from typing import TYPE_CHECKING
if TYPE_CHECKING:
    import my_dependency  # For type hints only
```

We can still consider the lazy import ideas in the future -- the lower level tools here would still be useful.

### Why `pip_install` now defaults to showing a progress dialog

Before this PR, `pip_install` was always blocking with no progress feedback. The new defaults (`blocking=True`, `show_progress=True`) mean existing code that calls `pip_install` will now get a modal progress dialog "for free" without any code changes. This improves UX for many extensions immediately, while still allowing opt-out via `show_progress=False`.

Hopefully it doesnt' break too many extensions...

### Prevention of multiple non-blocking pip installs

When `pip_install` runs with `blocking=False`, it returns immediately while pip runs in the background. If another non-blocking `pip_install` is started before the first completes then we get chaos.

The solution adopted here is a module-level `_pip_install_in_progress` flag that raises `RuntimeError` if a second non-blocking install is attempted. Developers can check `isPipInstallInProgress()` first if they want to guard against this themselves.

### Why `no_deps_requirements` parameter

Some Python packages declare overly strict dependency requirements that conflict with other packages in Slicer's environment. The standard workaround requires two separate pip calls:

```python
pip_install("--no-deps problematic-package==1.0")  # Ignore its deps
pip_install("numpy scipy")  # Install known-good deps manually
```

The `no_deps_requirements` parameter handles this two-step process internally, making the intent self-documenting:

```python
pip_install(requirements="numpy scipy", no_deps_requirements="problematic-pkg==1.0")
```

This also correctly handles non-blocking mode by chaining the two pip calls internally.

### Why `skip_packages` parameter

`skip_packages` is a discouraged workaround, included reluctantly because it solves a real problem that has no clean alternative for some packages.

Multiple Slicer extensions (SlicerTotalSegmentator, SlicerNNUNet) independently implement ~70-90 lines of recursive selective-install code to install packages while excluding certain transitive dependencies. Common examples: SimpleITK (Slicer bundles a custom version), torch (must be installed via SlicerPyTorch for the correct CUDA/CPU build), and requests (already bundled, replacing it forces an unnecessary restart). For packages like nnUNet with deep transitive dependency trees, manually enumerating the full dependency list (the alternative `no_deps_requirements` approach) would impose a significant maintenance burden across every upstream version bump.

The `skip_packages` parameter centralizes this logic so extensions don't each reinvent it. When provided, each package is installed with `--no-deps`, its dependency tree is walked recursively, and any package matching the skip list is excluded. Package METADATA is updated after installation so that `pip check` doesn't flag skipped packages as missing.

The downsides are real: METADATA scrubbing hides genuine conflicts, `pip show` no longer reflects the true dependency graph, and skip lists drift as Slicer's bundled packages change. Documentation discourages reaching for `skip_packages` first and points developers at upstream fixes or `no_deps_requirements` where those are tractable.

### `skip_packages` vs `no_deps_requirements`

Both are available; they serve different purposes:

- **`no_deps_requirements`**: "Install these packages without any of their deps." You provide the correct deps yourself. Fast (2 pip calls), doesn't modify METADATA. Use when a specific package has broken dependency declarations *and* the dependency tree is small enough to enumerate by hand.
- **`skip_packages`**: "Install everything except these specific packages, anywhere in the dependency tree." Automatic recursive walk with METADATA scrubbing. Slower (one pip call per package). The escape hatch for cases where the dependency tree is too deep to enumerate manually.

They are mutually exclusive — providing both raises `ValueError`.

### Why `pip_install` doesn't accept `list[Requirement]`

It would feel natural to write `pip_install(load_requirements("requirements.txt"))`. The fact that you can't is a little unfortunate — it looks like it *should* work. But `pip_install` is extremely widely used in the wild (via `slicer.util.pip_install`), and we don't want to make breaking changes to its signature. It's also a low-level function that mirrors the pip CLI, taking the same kind of string arguments you'd pass on the command line, so it makes sense to leave it working the way it does.

The new structured `list[Requirement]` input type goes into the new `slicer.packaging` functions instead: `pip_check` and `pip_ensure`. In practice, `slicer.packaging.pip_ensure(load_requirements("requirements.txt"))` is the call you want anyway -- it checks what's already installed, prompts the user, installs only what's missing, and detects whether a restart is needed. So accepting `Requirement` objects at the `pip_ensure` level rather than the `pip_install` level steers developers toward the safer, idempotent workflow.

### Why `pip_` function naming

The new functions follow the existing naming convention established by `slicer.util.pip_install` and `slicer.util.pip_uninstall`. All pip-related functions now live together in `slicer.packaging` with the `pip_` prefix, providing a consistent, discoverable API.

### Why `slicer.packaging` (module naming)

`slicer.packaging` was always the preferred name -- it's descriptive and mirrors the well-known third-party `packaging` library. Getting there involved an unexpected detour.

The first attempt at the name failed: `slicer/packaging.py` shadowed the third-party `packaging` library, breaking `from packaging.requirements import Requirement` everywhere. Tracing the root cause led to CTK: `ctkAbstractPythonManager::executeFile` prepends the executed script's directory to `sys.path[0]` and never removes it. Since Slicer runs `slicerqt.py` at startup, and `slicerqt.py` lived inside `bin/Python/slicer/`, that directory landed on `sys.path[0]` -- which silently promoted every file inside the `slicer/` package to a top-level module name and shadowed any PyPI package of the same name.

The Slicer-side fix is to move `slicerqt.py` out of the `slicer/` package directory (commit 4 in this PR). With `slicerqt.py` at `bin/Python/`, CTK's prepend lands on a path that's already on `sys.path`, so the harmful side effect goes away. The CTK behavior is still a bug and worth fixing upstream separately, but the workaround on the Slicer side is good cleanup on its own merits: `slicerqt.py` is conceptually a startup script, not a member of the `slicer` package.

With `slicerqt.py` moved, `slicer.packaging` is once again a safe name and is what this PR ships.

### Why `import slicer.packaging` is explicit

You need `import slicer.packaging` to use it -- like any normal Python submodule. The reason this is even worth mentioning is that historically `slicer.util` works without an explicit import, because the interactor startup script reaches into the user's `__main__` namespace and pre-populates a handful of names from it. This PR narrows that startup pre-population from a wildcard to an explicit 5-name list (see commit 4), which is part of why the contrast is now sharper. There's no special reason `slicer.packaging` couldn't be added to that startup list; we chose not to because top-level Python module imports in `slicer.packaging` (e.g. `packaging.requirements`, `importlib.metadata`) would be paid by every Slicer session even though most never install a Python package, and "type one extra import line in your extension" is a trivial cost.

### Why `pip_uninstall` was also modified

While the focus of this work is on dependency installation, `pip_uninstall` was updated with the same non-blocking parameters (`blocking`, `logCallback`, `completedCallback`) for API consistency. Since both functions share the same underlying infrastructure (`launchConsoleProcess` and `_executePythonModule`) in `slicer.packaging`, extending non-blocking support to `pip_uninstall` required minimal additional code and ensures users have a symmetric API for both operations.

### Non-blocking implementation

The non-blocking mode uses a QTimer-based polling approach inspired by [SlicerMONAIAuto3DSeg](https://github.com/lassoan/SlicerMONAIAuto3DSeg). A background thread reads process output into a queue while QTimer polls from the main thread, keeping the Qt event loop responsive.

### How the restart prompt works

After `pip_ensure` installs packages, it snapshots all installed package versions (before and after) using `importlib.metadata`. For any packages whose version changed, it checks whether their top-level import names appear in `sys.modules` (meaning they were already imported in the current session). The distribution-to-import-name mapping uses `importlib.metadata.packages_distributions()` (Python 3.11+). If any already-imported packages were updated, a "Restart Recommended" dialog shows the affected packages with their old → new versions. The `prompt_restart=False` parameter disables this check.

</details>

---

<details>
<summary><strong>Interactive Feature Tour (click to expand)</strong></summary>

Build Slicer from the `python-dependency-handling-improvements` branch, launch it, open the Python console, and paste the script below. A menu lets you pick which demos to run — or select "Run All" for the full walkthrough.

```python
import importlib.metadata as _md
import os
import tempfile

import qt
from packaging.requirements import Requirement

import slicer
import slicer.packaging

# ---------------------------------------------------------------------------
# Configuration — change these to try a different demo package
# ---------------------------------------------------------------------------

DEMO_PACKAGE = "scikit-image"        # pip install name
DEMO_IMPORT = "skimage"              # Python import name
DEMO_CONSTRAINT = ">=0.20,<0.25"     # version range for constraints demo
DEMO_SKIP_DEP = "imageio"            # dependency to skip in skip_packages demo

# ---------------------------------------------------------------------------
# State
# ---------------------------------------------------------------------------

try:
    pkg_version_before_tour = _md.version(DEMO_PACKAGE)
except _md.PackageNotFoundError:
    pkg_version_before_tour = None


# ---------------------------------------------------------------------------
# Helpers
# ---------------------------------------------------------------------------

def clear_cache():
    """Purge the pip download cache so installs show real download progress."""
    slicer.packaging._executePythonModule("pip", ["cache", "purge"])


def uninstall_pkg():
    """Remove the demo package if present."""
    try:
        slicer.util.pip_uninstall(DEMO_PACKAGE)
    except Exception:
        pass


def fresh_slate():
    """Uninstall the demo package and clear the cache."""
    uninstall_pkg()
    clear_cache()


# ---------------------------------------------------------------------------
# Demo 1 — Loading Dependencies
# ---------------------------------------------------------------------------

def demo_loading_deps():
    """load_requirements() and load_pyproject_dependencies()"""

    # --- requirements.txt ---
    slicer.util.infoDisplay(
        "load_requirements(path) parses a requirements.txt file into\n"
        "Requirement objects, skipping comments, blanks, and pip options.\n"
        "\n"
        "Watch the Python console for parsed results.",
        windowTitle="Demo 1: Loading Dependencies — requirements.txt",
    )

    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
        f.write("# Example requirements file\n")
        f.write("numpy>=1.20\n")
        f.write(f"{DEMO_PACKAGE}>=0.20\n")
        f.write("nonexistent-package-xyz>=1.0\n")
        f.write("-c constraints.txt\n")
        f.write("\n")
        path = f.name

    reqs = slicer.packaging.load_requirements(path)
    os.unlink(path)

    lines = [f"  {r.name}  {r.specifier}" for r in reqs]
    print(f"[Tour] load_requirements -> {len(reqs)} requirements:\n" + "\n".join(lines))

    # --- pyproject.toml ---
    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
        f.write("[project]\n")
        f.write("dependencies = [\n")
        f.write('    "numpy>=1.20",\n')
        f.write(f'    "{DEMO_PACKAGE}>=0.20",\n')
        f.write('    "nonexistent-package-xyz>=1.0",\n')
        f.write("]\n")
        path = f.name

    reqs2 = slicer.packaging.load_pyproject_dependencies(path)
    os.unlink(path)

    lines2 = [f"  {r.name}  {r.specifier}" for r in reqs2]
    print(f"[Tour] load_pyproject_dependencies -> {len(reqs2)} requirements:\n" + "\n".join(lines2))

    slicer.util.infoDisplay(
        f"Loaded {len(reqs)} requirements from requirements.txt\n"
        f"and {len(reqs2)} from pyproject.toml.\n"
        "\n"
        "Both return the same Requirement objects — the downstream\n"
        "API (pip_check, pip_ensure) works identically with either.",
        windowTitle="Demo 1: Loading Dependencies — result",
    )


# ---------------------------------------------------------------------------
# Demo 2 — Checking Requirements
# ---------------------------------------------------------------------------

def demo_checking_reqs():
    """pip_check() — pure-Python requirement validation"""

    slicer.util.infoDisplay(
        "pip_check(req) checks if a requirement is satisfied.\n"
        "Pure Python, no subprocess — fast enough to call frequently.\n"
        "\n"
        "We will test several cases against the current environment.",
        windowTitle="Demo 2: Checking Requirements",
    )

    checks = [
        ("numpy>=1.0", "Bundled with Slicer — should be satisfied"),
        ("numpy>=99999.0", "Impossibly high version — should fail"),
        ("nonexistent-xyz>=1.0", "Package not installed"),
        ('foo; sys_platform == "nonexistent"', "Marker does not apply — treated as satisfied"),
    ]

    results = []
    for spec, desc in checks:
        req = Requirement(spec)
        ok = slicer.packaging.pip_check(req)
        mark = "SATISFIED" if ok else "NOT satisfied"
        results.append(f"  [{mark}]  {spec}\n      {desc}")

    slicer.util.infoDisplay(
        "pip_check results:\n"
        "\n" + "\n\n".join(results),
        windowTitle="Demo 2: Checking Requirements — results",
    )


# ---------------------------------------------------------------------------
# Demo 3 — Installing with Progress
# ---------------------------------------------------------------------------

def demo_install_progress():
    """pip_install() — modal dialog and non-blocking status bar"""

    # --- Part 1: Modal (blocking) ---
    fresh_slate()

    slicer.util.infoDisplay(
        "pip_install() — modal progress dialog (the new default).\n"
        "\n"
        "Try expanding the Details section!",
        windowTitle="Demo 3a: Modal Progress Dialog",
    )

    slicer.util.pip_install(DEMO_PACKAGE, requester="Feature Tour")

    slicer.util.infoDisplay(
        "Modal install done.\n"
        "\n"
        "Now switching to non-blocking mode: the call returns\n"
        "immediately and pip output appears in the status bar.",
        windowTitle="Demo 3a: Modal — done",
    )

    # --- Part 2: Non-blocking ---
    fresh_slate()

    slicer.util.infoDisplay(
        "pip_install() — non-blocking with status bar.\n"
        "\n"
        "Watch the STATUS BAR at the bottom. The UI stays interactive.\n"
        "isPipInstallInProgress() will be printed to the console.",
        windowTitle="Demo 3b: Status Bar Mode",
    )

    loop = qt.QEventLoop()
    _result = [None]

    def on_complete(return_code):
        _result[0] = return_code
        qt.QTimer.singleShot(0, loop.quit)

    slicer.util.pip_install(
        DEMO_PACKAGE,
        blocking=False,
        show_progress=True,
        requester="Feature Tour",
        completedCallback=on_complete,
    )

    # Check in-progress flag shortly after starting
    qt.QTimer.singleShot(500, lambda: print(
        f"[Tour] isPipInstallInProgress() = {slicer.packaging.isPipInstallInProgress()}"
    ))

    loop.exec_()

    slicer.util.infoDisplay(
        f"Non-blocking install finished (return code {_result[0]}).\n"
        "The status bar showed pip output while the UI stayed responsive.",
        windowTitle="Demo 3b: Status Bar — done",
    )


# ---------------------------------------------------------------------------
# Demo 4 — Smart Install Workflow
# ---------------------------------------------------------------------------

def demo_smart_install():
    """pip_ensure() — check, prompt, install, restart detection"""

    # --- Part 1: Normal pip_ensure ---
    fresh_slate()

    slicer.util.infoDisplay(
        "pip_ensure() — the recommended high-level API for extensions.\n"
        "Checks requirements, shows confirmation, installs with progress.\n"
        "\n"
        "You will see a confirmation dialog, then a progress dialog.",
        windowTitle="Demo 4a: pip_ensure",
    )

    reqs = [Requirement(f"{DEMO_PACKAGE}>=0.20")]
    slicer.packaging.pip_ensure(reqs, requester="Feature Tour")

    slicer.util.infoDisplay(
        "pip_ensure done. Now we will call it again immediately.\n"
        "\n"
        "pip_check sees the package is already installed, so\n"
        "pip_ensure skips everything — no dialogs, instant return.",
        windowTitle="Demo 4a: pip_ensure — done",
    )

    slicer.packaging.pip_ensure(reqs, requester="Feature Tour (no-op)")

    slicer.util.infoDisplay(
        "pip_ensure returned instantly — nothing to install.\n"
        "\n"
        "Now: restart prompt demo. We will import the package, uninstall\n"
        "it, then pip_ensure again. Since it is in memory, a restart\n"
        "dialog will appear. (Click NO when asked to restart to continue the tour.)",
        windowTitle="Demo 4a: pip_ensure — no-op verified",
    )

    # --- Part 2: Restart prompt ---
    import importlib
    mod = importlib.import_module(DEMO_IMPORT)
    print(f"[Tour] Imported {DEMO_IMPORT} {mod.__version__}")

    uninstall_pkg()
    clear_cache()

    slicer.packaging.pip_ensure(reqs, requester="Feature Tour (restart demo)")

    slicer.util.infoDisplay(
        "Restart prompt demonstrated.\n"
        "\n"
        "This helps users know when a restart is needed after\n"
        "updating packages that were already imported.",
        windowTitle="Demo 4b: Restart Prompt — done",
    )


# ---------------------------------------------------------------------------
# Demo 5 — Advanced Options
# ---------------------------------------------------------------------------

def demo_advanced_options():
    """Constraints file and skip_packages"""

    # --- Part 1: Constraints ---
    fresh_slate()

    slicer.util.infoDisplay(
        "Constraints file: limits which versions pip may install.\n"
        f"\n"
        f"Installing {DEMO_PACKAGE} constrained to {DEMO_CONSTRAINT}.",
        windowTitle="Demo 5a: Constraints",
    )

    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
        f.write(f"{DEMO_PACKAGE}{DEMO_CONSTRAINT}\n")
        constraints_path = f.name

    slicer.util.pip_install(
        DEMO_PACKAGE,
        constraints=constraints_path,
        requester="Feature Tour (constrained)",
    )
    os.unlink(constraints_path)

    ver = _md.version(DEMO_PACKAGE)
    slicer.util.infoDisplay(
        f"Installed {DEMO_PACKAGE} {ver} (constrained to {DEMO_CONSTRAINT}).\n"
        "\n"
        f"Now: skip_packages demo — installing {DEMO_PACKAGE}\n"
        f"while skipping '{DEMO_SKIP_DEP}' (one of its dependencies).\n"
        f"\n"
        f"First we uninstall {DEMO_SKIP_DEP} (if present) so we can\n"
        f"verify at the end that skip_packages actually prevented it.",
        windowTitle="Demo 5a: Constraints — done",
    )

    # --- Part 2: skip_packages ---
    fresh_slate()
    try:
        slicer.util.pip_uninstall(DEMO_SKIP_DEP)
    except Exception:
        pass

    skipped = slicer.util.pip_install(
        DEMO_PACKAGE,
        skip_packages=[DEMO_SKIP_DEP],
        requester="Feature Tour (skip_packages)",
    )

    lines = [f"  {s}" for s in (skipped or [])]
    print(f"[Tour] Skipped packages:\n" + "\n".join(lines))

    # Verify the metadata scrub: re-install normally, check the skipped dep
    slicer.util.pip_install(DEMO_PACKAGE, requester="Feature Tour (verify scrub)")
    dep_installed = slicer.packaging.pip_check(Requirement(DEMO_SKIP_DEP))

    slicer.util.infoDisplay(
        f"Skipped {len(skipped or [])} package(s).\n"
        f"{DEMO_SKIP_DEP} installed after normal re-install: {dep_installed}\n"
        "\n"
        "Re-installing normally did NOT pull in the skipped dependency\n"
        "because the metadata scrub removed it.",
        windowTitle="Demo 5b: skip_packages — verified",
    )


# ---------------------------------------------------------------------------
# Cleanup
# ---------------------------------------------------------------------------

def do_cleanup():
    """Restore the user's environment."""
    if pkg_version_before_tour is not None:
        msg = (
            f"{DEMO_PACKAGE} {pkg_version_before_tour} was installed before\n"
            "the tour. Restore it now?"
        )
    else:
        msg = f"Uninstall {DEMO_PACKAGE} to leave your environment clean?"

    if slicer.util.confirmYesNoDisplay(msg, windowTitle="Feature Tour — Cleanup"):
        if pkg_version_before_tour is not None:
            uninstall_pkg()
            slicer.util.pip_install(
                f"{DEMO_PACKAGE}=={pkg_version_before_tour}",
                requester="Feature Tour (restore)",
            )
        else:
            uninstall_pkg()

    slicer.util.infoDisplay(
        "Tour complete! For full API docs:\n"
        "  help(slicer.packaging.pip_ensure)",
        windowTitle="Feature Tour — Done",
    )


# ---------------------------------------------------------------------------
# Menu and main loop
# ---------------------------------------------------------------------------

MENU_ITEMS = [
    "1. Loading Dependencies",
    "2. Checking Requirements",
    "3. Installing with Progress",
    "4. Smart Install Workflow",
    "5. Advanced Options",
    "---",
    "Run All",
    "Exit Tour",
]

DEMO_FUNCS = {
    MENU_ITEMS[0]: demo_loading_deps,
    MENU_ITEMS[1]: demo_checking_reqs,
    MENU_ITEMS[2]: demo_install_progress,
    MENU_ITEMS[3]: demo_smart_install,
    MENU_ITEMS[4]: demo_advanced_options,
}

DEMO_ORDER = MENU_ITEMS[:5]


def run_tour():
    slicer.util.infoDisplay(
        "Welcome to the PR #9010 Feature Tour!\n"
        "\n"
        "Pick demos from the menu. Uses scikit-image as a demo package\n"
        "(configurable via DEMO_PACKAGE at the top of the script).\n"
        'Select "Run All" for the full experience.',
        windowTitle="Feature Tour — Welcome",
    )

    while True:
        dialog = qt.QInputDialog(slicer.util.mainWindow())
        dialog.setWindowTitle("Feature Tour")
        dialog.setLabelText("Choose a demo:")
        dialog.setComboBoxItems(MENU_ITEMS)
        dialog.setComboBoxEditable(False)

        if dialog.exec_() != qt.QDialog.Accepted:
            break

        choice = dialog.textValue()

        if choice == "Exit Tour" or choice == "---":
            break

        if choice == "Run All":
            for key in DEMO_ORDER:
                DEMO_FUNCS[key]()
        else:
            func = DEMO_FUNCS.get(choice)
            if func:
                func()

    do_cleanup()


# ---------------------------------------------------------------------------
# Start the tour
# ---------------------------------------------------------------------------

run_tour()
```

</details>

---

<details>
<summary><strong>References (click to expand)</strong></summary>

- This work is part of the [44th Slicer project week](https://projectweek.na-mic.org/PW44_2026_GranCanaria/Projects/PythonDependenciesInExtensions/)!
- [#7171 — Improving Support for Python Package Dependencies in Slicer Extensions](https://github.com/Slicer/Slicer/issues/7171) — This PR implements the "runtime installation" approach described in the issue: extensions declare dependencies via `requirements.txt`, and the new `slicer.packaging` module handles checking and installation with optional constraints file support for coordinating versions across extensions.
- [#7707 — Allow scripted modules to declare and lazily install pip requirements](https://github.com/Slicer/Slicer/issues/7707) — Proposes a `LazyImportGroup` context manager that intercepts imports and triggers installation on first attribute access. This PR takes a simpler, more explicit approach: developers call `pip_ensure()` at the point dependencies are needed, then import normally. The explicit pattern trades some elegance for transparency and easier debugging. The `LazyImportGroup` approach could potentially be built on top of the primitives provided by `slicer.packaging` (`load_requirements`, `pip_check`, `pip_install` with callbacks) if desired in the future. See #8181.
- At https://github.com/KitwareMedical/SlicerNNUnet/pull/21 is a demo of how some of the features here can simplify python dependency handling in the NNUnet extension.

</details>

