### PR TITLE
ENH: Remove layout node assert impacting tests in debug mode

### DIFF
--- a/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
@@ -507,9 +507,8 @@ void qMRMLLayoutManagerPrivate::onNodeAddedEvent(vtkObject* scene, vtkObject* no
   vtkMRMLLayoutNode* layoutNode = vtkMRMLLayoutNode::SafeDownCast(node);
   if (layoutNode)
   {
-    // qDebug() << "qMRMLLayoutManagerPrivate::onLayoutNodeAddedEvent";
-    //  Only one Layout node is expected
-    Q_ASSERT(this->MRMLLayoutNode == nullptr);
+    // Only one Layout node is expected, but during scene operations (restore, etc.)
+    // a layout node may be added when one already exists. Handle gracefully.
     if (this->MRMLLayoutNode != nullptr)
     {
       return;


### PR DESCRIPTION
qMRMLLayoutManagerVisibilityTest and some other tests would throw an assert dialog on the Windows platform causing the batch run of automated tests to pause. The handling of an existing layout node already exists, so also having an assert appeared excessive.

<img width="412" height="276" alt="image" src="https://github.com/user-attachments/assets/d3b07818-9755-4abe-b82c-4d83ff349363" />
