### PR TITLE
ENH: Add JSON schema for additional extension metadata

### DIFF
--- a/Schemas/slicer-extension-catalog-entry-schema-v1.0.2.json
+++ b/Schemas/slicer-extension-catalog-entry-schema-v1.0.2.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.2.json#",
+  "type": "object",
+  "title": "3D Slicer extensions catalog entry schema",
+  "description": "Schema for storing information about a 3D Slicer extension to allow it to be listed in the extension catalog.",
+  "required": [
+    "$schema",
+    "category",
+    "scm_url"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "$id": "#schema",
+      "type": "string",
+      "title": "Schema",
+      "description": "URL of versioned schema."
+    },
+    "category": {
+      "$id": "#category",
+      "type": "string",
+      "title": "Category used to organize the extension in the extension catalog."
+    },
+    "scm_url": {
+      "$id": "#scm_url",
+      "type": "string",
+      "title": "Filename or URL of the repository."
+    },
+    "scm_revision": {
+      "$id": "#scm_revision",
+      "type": "string",
+      "title": "Hash, branch or tag name to identify the revision within the repository."
+    },
+    "scm_type": {
+      "$id": "#scm_type",
+      "type": "string",
+      "title": "Type of revision control system.",
+      "enum": [
+        "git",
+        "local"
+      ],
+      "default": "git"
+    },
+    "build_dependencies": {
+      "$id": "#build_dependencies",
+      "type": "array",
+      "title": "List of extensions required to build this extension.",
+      "additionalItems": false,
+      "items": { "type": "string" }
+    },
+    "dicom_support_rule": {
+      "$id": "#dicom_support_rule",
+      "type": "string",
+      "title": "Rule engine expression to determine DICOM support level of the extension. (https://pypi.org/project/rule-engine/)"
+    },
+    "build_subdirectory": {
+      "$id": "#build_subdirectory",
+      "type": "string",
+      "title": "Name of the inner build directory in case of superbuild based extension.",
+      "default": "."
+    },
+    "enabled": {
+      "$id": "#enabled",
+      "type": "boolean",
+      "title": "Specify if the extension should be enabled after its installation.",
+      "default": true
+    },
+    "tier": {
+      "$id": "#tier",
+      "type": "integer",
+      "title": "Maturity and support level of the extension. Higher is better. 1 means experimental, 3 means supported by community, 5 means supported by Slicer core developers.",
+      "default": 1,
+      "minimum": 1,
+      "maximum": 5
+    }
+  }
+}


### PR DESCRIPTION
This commit adds a new metadata field with the new extension JSON schema slicer-extension-catalog-entry-schema-v1.0.2.json.

- dicom_support_rule: Expression to determine DICOM data handling. This string will be evaluated to suggest extensions that can handle specific DICOM modalities

We chose to only update the patch version for this schema to follow previously used patterns in version numbering.