### PR TITLE
Add option for logarithmic color mapping

### DIFF
--- a/Docs/user_guide/modules/volumerendering.md
+++ b/Docs/user_guide/modules/volumerendering.md
@@ -92,7 +92,7 @@ See [video demo/tutorial of these steps](https://youtu.be/xZwyW6SaoM4?t=12) for 
     - Surface smoothing: check this checkbox to reduce staircase artifacts by adding a random noise pattern (jitter) to the raycasting lines
   - Volume Properties: Advanced views of the transfer functions.
     - Synchronize with Volumes module: show volume rendering with the same color mapping that is used in slice views
-      - Click: Apply once the properties (window/level, threshold, lut) of the Volumes module to the Volume Rendering module.
+      - Click: Apply once the properties (window/level, threshold, lut, scalar mapping mode) of the Volumes module to the Volume Rendering module.
       - Checkbox: By clicking on the checkbox, you can toggle the button. When toggled, any modification occurring in the Volumes module is continuously applied to the volume rendering
     - Control point properties: X = scalar value, O = opacity, M = mid-point, S = sharpness
     - Keyboard/mouse shortcuts:

--- a/Docs/user_guide/modules/volumes.md
+++ b/Docs/user_guide/modules/volumes.md
@@ -101,6 +101,10 @@ Note: Consumer file formats, such as jpg, png, and tiff are not well suited for 
   - Presets: Predefined volume display presets that set window/level and the lookup table for common visualization requirements.
   - Lookup Table: Select the color mapping for scalar volumes to colors.
   - Interpolate: When checked, slice views will display linearly interpolated slices through input volumes. Unchecked indicates nearest neighbor resampling
+  - Scalar Mapping Mode: Determines how scalar values within the window/level range are distributed across the lookup table. Useful for reducing saturation of the displayed image and emphasizing lower or higher intensity regions. In the formulas below, value is the voxel value being mapped, and colorIndex is the resulting normalized position (0-1 range) used to look up the corresponding color in the colormap.
+    - Linear (default): maps values proportionally. `colorIndex = (value - level + window/2) / window`
+    - Logarithmic: emphasizes the low end of the intensity range. `colorIndex = log10(1 + 9 * (value - level + window/2) / window)`
+    - Inverse logarithmic: emphasizes the high end of the intensity range. `colorIndex = 1 - log10(1 + 9 * (level + window/2 - value) / window)`
   - Window/Level Controls: Double slider with text input to define the range of input volume data that should be mapped to the display grayscale. Auto window level tries to estimate the intensity range of the foreground image data. An advanced options button can be clicked to display controls to add support for large dynamic range by giving control over the range of the window level double slider.
   - Threshold: Controls the range of the image that should be considered transparent when used in the foreground layer of the slice display. Same parameters also control transparency of slice models displayed in the 3D viewers.
   - Histogram: Shows the number of pixels (y axis) vs the image intensity (x axis) over a background of the current window/level and threshold mapping.

--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -150,6 +150,7 @@ set(MRMLCore_SRCS
   vtkDataIOManager.cxx
   vtkDataTransfer.cxx
   vtkEventBroker.cxx
+  vtkImageMapToWindowLevelAddon.cxx
   vtkImageMathematicsAddon.cxx
   vtkImplicitInvertableBoolean.cxx
   vtkMRMLAbstractLayoutNode.cxx

--- a/Libs/MRML/Core/vtkImageMapToWindowLevelAddon.cxx
+++ b/Libs/MRML/Core/vtkImageMapToWindowLevelAddon.cxx
@@ -1,0 +1,283 @@
+#include "vtkImageMapToWindowLevelAddon.h"
+
+#include "vtkDataArray.h"
+#include "vtkImageData.h"
+#include "vtkInformation.h"
+#include "vtkInformationVector.h"
+#include "vtkObjectFactory.h"
+#include "vtkPointData.h"
+#include "vtkScalarsToColors.h"
+
+#include <cmath>
+
+vtkStandardNewMacro(vtkImageMapToWindowLevelAddon);
+
+// Constructor sets default values
+vtkImageMapToWindowLevelAddon::vtkImageMapToWindowLevelAddon()
+{
+  this->MappingMode = WindowMappingMode::Linear;
+}
+
+vtkImageMapToWindowLevelAddon::~vtkImageMapToWindowLevelAddon() = default;
+
+//------------------------------------------------------------------------------
+// This method checks to see if we can simply reference the input data
+int vtkImageMapToWindowLevelAddon::RequestData(vtkInformation* request, vtkInformationVector** inputVector, vtkInformationVector* outputVector)
+{
+  vtkInformation* outInfo = outputVector->GetInformationObject(0);
+  vtkInformation* inInfo = inputVector[0]->GetInformationObject(0);
+
+  vtkImageData* outData = vtkImageData::SafeDownCast(outInfo->Get(vtkDataObject::DATA_OBJECT()));
+  vtkImageData* inData = vtkImageData::SafeDownCast(inInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+  // If LookupTable is null and window / level produces no change,
+  // then just pass the data
+  if (this->LookupTable == nullptr && this->MappingMode == WindowMappingMode::Linear
+      && (inData->GetScalarType() == VTK_UNSIGNED_CHAR && this->Window == 255 && this->Level == 127.5))
+  {
+    vtkDebugMacro("ExecuteData: LookupTable not set, "
+                  "Window / Level at default, "
+                  "passing input to output.");
+
+    outData->SetExtent(inData->GetExtent());
+    outData->GetPointData()->PassData(inData->GetPointData());
+    this->DataWasPassed = 1;
+  }
+  else
+  // normal behaviour - skip up a level since we don't want to
+  // call the superclasses ExecuteData - it would pass the data if there
+  // is no lookup table even if there is a window / level - wrong
+  // behavior.
+  {
+    if (this->DataWasPassed)
+    {
+      outData->GetPointData()->SetScalars(nullptr);
+      this->DataWasPassed = 0;
+    }
+
+    // NOLINTNEXTLINE(bugprone-parent-virtual-call)
+    return this->vtkThreadedImageAlgorithm::RequestData(request, inputVector, outputVector);
+  }
+
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+int vtkImageMapToWindowLevelAddon::RequestInformation(vtkInformation* vtkNotUsed(request), vtkInformationVector** inputVector, vtkInformationVector* outputVector)
+{
+  vtkInformation* inInfo = inputVector[0]->GetInformationObject(0);
+  vtkInformation* outInfo = outputVector->GetInformationObject(0);
+
+  vtkInformation* inScalarInfo = vtkDataObject::GetActiveFieldInformation(inInfo, vtkDataObject::FIELD_ASSOCIATION_POINTS, vtkDataSetAttributes::SCALARS);
+  if (!inScalarInfo)
+  {
+    vtkErrorMacro("Missing scalar field on input information!");
+    return 0;
+  }
+
+  // If LookupTable is null, mapping is linear, and window / level produces no change,
+  // then the data will be passed
+  if (this->LookupTable == nullptr && this->MappingMode == WindowMappingMode::Linear
+      && (inScalarInfo->Get(vtkDataObject::FIELD_ARRAY_TYPE()) == VTK_UNSIGNED_CHAR && this->Window == 255 && this->Level == 127.5))
+  {
+    // no lookup table, pass the input if it was VTK_UNSIGNED_CHAR
+    vtkDataObject::SetPointDataActiveScalarInfo(outInfo, VTK_UNSIGNED_CHAR, inScalarInfo->Get(vtkDataObject::FIELD_NUMBER_OF_COMPONENTS()));
+  }
+  else // the lookup table was set or window / level produces a change
+  {
+    int numComponents = 4;
+    switch (this->OutputFormat)
+    {
+      case VTK_RGBA: numComponents = 4; break;
+      case VTK_RGB: numComponents = 3; break;
+      case VTK_LUMINANCE_ALPHA: numComponents = 2; break;
+      case VTK_LUMINANCE: numComponents = 1; break;
+      default: vtkErrorMacro("ExecuteInformation: Unrecognized color format."); break;
+    }
+    vtkDataObject::SetPointDataActiveScalarInfo(outInfo, VTK_UNSIGNED_CHAR, numComponents);
+  }
+
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+// This non-templated function executes the filter for any type of data.
+template <class T>
+void vtkImageMapToWindowLevelAddonExecute(vtkImageMapToWindowLevelAddon* self, vtkImageData* inData, T* inPtr, vtkImageData* outData, unsigned char* outPtr, int outExt[6], int id)
+{
+  int idxX, idxY, idxZ;
+  int extX, extY, extZ;
+  vtkIdType inIncX, inIncY, inIncZ;
+  vtkIdType outIncX, outIncY, outIncZ;
+  unsigned long count = 0;
+  unsigned long target;
+  int dataType = inData->GetScalarType();
+  int numberOfComponents, numberOfOutputComponents, outputFormat;
+  int rowLength;
+  vtkScalarsToColors* lookupTable = self->GetLookupTable();
+  unsigned char* outPtr1;
+  T* inPtr1;
+  unsigned char* optr;
+  T* iptr;
+
+  double window = self->GetWindow();
+  double level = self->GetLevel();
+  double lower = level - window / 2.0;
+  double upper = lower + window;
+
+  // Precompute all per-frame invariants so the pixel loop is branch-free
+  // with respect to window orientation and mode selection.
+  const bool invertWindow = (lower > upper);
+  if (invertWindow)
+  {
+    std::swap(lower, upper);
+  }
+  // rangeWidth >= 0; if 0 the boundary checks below cover every pixel
+  const double rangeWidth = upper - lower;
+  const auto mappingMode = self->GetMappingMode();
+
+  // find the region to loop over
+  extX = outExt[1] - outExt[0] + 1;
+  extY = outExt[3] - outExt[2] + 1;
+  extZ = outExt[5] - outExt[4] + 1;
+
+  target = static_cast<unsigned long>(extZ * extY / 50.0);
+  target++;
+
+  // Get increments to march through data
+  inData->GetContinuousIncrements(outExt, inIncX, inIncY, inIncZ);
+
+  outData->GetContinuousIncrements(outExt, outIncX, outIncY, outIncZ);
+  numberOfComponents = inData->GetNumberOfScalarComponents();
+  numberOfOutputComponents = outData->GetNumberOfScalarComponents();
+  outputFormat = self->GetOutputFormat();
+
+  rowLength = extX * numberOfComponents;
+
+  // Loop through output pixels
+  outPtr1 = outPtr;
+  inPtr1 = inPtr + self->GetActiveComponent();
+  for (idxZ = 0; idxZ < extZ; idxZ++)
+  {
+    for (idxY = 0; !self->AbortExecute && idxY < extY; idxY++)
+    {
+      if (!id)
+      {
+        if (!(count % target))
+        {
+          self->UpdateProgress(count / (50.0 * target));
+        }
+        count++;
+      }
+
+      iptr = inPtr1;
+      optr = outPtr1;
+
+      if (lookupTable)
+      {
+        lookupTable->MapScalarsThroughTable2(inPtr1, outPtr1, dataType, extX, numberOfComponents, outputFormat);
+        for (idxX = 0; idxX < extX; idxX++)
+        {
+          const double windowFactor = vtkImageMapToWindowLevelAddon::computeWindowFactor( //
+            static_cast<double>(*iptr),
+            lower,
+            upper,
+            rangeWidth,
+            invertWindow,
+            mappingMode);
+          *optr = static_cast<unsigned char>(*optr * windowFactor);
+          switch (outputFormat)
+          {
+            case VTK_RGBA:
+              *(optr + 1) = static_cast<unsigned char>(*(optr + 1) * windowFactor);
+              *(optr + 2) = static_cast<unsigned char>(*(optr + 2) * windowFactor);
+              *(optr + 3) = 255;
+              break;
+            case VTK_RGB:
+              *(optr + 1) = static_cast<unsigned char>(*(optr + 1) * windowFactor);
+              *(optr + 2) = static_cast<unsigned char>(*(optr + 2) * windowFactor);
+              break;
+            case VTK_LUMINANCE_ALPHA: *(optr + 1) = 255; break;
+          }
+          iptr += numberOfComponents;
+          optr += numberOfOutputComponents;
+        }
+      }
+      else
+      {
+        for (idxX = 0; idxX < extX; idxX++)
+        {
+          const unsigned char result_val = static_cast<unsigned char>( //
+            255.0
+            * vtkImageMapToWindowLevelAddon::computeWindowFactor( //
+              static_cast<double>(*iptr),
+              lower,
+              upper,
+              rangeWidth,
+              invertWindow,
+              mappingMode));
+          *optr = result_val;
+          switch (outputFormat)
+          {
+            case VTK_RGBA:
+              *(optr + 1) = result_val;
+              *(optr + 2) = result_val;
+              *(optr + 3) = 255;
+              break;
+            case VTK_RGB:
+              *(optr + 1) = result_val;
+              *(optr + 2) = result_val;
+              break;
+            case VTK_LUMINANCE_ALPHA: *(optr + 1) = 255; break;
+          }
+          iptr += numberOfComponents;
+          optr += numberOfOutputComponents;
+        }
+      }
+      outPtr1 += outIncY + extX * numberOfOutputComponents;
+      inPtr1 += inIncY + rowLength;
+    }
+    outPtr1 += outIncZ;
+    inPtr1 += inIncZ;
+  }
+}
+
+//------------------------------------------------------------------------------
+// This method is passed a input and output data, and executes the filter
+// algorithm to fill the output from the input.
+
+void vtkImageMapToWindowLevelAddon::ThreadedRequestData(vtkInformation* vtkNotUsed(request),
+                                                        vtkInformationVector** vtkNotUsed(inputVector),
+                                                        vtkInformationVector* vtkNotUsed(outputVector),
+                                                        vtkImageData*** inData,
+                                                        vtkImageData** outData,
+                                                        int outExt[6],
+                                                        int id)
+{
+  void* inPtr = inData[0][0]->GetScalarPointerForExtent(outExt);
+  void* outPtr = outData[0]->GetScalarPointerForExtent(outExt);
+
+  switch (inData[0][0]->GetScalarType())
+  {
+    vtkTemplateMacro(vtkImageMapToWindowLevelAddonExecute(this, inData[0][0], static_cast<VTK_TT*>(inPtr), outData[0], static_cast<unsigned char*>(outPtr), outExt, id));
+    default: vtkErrorMacro(<< "Execute: Unknown ScalarType"); return;
+  }
+}
+
+void vtkImageMapToWindowLevelAddon::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+  os << indent << "WindowMappingMode: " << this->MappingMode << endl;
+}
+
+// --------------------------------------------------------------------------
+vtkImageMapToWindowLevelAddon::WindowMappingMode vtkImageMapToWindowLevelAddon::GetMappingMode() const
+{
+  return this->MappingMode;
+}
+
+// --------------------------------------------------------------------------
+void vtkImageMapToWindowLevelAddon::SetMappingMode(vtkImageMapToWindowLevelAddon::WindowMappingMode mappingMode)
+{
+  this->MappingMode = mappingMode;
+}

--- a/Libs/MRML/Core/vtkImageMapToWindowLevelAddon.h
+++ b/Libs/MRML/Core/vtkImageMapToWindowLevelAddon.h
@@ -1,0 +1,137 @@
+/*==============================================================================
+
+  Copyright (c) TBD
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Alex Allphin, PhD at Revvity.
+
+==============================================================================*/
+/**
+ * @class   vtkImageMapToWindowLevelAddon
+ * @brief   Subclass of vtkImageMapToWindowLevelColors that adds the option to compress values within the window logarithmically.
+ *
+ * This class is a subclass of vtkImageMapToWindowLevelColors that adds optional logarithmic window compression.
+ *
+ * In the long term, this class may be removed and the functionality added to vtkImageMapToWindowLevelColors, if it is found to be useful.
+ */
+
+#ifndef vtkImageMapToWindowLevelAddon_h
+#define vtkImageMapToWindowLevelAddon_h
+
+// Standard includes
+#include <algorithm> // For clamp
+#include <cmath>     // For log10
+
+// VTK includes
+#include "vtkImageMapToWindowLevelColors.h"
+
+// MRML includes
+#include "vtkMRML.h"
+
+class VTK_MRML_EXPORT vtkImageMapToWindowLevelAddon : public vtkImageMapToWindowLevelColors
+{
+public:
+  vtkTypeMacro(vtkImageMapToWindowLevelAddon, vtkImageMapToWindowLevelColors);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+  static vtkImageMapToWindowLevelAddon* New();
+
+  /// Window Scalar Mapping Modes
+  enum WindowMappingMode
+  {
+    Linear = 0,
+    Logarithmic,        // emphasize low values
+    InverseLogarithmic, // emphasize high values
+  };
+
+  /// Method for mapping/compressing scalar values to the window range
+  /// \sa mappingMode, SetMappingMode
+  WindowMappingMode GetMappingMode() const;
+
+  /// Set the method for mapping/compressing scalar values to the window range
+  /// \sa GetMappingMode
+  void SetMappingMode(vtkImageMapToWindowLevelAddon::WindowMappingMode mappingMode);
+
+  /// Maps inputValue within [rangeMin, rangeMax] to [0, 1].
+  /// A negative window (rangeMin > rangeMax) inverts the output direction.
+  template <typename T>
+  static inline double mapScalarToWindow(T inputValue, double rangeMin, double rangeMax, WindowMappingMode mappingMode) noexcept
+  {
+    static_assert(std::is_arithmetic_v<T>, "mapScalarToWindow requires numeric input");
+    if (rangeMin == rangeMax)
+    {
+      return 0.0;
+    }
+    const bool invertWindow = (rangeMin > rangeMax);
+    if (invertWindow)
+    {
+      std::swap(rangeMin, rangeMax);
+    }
+    const double rangeWidth = rangeMax - rangeMin;
+    return computeWindowFactor(static_cast<double>(inputValue), rangeMin, rangeMax, rangeWidth, invertWindow, mappingMode);
+  }
+
+protected:
+  vtkImageMapToWindowLevelAddon();
+  ~vtkImageMapToWindowLevelAddon() override;
+
+  int RequestInformation(vtkInformation*, vtkInformationVector**, vtkInformationVector*) override;
+  void ThreadedRequestData(vtkInformation* request,
+                           vtkInformationVector** inputVector,
+                           vtkInformationVector* outputVector,
+                           vtkImageData*** inData,
+                           vtkImageData** outData,
+                           int outExt[6],
+                           int id) override;
+  int RequestData(vtkInformation* request, vtkInformationVector** inputVector, vtkInformationVector* outputVector) override;
+
+  WindowMappingMode MappingMode;
+
+private:
+  template <class T>
+  friend void vtkImageMapToWindowLevelAddonExecute(vtkImageMapToWindowLevelAddon*, vtkImageData*, T*, vtkImageData*, unsigned char*, int[6], int);
+
+  /// Core per-pixel mapping. Pre-conditions: lower <= upper, rangeWidth == upper - lower.
+  /// Returns a value in [0, 1]; invertWindow flips the direction to [1, 0].
+  static inline double computeWindowFactor( //
+    double inVal,
+    double lower,
+    double upper,
+    double rangeWidth,
+    bool invertWindow,
+    WindowMappingMode mappingMode) noexcept
+  {
+    double factor;
+    if (inVal <= lower)
+    {
+      factor = 0.0;
+    }
+    else if (inVal >= upper)
+    {
+      factor = 1.0;
+    }
+    else
+    {
+      // lower < inVal < upper, so 0 < t < 1, therefore no clamping needed
+      const double t = (inVal - lower) / rangeWidth;
+      switch (mappingMode)
+      {
+        case WindowMappingMode::Logarithmic: factor = std::log10(1.0 + 9.0 * t); break;
+        case WindowMappingMode::InverseLogarithmic: factor = 1.0 - std::log10(1.0 + 9.0 * (1.0 - t)); break;
+        default: factor = t; break;
+      }
+    }
+    return invertWindow ? 1.0 - factor : factor;
+  }
+
+  vtkImageMapToWindowLevelAddon(const vtkImageMapToWindowLevelAddon&) = delete;
+  void operator=(const vtkImageMapToWindowLevelAddon&) = delete;
+};
+#endif

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.cxx
@@ -29,7 +29,7 @@ Version:   $Revision: 1.2 $
 #include <vtkImageExtractComponents.h>
 #include <vtkImageLogic.h>
 #include <vtkImageMathematics.h>
-#include <vtkImageMapToWindowLevelColors.h>
+#include <vtkImageMapToWindowLevelAddon.h>
 #include <vtkImageShiftScale.h>
 #include <vtkImageThreshold.h>
 #include <vtkMatrix4x4.h>

--- a/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeDisplayNode.cxx
@@ -19,7 +19,7 @@ Version:   $Revision: 1.2 $
 #include <vtkImageAppendComponents.h>
 #include <vtkImageData.h>
 #include <vtkImageExtractComponents.h>
-#include <vtkImageMapToWindowLevelColors.h>
+#include <vtkImageMapToWindowLevelAddon.h>
 #include <vtkImageThreshold.h>
 #include <vtkObjectFactory.h>
 #include <vtkVersion.h>

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
@@ -17,6 +17,7 @@ Version:   $Revision: 1.2 $
 #include "vtkMRMLScene.h"
 #include "vtkMRMLProceduralColorNode.h"
 #include "vtkMRMLVolumeNode.h"
+#include "vtkImageMapToWindowLevelAddon.h"
 
 // VTK includes
 #include <vtkAlgorithmOutput.h>
@@ -27,7 +28,6 @@ Version:   $Revision: 1.2 $
 #include <vtkImageExtractComponents.h>
 #include <vtkImageHistogramStatistics.h>
 #include <vtkImageLogic.h>
-#include <vtkImageMapToWindowLevelColors.h>
 #include <vtkImageStencil.h>
 #include <vtkImageThreshold.h>
 #include <vtkObjectFactory.h>
@@ -55,6 +55,7 @@ vtkMRMLScalarVolumeDisplayNode::vtkMRMLScalarVolumeDisplayNode()
   this->AutoThreshold = 0;
   this->ApplyThreshold = 0;
   this->InvertDisplayScalarRange = 0;
+  this->WindowMappingMethod = vtkImageMapToWindowLevelAddon::Linear;
 
   // try setting a default grayscale color map
   // this->SetDefaultColorMap(0);
@@ -69,10 +70,11 @@ vtkMRMLScalarVolumeDisplayNode::vtkMRMLScalarVolumeDisplayNode()
   this->ExtractAlpha = vtkImageExtractComponents::New();
   this->MultiplyAlpha = vtkImageStencil::New();
 
-  this->MapToWindowLevelColors = vtkImageMapToWindowLevelColors::New();
+  this->MapToWindowLevelColors = vtkImageMapToWindowLevelAddon::New();
   this->MapToWindowLevelColors->SetOutputFormatToLuminance();
   this->MapToWindowLevelColors->SetWindow(256.);
   this->MapToWindowLevelColors->SetLevel(128.);
+  this->SetWindowMappingMethod(this->WindowMappingMethod);
 
   this->MapToColors->SetOutputFormatToRGBA();
   // This input may be changed later if ScalarRangeFlag is modified.
@@ -245,6 +247,11 @@ void vtkMRMLScalarVolumeDisplayNode::WriteXML(ostream& of, int nIndent)
   }
   {
     std::stringstream ss;
+    ss << vtkMRMLNode::XMLAttributeEncodeString(GetWindowMappingMethodAsString(GetWindowMappingMethod()));
+    of << " windowMappingMethod=\"" << ss.str() << "\"";
+  }
+  {
+    std::stringstream ss;
     ss << this->AutoWindowLevel;
     of << " autoWindowLevel=\"" << ss.str() << "\"";
   }
@@ -327,6 +334,18 @@ void vtkMRMLScalarVolumeDisplayNode::ReadXMLAttributes(const char** atts)
       ss << attValue;
       ss >> this->InvertDisplayScalarRange;
     }
+    else if (!strcmp(attName, "windowMappingMethod"))
+    {
+      int propertyValue = this->GetWindowMappingMethodFromString(attValue);
+      if (propertyValue >= 0)
+      {
+        this->SetWindowMappingMethod(propertyValue);
+      }
+      else
+      {
+        vtkErrorMacro("Failed to read windowMappingMethod attribute value from string '" << attValue << "'");
+      }
+    }
     else if (!strcmp(attName, "autoWindowLevel"))
     {
       std::stringstream ss;
@@ -378,6 +397,7 @@ void vtkMRMLScalarVolumeDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCo
     this->SetThreshold(node->GetLowerThreshold(), node->GetUpperThreshold());
     this->SetInterpolate(node->Interpolate);
     this->SetInvertDisplayScalarRange(node->GetInvertDisplayScalarRange());
+    this->SetWindowMappingMethod(node->GetWindowMappingMethod());
     this->SetWindowLevelPresets(node->WindowLevelPresets);
   }
 
@@ -404,6 +424,7 @@ void vtkMRMLScalarVolumeDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "LowerThreshold:    " << this->GetLowerThreshold() << "\n";
   os << indent << "Interpolate:       " << this->Interpolate << "\n";
   os << indent << "InvertDisplayScalarRange: " << this->InvertDisplayScalarRange << "\n";
+  os << indent << "WindowMappingMethod: " << this->GetWindowMappingMethodAsString(this->WindowMappingMethod) << "\n";
 }
 
 //---------------------------------------------------------------------------
@@ -882,4 +903,82 @@ void vtkMRMLScalarVolumeDisplayNode::SetInvertDisplayScalarRange(int invert)
   this->InvertDisplayScalarRange = invert;
   this->UpdateLookupTable(this->GetColorNode());
   this->Modified();
+}
+
+//-----------------------------------------------------------------------------
+void vtkMRMLScalarVolumeDisplayNode::SetWindowMappingMethod(int method)
+{
+  switch (method)
+  {
+    case vtkImageMapToWindowLevelAddon::Linear:
+    {
+      this->MapToWindowLevelColors->SetMappingMode(vtkImageMapToWindowLevelAddon::Linear);
+      break;
+    }
+    case vtkImageMapToWindowLevelAddon::Logarithmic:
+    {
+      this->MapToWindowLevelColors->SetMappingMode(vtkImageMapToWindowLevelAddon::Logarithmic);
+      break;
+    }
+    case vtkImageMapToWindowLevelAddon::InverseLogarithmic:
+    {
+      this->MapToWindowLevelColors->SetMappingMode(vtkImageMapToWindowLevelAddon::InverseLogarithmic);
+      break;
+    }
+    default:
+    {
+      return;
+    }
+  }
+  this->WindowMappingMethod = method;
+  this->Modified();
+}
+
+//-----------------------------------------------------------------------------
+vtkImageMapToWindowLevelAddon::WindowMappingMode vtkMRMLScalarVolumeDisplayNode::GetWindowMappingMethodFromIndex(int method)
+{
+  switch (method)
+  {
+    case vtkImageMapToWindowLevelAddon::Logarithmic: return vtkImageMapToWindowLevelAddon::Logarithmic;
+    case vtkImageMapToWindowLevelAddon::InverseLogarithmic: return vtkImageMapToWindowLevelAddon::InverseLogarithmic;
+    default: return vtkImageMapToWindowLevelAddon::Linear;
+  }
+}
+
+//-----------------------------------------------------------------------------
+int vtkMRMLScalarVolumeDisplayNode::GetWindowMappingMethodFromString(const char* name)
+{
+  if (name == nullptr)
+  {
+    // invalid name
+    return -1;
+  }
+  if (!strcmp(name, "Linear"))
+  {
+    return vtkImageMapToWindowLevelAddon::Linear;
+  }
+  else if (!strcmp(name, "Logarithmic"))
+  {
+    return vtkImageMapToWindowLevelAddon::Logarithmic;
+  }
+  else if (!strcmp(name, "InverseLogarithmic"))
+  {
+    return vtkImageMapToWindowLevelAddon::InverseLogarithmic;
+  }
+  // unknown name
+  return -1;
+}
+
+//-----------------------------------------------------------------------------
+const char* vtkMRMLScalarVolumeDisplayNode::GetWindowMappingMethodAsString(int type)
+{
+  switch (type)
+  {
+    case vtkImageMapToWindowLevelAddon::Linear: return "Linear";
+    case vtkImageMapToWindowLevelAddon::Logarithmic: return "Logarithmic";
+    case vtkImageMapToWindowLevelAddon::InverseLogarithmic: return "InverseLogarithmic";
+    default:
+      // invalid id
+      return "";
+  }
 }

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
@@ -17,6 +17,7 @@
 
 // MRML includes
 #include "vtkMRMLVolumeDisplayNode.h"
