### PR TITLE
BUG: Add missing Superclass::setup() calls in 13 module widgets

### DIFF
--- a/Base/QTCLI/qSlicerCLIModuleWidget.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleWidget.cxx
@@ -323,6 +323,7 @@ qSlicerCLIModuleWidget::~qSlicerCLIModuleWidget() = default;
 void qSlicerCLIModuleWidget::setup()
 {
   Q_D(qSlicerCLIModuleWidget);
+  this->Superclass::setup();
 
   d->setupUi(this);
 }

--- a/Modules/Core/EventBroker/qSlicerEventBrokerModuleWidget.cxx
+++ b/Modules/Core/EventBroker/qSlicerEventBrokerModuleWidget.cxx
@@ -55,6 +55,7 @@ qSlicerEventBrokerModuleWidget::~qSlicerEventBrokerModuleWidget() = default;
 void qSlicerEventBrokerModuleWidget::setup()
 {
   Q_D(qSlicerEventBrokerModuleWidget);
+  this->Superclass::setup();
   d->setupUi(this);
 }
 

--- a/Modules/Loadable/Cameras/qSlicerCamerasModuleWidget.cxx
+++ b/Modules/Loadable/Cameras/qSlicerCamerasModuleWidget.cxx
@@ -50,6 +50,7 @@ qSlicerCamerasModuleWidget::~qSlicerCamerasModuleWidget() = default;
 void qSlicerCamerasModuleWidget::setup()
 {
   Q_D(qSlicerCamerasModuleWidget);
+  this->Superclass::setup();
   d->setupUi(this);
 
   connect(d->ViewNodeSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)), this, SLOT(onCurrentViewNodeChanged(vtkMRMLNode*)));

