### PR TITLE
ENH: Make Teem a private dependency

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -69,6 +69,8 @@
 # include <itkNrrdImageIO.h>
 #endif
 
+#include "teem/nrrd.h"
+
 // STL & C++ includes
 #include <iterator>
 #include <sstream>

--- a/Libs/vtkTeem/vtkTeemNRRDReader.h
+++ b/Libs/vtkTeem/vtkTeemNRRDReader.h
@@ -44,8 +44,6 @@
 #include <vtkSmartPointer.h>
 #include <vtkVersion.h>
 
-#include "teem/nrrd.h"
-
 /// \brief Reads Nearly Raw Raster Data files.
 ///
 /// Reads Nearly Raw Raster Data files using the nrrdio library as used in ITK
@@ -142,56 +140,9 @@ public:
   vtkSetMacro(DataArrayName, std::string);
   vtkGetMacro(DataArrayName, std::string);
 
-  int NrrdToVTKScalarType(const int nrrdPixelType) const
-  {
-    switch (nrrdPixelType)
-    {
-      default:
-      case nrrdTypeDefault: return VTK_VOID; break;
-      case nrrdTypeChar: return VTK_CHAR; break;
-      case nrrdTypeUChar: return VTK_UNSIGNED_CHAR; break;
-      case nrrdTypeShort: return VTK_SHORT; break;
-      case nrrdTypeUShort:
-        return VTK_UNSIGNED_SHORT;
-        break;
-        ///    case nrrdTypeLLong:
-        ///      return LONG ;
-        ///      break;
-        ///    case nrrdTypeULong:
-        ///      return ULONG;
-        ///      break;
-      case nrrdTypeInt: return VTK_INT; break;
-      case nrrdTypeUInt: return VTK_UNSIGNED_INT; break;
-      case nrrdTypeFloat: return VTK_FLOAT; break;
-      case nrrdTypeDouble: return VTK_DOUBLE; break;
-      case nrrdTypeBlock: return -1; break;
-    }
-  }
+  int NrrdToVTKScalarType(const int nrrdPixelType) const;
+  int VTKToNrrdPixelType(const int vtkPixelType) const;
 
-  int VTKToNrrdPixelType(const int vtkPixelType) const
-  {
-    switch (vtkPixelType)
-    {
-      default:
-      case VTK_VOID: return nrrdTypeDefault; break;
-      case VTK_CHAR: return nrrdTypeChar; break;
-      case VTK_UNSIGNED_CHAR: return nrrdTypeUChar; break;
-      case VTK_SHORT: return nrrdTypeShort; break;
-      case VTK_UNSIGNED_SHORT:
-        return nrrdTypeUShort;
-        break;
-        ///    case nrrdTypeLLong:
-        ///      return LONG ;
-        ///      break;
-        ///    case nrrdTypeULong:
-        ///      return ULONG;
-        ///      break;
-      case VTK_INT: return nrrdTypeInt; break;
-      case VTK_UNSIGNED_INT: return nrrdTypeUInt; break;
-      case VTK_FLOAT: return nrrdTypeFloat; break;
-      case VTK_DOUBLE: return nrrdTypeDouble; break;
-    }
-  }
   vtkImageData* AllocateOutputData(vtkDataObject* out, vtkInformation* outInfo) override;
   void AllocateOutputData(vtkImageData* out, vtkInformation* outInfo, int* uExtent) override { Superclass::AllocateOutputData(out, outInfo, uExtent); }
   void AllocatePointData(vtkImageData* out, vtkInformation* outInfo);
@@ -200,7 +151,7 @@ protected:
   vtkTeemNRRDReader();
   ~vtkTeemNRRDReader() override;
 
-  static bool GetPointType(Nrrd* nrrdTemp, int& pointDataType, int& numOfComponents);
+  static bool GetPointType(void* nrrdTemp, int& pointDataType, int& numOfComponents);
 
   vtkSmartPointer<vtkMatrix4x4> RasToIjkMatrix;
   vtkSmartPointer<vtkMatrix4x4> MeasurementFrameMatrix;
@@ -208,7 +159,7 @@ protected:
 
   std::string CurrentFileName;
 