+#include "vtkImageMapToWindowLevelAddon.h"
 
 // VTK includes
 class vtkImageAlgorithm;
@@ -25,7 +26,6 @@ class vtkImageHistogramStatistics;
 class vtkImageCast;
 class vtkImageLogic;
 class vtkImageMapToColors;
-class vtkImageMapToWindowLevelColors;
 class vtkImageStencil;
 class vtkImageThreshold;
 class vtkImageExtractComponents;
@@ -151,6 +151,18 @@ public:
   virtual void SetInvertDisplayScalarRange(int invert);
   vtkBooleanMacro(InvertDisplayScalarRange, int);
 
+  /// Get or set the mapping method.
+  /// The mapping method determines how scalar values are assigned an integer value within the colormap
+  /// \sa WindowMappingMethodType
+  vtkGetMacro(WindowMappingMethod, int);
+  virtual void SetWindowMappingMethod(int method);
+
+  /// Get the mapping method from/as a string
+  /// \sa WindowMappingMethodType
+  static int GetWindowMappingMethodFromString(const char* name);
+  static const char* GetWindowMappingMethodAsString(int type);
+  static vtkImageMapToWindowLevelAddon::WindowMappingMode GetWindowMappingMethodFromIndex(int idx);
+
   void SetDefaultColorMap() override;
 
   ///
