### PR TITLE
BUG: Fix VTK observer leak in parameterNodeWrapper connectGui/disconnectGui

### DIFF
--- a/Base/Python/slicer/parameterNodeWrapper/wrapper.py
+++ b/Base/Python/slicer/parameterNodeWrapper/wrapper.py
@@ -131,6 +131,7 @@ def _initMethod(self, parameterNode, prefix: str | None = None):
     self.parameterNode = parameterNode
     self._parameterGUIs = dict()
     self._nextParameterGUIsTag = 0
+    self._guiVtkObserverTags = dict()
     self._updatingGUIFromParameterNode = False
     for parameterInfo in self.allParameters.values():
         parameter = _Parameter(parameterInfo, prefix)
@@ -209,7 +210,8 @@ def _connectParametersToGui(self, mapping):
         connector.write(self.getValue(paramName))
         connector.onChanged(_makeGuiToParamCallback(self, paramName, connector))
 
-    self.AddObserver(vtk.vtkCommand.ModifiedEvent, lambda caller, event: _updateGUIFromParameterNode(self))
+    vtkObserverTag = self.AddObserver(vtk.vtkCommand.ModifiedEvent, lambda caller, event: _updateGUIFromParameterNode(self))
+    self._guiVtkObserverTags[tag] = vtkObserverTag
     return tag
 
 
@@ -258,6 +260,9 @@ def _disconnectGui(self, guiTag):
         for _, connector in self._parameterGUIs[guiTag].items():
             connector.onChanged(None)  # remove callback
         del self._parameterGUIs[guiTag]
+    if guiTag in self._guiVtkObserverTags:
+        self.RemoveObserver(self._guiVtkObserverTags[guiTag])
+        del self._guiVtkObserverTags[guiTag]
 
 
 def _getValue(self, name):

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
@@ -1171,3 +1171,32 @@ class ParameterNodeWrapperGuiTest(unittest.TestCase):
         param.connectParametersToGui(mapping)
 
         self.impl_parameterPacks_test_connected_parameter_node_wrapper(param, ui)
+
+    def test_disconnectGui_removes_vtk_observer(self):
+        """Verify that disconnectGui removes the ModifiedEvent VTK observer added by connectGui."""
+        @parameterNodeWrapper
+        class ParameterNodeWrapper:
+            alpha: bool
+
+        mappingWidget = qt.QWidget()
+        mappingWidget.setLayout(qt.QVBoxLayout())
+        widgetAlpha = qt.QCheckBox()
+        widgetAlpha.setProperty(SlicerParameterNamePropertyName, "alpha")
+        mappingWidget.layout().addWidget(widgetAlpha)
+        mappingWidget.deleteLater()
+
+        param = ParameterNodeWrapper(newParameterNode())
+
+        self.assertEqual(len(param._guiVtkObserverTags), 0)
+
+        tag = param.connectGui(mappingWidget)
+        self.assertEqual(len(param._guiVtkObserverTags), 1)
+
+        param.disconnectGui(tag)
+        self.assertEqual(len(param._guiVtkObserverTags), 0)
+
+        # Multiple cycles should not accumulate observers
+        for _ in range(10):
+            tag = param.connectGui(mappingWidget)
+            param.disconnectGui(tag)
+        self.assertEqual(len(param._guiVtkObserverTags), 0)


### PR DESCRIPTION
In the parameter node wrapper, calling `disconnectGui()` doesn't remove the VTK `ModifiedEvent` observer that `connectGui()` added. Each connect/disconnect cycle leaks one observer on the underlying MRML node.

(How I ran into this: The stale observers are normally silent, but I have a custom application that pre-creates a lot of module widgets at startup. Clearing the scene during a unit test caused a crash because the stale observers fired while the parameter nodes were being re-initialized.)

The fix stores the observer tag on connect and removes it on disconnect.