### PR TITLE
COMP: Add option for IDImageIO support in CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,9 @@ CMAKE_DEPENDENT_OPTION(
   "Slicer_USE_PYTHONQT" OFF)
 mark_as_superbuild(Slicer_USE_SimpleITK)
 
+option(Slicer_USE_IDImageIO "Build Slicer with IDImageIO support" OFF)
+mark_as_superbuild(Slicer_USE_IDImageIO)
+
 option(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT "Build Slicer with parameter serializer support" OFF)
 mark_as_superbuild(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT)
 

--- a/Libs/CMakeLists.txt
+++ b/Libs/CMakeLists.txt
@@ -34,8 +34,12 @@ list(APPEND dirs
   RemoteIO
   MRML/Logic
   MRML/DisplayableManager
-  MRML/IDImageIO
   )
+if(Slicer_USE_IDImageIO)
+  list(APPEND dirs
+    MRML/IDImageIO
+    )
+endif()
 list(APPEND dirs
   MRML/Widgets
   )
@@ -79,8 +83,10 @@ message(STATUS "  MRML_APPLICATION_SUPPORT_VERSION is ${MRML_APPLICATION_SUPPORT
 set(MRML_BUILD_QT_DESIGNER_PLUGINS ${Slicer_BUILD_QT_DESIGNER_PLUGINS})
 
 # ITKFactories directories
-set(MRMLIDImageIO_ITKFACTORIES_DIR ${Slicer_ITKFACTORIES_DIR})
-set(MRMLIDImageIO_INSTALL_ITKFACTORIES_DIR ${Slicer_INSTALL_ITKFACTORIES_DIR})
+if(Slicer_USE_IDImageIO)
+  set(MRMLIDImageIO_ITKFACTORIES_DIR ${Slicer_ITKFACTORIES_DIR})
+  set(MRMLIDImageIO_INSTALL_ITKFACTORIES_DIR ${Slicer_INSTALL_ITKFACTORIES_DIR})
+endif()
 
 # Name of the environment variable that contains the requested OpenGL profile.
 # Accepted values are "default" (same as not specifying a value) or


### PR DESCRIPTION
@pieper @lassoan @blowekamp

Alternative solution for https://github.com/Slicer/Slicer/issues/8947

I have simply added a cmake option to disable the build of the IDImageIO plugin (default OFF), but if you would like to completely remove the plugin from Slicer core code, please let me know.

See also 
https://github.com/Slicer/ITK/pull/14
https://github.com/Slicer/ITK/pull/15
https://github.com/Slicer/Slicer/pull/9021