--- a/Modules/Loadable/Colors/qSlicerColorsModuleWidget.cxx
+++ b/Modules/Loadable/Colors/qSlicerColorsModuleWidget.cxx
@@ -133,6 +133,7 @@ qSlicerColorsModuleWidget::~qSlicerColorsModuleWidget() = default;
 void qSlicerColorsModuleWidget::setup()
 {
   Q_D(qSlicerColorsModuleWidget);
+  this->Superclass::setup();
 
   d->setupUi(this);
 

--- a/Modules/Loadable/Data/qSlicerDataModuleWidget.cxx
+++ b/Modules/Loadable/Data/qSlicerDataModuleWidget.cxx
@@ -135,6 +135,7 @@ void qSlicerDataModuleWidget::enter()
 void qSlicerDataModuleWidget::setup()
 {
   Q_D(qSlicerDataModuleWidget);
+  this->Superclass::setup();
 
   d->setupUi(this);
 

--- a/Modules/Loadable/Plots/qSlicerPlotsModuleWidget.cxx
+++ b/Modules/Loadable/Plots/qSlicerPlotsModuleWidget.cxx
@@ -110,6 +110,7 @@ qSlicerPlotsModuleWidget::~qSlicerPlotsModuleWidget() = default;
 void qSlicerPlotsModuleWidget::setup()
 {
   Q_D(qSlicerPlotsModuleWidget);
+  this->Superclass::setup();
   d->setupUi(this);
 
   this->connect(d->PlotChartNodeSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)), SLOT(onNodeSelected(vtkMRMLNode*)));

--- a/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
+++ b/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
@@ -299,6 +299,7 @@ qSlicerReformatModuleWidget::~qSlicerReformatModuleWidget() = default;
 void qSlicerReformatModuleWidget::setup()
 {
   Q_D(qSlicerReformatModuleWidget);
+  this->Superclass::setup();
   d->setupUi(this);
 
   // Populate the Linked menu

--- a/Modules/Loadable/Tables/qSlicerTablesModuleWidget.cxx
+++ b/Modules/Loadable/Tables/qSlicerTablesModuleWidget.cxx
@@ -110,6 +110,7 @@ qSlicerTablesModuleWidget::~qSlicerTablesModuleWidget() = default;
 void qSlicerTablesModuleWidget::setup()
 {
   Q_D(qSlicerTablesModuleWidget);
+  this->Superclass::setup();
   d->setupUi(this);
 
   // Create shortcuts for copy/paste

--- a/Modules/Loadable/Texts/qSlicerTextsModuleWidget.cxx
+++ b/Modules/Loadable/Texts/qSlicerTextsModuleWidget.cxx
@@ -68,6 +68,7 @@ qSlicerTextsModuleWidget::~qSlicerTextsModuleWidget() = default;
 void qSlicerTextsModuleWidget::setup()
 {
   Q_D(qSlicerTextsModuleWidget);
+  this->Superclass::setup();
   d->setupUi(this);
 }
 

--- a/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.cxx
+++ b/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.cxx
@@ -121,6 +121,7 @@ qSlicerTransformsModuleWidget::~qSlicerTransformsModuleWidget() = default;
 void qSlicerTransformsModuleWidget::setup()
 {
   Q_D(qSlicerTransformsModuleWidget);
+  this->Superclass::setup();
   d->setupUi(this);
 
   // Add coordinate reference button to a button group

--- a/Modules/Loadable/ViewControllers/qSlicerViewControllersModuleWidget.cxx
+++ b/Modules/Loadable/ViewControllers/qSlicerViewControllersModuleWidget.cxx
@@ -212,6 +212,7 @@ qSlicerViewControllersModuleWidget::~qSlicerViewControllersModuleWidget() = defa
 void qSlicerViewControllersModuleWidget::setup()
 {
   Q_D(qSlicerViewControllersModuleWidget);
+  this->Superclass::setup();
   d->setupUi(this);
 
   connect(d->MRMLViewNodeComboBox, SIGNAL(currentNodeChanged(vtkMRMLNode*)), this, SLOT(onAdvancedViewNodeChanged(vtkMRMLNode*)));

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModuleWidget.cxx
@@ -266,6 +266,7 @@ qSlicerVolumeRenderingModuleWidget::~qSlicerVolumeRenderingModuleWidget() = defa
 void qSlicerVolumeRenderingModuleWidget::setup()
 {
   Q_D(qSlicerVolumeRenderingModuleWidget);
+  this->Superclass::setup();
   d->setupUi(this);
 }
 

--- a/Modules/Loadable/Volumes/qSlicerVolumesModuleWidget.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesModuleWidget.cxx
@@ -65,6 +65,7 @@ qSlicerVolumesModuleWidget::~qSlicerVolumesModuleWidget() = default;
 void qSlicerVolumesModuleWidget::setup()
 {
   Q_D(qSlicerVolumesModuleWidget);
+  this->Superclass::setup();
   d->setupUi(this);
 
   QObject::connect(d->ActiveVolumeNodeSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)), d->MRMLVolumeInfoWidget, SLOT(setVolumeNode(vtkMRMLNode*)));


### PR DESCRIPTION
[Edited based on @jamesobutler's comments]

## Summary

`qSlicerAbstractModuleWidget::setup()` sets `objectName`, `windowTitle`, and `windowIcon` from module metadata. 13 module widget subclasses override `setup()` without calling `Superclass::setup()`, causing missing widget, but not module, identity (invisible to Qt debugging tools).

27 other module widgets in the codebase correctly call `this->Superclass::setup()`. These 13 are the exceptions.

## Changes

Added `this->Superclass::setup();` immediately after the `Q_D()` macro and before `d->setupUi(this)` in each affected class, matching the pattern used by all other module widgets:

- `qSlicerCLIModuleWidget`
- `qSlicerEventBrokerModuleWidget`
- `qSlicerCamerasModuleWidget`
- `qSlicerColorsModuleWidget`
- `qSlicerDataModuleWidget`
- `qSlicerPlotsModuleWidget`
- `qSlicerReformatModuleWidget`
- `qSlicerTablesModuleWidget`
- `qSlicerTextsModuleWidget`
- `qSlicerTransformsModuleWidget`
- `qSlicerViewControllersModuleWidget`
- `qSlicerVolumeRenderingModuleWidget`
- `qSlicerVolumesModuleWidget`

## How this was found

Static analysis of lifecycle method implementations across the Slicer codebase, checking for overrides of key virtual methods (`setup`, `enter`, `exit`, `SetMRMLSceneInternal`, etc.) that do not call their `Superclass::` counterpart.

## Test plan

- [ ] Verify no regressions in module UI behavior (all `setupUi` calls remain in place after the super call)
- [ ] Run existing module widget tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)