### PR TITLE
BUG: Fix leaked raw observers in qMRMLThreeDView

### DIFF
--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -260,20 +260,27 @@ qMRMLThreeDView::qMRMLThreeDView(QWidget* _parent)
 
   vtkRenderWindowInteractor* renderWindowInteractor = this->interactor();
 
-  vtkSmartPointer<vtkCallbackCommand> clickCallback = vtkSmartPointer<vtkCallbackCommand>::New();
-  clickCallback->SetClientData(this);
-  clickCallback->SetCallback(ClickCallbackFunction);
+  d->ClickCallback = vtkSmartPointer<vtkCallbackCommand>::New();
+  d->ClickCallback->SetClientData(this);
+  d->ClickCallback->SetCallback(ClickCallbackFunction);
 
-  renderWindowInteractor->AddObserver(vtkCommand::MouseWheelForwardEvent, clickCallback);
-  renderWindowInteractor->AddObserver(vtkCommand::MouseWheelBackwardEvent, clickCallback);
-  renderWindowInteractor->AddObserver(vtkCommand::InteractionEvent, clickCallback);
-  renderWindowInteractor->AddObserver(vtkCommand::KeyPressEvent, clickCallback);
+  renderWindowInteractor->AddObserver(vtkCommand::MouseWheelForwardEvent, d->ClickCallback);
+  renderWindowInteractor->AddObserver(vtkCommand::MouseWheelBackwardEvent, d->ClickCallback);
+  renderWindowInteractor->AddObserver(vtkCommand::InteractionEvent, d->ClickCallback);
+  renderWindowInteractor->AddObserver(vtkCommand::KeyPressEvent, d->ClickCallback);
 }
 
 // --------------------------------------------------------------------------
 qMRMLThreeDView::~qMRMLThreeDView()
 {
   Q_D(qMRMLThreeDView);
+
+  // Remove interactor observers to prevent use-after-free callbacks
+  vtkRenderWindowInteractor* interactor = this->interactor();
+  if (interactor && d->ClickCallback)
+  {
+    interactor->RemoveObserver(d->ClickCallback);
+  }
 
   if (this->renderer())
   {

--- a/Libs/MRML/Widgets/qMRMLThreeDView_p.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDView_p.h
@@ -38,8 +38,10 @@
 #include <ctkVTKObject.h>
 
 // VTK includes
+#include <vtkCallbackCommand.h>
 #include <vtkNew.h>
 #include <vtkRenderStepsPass.h>
+#include <vtkSmartPointer.h>
 #include <vtkSSAOPass.h>
 
 // qMRML includes
@@ -83,6 +85,8 @@ protected:
 
   vtkNew<vtkSSAOPass> ShadowsRenderPass;
   vtkNew<vtkRenderStepsPass> BasicRenderPass;
+
+  vtkSmartPointer<vtkCallbackCommand> ClickCallback;
 };
 
 #endif


### PR DESCRIPTION
## Summary

The `qMRMLThreeDView` constructor creates a local `vtkSmartPointer<vtkCallbackCommand>` and adds 4 observers to the render window interactor (`MouseWheelForwardEvent`, `MouseWheelBackwardEvent`, `InteractionEvent`, `KeyPressEvent`), but:

- The callback command smart pointer is **never stored** as a class member
- The destructor has **no `RemoveObserver` calls**
- `ClickCallbackFunction` does `reinterpret_cast<qMRMLThreeDView*>(clientData)` — if the callback fires after the widget is destroyed, this is a **use-after-free**

## Changes

- Store the callback command in `qMRMLThreeDViewPrivate::ClickCallback` (added as a `vtkSmartPointer<vtkCallbackCommand>` member)
- Remove all observers in the destructor before renderer cleanup via `interactor->RemoveObserver(d->ClickCallback)`

## How this was found

Static analysis of observer lifecycle patterns across the Slicer codebase, checking for `AddObserver` calls without matching `RemoveObserver` in the same class, its private implementation, or ancestor destructors.

## Test plan

- [ ] Verify 3D view mouse wheel zoom, keyboard interaction, and camera interaction events still work
- [ ] Verify no crash on repeated creation/destruction of 3D views (e.g., switching layouts)
- [ ] Run existing `qMRMLThreeDView` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)