@@ -260,12 +272,13 @@ protected:
   int ApplyThreshold;
   int AutoThreshold;
   int InvertDisplayScalarRange;
+  int WindowMappingMethod;
 
   vtkImageLogic* AlphaLogic;
   vtkImageMapToColors* MapToColors;
   vtkImageThreshold* Threshold;
   vtkImageAppendComponents* AppendComponents;
-  vtkImageMapToWindowLevelColors* MapToWindowLevelColors;
+  vtkImageMapToWindowLevelAddon* MapToWindowLevelColors;
   vtkImageExtractComponents* ExtractRGB;
   vtkImageExtractComponents* ExtractAlpha;
   vtkImageStencil* MultiplyAlpha;

--- a/Modules/Loadable/Colors/MRMLDM/vtkMRMLColorLegendDisplayableManager.cxx
+++ b/Modules/Loadable/Colors/MRMLDM/vtkMRMLColorLegendDisplayableManager.cxx
@@ -481,21 +481,33 @@ bool vtkMRMLColorLegendDisplayableManager::vtkInternal::UpdateActor(vtkMRMLColor
     return false;
   }
 
-  // Handle invert flag for scalar volume display nodes
-  if (scalarVolumeDisplayNode && scalarVolumeDisplayNode->GetInvertDisplayScalarRange())
+  // Handle invert flag and different scalar mapping methods
+
+  if (scalarVolumeDisplayNode)
   {
-    // Invert the lookup table colors
-    vtkNew<vtkLookupTable> invertedLut;
-    invertedLut->DeepCopy(lut);
-    // Reverse the order of colors in the table
-    int numColors = invertedLut->GetNumberOfTableValues();
+    bool invertMap = scalarVolumeDisplayNode->GetInvertDisplayScalarRange();
+    auto mappingMode = scalarVolumeDisplayNode->GetWindowMappingMethodFromIndex(scalarVolumeDisplayNode->GetWindowMappingMethod());
+
+    vtkNew<vtkLookupTable> resampledLut;
+    resampledLut->DeepCopy(lut);
+
+    int numColors = resampledLut->GetNumberOfTableValues();
+    double lutScale = (double)(numColors - 1);
+    int lookupIndex = 0;
+    double normalizedWindowLocation = 0.0;
+    double rgba[4] = { 0.0, 0.0, 0.0, 0.0 };
     for (int i = 0; i < numColors; i++)
     {
-      double rgba[4] = { 0.0, 0.0, 0.0, 0.0 };
-      lut->GetTableValue(i, rgba);
-      invertedLut->SetTableValue(numColors - 1 - i, rgba);
+      normalizedWindowLocation = vtkImageMapToWindowLevelAddon::mapScalarToWindow(double(i), 0.0, lutScale, mappingMode);
+      if (invertMap)
+      {
+        normalizedWindowLocation = 1.0 - normalizedWindowLocation;
+      }
+      lookupIndex = round(lutScale * normalizedWindowLocation);
+      lut->GetTableValue(lookupIndex, rgba);
+      resampledLut->SetTableValue(i, rgba);
     }
-    lut = invertedLut;
+    lut = resampledLut;
   }
 
   lut->SetTableRange(range);

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -469,17 +469,18 @@ void vtkSlicerVolumeRenderingLogic::SetThresholdToVolumeProp(double scalarRange[
 }
 
 //----------------------------------------------------------------------------
-void vtkSlicerVolumeRenderingLogic::SetWindowLevelToVolumeProp(double scalarRange[2], double windowLevel[2], vtkScalarsToColors* colors, vtkVolumeProperty* volumeProp)
+void vtkSlicerVolumeRenderingLogic::SetWindowLevelToVolumeProp(double scalarRange[2],
+                                                               double windowLevel[2],
+                                                               vtkScalarsToColors* colors,
+                                                               vtkVolumeProperty* volumeProp,
+                                                               vtkImageMapToWindowLevelAddon::WindowMappingMode mappingMode,
+                                                               bool invertColormap)
 {
   if (!volumeProp || !scalarRange || !windowLevel)
   {
     vtkWarningMacro("SetWindowLevelToVolumeProp: Inputs do not exist.");
     return;
   }
-
-  // Note that window can be negative, which means that the color lookup table should be reversed
-  // (low voxel values are assigned to high values in the color lookup table).
-  bool invertColorTable = (windowLevel[0] < 0.0);
 
   vtkNew<vtkColorTransferFunction> colorTransfer;
 
@@ -496,7 +497,7 @@ void vtkSlicerVolumeRenderingLogic::SetWindowLevelToVolumeProp(double scalarRang
     double color_X_RGB_MS[6] = { 0., 0., 0., 0., 0.5, 1.0 }; // x, RGB, midpoint, sharpness
     for (vtkIdType i = 0; i < colorCount; ++i)
     {
-      vtkIdType colorIndex = (invertColorTable ? colorCount - 1 - i : i);
+      vtkIdType colorIndex = (invertColormap ? colorCount - 1 - i : i);
       inputColorTransfer->GetNodeValue(colorIndex, color_X_RGB_MS);
       colorTransfer->AddRGBPoint(offset + color_X_RGB_MS[0] * scale, color_X_RGB_MS[1], color_X_RGB_MS[2], color_X_RGB_MS[3], color_X_RGB_MS[4], color_X_RGB_MS[5]);
     }
@@ -534,7 +535,7 @@ void vtkSlicerVolumeRenderingLogic::SetWindowLevelToVolumeProp(double scalarRang
     else // if (numberOfColors > 1)
     {
       double color[4] = { 0.0, 0.0, 0.0, 1.0 };
-      vtkIdType firstColorTableIndex = (invertColorTable ? numberOfColors - 1 : 0);
+      vtkIdType firstColorTableIndex = (invertColormap ? numberOfColors - 1 : 0);
       lut->GetTableValue(firstColorTableIndex, color);
       colorTransfer->AddRGBPoint(vtkMRMLVolumePropertyNode::HigherAndUnique(scalarRange[0], previous), color[0], color[1], color[2]);
 
@@ -544,20 +545,26 @@ void vtkSlicerVolumeRenderingLogic::SetWindowLevelToVolumeProp(double scalarRang
       const vtkIdType maxNumberOfPoints = 24;
 
       const vtkIdType numberOfPoints = std::min(numberOfColors, maxNumberOfPoints);
-      // convert from point index to color index
-      double pointIndexScale = static_cast<double>(numberOfColors - 1) / (numberOfPoints - 1);
-      double offset = outputRange[0];
-      double scale = fabs(windowLevel[0]) / (numberOfColors - 1);
+      double pointMaxIndex = static_cast<double>(numberOfPoints - 1);
+      double colorMaxIndex = static_cast<double>(numberOfColors - 1);
+
+      const double window = fabs(windowLevel[0]);
+      const double xOffset = outputRange[0];
+      double xStepSize = window / numberOfPoints;
+
       for (vtkIdType pointIndex = 0; pointIndex < numberOfPoints; ++pointIndex)
       {
-        vtkIdType colorIndex = pointIndex * pointIndexScale;
-        const double value = offset + colorIndex * scale;
-        vtkIdType colorTableIndex = (invertColorTable ? numberOfColors - 1 - colorIndex : colorIndex);
-        lut->GetTableValue(colorTableIndex, color);
-        colorTransfer->AddRGBPoint(vtkMRMLVolumePropertyNode::HigherAndUnique(value, previous), color[0], color[1], color[2]);
+        double xValue = xOffset + pointIndex * xStepSize;
+        double normalizedColorIndex = vtkImageMapToWindowLevelAddon::mapScalarToWindow(double(pointIndex), 0.0, pointMaxIndex, mappingMode);
+        if (invertColormap)
+        {
+          normalizedColorIndex = 1.0 - normalizedColorIndex;
+        }
+        vtkIdType colorIndex = normalizedColorIndex * colorMaxIndex;
+        lut->GetTableValue(colorIndex, color);
+        colorTransfer->AddRGBPoint(vtkMRMLVolumePropertyNode::HigherAndUnique(xValue, previous), color[0], color[1], color[2]);
       }
-
-      vtkIdType lastColorTableIndex = (invertColorTable ? 0 : numberOfColors - 1);
+      vtkIdType lastColorTableIndex = (invertColormap ? 0 : numberOfColors - 1);
       lut->GetTableValue(lastColorTableIndex, color);
       colorTransfer->AddRGBPoint(vtkMRMLVolumePropertyNode::HigherAndUnique(outputRange[1], previous), color[0], color[1], color[2]);
       colorTransfer->AddRGBPoint(vtkMRMLVolumePropertyNode::HigherAndUnique(scalarRange[1], previous), color[0], color[1], color[2]);
@@ -734,17 +741,15 @@ void vtkSlicerVolumeRenderingLogic::CopyScalarDisplayToVolumeRenderingDisplayNod
 
   vtkScalarsToColors* lut = vpNode->GetColorNode() ? vpNode->GetColorNode()->GetScalarsToColors() : nullptr;
   vtkVolumeProperty* prop = vspNode->GetVolumePropertyNode()->GetVolumeProperty();
+  vtkImageMapToWindowLevelAddon::WindowMappingMode scalarMappingMode = vpNode->GetWindowMappingMethodFromIndex(vpNode->GetWindowMappingMethod());
+  bool invertedColormap = vpNode->GetInvertDisplayScalarRange();
 
   int disabledModify = vspNode->StartModify();
   int vpNodeDisabledModify = vspNode->GetVolumePropertyNode()->StartModify();
 
   this->SetThresholdToVolumeProp(scalarRange, threshold, prop, this->UseLinearRamp, ignoreVolumeDisplayNodeThreshold);
 
-  if (vpNode->GetInvertDisplayScalarRange())
-  {
-    windowLevel[0] *= -1;
-  }
-  this->SetWindowLevelToVolumeProp(scalarRange, windowLevel, lut, prop);
+  this->SetWindowLevelToVolumeProp(scalarRange, windowLevel, lut, prop, scalarMappingMode, invertedColormap);
   this->SetGradientOpacityToVolumeProp(scalarRange, prop);
 
   vspNode->GetVolumePropertyNode()->EndModify(vpNodeDisabledModify);

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -535,15 +535,23 @@ void vtkSlicerVolumeRenderingLogic::SetWindowLevelToVolumeProp(double scalarRang
     else // if (numberOfColors > 1)
     {
       double color[4] = { 0.0, 0.0, 0.0, 1.0 };
+      double predictedColor[3] = { 0.0, 0.0, 0.0 };
+      const double colorDeviationThreshold = 0.25;
+
+      // We start with all relevant endpoints.
       vtkIdType firstColorTableIndex = (invertColormap ? numberOfColors - 1 : 0);
       lut->GetTableValue(firstColorTableIndex, color);
       colorTransfer->AddRGBPoint(vtkMRMLVolumePropertyNode::HigherAndUnique(scalarRange[0], previous), color[0], color[1], color[2]);
+      colorTransfer->AddRGBPoint(vtkMRMLVolumePropertyNode::HigherAndUnique(outputRange[0], previous), color[0], color[1], color[2]);
+      vtkIdType lastColorTableIndex = (invertColormap ? 0 : numberOfColors - 1);
+      lut->GetTableValue(lastColorTableIndex, color);
+      colorTransfer->AddRGBPoint(vtkMRMLVolumePropertyNode::HigherAndUnique(outputRange[1], previous), color[0], color[1], color[2]);
+      colorTransfer->AddRGBPoint(vtkMRMLVolumePropertyNode::HigherAndUnique(scalarRange[1], previous), color[0], color[1], color[2]);
 
       // We place up to maxNumberOfPoints points in the color transfer function.
       // The number is high enough to accurately describe most color tables,
       // but not too high so that the user can still edit the function manually.
-      const vtkIdType maxNumberOfPoints = 24;
-
+      const vtkIdType maxNumberOfPoints = 50;
       const vtkIdType numberOfPoints = std::min(numberOfColors, maxNumberOfPoints);
       double pointMaxIndex = static_cast<double>(numberOfPoints - 1);
       double colorMaxIndex = static_cast<double>(numberOfColors - 1);
@@ -560,14 +568,17 @@ void vtkSlicerVolumeRenderingLogic::SetWindowLevelToVolumeProp(double scalarRang
         {
           normalizedColorIndex = 1.0 - normalizedColorIndex;
         }
-        vtkIdType colorIndex = normalizedColorIndex * colorMaxIndex;
+        vtkIdType colorIndex = std::lround(normalizedColorIndex * colorMaxIndex);
         lut->GetTableValue(colorIndex, color);
-        colorTransfer->AddRGBPoint(vtkMRMLVolumePropertyNode::HigherAndUnique(xValue, previous), color[0], color[1], color[2]);
+        colorTransfer->GetColor(xValue, predictedColor);
+        const double d0 = std::fabs(color[0] - predictedColor[0]);
+        const double d1 = std::fabs(color[1] - predictedColor[1]);
+        const double d2 = std::fabs(color[2] - predictedColor[2]);
+        if ((d0 + d1 + d2) > colorDeviationThreshold)
+        {
+          colorTransfer->AddRGBPoint(vtkMRMLVolumePropertyNode::HigherAndUnique(xValue, previous), color[0], color[1], color[2]);
+        }
       }
-      vtkIdType lastColorTableIndex = (invertColormap ? 0 : numberOfColors - 1);
-      lut->GetTableValue(lastColorTableIndex, color);
-      colorTransfer->AddRGBPoint(vtkMRMLVolumePropertyNode::HigherAndUnique(outputRange[1], previous), color[0], color[1], color[2]);
-      colorTransfer->AddRGBPoint(vtkMRMLVolumePropertyNode::HigherAndUnique(scalarRange[1], previous), color[0], color[1], color[2]);
     }
   }
 

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.h
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.h
@@ -39,6 +39,7 @@ class vtkColorTransferFunction;
 class vtkPiecewiseFunction;
 class vtkScalarsToColors;
 class vtkVolumeProperty;
+#include "vtkImageMapToWindowLevelAddon.h"
 
 // STD includes
 #include <map>
@@ -200,9 +201,17 @@ public:
   /// generated points.
   /// If \a lut contains more than 1 value, each color is used in the ramp.
   /// The generated transfer function will be made of lut->size() + 2 points.
+  /// The optional \a mappingMethod adjusts how values are compressed within
+  /// the scalar range. The default option is linear compression.
+  /// \a invertColormap optionally flips the colormap.
   /// The function is then applied to the volume property \a node.
   /// \sa SetThresholdToVolumeProp
-  void SetWindowLevelToVolumeProp(double scalarRange[2], double windowLevel[2], vtkScalarsToColors* lut, vtkVolumeProperty* node);
+  void SetWindowLevelToVolumeProp(double scalarRange[2],
+                                  double windowLevel[2],
+                                  vtkScalarsToColors* lut,
+                                  vtkVolumeProperty* node,
+                                  vtkImageMapToWindowLevelAddon::WindowMappingMode mode = vtkImageMapToWindowLevelAddon::Linear,
+                                  bool invertColormap = false);
 
   /// Create an opacity transfer function for gradient opacity.
   /// It ranges from 0 to scalarRange[1] - scalarRange[0].

--- a/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerScalarVolumeDisplayWidget.ui
+++ b/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerScalarVolumeDisplayWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>302</width>
-    <height>224</height>
+    <height>384</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -107,7 +107,21 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="4" column="0">
+    <widget class="QLabel" name="ScalarMappingLabel">
+     <property name="text">
+      <string>Scalar Mapping Mode:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QComboBox" name="ScalarMappingComboBox">
+     <property name="toolTip">
+      <string>Method for mapping scalar values to the current window/level.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string/>
@@ -125,7 +139,7 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string/>
@@ -143,7 +157,7 @@
      </layout>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="7" column="0" colspan="2">
     <widget class="ctkCollapsibleGroupBox" name="HistogramGroupBox">
      <property name="toolTip">
       <string>Shows the number of pixels (y axis) vs the image intensity (x axis) over a background of the current window/level and threshold mapping.</string>

--- a/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
@@ -16,6 +16,7 @@
 #include "vtkMRMLScalarVolumeDisplayNode.h"
 #include "vtkMRMLScalarVolumeNode.h"
 #include "vtkMRMLScene.h"
+#include "vtkImageMapToWindowLevelAddon.h"
 
 // VTK includes
 #include <vtkAlgorithm.h>
@@ -89,6 +90,17 @@ void qSlicerScalarVolumeDisplayWidgetPrivate::init()
   barsItem->setBarWidth(1.);
   scene->addItem(barsItem);
 
+  // Set up options for linear or logarithmic color mapping
+  this->ScalarMappingComboBox->insertItem( //
+    vtkImageMapToWindowLevelAddon::Linear,
+    qSlicerScalarVolumeDisplayWidget::tr("Linear"));
+  this->ScalarMappingComboBox->insertItem( //
+    vtkImageMapToWindowLevelAddon::Logarithmic,
+    qSlicerScalarVolumeDisplayWidget::tr("Logarithmic"));
+  this->ScalarMappingComboBox->insertItem( //
+    vtkImageMapToWindowLevelAddon::InverseLogarithmic,
+    qSlicerScalarVolumeDisplayWidget::tr("Inverse logarithmic"));
+
   // Add mapping from presets defined in the Volumes module logic (VolumeDisplayPresets.json)
 
   // read volume preset names from volumes logic
@@ -128,6 +140,7 @@ void qSlicerScalarVolumeDisplayWidgetPrivate::init()
 
   QObject::connect(this->InterpolateCheckbox, SIGNAL(toggled(bool)), q, SLOT(setInterpolate(bool)));
   QObject::connect(this->InvertDisplayScalarRangeCheckbox, SIGNAL(toggled(bool)), q, SLOT(setInvert(bool)));
+  QObject::connect(this->ScalarMappingComboBox, SIGNAL(currentIndexChanged(int)), q, SLOT(setScalarMappingMethod(int)));
   QObject::connect(this->ColorTableComboBox, SIGNAL(currentNodeChanged(vtkMRMLNode*)), q, SLOT(setColorNode(vtkMRMLNode*)));
   QObject::connect(this->HistogramGroupBox, SIGNAL(toggled(bool)), q, SLOT(onHistogramSectionExpanded(bool)));
 }
@@ -222,9 +235,11 @@ void qSlicerScalarVolumeDisplayWidget::updateWidgetFromMRML()
     QSignalBlocker blocker1(d->ColorTableComboBox);
     QSignalBlocker blocker2(d->InterpolateCheckbox);
     QSignalBlocker blocker3(d->InvertDisplayScalarRangeCheckbox);
+    QSignalBlocker blocker4(d->ScalarMappingComboBox);
     d->ColorTableComboBox->setCurrentNode(displayNode->GetColorNode());
     d->InterpolateCheckbox->setChecked(displayNode->GetInterpolate());
     d->InvertDisplayScalarRangeCheckbox->setChecked(displayNode->GetInvertDisplayScalarRange());
+    d->ScalarMappingComboBox->setCurrentIndex(displayNode->GetWindowMappingMethod());
   }
   this->updateHistogram();
 }
@@ -381,10 +396,14 @@ void qSlicerScalarVolumeDisplayWidget::updateHistogram()
       {
         int resolution = 50;
         double rgb[3] = { 0.0, 0.0, 0.0 };
+        double colorMapPosition;
+        auto mode = this->scalarMappingMethod();
+
         for (int i = 0; i < resolution; i++)
         {
+          colorMapPosition = vtkImageMapToWindowLevelAddon::mapScalarToWindow(double(i), 0.0, double(resolution - 1), mode);
+          mapToColors->GetColor((colorTableIndexRange[0] + (colorTableIndexRange[1] - colorTableIndexRange[0]) * colorMapPosition), rgb);
           currentPosition = colorTableVisibleRange[0] + (colorTableVisibleRange[1] - colorTableVisibleRange[0]) * double(i) / (resolution - 1) + eps;
-          mapToColors->GetColor((colorTableIndexRange[0] + (colorTableIndexRange[1] - colorTableIndexRange[0]) * double(i) / (resolution - 1)), rgb);
           d->ColorTransferFunction->AddRGBPoint(currentPosition, rgb[0], rgb[1], rgb[2]);
         }
       }
@@ -457,6 +476,17 @@ void qSlicerScalarVolumeDisplayWidget::setInvert(bool invert)
 }
 
 // --------------------------------------------------------------------------
+void qSlicerScalarVolumeDisplayWidget::setScalarMappingMethod(int method)
+{
+  vtkMRMLScalarVolumeDisplayNode* displayNode = this->volumeDisplayNode();
+  if (!displayNode)
+  {
+    return;
+  }
+  displayNode->SetWindowMappingMethod(method);
+}
+
+// --------------------------------------------------------------------------
 void qSlicerScalarVolumeDisplayWidget::setColorNode(vtkMRMLNode* colorNode)
 {
   vtkMRMLScalarVolumeDisplayNode* displayNode = this->volumeDisplayNode();
@@ -486,4 +516,17 @@ void qSlicerScalarVolumeDisplayWidget::setPreset(const QString& presetId)
     return;
   }
   volumesModuleLogic->ApplyVolumeDisplayPreset(this->volumeDisplayNode(), presetId.toStdString());
+}
+
+// --------------------------------------------------------------------------
+vtkImageMapToWindowLevelAddon::WindowMappingMode qSlicerScalarVolumeDisplayWidget::scalarMappingMethod()
+{
+  Q_D(qSlicerScalarVolumeDisplayWidget);
+  int mode = d->ScalarMappingComboBox->currentIndex();
+  switch (mode)
+  {
+    case vtkImageMapToWindowLevelAddon::Logarithmic: return vtkImageMapToWindowLevelAddon::Logarithmic;
+    case vtkImageMapToWindowLevelAddon::InverseLogarithmic: return vtkImageMapToWindowLevelAddon::InverseLogarithmic;
+    default: return vtkImageMapToWindowLevelAddon::Linear;
+  }
 }

--- a/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.h
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.h
@@ -9,6 +9,7 @@
 
 // Slicer includes
 #include <qSlicerWidget.h>
+#include "vtkImageMapToWindowLevelAddon.h"
 
 #include "qSlicerVolumesModuleWidgetsExport.h"
 
@@ -23,6 +24,7 @@ class Q_SLICER_QTMODULES_VOLUMES_WIDGETS_EXPORT qSlicerScalarVolumeDisplayWidget
   QVTK_OBJECT
   Q_PROPERTY(bool enableColorTableComboBox READ isColorTableComboBoxEnabled WRITE setColorTableComboBoxEnabled)
   Q_PROPERTY(bool enableMRMLWindowLevelWidget READ isMRMLWindowLevelWidgetEnabled WRITE setMRMLWindowLevelWidgetEnabled)
+
 public:
   /// Constructors
   typedef qSlicerWidget Superclass;
@@ -38,8 +40,11 @@ public:
   bool isMRMLWindowLevelWidgetEnabled() const;
   void setMRMLWindowLevelWidgetEnabled(bool);
 
-public slots:
+  /// Get the option for how to map scalar values within the current window
+  /// \sa scalarMappingMethod, setScalarMappingMethod()
+  vtkImageMapToWindowLevelAddon::WindowMappingMode scalarMappingMethod();
 
+public slots:
   ///
   /// Set the MRML node of interest
   void setMRMLVolumeNode(vtkMRMLNode* node);
@@ -49,6 +54,10 @@ public slots:
   void setInvert(bool invert);
   void setColorNode(vtkMRMLNode* node);
   void setPreset(const QString& presetName);
+
+  /// Set the option for how to map scalar values within the current window
+  /// \sa scalarMappingMethod
+  void setScalarMappingMethod(int mappingMethod);
 
 protected slots:
   void updateWidgetFromMRML();


### PR DESCRIPTION
# TLDR Version
This PR subclasses the current vtkImageMapToWindowLevelColors to add an option for logarithmic color mapping within vtkMRMLScalarVolumeDisplayNodes:
<img width="1798" height="898" alt="image" src="https://github.com/user-attachments/assets/84888af5-a72f-4f09-80da-7090d3d400b6" />

# Full Version
## Terminology Specification
This PR relates to the mapping of scalar vtkImageData to RGB colors for vtkMRMLScalarVolumeDisplayNodes. When I refer to "logarithmic color mapping," the following image presents what I mean.
<img width="1798" height="898" alt="image" src="https://github.com/user-attachments/assets/84888af5-a72f-4f09-80da-7090d3d400b6" />
In some applications, it is beneficial to map colors in this nonlinear way to enhance small image intensity differences.

## Current color mapping approach (as of c6a6e4eb7aaa6be318b18438757d26e3f8510cfd)
As of c6a6e4eb7aaa6be318b18438757d26e3f8510cfd, the primary components of the scalar mapping pipeline are shown here:
<table>
  <tr>
    <td>Reference Figure</td>
    <td>Label</td>
    <td>Description</td>
  </tr>
  <tr>
    <td rowspan="3"><img width="1196" height="887" alt="image" src="https://github.com/user-attachments/assets/fbc233d6-02e3-415b-8886-33959820d3a2" />
    <td>A</td>
    <td>Input ImageData</td>
</td>
  <tr>
    <td>B</td>
    <td>Output from "MapToWindowLevelColors" (ImageData rescaled from 0 - 255)</td>
  </tr>
  <tr>
    <td>C</td>
    <td> ColorNode lookup table used by "MapToColors" to assign each value in B an RGB value.</td>
  </tr>
</table>

And the relevant code here:
https://github.com/Slicer/Slicer/blob/c6a6e4eb7aaa6be318b18438757d26e3f8510cfd/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx#L72-L82

## This PR
This PR's implementation is summarized here:
<img width="1836" height="1128" alt="image" src="https://github.com/user-attachments/assets/df862195-0b5c-48e1-9872-26e063cf31da" />

This PR changes the middle section which rescales the image data based on the current window/level. 

The linear mapping equation (unchanged):
<p align="center">
${LookupIndices}_{(0−255)}=\left(\frac{ImageData −WindowMIN}{WINDOW}\right)∗255.0$
</p>

The logarithmic mapping equation (new):
<p align="center">
${LookupIndices}_{(0−255)}=log10\left(1+9\left(\frac{ImageData −WindowMIN}{WINDOW}\right)\right)∗255.0$
</p>

The output of both equations is normalized UCHAR values ranging from 0-255. These values serve as indices to choose a color from the ColorNode.

To facilitate the introduction of this new equation, this PR adds a "vtkImageMapToWindowLevelAddon" which subclasses the existing "vtkImageMapToWindowLevelColors". Alternatively, we could update "vtkImageMapToWindowLevelColors" directly.

## Downstream effects
Because the Color Node is untouched by these changes, this PR also updates some downstream logic to make sure that the Colorbar is displayed in a logarithmic state. I.e.:
1. This PR updates how the color legend is shown
2. This PR updates how the color gradient is shown in the Volumes widget transfer function (the one with a histogram)
3. This PR updates how points are placed when volume display properties are transferred from the Volumes module to the Volume Rendering module. (Triggered by the "Synchronize with Volumes module" checkable button.)


## Related enhancement
The other enhancement in this PR is to reduce the number of control points that get placed in the "Scalar Color Mapping" Volume Rendering widget when synchronizing the Volume module and the Volume Rendering module. Manual editing in that interface becomes extremely tedious with many points placed close together. This is especially apparent when points are placed logarithmically.

The approach taken in this PR is to first initialize a full linear transfer function by placing endpoints.
Then, before we add the next new points, we check to see how different that new color will be from what is already shown in the transfer function. For linear maps like "Grey", we don't need any more control points. For maps like "Rainbow" we will need more points.
| fcd8017 | This PR | This PR (logarithmic applied) |
|--------|--------|--------|
|<img width="497" height="224" alt="image" src="https://github.com/user-attachments/assets/e429964d-33e6-499e-ab0b-fa56a6fe286f" />|<img width="549" height="222" alt="image" src="https://github.com/user-attachments/assets/ded4aaf2-8cac-47ff-a9a4-6c35cdb9035e" />|<img width="551" height="224" alt="image" src="https://github.com/user-attachments/assets/7b9cadea-78a5-4d70-9a87-f91f90d246c8" />| 
|<img width="504" height="251" alt="image" src="https://github.com/user-attachments/assets/a3f8d2d0-bfcd-4207-9aca-21766fe05460" />|<img width="561" height="254" alt="image" src="https://github.com/user-attachments/assets/3e6c414d-deec-44f4-863b-0a66a31ff474" />|<img width="545" height="220" alt="image" src="https://github.com/user-attachments/assets/3856a9ba-c01c-4a55-b778-d82586b634ff" />|

Currently, this PR just sets a hard-coded threshold for how much deviation is allowed before we should add a new point. That threshold can certainly be tuned.