-  Nrrd* nrrd;
+  void* nrrd;
 
   int ReadStatus;
 
@@ -227,7 +178,7 @@ protected:
   void ExecuteInformation() override;
   void ExecuteDataWithInformation(vtkDataObject* output, vtkInformation* outInfo) override;
 
-  int tenSpaceDirectionReduce(Nrrd* nout, const Nrrd* nin, double SD[9]);
+  int tenSpaceDirectionReduce(void* nout, const void* nin, double SD[9]);
 
 private:
   vtkTeemNRRDReader(const vtkTeemNRRDReader&) = delete;

--- a/Libs/vtkTeem/vtkTeemNRRDWriter.cxx
+++ b/Libs/vtkTeem/vtkTeemNRRDWriter.cxx
@@ -1,6 +1,7 @@
 #include <map>
 
 #include "vtkTeemNRRDWriter.h"
+#include "teem/nrrd.h"
 
 #include "vtkImageData.h"
 #include "vtkPointData.h"
@@ -475,4 +476,24 @@ void vtkTeemNRRDWriter::SetAxisUnit(unsigned int axis, const char* unit)
 void vtkTeemNRRDWriter::SetVectorAxisKind(int kind)
 {
   this->VectorAxisKind = kind;
+}
+
+void vtkTeemNRRDWriter::vtkSetSpaceToRAS()
+{
+  this->SetSpace(nrrdSpaceRightAnteriorSuperior);
+}
+
+void vtkTeemNRRDWriter::vtkSetSpaceToRAST()
+{
+  this->SetSpace(nrrdSpaceRightAnteriorSuperiorTime);
+}
+
+void vtkTeemNRRDWriter::vtkSetSpaceToLPS()
+{
+  this->SetSpace(nrrdSpaceLeftPosteriorSuperior);
+}
+
+void vtkTeemNRRDWriter::vtkSetSpaceToLPST()
+{
+  this->SetSpace(nrrdSpaceLeftPosteriorSuperiorTime);
 }

--- a/Libs/vtkTeem/vtkTeemNRRDWriter.h
+++ b/Libs/vtkTeem/vtkTeemNRRDWriter.h
@@ -7,7 +7,6 @@
 #include "vtkDoubleArray.h"
 #include "vtkMatrix4x4.h"
 #include "vtkSmartPointer.h"
-#include "teem/nrrd.h"
 
 #include "vtkTeemConfigure.h"
 
@@ -94,12 +93,12 @@ public:
   vtkGetMacro(Space, int);
 
   /// Set coordinate system to RAS
-  void vtkSetSpaceToRAS() { this->SetSpace(nrrdSpaceRightAnteriorSuperior); };
-  void vtkSetSpaceToRAST() { this->SetSpace(nrrdSpaceRightAnteriorSuperiorTime); };
+  void vtkSetSpaceToRAS();
+  void vtkSetSpaceToRAST();
 
   /// Set coordinate system to LPS
-  void vtkSetSpaceToLPS() { this->SetSpace(nrrdSpaceLeftPosteriorSuperior); };
-  void vtkSetSpaceToLPST() { this->SetSpace(nrrdSpaceLeftPosteriorSuperiorTime); };
+  void vtkSetSpaceToLPS();
+  void vtkSetSpaceToLPST();
 
   /// Force the addition of a range axis, even when the size of the first image dimension (components, or frame list) is 1.
   /// This is useful when attempting to write an image sequence with a single frame, as otherwise the range dimension would be omitted.


### PR DESCRIPTION
Teem does not need to be a public dependency as it is an implementation detail that leaked due to historical reasons:
- vtkTeemNRRDReader was implemented first 20 years ago and included teem.h in its header
- vtkTeemNRRDWriter is newer and partially hide the teem include already

This is a small breaking change, as it changes the signature of two protected functions and the type of a protected member, but I do not expect any code to do anything with them in practice.

This will be critical to build Slicer as a SDK in the context of SlicerCore project as Teem CMake install tree is ill-formed, making it a private dependency removes the need to use it and makes packaging of SlicerCore easier.

Please review @Thibault-Pelletier @lassoan 
FYI @finetjul 