### PR TITLE
COMP: Rename itkLoad to slicer_itkLoad for consistency in plugin

### DIFF
--- a/Libs/MRML/IDImageIO/itkMRMLIDIOPlugin.cxx
+++ b/Libs/MRML/IDImageIO/itkMRMLIDIOPlugin.cxx
@@ -5,9 +5,9 @@
  * Routine that is called when the shared library is loaded by
  * itk::ObjectFactoryBase::LoadDynamicFactories().
  *
- * itkLoad() is C (not C++) function.
+ * slicer_itkLoad() is C (not C++) function.
  */
-itk::ObjectFactoryBase* itkLoad()
+itk::ObjectFactoryBase* slicer_itkLoad()
 {
   static itk::MRMLIDImageIOFactory::Pointer f = itk::MRMLIDImageIOFactory::New();
   return f;

--- a/Libs/MRML/IDImageIO/itkMRMLIDIOPlugin.h
+++ b/Libs/MRML/IDImageIO/itkMRMLIDIOPlugin.h
@@ -17,10 +17,10 @@
  * Routine that is called when the shared library is loaded by
  * itk::ObjectFactoryBase::LoadDynamicFactories().
  *
- * itkLoad() is C (not C++) function.
+ * slicer_itkLoad() is C (not C++) function.
  */
 extern "C"
 {
-  MRMLIDIOPlugin_EXPORT itk::ObjectFactoryBase* itkLoad();
+  MRMLIDIOPlugin_EXPORT itk::ObjectFactoryBase* slicer_itkLoad();
 }
 #endif


### PR DESCRIPTION
@lassoan @pieper @vboussot @blowekamp @jamesobutler 

Fix https://github.com/Slicer/Slicer/issues/8947

needs https://github.com/Slicer/ITK/pull/15

tested running the example script
https://slicer.readthedocs.io/en/latest/developer_guide/script_repository.html#running-an-itk-filter-in-python-using-simpleitk