### PR TITLE
BUG: Fix markup control point coordinates not updating in table

### DIFF
--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -2765,6 +2765,7 @@ void qSlicerMarkupsModuleWidget::onActiveMarkupsNodeTransformModifiedEvent()
   // update the transform check box label
   // update the coordinates in the table
   this->updateWidgetFromMRML();
+  this->updateRows();
 }
 
 //-----------------------------------------------------------------------------
@@ -2867,6 +2868,7 @@ void qSlicerMarkupsModuleWidget::onHideCoordinateColumnsToggled(int index)
     d->activeMarkupTableWidget->setColumnWidth(qSlicerMarkupsModuleWidgetPrivate::DescriptionColumn, 240);
   }
   this->updateWidgetFromMRML();
+  this->updateRows();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix control point coordinates not refreshing when switching between World and Local coordinate modes
- Fix World coordinates not updating when the parent transform is modified

Fixes #8024
Reported at https://discourse.slicer.org/t/markup-control-point-coordinate-values-are-not-automatically-updated-when-switching-between-world-and-local/39982

## Details

`updateWidgetFromMRML()` only calls `updateRows()` when the table row count changes (line 964):

```cpp
if (d->activeMarkupTableWidget->rowCount() != numberOfPoints)
{
    this->updateRows();
}
```

Neither switching coordinate modes nor modifying transforms changes the number of control points, so `updateRows()` is never called and the table retains stale coordinate values.

The `updateRow()` method already correctly handles World vs Local — it reads the `coordinatesComboBox` state and calls either `GetNthControlPointPositionWorld()` or `GetNthControlPointPosition()`. It just was never reached.

Fix: add explicit `updateRows()` calls in `onHideCoordinateColumnsToggled()` and `onActiveMarkupsNodeTransformModifiedEvent()`.

## Test plan

- [ ] Create a markups line or fiducial node with several control points
- [ ] Apply a transform to the node
- [ ] In the Markups module, switch the Coordinates dropdown between World and Local — verify values update immediately
- [ ] Modify the parent transform — verify World coordinates update in the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)