### PR TITLE
BUG: Fix operator precedence in time unit display coefficients

### DIFF
--- a/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx
+++ b/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx
@@ -260,13 +260,13 @@ void vtkSlicerUnitsLogic::AddBuiltInUnits(vtkMRMLScene* scene)
 
   // 30.436875 is average number of days in a month
   this->AddUnitNodeToScene(scene,
-    "Year", "time", "", "year", 2, -10000., 10000., 1.0 / 12.0*30.436875*24.0*60.0*60.0, 0.);
+    "Year", "time", "", "year", 2, -10000., 10000., 1.0 / (12.0*30.436875*24.0*60.0*60.0), 0.);
   this->AddUnitNodeToScene(scene,
-    "Month", "time", "", "month", 2, -10000., 10000., 1.0 / 30.436875*24.0*60.0*60.0, 0.);
+    "Month", "time", "", "month", 2, -10000., 10000., 1.0 / (30.436875*24.0*60.0*60.0), 0.);
   this->AddUnitNodeToScene(scene,
-    "Day", "time", "", "day", 2, -10000., 10000., 1.0 / 24.0*60.0*60.0, 0.);
+    "Day", "time", "", "day", 2, -10000., 10000., 1.0 / (24.0*60.0*60.0), 0.);
   this->AddUnitNodeToScene(scene,
-    "Hour", "time", "", "h", 2, -10000., 10000., 1.0 / 60.0*60.0, 0.);
+    "Hour", "time", "", "h", 2, -10000., 10000., 1.0 / (60.0*60.0), 0.);
   this->AddUnitNodeToScene(scene,
     "Minute", "time", "", "min", 2, -10000., 10000., 1.0/60.0, 0.);
   this->AddUnitNodeToScene(scene,


### PR DESCRIPTION
## Summary

- Fix missing parentheses in display coefficient expressions for Year, Month, Day, and Hour time units
- C++ left-to-right evaluation of `/` and `*` caused the denominator terms to be multiplied instead of divided

## Details

The `displayCoeff` parameter converts stored values (in seconds) to display units. The expressions were missing parentheses around the denominator, causing wildly incorrect coefficients:

| Unit | Before (wrong) | After (correct) |
|------|----------------|-----------------|
| Hour | `1.0 / 60.0*60.0` = **1.0** | `1.0 / (60.0*60.0)` = **2.78e-4** |
| Day | `1.0 / 24.0*60.0*60.0` = **150.0** | `1.0 / (24.0*60.0*60.0)` = **1.16e-5** |
| Month | `1.0 / 30.44*24.0*60.0*60.0` = **2838.3** | `1.0 / (30.44*24.0*60.0*60.0)` = **3.80e-7** |
| Year | `1.0 / 12.0*30.44*24.0*60.0*60.0` = **219145.5** | `1.0 / (12.0*30.44*24.0*60.0*60.0)` = **3.17e-8** |

The Minute coefficient (`1.0/60.0`) was already correct because it has only one term in the denominator.

Any measurement displayed using these time units (e.g., via `vtkMRMLMeasurement`, `qMRMLSpinBox`, or `qMRMLSliderWidget`) would show values off by orders of magnitude. For example, 3600 seconds displayed as "hours" would show `3600.0 h` instead of `1.0 h`.

## Test plan

- [ ] Open Slicer, go to Edit > Application Settings > Units
- [ ] Change the time unit from Second to Hour
- [ ] Verify that time-based measurements display correctly (e.g., sequence browser time values)
- [ ] Repeat for Day, Month, Year units

🤖 Generated with [Claude Code](https://claude.com/claude-code)