### PR TITLE
ENH: Add directional glyphs to curve and line nodes

### DIFF
--- a/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.cxx
@@ -107,6 +107,15 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   this->LineColorFadingSaturation = 1.;
   this->LineColorFadingHueOffset = 0.;
 
+  // Direction markers
+  this->LineDirectionVisibility = false;
+  this->LineDirectionVisibility3D = true;
+  this->LineDirectionVisibility2D = true;
+  this->LineDirectionMarkerScale = 1.5;
+  this->LineDirectionMarkerSpacingScale = 2.0;
+  this->LineDirectionFirstToLastControlPoint = true;
+  this->LineSliceIntersectionPointVisibility = true;
+
   this->OccludedVisibility = false;
   this->OccludedOpacity = 0.3;
 
@@ -179,6 +188,13 @@ void vtkMRMLMarkupsDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLFloatMacro(lineColorFadingEnd, LineColorFadingEnd);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingSaturation, LineColorFadingSaturation);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingHueOffset, LineColorFadingHueOffset);
+  vtkMRMLWriteXMLBooleanMacro(lineDirectionVisibility, LineDirectionVisibility);
+  vtkMRMLWriteXMLBooleanMacro(lineDirectionVisibility3D, LineDirectionVisibility3D);
+  vtkMRMLWriteXMLBooleanMacro(lineDirectionVisibility2D, LineDirectionVisibility2D);
+  vtkMRMLWriteXMLFloatMacro(lineDirectionMarkerScale, LineDirectionMarkerScale);
+  vtkMRMLWriteXMLFloatMacro(lineDirectionMarkerSpacingScale, LineDirectionMarkerSpacingScale);
+  vtkMRMLWriteXMLBooleanMacro(lineDirectionFirstToLastControlPoint, LineDirectionFirstToLastControlPoint);
+  vtkMRMLWriteXMLBooleanMacro(lineSliceIntersectionPointVisibility, LineSliceIntersectionPointVisibility);
   vtkMRMLWriteXMLBooleanMacro(handlesInteractive, HandlesInteractive);
   vtkMRMLWriteXMLBooleanMacro(translationHandleVisibility, TranslationHandleVisibility);
   vtkMRMLWriteXMLBooleanMacro(rotationHandleVisibility, RotationHandleVisibility);
@@ -228,6 +244,13 @@ void vtkMRMLMarkupsDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLFloatMacro(lineColorFadingEnd, LineColorFadingEnd);
   vtkMRMLReadXMLFloatMacro(lineColorFadingSaturation, LineColorFadingSaturation);
   vtkMRMLReadXMLFloatMacro(lineColorFadingHueOffset, LineColorFadingHueOffset);
+  vtkMRMLReadXMLBooleanMacro(lineDirectionVisibility, LineDirectionVisibility);
+  vtkMRMLReadXMLBooleanMacro(lineDirectionVisibility3D, LineDirectionVisibility3D);
+  vtkMRMLReadXMLBooleanMacro(lineDirectionVisibility2D, LineDirectionVisibility2D);
+  vtkMRMLReadXMLFloatMacro(lineDirectionMarkerScale, LineDirectionMarkerScale);
+  vtkMRMLReadXMLFloatMacro(lineDirectionMarkerSpacingScale, LineDirectionMarkerSpacingScale);
+  vtkMRMLReadXMLBooleanMacro(lineDirectionFirstToLastControlPoint, LineDirectionFirstToLastControlPoint);
+  vtkMRMLReadXMLBooleanMacro(lineSliceIntersectionPointVisibility, LineSliceIntersectionPointVisibility);
   vtkMRMLReadXMLBooleanMacro(handlesInteractive, HandlesInteractive);
   vtkMRMLReadXMLBooleanMacro(translationHandleVisibility, TranslationHandleVisibility);
   vtkMRMLReadXMLBooleanMacro(rotationHandleVisibility, RotationHandleVisibility);
@@ -309,6 +332,13 @@ void vtkMRMLMarkupsDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*
   vtkMRMLCopyFloatMacro(LineColorFadingEnd);
   vtkMRMLCopyFloatMacro(LineColorFadingSaturation);
   vtkMRMLCopyFloatMacro(LineColorFadingHueOffset);
+  vtkMRMLCopyBooleanMacro(LineDirectionVisibility);
+  vtkMRMLCopyBooleanMacro(LineDirectionVisibility3D);
+  vtkMRMLCopyBooleanMacro(LineDirectionVisibility2D);
+  vtkMRMLCopyFloatMacro(LineDirectionMarkerScale);
+  vtkMRMLCopyFloatMacro(LineDirectionMarkerSpacingScale);
+  vtkMRMLCopyBooleanMacro(LineDirectionFirstToLastControlPoint);
+  vtkMRMLCopyBooleanMacro(LineSliceIntersectionPointVisibility);
   vtkMRMLCopyBooleanMacro(HandlesInteractive);
   vtkMRMLCopyBooleanMacro(TranslationHandleVisibility);
   vtkMRMLCopyBooleanMacro(RotationHandleVisibility);
@@ -507,6 +537,13 @@ void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintFloatMacro(LineColorFadingEnd);
   vtkMRMLPrintFloatMacro(LineColorFadingSaturation);
   vtkMRMLPrintFloatMacro(LineColorFadingHueOffset);
+  vtkMRMLPrintBooleanMacro(LineDirectionVisibility);
+  vtkMRMLPrintBooleanMacro(LineDirectionVisibility3D);
+  vtkMRMLPrintBooleanMacro(LineDirectionVisibility2D);
+  vtkMRMLPrintFloatMacro(LineDirectionMarkerScale);
+  vtkMRMLPrintFloatMacro(LineDirectionMarkerSpacingScale);
+  vtkMRMLPrintBooleanMacro(LineDirectionFirstToLastControlPoint);
+  vtkMRMLPrintBooleanMacro(LineSliceIntersectionPointVisibility);
   vtkMRMLPrintBooleanMacro(HandlesInteractive);
   vtkMRMLPrintBooleanMacro(TranslationHandleVisibility);
   vtkMRMLPrintBooleanMacro(RotationHandleVisibility);

--- a/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.h
@@ -400,6 +400,54 @@ public:
   vtkSetClampMacro(LineColorFadingHueOffset, double, 0.0, 1.0);
   vtkGetMacro(LineColorFadingHueOffset, double);
 
+  /// Show or hide direction markers (arrows) along the curve/line.
+  /// Default value = false
+  vtkSetMacro(LineDirectionVisibility, bool);
+  vtkGetMacro(LineDirectionVisibility, bool);
+  vtkBooleanMacro(LineDirectionVisibility, bool);
+
+  /// Show direction markers in 3D views (effective only when LineDirectionVisibility is true).
+  /// Default value = true
+  vtkSetMacro(LineDirectionVisibility3D, bool);
+  vtkGetMacro(LineDirectionVisibility3D, bool);
+  vtkBooleanMacro(LineDirectionVisibility3D, bool);
+
+  /// Show direction markers in 2D slice views (effective only when LineDirectionVisibility is true).
+  /// Default value = true
+  vtkSetMacro(LineDirectionVisibility2D, bool);
+  vtkGetMacro(LineDirectionVisibility2D, bool);
+  vtkBooleanMacro(LineDirectionVisibility2D, bool);
+
+  /// Base multiplier applied to LineDirectionMarkerScale before converting to physical size.
+  /// Ensures that at the default scale (150%) the marker is clearly visible relative to the line.
+  static constexpr double LineDirectionMarkerBaseScaleFactor = 3.0;
+
+  /// Size of the line direction marker relative to the physical line thickness, expressed as a decimal fraction
+  /// (1.0 = 100% = same as line thickness, 1.5 = 150% = one and a half times the line thickness).
+  /// Default value = 1.5 (150% of line thickness)
+  vtkSetMacro(LineDirectionMarkerScale, double);
+  vtkGetMacro(LineDirectionMarkerScale, double);
+
+  /// Distance between consecutive line direction markers relative to the physical marker height
+  /// (1.0 = 100% = markers touch, 2.0 = 200% = one gap-width between markers).
+  /// Default value = 2.0 (200% of marker height)
+  vtkSetMacro(LineDirectionMarkerSpacingScale, double);
+  vtkGetMacro(LineDirectionMarkerSpacingScale, double);
+
+  /// Direction of the line direction markers (arrows) along the curve/line.
+  /// If true, the arrows point from the first to the last control point of the curve/line.
+  /// Default value = true
+  vtkSetMacro(LineDirectionFirstToLastControlPoint, bool);
+  vtkGetMacro(LineDirectionFirstToLastControlPoint, bool);
+  vtkBooleanMacro(LineDirectionFirstToLastControlPoint, bool);
+
+  /// Show or hide slice line intersection point markers in 2D slice views.
+  /// These markers indicate where curves/lines cross the slice plane.
+  /// Default value = false
+  vtkSetMacro(LineSliceIntersectionPointVisibility, bool);
+  vtkGetMacro(LineSliceIntersectionPointVisibility, bool);
+  vtkBooleanMacro(LineSliceIntersectionPointVisibility, bool);
+
   /// Set the line color node ID used for the projection on the line actors on the 2D viewers.
   /// Setting a line color node allows to define any arbitrary color mapping.
   /// Setting a line color node will overwrite the settings given by the
@@ -539,6 +587,14 @@ protected:
   double LineColorFadingEnd;
   double LineColorFadingSaturation;
   double LineColorFadingHueOffset;
+
+  bool LineDirectionVisibility;
+  bool LineDirectionVisibility3D;
+  bool LineDirectionVisibility2D;
+  double LineDirectionMarkerScale;
+  double LineDirectionMarkerSpacingScale;
+  bool LineDirectionFirstToLastControlPoint;
+  bool LineSliceIntersectionPointVisibility;
 
   bool OccludedVisibility;
   double OccludedOpacity;

--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.cxx
@@ -2159,6 +2159,108 @@ vtkAlgorithmOutput* vtkMRMLMarkupsNode::GetCurveWorldConnection()
   return this->CurvePolyToWorldTransformer->GetOutputPort();
 }
 
+//---------------------------------------------------------------------------
+bool vtkMRMLMarkupsNode::BuildLineDirectionMarkers(vtkPoints* curvePoints,
+                                                   bool closedCurve,
+                                                   double spacing,
+                                                   vtkPoints* outPositions,
+                                                   vtkDoubleArray* outTangents,
+                                                   bool directionFirstToLastControlPoint /*=true*/)
+{
+  if (!curvePoints || !outPositions || !outTangents)
+  {
+    vtkGenericWarningMacro("vtkMRMLMarkupsNode::BuildLineDirectionMarkers failed: invalid inputs");
+    return false;
+  }
+
+  outPositions->Reset();
+  outTangents->Reset();
+  outTangents->SetNumberOfComponents(3);
+
+  vtkIdType numberOfPoints = curvePoints->GetNumberOfPoints();
+  if (numberOfPoints < 2 || spacing <= 1.e-6)
+  {
+    return false;
+  }
+
+  // Compute total curve length so we can anchor markers to the curve center.
+  // Same algorithm as vtkMRMLMarkupsCurveNode::GetCurveLength.
+  double totalLength = 0.0;
+  double previousPoint[3] = { 0.0 };
+  double nextPoint[3] = { 0.0 };
+  curvePoints->GetPoint(0, previousPoint);
+  for (vtkIdType pointIndex = 1; pointIndex < numberOfPoints; ++pointIndex)
+  {
+    curvePoints->GetPoint(pointIndex, nextPoint);
+    totalLength += std::sqrt(vtkMath::Distance2BetweenPoints(previousPoint, nextPoint));
+    vtkMath::Assign(nextPoint, previousPoint);
+  }
+  if (closedCurve)
+  {
+    curvePoints->GetPoint(0, nextPoint);
+    totalLength += std::sqrt(vtkMath::Distance2BetweenPoints(previousPoint, nextPoint));
+  }
+
+  // Start from the center of the curve so that a marker always lands exactly at the midpoint.
+  // Markers are at positions: fmod(half, spacing), fmod(half, spacing)+spacing, ...
+  // so the initial "distance already travelled since last marker" is spacing - fmod(half, spacing).
+  // Special-case fmod==0 to avoid a zero distanceToNextMarker in the walk loop.
+  double halfMod = std::fmod(totalLength * 0.5, spacing);
+  double distanceFromLastMarker = (halfMod > 0.0) ? (spacing - halfMod) : 0.0;
+  curvePoints->GetPoint(0, previousPoint);
+
+  bool addClosingSegment = closedCurve;
+  for (vtkIdType pointIndex = 1; pointIndex < numberOfPoints || addClosingSegment; ++pointIndex)
+  {
+    double currentPoint[3] = { 0.0 };
+    if (pointIndex >= numberOfPoints)
+    {
+      addClosingSegment = false;
+      curvePoints->GetPoint(0, currentPoint);
+    }
+    else
+    {
+      curvePoints->GetPoint(pointIndex, currentPoint);
+    }
+
+    // Compute normalized tangent; vtkMath::Normalize returns the original norm.
+    double tangent[3];
+    vtkMath::Subtract(currentPoint, previousPoint, tangent);
+    double segmentLength = vtkMath::Normalize(tangent);
+    if (segmentLength <= 0.0)
+    {
+      continue;
+    }
+    double sign = directionFirstToLastControlPoint ? 1.0 : -1.0;
+    double outputTangent[3];
+    vtkMath::Assign(tangent, outputTangent);
+    vtkMath::MultiplyScalar(outputTangent, sign);
+
+    // Walk along this segment emitting markers whenever the distance from the last
+    // marker reaches the requested spacing.
+    double distanceTravelledInSegment = 0.0;
+    double distanceToNextMarker = spacing - distanceFromLastMarker;
+    while (distanceTravelledInSegment + distanceToNextMarker <= segmentLength)
+    {
+      distanceTravelledInSegment += distanceToNextMarker;
+      double markerPoint[3];
+      vtkMath::Assign(tangent, markerPoint);
+      vtkMath::MultiplyScalar(markerPoint, distanceTravelledInSegment);
+      vtkMath::Add(previousPoint, markerPoint, markerPoint);
+
+      outPositions->InsertNextPoint(markerPoint);
+      outTangents->InsertNextTuple(outputTangent);
+      distanceFromLastMarker = 0.0;
+      distanceToNextMarker = spacing;
+    }
+    distanceFromLastMarker += segmentLength - distanceTravelledInSegment;
+
+    vtkMath::Assign(currentPoint, previousPoint);
+  }
+
+  return true;
+}
+
 //----------------------------------------------------------------------
 int vtkMRMLMarkupsNode::GetControlPointIndexFromInterpolatedPointIndex(vtkIdType interpolatedPointIndex)
 {

--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.h
@@ -676,6 +676,23 @@ public:
   /// Converts curve point index to control point index.
   int GetControlPointIndexFromInterpolatedPointIndex(vtkIdType interpolatedPointIndex);
 
+  /// Compute evenly-spaced direction marker positions and unit tangents along a curve.
+  /// Markers are placed starting at half the spacing from the first point so they are
+  /// centered within each interval. For closed curves the closing segment is included.
+  /// \param curvePoints input polyline points (world or local coordinates)
+  /// \param closedCurve if true the last point is connected back to the first
+  /// \param spacing arc-length distance between successive markers (same units as curvePoints)
+  /// \param outPositions output marker positions (Reset() is called before filling)
+  /// \param outTangents output unit tangent vectors, one 3-tuple per marker (Reset() is called before filling)
+  /// \param directionFirstToLastControlPoint if false, arrows point in the opposite direction
+  /// \return true on success
+  static bool BuildLineDirectionMarkers(vtkPoints* curvePoints,
+                                        bool closedCurve,
+                                        double spacing,
+                                        vtkPoints* outPositions,
+                                        vtkDoubleArray* outTangents,
+                                        bool directionFirstToLastControlPoint = true);
+
   /// Returns true if the curve generator creates a closed curve.
   vtkGetMacro(CurveClosed, bool);
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkMarkupsGlyphSource2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkMarkupsGlyphSource2D.cxx
@@ -108,6 +108,8 @@ int vtkMarkupsGlyphSource2D::RequestData(vtkInformation* vtkNotUsed(request), vt
     case GlyphArrow: this->CreateArrow(pts, lines, polys, colors); break;
     case GlyphThickArrow: this->CreateThickArrow(pts, lines, polys, colors); break;
     case GlyphHookedArrow: this->CreateHookedArrow(pts, lines, polys, colors); break;
+    case GlyphCircledCross: this->CreateCircledCross(pts, lines, polys, colors); break;
+    case GlyphCircledPoint: this->CreateCircledPoint(pts, lines, polys, colors); break;
   }
 
   this->TransformGlyph(pts);
@@ -491,6 +493,81 @@ void vtkMarkupsGlyphSource2D::CreateHookedArrow(vtkPoints* pts, vtkCellArray* li
     colors->InsertNextValue(this->RGB[1]);
     colors->InsertNextValue(this->RGB[2]);
   }
+}
+
+//----------------------------------------------------------------------------
+void vtkMarkupsGlyphSource2D::CreateCircledCross(vtkPoints* pts, vtkCellArray* lines, vtkCellArray* vtkNotUsed(polys), vtkUnsignedCharArray* colors)
+{
+  // Circle outline (16-segment polyline, radius 0.5)
+  const unsigned int numberOfCirclePoints = 16;
+  vtkIdType circlePtIds[numberOfCirclePoints + 1];
+  double theta = 2.0 * vtkMath::Pi() / static_cast<double>(numberOfCirclePoints);
+  for (unsigned int i = 0; i < numberOfCirclePoints; i++)
+  {
+    double x = 0.5 * cos(static_cast<double>(i) * theta);
+    double y = 0.5 * sin(static_cast<double>(i) * theta);
+    circlePtIds[i] = pts->InsertNextPoint(x, y, 0.0);
+  }
+  circlePtIds[numberOfCirclePoints] = circlePtIds[0];
+  lines->InsertNextCell(numberOfCirclePoints + 1, circlePtIds);
+  colors->InsertNextValue(this->RGB[0]);
+  colors->InsertNextValue(this->RGB[1]);
+  colors->InsertNextValue(this->RGB[2]);
+
+  // Diagonal cross arms (45 degrees)
+  double crossRadius = 0.35;
+  double diag = crossRadius * 0.70710678118; // cos(45°) = sin(45°) = sqrt(2)/2
+  vtkIdType aIds[2];
+  aIds[0] = pts->InsertNextPoint(-diag, -diag, 0.0);
+  aIds[1] = pts->InsertNextPoint(diag, diag, 0.0);
+  lines->InsertNextCell(2, aIds);
+  colors->InsertNextValue(this->RGB[0]);
+  colors->InsertNextValue(this->RGB[1]);
+  colors->InsertNextValue(this->RGB[2]);
+
+  vtkIdType bIds[2];
+  bIds[0] = pts->InsertNextPoint(-diag, diag, 0.0);
+  bIds[1] = pts->InsertNextPoint(diag, -diag, 0.0);
+  lines->InsertNextCell(2, bIds);
+  colors->InsertNextValue(this->RGB[0]);
+  colors->InsertNextValue(this->RGB[1]);
+  colors->InsertNextValue(this->RGB[2]);
+}
+
+//----------------------------------------------------------------------------
+void vtkMarkupsGlyphSource2D::CreateCircledPoint(vtkPoints* pts, vtkCellArray* lines, vtkCellArray* polys, vtkUnsignedCharArray* colors)
+{
+  // Circle outline (16-segment polyline, radius 0.5)
+  const unsigned int numberOfCirclePoints = 16;
+  vtkIdType circlePtIds[numberOfCirclePoints + 1];
+  double theta = 2.0 * vtkMath::Pi() / static_cast<double>(numberOfCirclePoints);
+  for (unsigned int i = 0; i < numberOfCirclePoints; i++)
+  {
+    double x = 0.5 * cos(static_cast<double>(i) * theta);
+    double y = 0.5 * sin(static_cast<double>(i) * theta);
+    circlePtIds[i] = pts->InsertNextPoint(x, y, 0.0);
+  }
+  circlePtIds[numberOfCirclePoints] = circlePtIds[0];
+  lines->InsertNextCell(numberOfCirclePoints + 1, circlePtIds);
+  colors->InsertNextValue(this->RGB[0]);
+  colors->InsertNextValue(this->RGB[1]);
+  colors->InsertNextValue(this->RGB[2]);
+
+  // Filled center dot
+  const unsigned int numberOfDotPoints = 8;
+  vtkIdType dotPtIds[numberOfDotPoints];
+  double dotTheta = 2.0 * vtkMath::Pi() / static_cast<double>(numberOfDotPoints);
+  double dotRadius = 0.2;
+  for (unsigned int i = 0; i < numberOfDotPoints; i++)
+  {
+    double x = dotRadius * cos(static_cast<double>(i) * dotTheta);
+    double y = dotRadius * sin(static_cast<double>(i) * dotTheta);
+    dotPtIds[i] = pts->InsertNextPoint(x, y, 0.0);
+  }
+  polys->InsertNextCell(numberOfDotPoints, dotPtIds);
+  colors->InsertNextValue(this->RGB[0]);
+  colors->InsertNextValue(this->RGB[1]);
+  colors->InsertNextValue(this->RGB[2]);
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/VTKWidgets/vtkMarkupsGlyphSource2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkMarkupsGlyphSource2D.h
@@ -120,6 +120,8 @@ public:
   void SetGlyphTypeToArrow() { this->SetGlyphType(GlyphArrow); }
   void SetGlyphTypeToThickArrow() { this->SetGlyphType(GlyphThickArrow); }
   void SetGlyphTypeToHookedArrow() { this->SetGlyphType(GlyphHookedArrow); }
+  void SetGlyphTypeToCircledCross() { this->SetGlyphType(GlyphCircledCross); }
+  void SetGlyphTypeToCircledPoint() { this->SetGlyphType(GlyphCircledPoint); }
 
   void SetNextGlyphType();
 
@@ -139,6 +141,8 @@ public:
     GlyphArrow,
     GlyphThickArrow,
     GlyphHookedArrow,
+    GlyphCircledCross,
+    GlyphCircledPoint,
     GlyphType_Last // insert new types above this line
   };
 
@@ -173,6 +177,8 @@ protected:
   void CreateArrow(vtkPoints* pts, vtkCellArray* lines, vtkCellArray* polys, vtkUnsignedCharArray* colors);
   void CreateThickArrow(vtkPoints* pts, vtkCellArray* lines, vtkCellArray* polys, vtkUnsignedCharArray* colors);
   void CreateHookedArrow(vtkPoints* pts, vtkCellArray* lines, vtkCellArray* polys, vtkUnsignedCharArray* colors);
+  void CreateCircledCross(vtkPoints* pts, vtkCellArray* lines, vtkCellArray* polys, vtkUnsignedCharArray* colors);
+  void CreateCircledPoint(vtkPoints* pts, vtkCellArray* lines, vtkCellArray* polys, vtkUnsignedCharArray* colors);
   void CreateStarBurst(vtkPoints* pts, vtkCellArray* lines, vtkCellArray* polys, vtkUnsignedCharArray* colors);
 
 private:

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.cxx
@@ -26,8 +26,6 @@
 #include "vtkMatrix4x4.h"
 #include "vtkObjectFactory.h"
 #include "vtkPlane.h"
-#include "vtkPoints.h"
-#include "vtkPointData.h"
 #include "vtkPolyData.h"
 #include "vtkPolyDataMapper2D.h"
 #include "vtkProperty2D.h"
@@ -35,8 +33,6 @@
 #include "vtkSampleImplicitFunctionFilter.h"
 #include "vtkSlicerAngleRepresentation2D.h"
 #include "vtkTextActor.h"
-#include "vtkTextProperty.h"
-#include "vtkTransform.h"
 #include "vtkTransformPolyDataFilter.h"
 #include "vtkTubeFilter.h"
 
@@ -52,6 +48,7 @@ vtkStandardNewMacro(vtkSlicerAngleRepresentation2D);
 vtkSlicerAngleRepresentation2D::vtkSlicerAngleRepresentation2D()
 {
   this->Line = vtkSmartPointer<vtkPolyData>::New();
+  this->ArcLine = vtkSmartPointer<vtkPolyData>::New();
   this->Arc = vtkSmartPointer<vtkArcSource>::New();
   this->Arc->SetResolution(30);
 
@@ -64,8 +61,8 @@ vtkSlicerAngleRepresentation2D::vtkSlicerAngleRepresentation2D()
   this->ArcWorldToSliceTransformer = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
   this->LineWorldToSliceTransformer->SetTransform(this->WorldToSliceTransform);
   this->ArcWorldToSliceTransformer->SetTransform(this->WorldToSliceTransform);
-  this->LineWorldToSliceTransformer->SetInputConnection(this->LineSliceDistance->GetOutputPort());
-  this->ArcWorldToSliceTransformer->SetInputConnection(this->ArcSliceDistance->GetOutputPort());
+  this->LineWorldToSliceTransformer->SetInputData(this->Line);
+  this->ArcWorldToSliceTransformer->SetInputData(this->ArcLine);
 
   this->TubeFilter = vtkSmartPointer<vtkTubeFilter>::New();
   this->TubeFilter->SetInputConnection(this->LineWorldToSliceTransformer->GetOutputPort());
@@ -227,7 +224,6 @@ void vtkSlicerAngleRepresentation2D::UpdateFromMRMLInternal(vtkMRMLNode* caller,
   this->BuildArc();
 
   // Update lines display properties
-
   double diameter =
     (this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ? this->MarkupsDisplayNode->GetLineDiameter() / this->ViewScaleFactorMmPerPixel
                                                                                                     : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness());
@@ -238,12 +234,36 @@ void vtkSlicerAngleRepresentation2D::UpdateFromMRMLInternal(vtkMRMLNode* caller,
   this->LineActor->SetVisibility(numberOfDefinedControlPoints >= 2);
   this->ArcActor->SetVisibility(numberOfDefinedControlPoints == 3);
 
-  // Hide the actor if it doesn't intersect the current slice
+  // Hide the line actor if it doesn't intersect the current slice
   this->LineSliceDistance->Update();
   if (!this->IsRepresentationIntersectingSlice(vtkPolyData::SafeDownCast(this->LineSliceDistance->GetOutput()), this->LineSliceDistance->GetScalarArrayName()))
   {
     this->LineActor->SetVisibility(false);
+  }
+
+  // Hide the arc actor if it doesn't intersect the current slice
+  this->ArcSliceDistance->Update();
+  if (!this->IsRepresentationIntersectingSlice(vtkPolyData::SafeDownCast(this->ArcSliceDistance->GetOutput()), this->ArcSliceDistance->GetScalarArrayName()))
+  {
     this->ArcActor->SetVisibility(false);
+  }
+
+  // Compute fading scalars for accurate line/arc projection on the 2D slice.
+  if (this->LineActor->GetVisibility())
+  {
+    vtkPolyData* worldCurve = markupsNode->GetCurveWorld();
+    if (worldCurve && worldCurve->GetNumberOfPoints() >= 2)
+    {
+      this->ComputeIntersectionFadingScalars(worldCurve, this->SlicePlane, this->Line);
+    }
+  }
+  if (this->ArcActor->GetVisibility())
+  {
+    vtkPolyData* arcPolyData = this->Arc->GetOutput();
+    if (arcPolyData && arcPolyData->GetNumberOfPoints() >= 2)
+    {
+      this->ComputeIntersectionFadingScalars(arcPolyData, this->SlicePlane, this->ArcLine);
+    }
   }
 
   int controlPointType = Unselected;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.h
@@ -80,7 +80,10 @@ protected:
 
   void BuildArc();
 
+  /// Compute fading scalars for accurate line/arc projection on the 2D slice.
+  /// The 2D mapper interpolates RGBA per-vertex (not scalars), so long tube segments
   vtkSmartPointer<vtkPolyData> Line;
+  vtkSmartPointer<vtkPolyData> ArcLine;
   vtkSmartPointer<vtkPolyDataMapper2D> LineMapper;
   vtkSmartPointer<vtkActor2D> LineActor;
   vtkSmartPointer<vtkArcSource> Arc;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.cxx
@@ -17,18 +17,12 @@
 =========================================================================*/
 
 // VTK includes
-#include "vtkActor2D.h"
 #include "vtkArcSource.h"
-#include "vtkCellLocator.h"
-#include "vtkGlyph3D.h"
 #include "vtkPolyDataMapper.h"
-#include "vtkPointData.h"
 #include "vtkProperty.h"
 #include "vtkRenderer.h"
-#include "vtkSelectVisiblePoints.h"
 #include "vtkSlicerAngleRepresentation3D.h"
 #include "vtkTextActor.h"
-#include "vtkTextProperty.h"
 #include "vtkTubeFilter.h"
 
 // MRML includes
@@ -192,12 +186,16 @@ void vtkSlicerAngleRepresentation3D::UpdateFromMRMLInternal(vtkMRMLNode* caller,
   this->VisibilityOn();
 
   // Update lines geometry
-
-  this->BuildLine(this->Line, false);
-  this->BuildArc();
+  if (!event || event == vtkMRMLMarkupsNode::PointModifiedEvent || event == vtkMRMLMarkupsNode::PointAddedEvent || event == vtkMRMLMarkupsNode::PointRemovedEvent
+      || event == vtkMRMLMarkupsNode::PointPositionDefinedEvent || event == vtkMRMLMarkupsNode::PointPositionUndefinedEvent
+      || event == vtkMRMLMarkupsNode::PointPositionMissingEvent || event == vtkMRMLMarkupsNode::PointPositionNonMissingEvent
+      || event == vtkMRMLTransformableNode::TransformModifiedEvent)
+  {
+    this->BuildLine(this->Line, false);
+    this->BuildArc();
+  }
 
   // Update lines display properties
-
   this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper, this->LineOccludedMapper);
   this->UpdateRelativeCoincidentTopologyOffsets(this->ArcMapper, this->ArcOccludedMapper);
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
@@ -20,7 +20,8 @@
 #include "vtkCellLocator.h"
 #include "vtkCleanPolyData.h"
 #include "vtkDiscretizableColorTransferFunction.h"
-#include "vtkLine.h"
+#include "vtkFloatArray.h"
+#include "vtkGlyph2D.h"
 #include "vtkMath.h"
 #include "vtkObjectFactory.h"
 #include "vtkPlane.h"
@@ -33,13 +34,13 @@
 #include "vtkSampleImplicitFunctionFilter.h"
 #include "vtkSlicerCurveRepresentation2D.h"
 #include "vtkTextActor.h"
-#include "vtkTextProperty.h"
 #include "vtkTransform.h"
 #include "vtkTransformPolyDataFilter.h"
 #include "vtkTubeFilter.h"
 
 // MRML includes
 #include "vtkMRMLInteractionEventData.h"
+#include "vtkMRMLMarkupsCurveNode.h"
 #include "vtkMRMLMarkupsDisplayNode.h"
 #include "vtkMRMLProceduralColorNode.h"
 
@@ -55,10 +56,11 @@ vtkSlicerCurveRepresentation2D::vtkSlicerCurveRepresentation2D()
 
   this->WorldToSliceTransformer = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
   this->WorldToSliceTransformer->SetTransform(this->WorldToSliceTransform);
-  this->WorldToSliceTransformer->SetInputConnection(this->SliceDistance->GetOutputPort());
+  this->WorldToSliceTransformer->SetInputData(this->Line);
 
   this->TubeFilter = vtkSmartPointer<vtkTubeFilter>::New();
 
+  // 'cleaner' is a local variable; VTK's pipeline keeps it alive as needed.
   vtkNew<vtkCleanPolyData> cleaner;
   cleaner->PointMergingOn();
   cleaner->SetInputConnection(this->WorldToSliceTransformer->GetOutputPort());
@@ -78,6 +80,9 @@ vtkSlicerCurveRepresentation2D::vtkSlicerCurveRepresentation2D()
   this->LineActor->SetProperty(this->GetControlPointsPipeline(Unselected)->Property);
 
   this->SliceCurvePointLocator = vtkSmartPointer<vtkCellLocator>::New();
+
+  // Share the LineColorMap LUT with the direction arrow mapper (initialized in base class)
+  this->LineDirectionArrowPipeline->Mapper->SetLookupTable(this->LineColorMap);
 }
 
 //----------------------------------------------------------------------
@@ -90,29 +95,42 @@ void vtkSlicerCurveRepresentation2D::UpdateFromMRMLInternal(vtkMRMLNode* caller,
 
   this->NeedToRenderOn();
 
-  vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
+  vtkMRMLMarkupsCurveNode* markupsNode = vtkMRMLMarkupsCurveNode::SafeDownCast(this->GetMarkupsNode());
   if (!markupsNode || !this->IsDisplayable())
   {
     this->VisibilityOff();
     return;
   }
+
+  vtkPolyData* curveWorld = markupsNode->GetCurveWorld();
+  if (!curveWorld)
+  {
+    this->VisibilityOff();
+    return;
+  }
+
   this->VisibilityOn();
 
-  // Line display
-
-  double diameter =
+  // Physical line diameter in pixels: absolute (mm->px) or relative to line thickness.
+  double lineDiameterPx =
     (this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ? this->MarkupsDisplayNode->GetLineDiameter() / this->ViewScaleFactorMmPerPixel
                                                                                                     : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness());
-  this->TubeFilter->SetRadius(diameter * 0.5);
+  double markerSizePx = vtkMRMLMarkupsDisplayNode::LineDirectionMarkerBaseScaleFactor * this->MarkupsDisplayNode->GetLineDirectionMarkerScale() * lineDiameterPx;
 
-  this->LineActor->SetVisibility(markupsNode->GetNumberOfControlPoints() >= 2);
+  // Line display
+  this->TubeFilter->SetRadius(lineDiameterPx * 0.5);
 
   // Hide the line actor if it doesn't intersect the current slice
   this->SliceDistance->Update();
-  if (!this->IsRepresentationIntersectingSlice(vtkPolyData::SafeDownCast(this->SliceDistance->GetOutput()), this->SliceDistance->GetScalarArrayName()))
+  vtkPolyData* representation = vtkPolyData::SafeDownCast(this->SliceDistance->GetOutput());
+  const char* arrayName = this->SliceDistance->GetScalarArrayName();
+  vtkFloatArray* distanceArray = nullptr;
+  if (representation)
   {
-    this->LineActor->SetVisibility(false);
+    distanceArray = vtkFloatArray::SafeDownCast(representation->GetPointData()->GetArray(this->SliceDistance->GetScalarArrayName()));
   }
+  bool isRepresentationIntersectingSlice = this->IsRepresentationIntersectingSlice(representation, arrayName);
+  this->LineActor->SetVisibility(markupsNode->GetNumberOfControlPoints() > 1 && isRepresentationIntersectingSlice);
 
   bool allControlPointsSelected = this->GetAllControlPointsSelected();
   int controlPointType = Active;
@@ -123,18 +141,22 @@ void vtkSlicerCurveRepresentation2D::UpdateFromMRMLInternal(vtkMRMLNode* caller,
   this->LineActor->SetProperty(this->GetControlPointsPipeline(controlPointType)->Property);
   this->TextActor->SetTextProperty(this->GetControlPointsPipeline(controlPointType)->TextProperty);
 
+  vtkColorTransferFunction* colorMap = nullptr;
   if (this->MarkupsDisplayNode->GetLineColorNode() && this->MarkupsDisplayNode->GetLineColorNode()->GetColorTransferFunction())
   {
     // Update the line color mapping from the colorNode stored in the markups display node
-    this->LineMapper->SetLookupTable(this->MarkupsDisplayNode->GetLineColorNode()->GetColorTransferFunction());
+    colorMap = this->MarkupsDisplayNode->GetLineColorNode()->GetColorTransferFunction();
   }
   else
   {
     // if there is no line color node, build the color mapping from few variables
     // (color, opacity, distance fading, saturation and hue offset) stored in the display node
     this->UpdateDistanceColorMap(this->LineColorMap, this->LineActor->GetProperty()->GetColor());
-    this->LineMapper->SetLookupTable(this->LineColorMap);
+    colorMap = this->LineColorMap;
   }
+
+  this->LineMapper->SetLookupTable(colorMap);
+  this->LineDirectionArrowPipeline->Mapper->SetLookupTable(colorMap);
 
   bool allNodesHidden = true;
   for (int controlPointIndex = 0; controlPointIndex < markupsNode->GetNumberOfControlPoints(); controlPointIndex++)
@@ -176,7 +198,6 @@ void vtkSlicerCurveRepresentation2D::UpdateFromMRMLInternal(vtkMRMLNode* caller,
   }
 
   // Properties label display
-
   if (this->MarkupsDisplayNode->GetPropertiesLabelVisibility()   //
       && this->AnyPointVisibilityOnSlice                         //
       && markupsNode->GetNumberOfDefinedControlPoints(true) > 0) // including preview
@@ -201,6 +222,143 @@ void vtkSlicerCurveRepresentation2D::UpdateFromMRMLInternal(vtkMRMLNode* caller,
   else
   {
     this->TextActor->SetVisibility(false);
+  }
+
+  // Compute fading scalars for the 2D line projection
+  this->ComputeIntersectionFadingScalars(curveWorld, this->SlicePlane, this->Line, distanceArray, this->LineSliceIntersectionWorldPoints);
+
+  // Direction markers update (2D)
+  // Sample in world space then filter by proximity to the current slice plane.
+  if (isRepresentationIntersectingSlice && this->MarkupsDisplayNode->GetLineDirectionVisibility() && this->MarkupsDisplayNode->GetLineDirectionVisibility2D() && curveWorld
+      && curveWorld->GetNumberOfPoints() > 1)
+  {
+    // Spacing in mm, relative to cone height (100% = touching).
+    double markerSpacingMm = this->MarkupsDisplayNode->GetLineDirectionMarkerSpacingScale() * markerSizePx * this->ViewScaleFactorMmPerPixel;
+    double intersectionExclR2 = markerSizePx * markerSizePx * 0.75;
+    // Rebuild the sampled world positions/tangents only when spacing or curve geometry changed.
+    vtkMTimeType curveMTime = curveWorld->GetMTime();
+    bool lineDirectionFirstToLastControlPoint = this->MarkupsDisplayNode->GetLineDirectionFirstToLastControlPoint();
+    bool updateDirectionMarkers = markerSpacingMm != this->LineDirectionMarkerLastSpacing || curveMTime != this->LineDirectionMarkerLastGeometryMTime
+                                  || lineDirectionFirstToLastControlPoint != this->LineDirectionFirstToLastControlPoint;
+    if (updateDirectionMarkers)
+    {
+      vtkMRMLMarkupsNode::BuildLineDirectionMarkers(curveWorld->GetPoints(),
+                                                    this->CurveClosed,
+                                                    markerSpacingMm,
+                                                    this->LineDirectionMarkerCachedWorldPositions,
+                                                    this->LineDirectionMarkerCachedWorldTangents,
+                                                    lineDirectionFirstToLastControlPoint);
+      this->LineDirectionMarkerLastSpacing = markerSpacingMm;
+      this->LineDirectionMarkerLastGeometryMTime = curveMTime;
+      this->LineDirectionFirstToLastControlPoint = lineDirectionFirstToLastControlPoint;
+    }
+    vtkMTimeType slicePlaneMTime = this->SlicePlane->GetMTime();
+    vtkMTimeType markupsDisplayMTime = this->GetMarkupsDisplayNode()->GetMTime();
+    bool hoverUpdate = caller == this->GetMarkupsNode() && event == vtkMRMLDisplayableNode::DisplayModifiedEvent;
+    if (updateDirectionMarkers || slicePlaneMTime != this->LineDirectionMarkerLastSlicePlaneMTime || markupsDisplayMTime != this->LineDirectionMarkerLastMarkupsDisplayMTime)
+    {
+      this->LineDirectionArrowPipeline->Points->Reset();
+      this->LineDirectionArrowPipeline->Normals->Reset();
+      this->LineDirectionArrowPipeline->SliceDistances->Reset();
+
+      for (vtkIdType pointIndex = 0; pointIndex < this->LineDirectionMarkerCachedWorldPositions->GetNumberOfPoints(); ++pointIndex)
+      {
+        double worldPos[3];
+        this->LineDirectionMarkerCachedWorldPositions->GetPoint(pointIndex, worldPos);
+
+        // Signed distance to the slice plane; drives opacity fading through LineColorMap.
+        double sliceDist = this->SlicePlane->EvaluateFunction(worldPos);
+
+        double displayPos[4] = { 0.0 };
+        this->GetWorldToDisplayCoordinates(worldPos, displayPos);
+        // Skip arrows that are completely outside the fading range (avoids projecting far-off markers).
+        double limit = this->MarkupsDisplayNode->GetLineColorFadingEnd();
+        if (std::abs(sliceDist) > limit)
+        {
+          continue;
+        }
+
+        // Project the world tangent onto the slice plane using WorldToSliceTransform.
+        double worldTangent[3];
+        this->LineDirectionMarkerCachedWorldTangents->GetTuple(pointIndex, worldTangent);
+        double sliceTangent[3];
+        this->WorldToSliceTransform->TransformVector(worldTangent, sliceTangent);
+        sliceTangent[2] = 0.0;
+        double norm2D = std::sqrt(sliceTangent[0] * sliceTangent[0] + sliceTangent[1] * sliceTangent[1]);
+        if (norm2D < 1e-6)
+        {
+          continue; // tangent is perpendicular to the slice; no meaningful 2D direction
+        }
+        sliceTangent[0] /= norm2D;
+        sliceTangent[1] /= norm2D;
+
+        double arrowPos[3] = { displayPos[0], displayPos[1], 0.0 };
+
+        // Skip arrows that overlap with slice intersection points (only when intersection points are visible)
+        bool tooCloseToIntersection = false;
+        if (this->MarkupsDisplayNode->GetLineSliceIntersectionPointVisibility())
+        {
+          for (vtkIdType intersectionPointIndex = 0; intersectionPointIndex < this->LineSliceIntersectionWorldPoints->GetNumberOfPoints(); ++intersectionPointIndex)
+          {
+            double isectWorld[3];
+            this->LineSliceIntersectionWorldPoints->GetPoint(intersectionPointIndex, isectWorld);
+            double isectDisplay[4] = { 0.0 };
+            this->GetWorldToDisplayCoordinates(isectWorld, isectDisplay);
+            double isectPos[3] = { isectDisplay[0], isectDisplay[1], 0.0 };
+            if (vtkMath::Distance2BetweenPoints(arrowPos, isectPos) < intersectionExclR2)
+            {
+              tooCloseToIntersection = true;
+              break;
+            }
+          }
+        }
+        if (tooCloseToIntersection)
+        {
+          continue;
+        }
+
+        this->LineDirectionArrowPipeline->Points->InsertNextPoint(arrowPos);
+        this->LineDirectionArrowPipeline->Normals->InsertNextTuple(sliceTangent);
+        this->LineDirectionArrowPipeline->SliceDistances->InsertNextValue(static_cast<float>(sliceDist));
+      }
+
+      this->LineDirectionArrowPipeline->Points->Modified();
+      this->LineDirectionArrowPipeline->Normals->Modified();
+      this->LineDirectionArrowPipeline->SliceDistances->Modified();
+      this->LineDirectionArrowPipeline->PointsPoly->Modified();
+      this->LineDirectionArrowPipeline->Glypher->SetScaleFactor(markerSizePx);
+      this->LineDirectionArrowPipeline->Actor->SetVisibility(this->LineDirectionArrowPipeline->Points->GetNumberOfPoints() > 0);
+
+      // Update slice intersection point markers (same size as direction arrows, same color LUT)
+      this->UpdateSliceIntersectionPointDisplay(markerSizePx, colorMap);
+
+      this->LineDirectionMarkerLastSlicePlaneMTime = slicePlaneMTime;
+      this->LineDirectionMarkerLastMarkupsDisplayMTime = markupsDisplayMTime;
+    }
+    else if (hoverUpdate)
+    {
+      double fadingEnd = this->MarkupsDisplayNode->GetLineColorFadingEnd();
+      double sideOffset = fadingEnd * 0.5;
+      if (sideOffset <= 0.0)
+      {
+        sideOffset = 0.01;
+      }
+
+      double enteringColor[3];
+      colorMap->GetColor(+sideOffset, enteringColor);
+      this->LineSliceIntersectionEnteringPipeline->Property->SetColor(enteringColor);
+
+      double exitingColor[3];
+      colorMap->GetColor(-sideOffset, exitingColor);
+      this->LineSliceIntersectionExitingPipeline->Property->SetColor(exitingColor);
+    }
+    this->LineDirectionArrowPipeline->Actor->GetProperty()->SetColor(this->LineActor->GetProperty()->GetColor());
+  }
+  else
+  {
+    this->LineDirectionArrowPipeline->Actor->SetVisibility(false);
+    this->LineSliceIntersectionEnteringPipeline->Actor->SetVisibility(false);
+    this->LineSliceIntersectionExitingPipeline->Actor->SetVisibility(false);
   }
 }
 
@@ -247,7 +405,6 @@ int vtkSlicerCurveRepresentation2D::RenderOverlay(vtkViewport* viewport)
     count += this->LineActor->RenderOverlay(viewport);
   }
   count += this->Superclass::RenderOverlay(viewport);
-
   return count;
 }
 
@@ -260,7 +417,6 @@ int vtkSlicerCurveRepresentation2D::RenderOpaqueGeometry(vtkViewport* viewport)
     count += this->LineActor->RenderOpaqueGeometry(viewport);
   }
   count += this->Superclass::RenderOpaqueGeometry(viewport);
-
   return count;
 }
 
@@ -273,18 +429,17 @@ int vtkSlicerCurveRepresentation2D::RenderTranslucentPolygonalGeometry(vtkViewpo
     count += this->LineActor->RenderTranslucentPolygonalGeometry(viewport);
   }
   count += this->Superclass::RenderTranslucentPolygonalGeometry(viewport);
-
   return count;
 }
 
 //-----------------------------------------------------------------------------
 vtkTypeBool vtkSlicerCurveRepresentation2D::HasTranslucentPolygonalGeometry()
 {
-  if (this->Superclass::HasTranslucentPolygonalGeometry())
+  if (this->LineActor->GetVisibility() && this->LineActor->HasTranslucentPolygonalGeometry())
   {
     return true;
   }
-  if (this->LineActor->GetVisibility() && this->LineActor->HasTranslucentPolygonalGeometry())
+  if (this->Superclass::HasTranslucentPolygonalGeometry())
   {
     return true;
   }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.h
@@ -34,6 +34,7 @@
 #include "vtkSlicerMarkupsWidgetRepresentation2D.h"
 
 class vtkCellLocator;
+class vtkCleanPolyData;
 class vtkDiscretizableColorTransferFunction;
 class vtkSampleImplicitFunctionFilter;
 class vtkTubeFilter;
@@ -77,6 +78,8 @@ protected:
 
   void UpdateLineColorMap();
 
+  /// Compute fading scalars for accurate curve projection on the 2D slice.
+  /// The 2D mapper interpolates RGBA per-vertex (not scalars), so long tube segments
   vtkSmartPointer<vtkPolyData> Line;
   vtkSmartPointer<vtkPolyDataMapper2D> LineMapper;
   vtkSmartPointer<vtkActor2D> LineActor;
@@ -85,6 +88,7 @@ protected:
   vtkSmartPointer<vtkTubeFilter> TubeFilter;
 
   vtkSmartPointer<vtkTransformPolyDataFilter> WorldToSliceTransformer;
+  vtkSmartPointer<vtkCleanPolyData> SliceCurvePointsCleaner;
   vtkSmartPointer<vtkCellLocator> SliceCurvePointLocator;
 
   vtkSmartPointer<vtkSampleImplicitFunctionFilter> SliceDistance;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
@@ -34,6 +34,7 @@
 // MRML includes
 #include "vtkMRMLColorNode.h"
 #include "vtkMRMLInteractionEventData.h"
+#include "vtkMRMLMarkupsCurveNode.h"
 #include "vtkMRMLMarkupsDisplayNode.h"
 
 vtkStandardNewMacro(vtkSlicerCurveRepresentation3D);
@@ -78,14 +79,59 @@ void vtkSlicerCurveRepresentation3D::UpdateFromMRMLInternal(vtkMRMLNode* caller,
 
   this->NeedToRenderOn();
 
-  vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
+  vtkMRMLMarkupsCurveNode* markupsNode = vtkMRMLMarkupsCurveNode::SafeDownCast(this->GetMarkupsNode());
   if (!markupsNode || !this->IsDisplayable())
   {
     this->VisibilityOff();
     return;
   }
 
+  vtkPolyData* curveWorld = markupsNode->GetCurveWorld();
+  if (!curveWorld)
+  {
+    this->VisibilityOff();
+    return;
+  }
+
   this->VisibilityOn();
+
+  // Direction markers update
+  bool directionMarkersWasModified = false;
+  if (this->MarkupsDisplayNode->GetLineDirectionVisibility() && this->MarkupsDisplayNode->GetLineDirectionVisibility3D() && curveWorld && curveWorld->GetNumberOfPoints() > 1)
+  {
+    // Physical line diameter: absolute (mm) or relative to line thickness.
+    double lineDiameter =
+      (this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ? this->MarkupsDisplayNode->GetLineDiameter()
+                                                                                                      : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness());
+    double markerSizeWorld = vtkMRMLMarkupsDisplayNode::LineDirectionMarkerBaseScaleFactor * this->MarkupsDisplayNode->GetLineDirectionMarkerScale() * lineDiameter;
+    double markerSpacingWorld = this->MarkupsDisplayNode->GetLineDirectionMarkerSpacingScale() * markerSizeWorld;
+    this->LineDirectionArrowPipeline->Mapper->SetScaleFactor(markerSizeWorld);
+
+    // Only rebuild marker positions when spacing or curve geometry actually changed.
+    // UpdateFromMRMLInternal is called on mouse hover, selection changes, etc.
+    vtkMTimeType curveMTime = curveWorld->GetMTime();
+    bool lineDirectionFirstToLastControlPoint = this->MarkupsDisplayNode->GetLineDirectionFirstToLastControlPoint();
+    if (markerSpacingWorld != this->LineDirectionMarkerLastSpacing || curveMTime != this->LineDirectionMarkerLastGeometryMTime
+        || lineDirectionFirstToLastControlPoint != this->LineDirectionFirstToLastControlPoint)
+    {
+      vtkMRMLMarkupsNode::BuildLineDirectionMarkers(curveWorld->GetPoints(),
+                                                    this->CurveClosed,
+                                                    markerSpacingWorld,
+                                                    this->LineDirectionArrowPipeline->Points,
+                                                    this->LineDirectionArrowPipeline->Normals,
+                                                    lineDirectionFirstToLastControlPoint);
+      directionMarkersWasModified = true;
+      this->LineDirectionArrowPipeline->PointsPoly->Modified();
+      this->LineDirectionMarkerLastSpacing = markerSpacingWorld;
+      this->LineDirectionMarkerLastGeometryMTime = curveMTime;
+      this->LineDirectionFirstToLastControlPoint = lineDirectionFirstToLastControlPoint;
+    }
+    this->LineDirectionArrowPipeline->Actor->SetVisibility(true);
+  }
+  else
+  {
+    this->LineDirectionArrowPipeline->Actor->SetVisibility(false);
+  }
 
   // Properties label display
   // Display if there is at least one control point (even if preview)
@@ -154,7 +200,16 @@ void vtkSlicerCurveRepresentation3D::UpdateFromMRMLInternal(vtkMRMLNode* caller,
   {
     controlPointType = allControlPointsSelected ? Selected : Unselected;
   }
-  this->LineActor->SetProperty(this->GetControlPointsPipeline(controlPointType)->Property);
+  vtkProperty* pipelineProperty = this->GetControlPointsPipeline(controlPointType)->Property;
+  this->LineActor->SetProperty(pipelineProperty);
+  if (this->LineDirectionArrowPipeline->Actor->GetVisibility())
+  {
+    this->LineDirectionArrowPipeline->Actor->SetProperty(pipelineProperty);
+    if (!directionMarkersWasModified)
+    {
+      this->LineDirectionArrowPipeline->PointsPoly->Modified();
+    }
+  }
 
   this->TextActor->SetTextProperty(this->GetControlPointsPipeline(controlPointType)->TextProperty);
 
@@ -265,8 +320,7 @@ void vtkSlicerCurveRepresentation3D::ReleaseGraphicsResources(vtkWindow* win)
 //----------------------------------------------------------------------
 int vtkSlicerCurveRepresentation3D::RenderOverlay(vtkViewport* viewport)
 {
-  int count = 0;
-  count = this->Superclass::RenderOverlay(viewport);
+  int count = this->Superclass::RenderOverlay(viewport);
   if (this->LineActor->GetVisibility())
   {
     count += this->LineActor->RenderOverlay(viewport);
@@ -281,8 +335,7 @@ int vtkSlicerCurveRepresentation3D::RenderOverlay(vtkViewport* viewport)
 //-----------------------------------------------------------------------------
 int vtkSlicerCurveRepresentation3D::RenderOpaqueGeometry(vtkViewport* viewport)
 {
-  int count = 0;
-  count = this->Superclass::RenderOpaqueGeometry(viewport);
+  int count = this->Superclass::RenderOpaqueGeometry(viewport);
   if (this->LineActor->GetVisibility())
   {
     double diameter =
@@ -301,8 +354,7 @@ int vtkSlicerCurveRepresentation3D::RenderOpaqueGeometry(vtkViewport* viewport)
 //-----------------------------------------------------------------------------
 int vtkSlicerCurveRepresentation3D::RenderTranslucentPolygonalGeometry(vtkViewport* viewport)
 {
-  int count = 0;
-  count = this->Superclass::RenderTranslucentPolygonalGeometry(viewport);
+  int count = this->Superclass::RenderTranslucentPolygonalGeometry(viewport);
   if (this->LineActor->GetVisibility())
   {
     // The internal actor needs to share property keys.

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.cxx
@@ -19,7 +19,9 @@
 // VTK includes
 #include "vtkActor2D.h"
 #include "vtkDiscretizableColorTransferFunction.h"
-#include "vtkLine.h"
+#include "vtkDoubleArray.h"
+#include "vtkFloatArray.h"
+#include "vtkGlyph2D.h"
 #include "vtkMath.h"
 #include "vtkObjectFactory.h"
 #include "vtkPlane.h"
@@ -32,7 +34,6 @@
 #include "vtkSampleImplicitFunctionFilter.h"
 #include "vtkSlicerLineRepresentation2D.h"
 #include "vtkTextActor.h"
-#include "vtkTextProperty.h"
 #include "vtkTransform.h"
 #include "vtkTransformPolyDataFilter.h"
 #include "vtkTubeFilter.h"
@@ -54,7 +55,7 @@ vtkSlicerLineRepresentation2D::vtkSlicerLineRepresentation2D()
 
   this->WorldToSliceTransformer = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
   this->WorldToSliceTransformer->SetTransform(this->WorldToSliceTransform);
-  this->WorldToSliceTransformer->SetInputConnection(this->SliceDistance->GetOutputPort());
+  this->WorldToSliceTransformer->SetInputData(this->Line);
 
   this->TubeFilter = vtkSmartPointer<vtkTubeFilter>::New();
   this->TubeFilter->SetInputConnection(this->WorldToSliceTransformer->GetOutputPort());
@@ -71,6 +72,9 @@ vtkSlicerLineRepresentation2D::vtkSlicerLineRepresentation2D()
   this->LineActor = vtkSmartPointer<vtkActor2D>::New();
   this->LineActor->SetMapper(this->LineMapper);
   this->LineActor->SetProperty(this->GetControlPointsPipeline(Unselected)->Property);
+
+  // Share the LineColorMap LUT with the direction arrow mapper (initialized in base class)
+  this->LineDirectionArrowPipeline->Mapper->SetLookupTable(this->LineColorMap);
 }
 
 //----------------------------------------------------------------------
@@ -90,23 +94,35 @@ void vtkSlicerLineRepresentation2D::UpdateFromMRMLInternal(vtkMRMLNode* caller, 
     return;
   }
 
+  vtkPolyData* curveWorld = markupsNode->GetCurveWorld();
+  if (!curveWorld)
+  {
+    this->VisibilityOff();
+    return;
+  }
+
   this->VisibilityOn();
 
-  // Line display
-
-  double diameter =
+  // Physical line diameter in pixels: absolute (mm->px) or relative to line thickness.
+  double lineDiameterPx =
     (this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ? this->MarkupsDisplayNode->GetLineDiameter() / this->ViewScaleFactorMmPerPixel
                                                                                                     : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness());
-  this->TubeFilter->SetRadius(diameter * 0.5);
+  double markerSizePx = vtkMRMLMarkupsDisplayNode::LineDirectionMarkerBaseScaleFactor * this->MarkupsDisplayNode->GetLineDirectionMarkerScale() * lineDiameterPx;
 
-  this->LineActor->SetVisibility(markupsNode->GetNumberOfDefinedControlPoints(true) == 2);
+  // Line display
+  this->TubeFilter->SetRadius(lineDiameterPx * 0.5);
 
   // Hide the line actor if it doesn't intersect the current slice
   this->SliceDistance->Update();
-  if (!this->IsRepresentationIntersectingSlice(vtkPolyData::SafeDownCast(this->SliceDistance->GetOutput()), this->SliceDistance->GetScalarArrayName()))
+  vtkPolyData* representation = vtkPolyData::SafeDownCast(this->SliceDistance->GetOutput());
+  const char* arrayName = this->SliceDistance->GetScalarArrayName();
+  vtkFloatArray* distanceArray = nullptr;
+  if (representation)
   {
-    this->LineActor->SetVisibility(false);
+    distanceArray = vtkFloatArray::SafeDownCast(representation->GetPointData()->GetArray(this->SliceDistance->GetScalarArrayName()));
   }
+  bool isRepresentationIntersectingSlice = this->IsRepresentationIntersectingSlice(representation, arrayName);
+  this->LineActor->SetVisibility(markupsNode->GetNumberOfDefinedControlPoints(true) == 2 && isRepresentationIntersectingSlice);
 
   if (markupsNode->GetNumberOfDefinedControlPoints(true) == 2)
   {
@@ -147,17 +163,155 @@ void vtkSlicerLineRepresentation2D::UpdateFromMRMLInternal(vtkMRMLNode* caller, 
   this->LineActor->SetProperty(this->GetControlPointsPipeline(controlPointType)->Property);
   this->TextActor->SetTextProperty(this->GetControlPointsPipeline(controlPointType)->TextProperty);
 
+  vtkColorTransferFunction* colorMap = nullptr;
   if (this->MarkupsDisplayNode->GetLineColorNode() && this->MarkupsDisplayNode->GetLineColorNode()->GetColorTransferFunction())
   {
     // Update the line color mapping from the colorNode stored in the markups display node
-    this->LineMapper->SetLookupTable(this->MarkupsDisplayNode->GetLineColorNode()->GetColorTransferFunction());
+    colorMap = this->MarkupsDisplayNode->GetLineColorNode()->GetColorTransferFunction();
   }
   else
   {
     // if there is no line color node, build the color mapping from few variables
     // (color, opacity, distance fading, saturation and hue offset) stored in the display node
     this->UpdateDistanceColorMap(this->LineColorMap, this->LineActor->GetProperty()->GetColor());
-    this->LineMapper->SetLookupTable(this->LineColorMap);
+    colorMap = this->LineColorMap;
+  }
+
+  this->LineMapper->SetLookupTable(colorMap);
+  this->LineDirectionArrowPipeline->Mapper->SetLookupTable(colorMap);
+
+  // Compute fading scalars for the 2D line projection
+  this->ComputeIntersectionFadingScalars(curveWorld, this->SlicePlane, this->Line, distanceArray, this->LineSliceIntersectionWorldPoints);
+
+  // Direction markers update (2D)
+  if (isRepresentationIntersectingSlice && this->MarkupsDisplayNode->GetLineDirectionVisibility() && this->MarkupsDisplayNode->GetLineDirectionVisibility2D()
+      && markupsNode->GetNumberOfDefinedControlPoints(true) == 2)
+  {
+    // Spacing in mm, relative to cone height (100% = touching).
+    double markerSpacingMm = this->MarkupsDisplayNode->GetLineDirectionMarkerSpacingScale() * markerSizePx * this->ViewScaleFactorMmPerPixel;
+    double intersectionExclR2 = markerSizePx * markerSizePx * 0.75;
+    // Rebuild the sampled world positions/tangents only when spacing or world geometry changed.
+    vtkMTimeType curveMTime = curveWorld->GetMTime();
+    bool lineDirectionFirstToLastControlPoint = this->MarkupsDisplayNode->GetLineDirectionFirstToLastControlPoint();
+    bool updateDirectionMarkers = markerSpacingMm != this->LineDirectionMarkerLastSpacing || curveMTime != this->LineDirectionMarkerLastGeometryMTime
+                                  || lineDirectionFirstToLastControlPoint != this->LineDirectionFirstToLastControlPoint;
+    if (updateDirectionMarkers)
+    {
+      vtkMRMLMarkupsNode::BuildLineDirectionMarkers(curveWorld->GetPoints(),
+                                                    /*closedCurve=*/false,
+                                                    markerSpacingMm,
+                                                    this->LineDirectionMarkerCachedWorldPositions,
+                                                    this->LineDirectionMarkerCachedWorldTangents,
+                                                    lineDirectionFirstToLastControlPoint);
+      this->LineDirectionMarkerLastSpacing = markerSpacingMm;
+      this->LineDirectionMarkerLastGeometryMTime = curveMTime;
+      this->LineDirectionFirstToLastControlPoint = lineDirectionFirstToLastControlPoint;
+    }
+    vtkMTimeType slicePlaneMTime = this->SlicePlane->GetMTime();
+    vtkMTimeType markupsDisplayMTime = this->GetMarkupsDisplayNode()->GetMTime();
+    bool hoverUpdate = caller == this->GetMarkupsNode() && event == vtkMRMLDisplayableNode::DisplayModifiedEvent;
+    if (updateDirectionMarkers || slicePlaneMTime != this->LineDirectionMarkerLastSlicePlaneMTime || markupsDisplayMTime != this->LineDirectionMarkerLastMarkupsDisplayMTime)
+    {
+      this->LineDirectionArrowPipeline->Points->Reset();
+      this->LineDirectionArrowPipeline->Normals->Reset();
+      this->LineDirectionArrowPipeline->SliceDistances->Reset();
+
+      for (vtkIdType pointIndex = 0; pointIndex < this->LineDirectionMarkerCachedWorldPositions->GetNumberOfPoints(); ++pointIndex)
+      {
+        double worldPos[3];
+        this->LineDirectionMarkerCachedWorldPositions->GetPoint(pointIndex, worldPos);
+
+        // Signed distance to the slice plane; drives opacity fading through LineColorMap.
+        double sliceDist = this->SlicePlane->EvaluateFunction(worldPos);
+
+        double displayPos[4] = { 0.0 };
+        this->GetWorldToDisplayCoordinates(worldPos, displayPos);
+        // Skip arrows that are completely outside the fading range (avoids projecting far-off markers).
+        double limit = this->MarkupsDisplayNode->GetLineColorFadingEnd();
+        if (std::abs(sliceDist) > limit)
+        {
+          continue;
+        }
+
+        double worldTangent[3];
+        this->LineDirectionMarkerCachedWorldTangents->GetTuple(pointIndex, worldTangent);
+        double sliceTangent[3];
+        this->WorldToSliceTransform->TransformVector(worldTangent, sliceTangent);
+        sliceTangent[2] = 0.0;
+        double norm2D = std::sqrt(sliceTangent[0] * sliceTangent[0] + sliceTangent[1] * sliceTangent[1]);
+        if (norm2D < 1e-6)
+        {
+          continue;
+        }
+        sliceTangent[0] /= norm2D;
+        sliceTangent[1] /= norm2D;
+
+        double arrowPos[3] = { displayPos[0], displayPos[1], 0.0 };
+
+        // Skip arrows that overlap with slice intersection points (only when intersection points are visible)
+        bool tooCloseToIntersection = false;
+        if (this->MarkupsDisplayNode->GetLineSliceIntersectionPointVisibility())
+        {
+          for (vtkIdType intersectionPointIndex = 0; intersectionPointIndex < this->LineSliceIntersectionWorldPoints->GetNumberOfPoints(); ++intersectionPointIndex)
+          {
+            double isectWorld[3];
+            this->LineSliceIntersectionWorldPoints->GetPoint(intersectionPointIndex, isectWorld);
+            double isectDisplay[4] = { 0.0 };
+            this->GetWorldToDisplayCoordinates(isectWorld, isectDisplay);
+            double isectPos[3] = { isectDisplay[0], isectDisplay[1], 0.0 };
+            if (vtkMath::Distance2BetweenPoints(arrowPos, isectPos) < intersectionExclR2)
+            {
+              tooCloseToIntersection = true;
+              break;
+            }
+          }
+        }
+        if (tooCloseToIntersection)
+        {
+          continue;
+        }
+
+        this->LineDirectionArrowPipeline->Points->InsertNextPoint(arrowPos);
+        this->LineDirectionArrowPipeline->Normals->InsertNextTuple(sliceTangent);
+        this->LineDirectionArrowPipeline->SliceDistances->InsertNextValue(static_cast<float>(sliceDist));
+      }
+
+      this->LineDirectionArrowPipeline->Points->Modified();
+      this->LineDirectionArrowPipeline->Normals->Modified();
+      this->LineDirectionArrowPipeline->SliceDistances->Modified();
+      this->LineDirectionArrowPipeline->PointsPoly->Modified();
+      this->LineDirectionArrowPipeline->Glypher->SetScaleFactor(markerSizePx);
+
+      // Update slice intersection point markers (same size as direction arrows, same color LUT)
+      this->UpdateSliceIntersectionPointDisplay(markerSizePx, colorMap);
+
+      this->LineDirectionMarkerLastSlicePlaneMTime = slicePlaneMTime;
+      this->LineDirectionMarkerLastMarkupsDisplayMTime = markupsDisplayMTime;
+    }
+    else if (hoverUpdate)
+    {
+      double fadingEnd = this->MarkupsDisplayNode->GetLineColorFadingEnd();
+      double sideOffset = fadingEnd * 0.5;
+      if (sideOffset <= 0.0)
+      {
+        sideOffset = 0.01;
+      }
+
+      double enteringColor[3];
+      colorMap->GetColor(+sideOffset, enteringColor);
+      this->LineSliceIntersectionEnteringPipeline->Property->SetColor(enteringColor);
+
+      double exitingColor[3];
+      colorMap->GetColor(-sideOffset, exitingColor);
+      this->LineSliceIntersectionExitingPipeline->Property->SetColor(exitingColor);
+    }
+    this->LineDirectionArrowPipeline->Actor->SetVisibility(this->LineDirectionArrowPipeline->Points->GetNumberOfPoints() > 0);
+  }
+  else
+  {
+    this->LineDirectionArrowPipeline->Actor->SetVisibility(false);
+    this->LineSliceIntersectionEnteringPipeline->Actor->SetVisibility(false);
+    this->LineSliceIntersectionExitingPipeline->Actor->SetVisibility(false);
   }
 }
 
@@ -215,7 +369,7 @@ int vtkSlicerLineRepresentation2D::RenderOpaqueGeometry(vtkViewport* viewport)
   {
     count += this->LineActor->RenderOpaqueGeometry(viewport);
   }
-  count = this->Superclass::RenderOpaqueGeometry(viewport);
+  count += this->Superclass::RenderOpaqueGeometry(viewport);
   return count;
 }
 
@@ -227,18 +381,18 @@ int vtkSlicerLineRepresentation2D::RenderTranslucentPolygonalGeometry(vtkViewpor
   {
     count += this->LineActor->RenderTranslucentPolygonalGeometry(viewport);
   }
-  count = this->Superclass::RenderTranslucentPolygonalGeometry(viewport);
+  count += this->Superclass::RenderTranslucentPolygonalGeometry(viewport);
   return count;
 }
 
 //-----------------------------------------------------------------------------
 vtkTypeBool vtkSlicerLineRepresentation2D::HasTranslucentPolygonalGeometry()
 {
-  if (this->Superclass::HasTranslucentPolygonalGeometry())
+  if (this->LineActor->GetVisibility() && this->LineActor->HasTranslucentPolygonalGeometry())
   {
     return true;
   }
-  if (this->LineActor->GetVisibility() && this->LineActor->HasTranslucentPolygonalGeometry())
+  if (this->Superclass::HasTranslucentPolygonalGeometry())
   {
     return true;
   }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
@@ -17,22 +17,17 @@
 =========================================================================*/
 
 // VTK includes
-#include "vtkActor2D.h"
-#include "vtkGlyph3D.h"
-#include "vtkMatrix4x4.h"
+#include "vtkGlyph3DMapper.h"
 #include "vtkPolyDataMapper.h"
 #include "vtkProperty.h"
 #include "vtkRenderer.h"
 #include "vtkSlicerLineRepresentation3D.h"
 #include "vtkTextActor.h"
-#include "vtkTextProperty.h"
-#include "vtkTransform.h"
 #include "vtkTubeFilter.h"
 
 // MRML includes
 #include "vtkMRMLInteractionEventData.h"
 #include "vtkMRMLMarkupsDisplayNode.h"
-
 vtkStandardNewMacro(vtkSlicerLineRepresentation3D);
 
 //----------------------------------------------------------------------
@@ -85,8 +80,7 @@ void vtkSlicerLineRepresentation3D::ReleaseGraphicsResources(vtkWindow* win)
 //----------------------------------------------------------------------
 int vtkSlicerLineRepresentation3D::RenderOverlay(vtkViewport* viewport)
 {
-  int count = 0;
-  count = this->Superclass::RenderOverlay(viewport);
+  int count = this->Superclass::RenderOverlay(viewport);
   if (this->LineActor->GetVisibility())
   {
     count += this->LineActor->RenderOverlay(viewport);
@@ -101,8 +95,7 @@ int vtkSlicerLineRepresentation3D::RenderOverlay(vtkViewport* viewport)
 //-----------------------------------------------------------------------------
 int vtkSlicerLineRepresentation3D::RenderOpaqueGeometry(vtkViewport* viewport)
 {
-  int count = 0;
-  count = this->Superclass::RenderOpaqueGeometry(viewport);
+  int count = this->Superclass::RenderOpaqueGeometry(viewport);
   if (this->LineActor->GetVisibility())
   {
     double diameter =
@@ -121,8 +114,7 @@ int vtkSlicerLineRepresentation3D::RenderOpaqueGeometry(vtkViewport* viewport)
 //-----------------------------------------------------------------------------
 int vtkSlicerLineRepresentation3D::RenderTranslucentPolygonalGeometry(vtkViewport* viewport)
 {
-  int count = 0;
-  count = this->Superclass::RenderTranslucentPolygonalGeometry(viewport);
+  int count = this->Superclass::RenderTranslucentPolygonalGeometry(viewport);
   if (this->LineActor->GetVisibility())
   {
     // The internal actor needs to share property keys.
@@ -182,14 +174,61 @@ void vtkSlicerLineRepresentation3D::UpdateFromMRMLInternal(vtkMRMLNode* caller, 
     return;
   }
 
+  vtkPolyData* curveWorld = markupsNode->GetCurveWorld();
+  if (!curveWorld)
+  {
+    this->VisibilityOff();
+    return;
+  }
+
   this->VisibilityOn();
 
-  // Line geometry
+  // Line geometry – only rebuild when the number or position of control points changed
+  if (!event || event == vtkMRMLMarkupsNode::PointModifiedEvent || event == vtkMRMLMarkupsNode::PointAddedEvent || event == vtkMRMLMarkupsNode::PointRemovedEvent
+      || event == vtkMRMLMarkupsNode::PointPositionDefinedEvent || event == vtkMRMLMarkupsNode::PointPositionUndefinedEvent
+      || event == vtkMRMLMarkupsNode::PointPositionMissingEvent || event == vtkMRMLMarkupsNode::PointPositionNonMissingEvent
+      || event == vtkMRMLTransformableNode::TransformModifiedEvent || this->Line->GetNumberOfPoints() == 0)
+  {
+    this->BuildLine(this->Line, false);
+  }
 
-  this->BuildLine(this->Line, false);
+  // Direction markers update
+  bool directionMarkersWasModified = false;
+  if (this->MarkupsDisplayNode->GetLineDirectionVisibility() && this->MarkupsDisplayNode->GetLineDirectionVisibility3D() && this->Line->GetNumberOfPoints() >= 2)
+  {
+    double lineDiameter =
+      (this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ? this->MarkupsDisplayNode->GetLineDiameter()
+                                                                                                      : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness());
+    double markerSizeWorld = vtkMRMLMarkupsDisplayNode::LineDirectionMarkerBaseScaleFactor * this->MarkupsDisplayNode->GetLineDirectionMarkerScale() * lineDiameter;
+    double markerSpacingWorld = this->MarkupsDisplayNode->GetLineDirectionMarkerSpacingScale() * markerSizeWorld;
+    this->LineDirectionArrowPipeline->Mapper->SetScaleFactor(markerSizeWorld);
+    // Only rebuild marker positions when spacing or line geometry actually changed.
+    // UpdateFromMRMLInternal is called on mouse hover, selection changes, etc.
+    vtkMTimeType worldMTime = curveWorld ? curveWorld->GetMTime() : markupsNode->GetMTime();
+    bool lineDirectionFirstToLastControlPoint = this->MarkupsDisplayNode->GetLineDirectionFirstToLastControlPoint();
+    if (markerSpacingWorld != this->LineDirectionMarkerLastSpacing || worldMTime != this->LineDirectionMarkerLastGeometryMTime
+        || lineDirectionFirstToLastControlPoint != this->LineDirectionFirstToLastControlPoint)
+    {
+      vtkMRMLMarkupsNode::BuildLineDirectionMarkers(curveWorld->GetPoints(),
+                                                    /*closedCurve=*/false,
+                                                    markerSpacingWorld,
+                                                    this->LineDirectionArrowPipeline->Points,
+                                                    this->LineDirectionArrowPipeline->Normals,
+                                                    lineDirectionFirstToLastControlPoint);
+      directionMarkersWasModified = true;
+      this->LineDirectionArrowPipeline->PointsPoly->Modified();
+      this->LineDirectionMarkerLastSpacing = markerSpacingWorld;
+      this->LineDirectionMarkerLastGeometryMTime = worldMTime;
+      this->LineDirectionFirstToLastControlPoint = lineDirectionFirstToLastControlPoint;
+    }
+    this->LineDirectionArrowPipeline->Actor->SetVisibility(markupsNode->GetNumberOfDefinedControlPoints(true) == 2);
+  }
+  else
+  {
+    this->LineDirectionArrowPipeline->Actor->SetVisibility(false);
+  }
 
   // Line display
-
   this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper, this->LineOccludedMapper);
 
   double diameter =
@@ -203,7 +242,16 @@ void vtkSlicerLineRepresentation3D::UpdateFromMRMLInternal(vtkMRMLNode* caller, 
   {
     controlPointType = this->GetAllControlPointsSelected() ? Selected : Unselected;
   }
-  this->LineActor->SetProperty(this->GetControlPointsPipeline(controlPointType)->Property);
+  vtkProperty* pipelineProperty = this->GetControlPointsPipeline(controlPointType)->Property;
+  this->LineActor->SetProperty(pipelineProperty);
+  if (this->LineDirectionArrowPipeline->Actor->GetVisibility())
+  {
+    this->LineDirectionArrowPipeline->Actor->SetProperty(pipelineProperty);
+    if (!directionMarkersWasModified)
+    {
+      this->LineDirectionArrowPipeline->PointsPoly->Modified();
+    }
+  }
   this->TextActor->SetTextProperty(this->GetControlPointsPipeline(controlPointType)->TextProperty);
 
   this->LineOccludedActor->SetProperty(this->GetControlPointsPipeline(controlPointType)->OccludedProperty);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
@@ -18,8 +18,12 @@
 
 // VTK includes
 #include "vtkCamera.h"
+#include "vtkCellArray.h"
 #include "vtkCellLocator.h"
+#include "vtkConeSource.h"
+#include "vtkDoubleArray.h"
 #include "vtkDiscretizableColorTransferFunction.h"
+#include "vtkFloatArray.h"
 #include "vtkGlyph2D.h"
 #include "vtkLabelPlacementMapper.h"
 #include "vtkLine.h"
@@ -38,15 +42,17 @@
 #include "vtkSlicerMarkupsWidgetRepresentation2D.h"
 #include "vtkSphereSource.h"
 #include "vtkStringArray.h"
-#include "vtkTensorGlyph.h"
 #include "vtkTextActor.h"
 #include "vtkTextProperty.h"
 #include "vtkTransform.h"
-#include "vtkTransformPolyDataFilter.h"
 
 // MRML includes
 #include <vtkMRMLFolderDisplayNode.h>
 #include <vtkMRMLInteractionEventData.h>
+#include <vtkMRMLProceduralColorNode.h>
+
+#include <cmath>
+#include <vector>
 
 vtkSlicerMarkupsWidgetRepresentation2D::ControlPointsPipeline2D::ControlPointsPipeline2D()
 {
@@ -103,6 +109,82 @@ vtkSlicerMarkupsWidgetRepresentation2D::ControlPointsPipeline2D::ControlPointsPi
 vtkSlicerMarkupsWidgetRepresentation2D::ControlPointsPipeline2D::~ControlPointsPipeline2D() = default;
 
 //----------------------------------------------------------------------
+vtkSlicerMarkupsWidgetRepresentation2D::LineDirectionArrowPipeline2D::LineDirectionArrowPipeline2D()
+{
+  this->Points = vtkSmartPointer<vtkPoints>::New();
+
+  this->Normals = vtkSmartPointer<vtkDoubleArray>::New();
+  this->Normals->SetNumberOfComponents(3);
+  this->Normals->SetName("Normals");
+
+  this->SliceDistances = vtkSmartPointer<vtkFloatArray>::New();
+  this->SliceDistances->SetName("SliceDistance");
+
+  this->PointsPoly = vtkSmartPointer<vtkPolyData>::New();
+  this->PointsPoly->SetPoints(this->Points);
+  this->PointsPoly->GetPointData()->AddArray(this->Normals);
+  this->PointsPoly->GetPointData()->SetActiveNormals("Normals");
+  this->PointsPoly->GetPointData()->AddArray(this->SliceDistances);
+  this->PointsPoly->GetPointData()->SetActiveScalars("SliceDistance");
+
+  // 'coneSource' is a local variable; VTK's pipeline keeps it alive as needed.
+  vtkNew<vtkConeSource> coneSource;
+  coneSource->SetHeight(1.0);
+  coneSource->SetRadius(0.4);
+  coneSource->SetResolution(6);
+  coneSource->SetDirection(1, 0, 0);
+
+  this->Glypher = vtkSmartPointer<vtkGlyph2D>::New();
+  this->Glypher->SetInputData(this->PointsPoly);
+  this->Glypher->SetSourceConnection(coneSource->GetOutputPort());
+  this->Glypher->SetVectorModeToUseNormal();
+  this->Glypher->OrientOn();
+  this->Glypher->SetScaleModeToDataScalingOff();
+  this->Glypher->SetScaleFactor(1.0);
+
+  this->Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+  this->Mapper->SetInputConnection(this->Glypher->GetOutputPort());
+  this->Mapper->SetScalarVisibility(true);
+
+  this->Actor = vtkSmartPointer<vtkActor2D>::New();
+  this->Actor->SetMapper(this->Mapper);
+  this->Actor->SetVisibility(false);
+}
+
+//----------------------------------------------------------------------
+vtkSlicerMarkupsWidgetRepresentation2D::LineIntersectionPointsPipeline2D::LineIntersectionPointsPipeline2D(vtkAlgorithmOutput* glyphSourcePort, vtkProperty2D* property)
+{
+  this->DisplayPoints = vtkSmartPointer<vtkPoints>::New();
+
+  this->PointsPoly = vtkSmartPointer<vtkPolyData>::New();
+  this->PointsPoly->SetPoints(this->DisplayPoints);
+
+  this->Glypher = vtkSmartPointer<vtkGlyph2D>::New();
+  this->Glypher->SetInputData(this->PointsPoly);
+  this->Glypher->SetSourceConnection(glyphSourcePort);
+  this->Glypher->SetScaleModeToDataScalingOff();
+  this->Glypher->SetScaleFactor(1.0);
+
+  this->Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+  this->Mapper->SetInputConnection(this->Glypher->GetOutputPort());
+  this->Mapper->SetScalarVisibility(false);
+  vtkNew<vtkCoordinate> coord;
+  coord->SetCoordinateSystemToDisplay();
+  this->Mapper->SetTransformCoordinate(coord);
+
+  this->Property = vtkSmartPointer<vtkProperty2D>::New();
+  this->Property->SetColor(property->GetColor());
+  this->Property->SetOpacity(property->GetOpacity());
+  this->Property->SetPointSize(property->GetPointSize());
+  this->Property->SetLineWidth(property->GetLineWidth());
+
+  this->Actor = vtkSmartPointer<vtkActor2D>::New();
+  this->Actor->SetMapper(this->Mapper);
+  this->Actor->SetProperty(this->Property);
+  this->Actor->SetVisibility(false);
+}
+
+//----------------------------------------------------------------------
 vtkSlicerMarkupsWidgetRepresentation2D::vtkSlicerMarkupsWidgetRepresentation2D()
 {
   for (int i = 0; i < NumberOfControlPointTypes; i++)
@@ -126,6 +208,38 @@ vtkSlicerMarkupsWidgetRepresentation2D::vtkSlicerMarkupsWidgetRepresentation2D()
 
   this->SlicePlane = vtkSmartPointer<vtkPlane>::New();
   this->WorldToSliceTransform = vtkSmartPointer<vtkTransform>::New();
+
+  // Slice intersection point glyph pipelines
+  this->LineSliceIntersectionWorldPoints = vtkSmartPointer<vtkPoints>::New();
+  this->LineSliceIntersectionApproachingSigns = vtkSmartPointer<vtkFloatArray>::New();
+  this->LineSliceIntersectionApproachingSigns->SetName("ApproachingSign");
+  this->LineSliceIntersectionApproachingSigns->SetNumberOfComponents(1);
+
+  // Direction arrow glyph pipeline (2D)
+  this->LineDirectionArrowPipeline = std::make_unique<LineDirectionArrowPipeline2D>();
+  this->LineDirectionMarkerCachedWorldPositions = vtkSmartPointer<vtkPoints>::New();
+  this->LineDirectionMarkerCachedWorldTangents = vtkSmartPointer<vtkDoubleArray>::New();
+  this->LineDirectionMarkerCachedWorldTangents->SetNumberOfComponents(3);
+
+  this->LineSliceIntersectionProperty = vtkSmartPointer<vtkProperty2D>::New();
+  this->LineSliceIntersectionProperty->SetColor(1.0, 1.0, 1.0);
+  this->LineSliceIntersectionProperty->SetOpacity(1.0);
+  this->LineSliceIntersectionProperty->SetPointSize(3.0);
+  this->LineSliceIntersectionProperty->SetLineWidth(3.0);
+
+  // Entering pipeline (CircledCross glyph)
+  // 'enteringGlyphSource' is a local variable; VTK's pipeline keeps it alive as needed.
+  vtkNew<vtkMarkupsGlyphSource2D> enteringGlyphSource;
+  enteringGlyphSource->SetGlyphTypeToCircledCross();
+  enteringGlyphSource->FilledOff();
+  this->LineSliceIntersectionEnteringPipeline = std::make_unique<LineIntersectionPointsPipeline2D>(enteringGlyphSource->GetOutputPort(), this->LineSliceIntersectionProperty);
+
+  // Exiting pipeline (CircledPoint glyph)
+  // 'exitingGlyphSource' is a local variable; VTK's pipeline keeps it alive as needed.
+  vtkNew<vtkMarkupsGlyphSource2D> exitingGlyphSource;
+  exitingGlyphSource->SetGlyphTypeToCircledPoint();
+  exitingGlyphSource->FilledOff();
+  this->LineSliceIntersectionExitingPipeline = std::make_unique<LineIntersectionPointsPipeline2D>(exitingGlyphSource->GetOutputPort(), this->LineSliceIntersectionProperty);
 }
 
 //----------------------------------------------------------------------
@@ -625,6 +739,7 @@ void vtkSlicerMarkupsWidgetRepresentation2D::CanInteractWithLine(vtkMRMLInteract
 void vtkSlicerMarkupsWidgetRepresentation2D::GetActors(vtkPropCollection* pc)
 {
   Superclass::GetActors(pc);
+  this->LineDirectionArrowPipeline->Actor->GetActors(pc);
   for (int i = 0; i < NumberOfControlPointTypes; i++)
   {
     ControlPointsPipeline2D* controlPoints = reinterpret_cast<ControlPointsPipeline2D*>(this->ControlPoints[i]);
@@ -632,12 +747,15 @@ void vtkSlicerMarkupsWidgetRepresentation2D::GetActors(vtkPropCollection* pc)
     controlPoints->LabelsActor->GetActors(pc);
   }
   this->TextActor->GetActors(pc);
+  this->LineSliceIntersectionEnteringPipeline->Actor->GetActors(pc);
+  this->LineSliceIntersectionExitingPipeline->Actor->GetActors(pc);
 }
 
 //----------------------------------------------------------------------
 void vtkSlicerMarkupsWidgetRepresentation2D::ReleaseGraphicsResources(vtkWindow* win)
 {
   Superclass::ReleaseGraphicsResources(win);
+  this->LineDirectionArrowPipeline->Actor->ReleaseGraphicsResources(win);
   for (int i = 0; i < NumberOfControlPointTypes; i++)
   {
     ControlPointsPipeline2D* controlPoints = reinterpret_cast<ControlPointsPipeline2D*>(this->ControlPoints[i]);
@@ -645,12 +763,18 @@ void vtkSlicerMarkupsWidgetRepresentation2D::ReleaseGraphicsResources(vtkWindow*
     controlPoints->LabelsActor->ReleaseGraphicsResources(win);
   }
   this->TextActor->ReleaseGraphicsResources(win);
+  this->LineSliceIntersectionEnteringPipeline->Actor->ReleaseGraphicsResources(win);
+  this->LineSliceIntersectionExitingPipeline->Actor->ReleaseGraphicsResources(win);
 }
 
 //----------------------------------------------------------------------
 int vtkSlicerMarkupsWidgetRepresentation2D::RenderOverlay(vtkViewport* viewport)
 {
   int count = Superclass::RenderOverlay(viewport);
+  if (this->LineDirectionArrowPipeline->Actor->GetVisibility())
+  {
+    count += this->LineDirectionArrowPipeline->Actor->RenderOverlay(viewport);
+  }
   for (int i = 0; i < NumberOfControlPointTypes; i++)
   {
     ControlPointsPipeline2D* controlPoints = reinterpret_cast<ControlPointsPipeline2D*>(this->ControlPoints[i]);
@@ -667,6 +791,14 @@ int vtkSlicerMarkupsWidgetRepresentation2D::RenderOverlay(vtkViewport* viewport)
   {
     count += this->TextActor->RenderOverlay(viewport);
   }
+  if (this->LineSliceIntersectionEnteringPipeline->Actor->GetVisibility())
+  {
+    count += this->LineSliceIntersectionEnteringPipeline->Actor->RenderOverlay(viewport);
+  }
+  if (this->LineSliceIntersectionExitingPipeline->Actor->GetVisibility())
+  {
+    count += this->LineSliceIntersectionExitingPipeline->Actor->RenderOverlay(viewport);
+  }
   return count;
 }
 
@@ -674,6 +806,10 @@ int vtkSlicerMarkupsWidgetRepresentation2D::RenderOverlay(vtkViewport* viewport)
 int vtkSlicerMarkupsWidgetRepresentation2D::RenderOpaqueGeometry(vtkViewport* viewport)
 {
   int count = 0;
+  if (this->LineDirectionArrowPipeline->Actor->GetVisibility())
+  {
+    count += this->LineDirectionArrowPipeline->Actor->RenderOpaqueGeometry(viewport);
+  }
   if (this->TextActor->GetVisibility())
   {
     count += this->TextActor->RenderOpaqueGeometry(viewport);
@@ -690,6 +826,14 @@ int vtkSlicerMarkupsWidgetRepresentation2D::RenderOpaqueGeometry(vtkViewport* vi
       count += controlPoints->LabelsActor->RenderOpaqueGeometry(viewport);
     }
   }
+  if (this->LineSliceIntersectionEnteringPipeline->Actor->GetVisibility())
+  {
+    count += this->LineSliceIntersectionEnteringPipeline->Actor->RenderOpaqueGeometry(viewport);
+  }
+  if (this->LineSliceIntersectionExitingPipeline->Actor->GetVisibility())
+  {
+    count += this->LineSliceIntersectionExitingPipeline->Actor->RenderOpaqueGeometry(viewport);
+  }
   return count;
 }
 
@@ -697,6 +841,10 @@ int vtkSlicerMarkupsWidgetRepresentation2D::RenderOpaqueGeometry(vtkViewport* vi
 int vtkSlicerMarkupsWidgetRepresentation2D::RenderTranslucentPolygonalGeometry(vtkViewport* viewport)
 {
   int count = Superclass::RenderTranslucentPolygonalGeometry(viewport);
+  if (this->LineDirectionArrowPipeline->Actor->GetVisibility())
+  {
+    count += this->LineDirectionArrowPipeline->Actor->RenderTranslucentPolygonalGeometry(viewport);
+  }
   if (this->TextActor->GetVisibility())
   {
     count += this->TextActor->RenderTranslucentPolygonalGeometry(viewport);
@@ -713,6 +861,14 @@ int vtkSlicerMarkupsWidgetRepresentation2D::RenderTranslucentPolygonalGeometry(v
       count += controlPoints->LabelsActor->RenderTranslucentPolygonalGeometry(viewport);
     }
   }
+  if (this->LineSliceIntersectionEnteringPipeline->Actor->GetVisibility())
+  {
+    count += this->LineSliceIntersectionEnteringPipeline->Actor->RenderTranslucentPolygonalGeometry(viewport);
+  }
+  if (this->LineSliceIntersectionExitingPipeline->Actor->GetVisibility())
+  {
+    count += this->LineSliceIntersectionExitingPipeline->Actor->RenderTranslucentPolygonalGeometry(viewport);
+  }
   return count;
 }
 
@@ -720,6 +876,10 @@ int vtkSlicerMarkupsWidgetRepresentation2D::RenderTranslucentPolygonalGeometry(v
 vtkTypeBool vtkSlicerMarkupsWidgetRepresentation2D::HasTranslucentPolygonalGeometry()
 {
   if (this->Superclass::HasTranslucentPolygonalGeometry())
+  {
+    return true;
+  }
+  if (this->LineDirectionArrowPipeline->Actor->GetVisibility() && this->LineDirectionArrowPipeline->Actor->HasTranslucentPolygonalGeometry())
   {
     return true;
   }
@@ -738,6 +898,14 @@ vtkTypeBool vtkSlicerMarkupsWidgetRepresentation2D::HasTranslucentPolygonalGeome
     {
       return true;
     }
+  }
+  if (this->LineSliceIntersectionEnteringPipeline->Actor->GetVisibility() && this->LineSliceIntersectionEnteringPipeline->Actor->HasTranslucentPolygonalGeometry())
+  {
+    return true;
+  }
+  if (this->LineSliceIntersectionExitingPipeline->Actor->GetVisibility() && this->LineSliceIntersectionExitingPipeline->Actor->HasTranslucentPolygonalGeometry())
+  {
+    return true;
   }
   return false;
 }
@@ -784,6 +952,30 @@ void vtkSlicerMarkupsWidgetRepresentation2D::PrintSelf(ostream& os, vtkIndent in
     else
     {
       os << indent << "Property: (none)\n";
+    }
+    if (this->LineDirectionArrowPipeline->Actor)
+    {
+      os << indent << "Arrow Glyph Actor 2D Visibility: " << this->LineDirectionArrowPipeline->Actor->GetVisibility() << "\n";
+    }
+    else
+    {
+      os << indent << "Arrow Glyph Actor 2D: (none)\n";
+    }
+    if (this->LineSliceIntersectionEnteringPipeline->Actor)
+    {
+      os << indent << "Slice entering intersection Glyph Actor 2D Visibility: " << this->LineSliceIntersectionEnteringPipeline->Actor->GetVisibility() << "\n";
+    }
+    else
+    {
+      os << indent << "Slice entering intersection Actor 2D: (none)\n";
+    }
+    if (this->LineSliceIntersectionExitingPipeline->Actor)
+    {
+      os << indent << "Slice exiting intersection Actor 2D Visibility: " << this->LineSliceIntersectionExitingPipeline->Actor->GetVisibility() << "\n";
+    }
+    else
+    {
+      os << indent << "Slice exiting intersection Actor 2D: (none)\n";
     }
   }
 }
@@ -1183,4 +1375,330 @@ bool vtkSlicerMarkupsWidgetRepresentation2D::IsRepresentationIntersectingSlice(v
     return false;
   }
   return true;
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation2D::ComputeIntersectionFadingScalars(vtkPolyData* worldPolyData,
+                                                                              vtkPlane* slicePlane,
+                                                                              vtkPolyData* outputPolyData,
+                                                                              vtkFloatArray* distanceArray,
+                                                                              vtkPoints* intersectionPoints)
+{
+  vtkPoints* inputPoints = worldPolyData ? worldPolyData->GetPoints() : nullptr;
+  if (!inputPoints || !slicePlane || !outputPolyData || inputPoints->GetNumberOfPoints() < 2)
+  {
+    if (outputPolyData)
+    {
+      outputPolyData->Initialize();
+    }
+    return;
+  }
+
+  // Determine the fading range: the tube is fully transparent beyond fadingEnd.
+  double fadingEnd = this->MarkupsDisplayNode->GetLineColorFadingEnd();
+
+  // MTime guard: skip recomputation if inputs haven't changed since last call.
+  // This avoids expensive polyline walking and subdivision when neither the curve
+  // geometry, slice plane position, nor fading range have been modified.
+  // When cached, intersectionPoints is left untouched (still valid from previous call).
+  vtkMTimeType worldMTime = worldPolyData->GetMTime();
+  vtkMTimeType planeMTime = slicePlane->GetMTime();
+  if (worldMTime == this->FadingScalarsLastWorldDataMTime && planeMTime == this->FadingScalarsLastSlicePlaneMTime && fadingEnd == this->FadingScalarsLastFadingEnd
+      && outputPolyData->GetNumberOfPoints() > 0)
+  {
+    return;
+  }
+
+  // Number of subdivisions within the fading range for smooth opacity gradient
+  const int numFadingSteps = 10;
+  double subdivisionStep = fadingEnd / numFadingSteps;
+  vtkIdType numInputPts = inputPoints->GetNumberOfPoints();
+
+  vtkNew<vtkFloatArray> signedDist;
+  if (!distanceArray)
+  {
+    // Compute signed perpendicular distance from each input point to the slice plane.
+    signedDist->SetNumberOfValues(numInputPts);
+    slicePlane->EvaluateFunction(inputPoints->GetData(), signedDist);
+  }
+  else
+  {
+    signedDist->ShallowCopy(distanceArray);
+  }
+
+  // Walk along the polyline, detect plane crossings, and build the output point list.
+  // - Insert exact intersection points (scalar = 0) and collect them in intersectionPoints.
+  // - Subdivide segments that are near or cross the slice plane so that the per-vertex
+  //   opacity mapping produces an accurate fading gradient.
+  // - Skip portions of segments that are entirely beyond the fading range (both endpoints
+  //   beyond fadingEnd on the same side) to avoid rendering invisible geometry.
+  vtkNew<vtkPoints> outPoints;
+  outPoints->Allocate(numInputPts * (numFadingSteps + 3));
+  vtkNew<vtkFloatArray> outScalars;
+  outScalars->SetName("SliceDistance");
+  outScalars->SetNumberOfComponents(1);
+  outScalars->Allocate(numInputPts * (numFadingSteps + 3));
+
+  // Reset intersection points output for this polydata source.
+  if (intersectionPoints)
+  {
+    intersectionPoints->Reset();
+  }
+  this->LineSliceIntersectionApproachingSigns->Reset();
+
+  // Add first point (only if within the visible range)
+  double prevPt[3];
+  inputPoints->GetPoint(0, prevPt);
+  bool prevAdded = (fabs(signedDist->GetValue(0)) <= fadingEnd);
+  if (prevAdded)
+  {
+    outPoints->InsertNextPoint(prevPt);
+    outScalars->InsertNextValue(static_cast<float>(signedDist->GetValue(0)));
+  }
+
+  for (vtkIdType pointIndex = 1; pointIndex < numInputPts; pointIndex++)
+  {
+    double pt[3];
+    inputPoints->GetPoint(pointIndex, pt);
+
+    double d0 = signedDist->GetValue(pointIndex - 1);
+    double d1 = signedDist->GetValue(pointIndex);
+
+    // Check if both endpoints are beyond the fading range on the same side.
+    // No intersection is possible: segments entirely on one side of the plane
+    // that are also beyond the fading range cannot cross the slice plane.
+    if ((d0 > fadingEnd && d1 > fadingEnd) || (d0 < -fadingEnd && d1 < -fadingEnd))
+    {
+      // Entire segment is invisible — skip it
+      prevAdded = false;
+      vtkMath::Assign(pt, prevPt);
+      continue;
+    }
+
+    // This segment is at least partially visible. Compute the parameter range [tStart, tEnd]
+    // within [0,1] that corresponds to the visible portion (|distance| <= fadingEnd).
+    // d(t) = d0 + t*(d1 - d0), so t for a given distance D is: t = (D - d0)/(d1 - d0).
+    double tStart = 0.0;
+    double tEnd = 1.0;
+    double dDiff = d1 - d0;
+    bool notInPlane = fabs(dDiff) > 1e-6;
+    if (notInPlane)
+    {
+      // t where distance = +/-fadingEnd
+      double tPlus = (fadingEnd - d0) / dDiff;
+      double tMinus = (-fadingEnd - d0) / dDiff;
+
+      double tLow = (tPlus < tMinus) ? tPlus : tMinus;
+      double tHigh = (tPlus < tMinus) ? tMinus : tPlus;
+      tStart = (tLow > tStart) ? tLow : tStart;
+      tEnd = (tHigh < tEnd) ? tHigh : tEnd;
+    }
+
+    // Clamp to [0, 1]
+    tStart = vtkMath::ClampValue(tStart, 0.0, 1.0);
+    tEnd = vtkMath::ClampValue(tEnd, 0.0, 1.0);
+
+    if (tStart >= tEnd)
+    {
+      prevAdded = false;
+      vtkMath::Assign(pt, prevPt);
+      continue;
+    }
+
+    // Compute segment direction vector using vtkMath
+    double dir[3];
+    vtkMath::Subtract(pt, prevPt, dir);
+
+    // Add the start of the visible portion (if not already added)
+    if (tStart > 0.0 || !prevAdded)
+    {
+      double scaledStart[3] = { dir[0], dir[1], dir[2] };
+      vtkMath::MultiplyScalar(scaledStart, tStart);
+      double startPt[3];
+      vtkMath::Add(prevPt, scaledStart, startPt);
+      outPoints->InsertNextPoint(startPt);
+      outScalars->InsertNextValue(static_cast<float>(d0 + tStart * dDiff));
+    }
+
+    // Find the intersection of this segment with the slice plane (if any)
+    double tZero = 0.0;
+    double isectPt[3] = { 0.0, 0.0, 0.0 };
+    bool hasZeroCrossing = (slicePlane->IntersectWithLine(prevPt, pt, tZero, isectPt) != 0);
+
+    // Collect intersection point for the glyph display pipeline
+    if (hasZeroCrossing && intersectionPoints && notInPlane)
+    {
+      // Only add intersection point if it's not too close to the last one
+      vtkIdType numIsectPts = intersectionPoints->GetNumberOfPoints();
+      bool addIntersection = true;
+      if (numIsectPts > 0)
+      {
+        double lastIsectPt[3];
+        intersectionPoints->GetPoint(numIsectPts - 1, lastIsectPt);
+        double dist = vtkMath::Distance2BetweenPoints(isectPt, lastIsectPt);
+        // Use a small threshold (e.g., 1e-6) to avoid duplicate points
+        if (dist < 1e-6)
+        {
+          addIntersection = false;
+        }
+      }
+      if (addIntersection)
+      {
+        intersectionPoints->InsertNextPoint(isectPt);
+        this->LineSliceIntersectionApproachingSigns->InsertNextValue(static_cast<float>(d0 > 0. ? 1.0 : -1.0));
+      }
+    }
+
+    // Subdivide the visible portion [tStart, tEnd] at regular distance intervals
+    // and insert the zero crossing at the right position.
+    double distRange = fabs(dDiff * (tEnd - tStart));
+    int numSubdivisions = static_cast<int>(distRange / subdivisionStep);
+    if (numSubdivisions < 1)
+    {
+      numSubdivisions = 1;
+    }
+    double tStep = (tEnd - tStart) / numSubdivisions;
+    bool zeroCrossingInserted = (!hasZeroCrossing || tZero < tStart || tZero > tEnd);
+
+    for (int s = 1; s <= numSubdivisions; s++)
+    {
+      double t = tStart + s * tStep;
+
+      // Insert the zero-crossing point at its exact position if we pass it
+      if (!zeroCrossingInserted && t >= tZero)
+      {
+        outPoints->InsertNextPoint(isectPt);
+        outScalars->InsertNextValue(0.0f);
+        zeroCrossingInserted = true;
+
+        // Don't add a subdivision point if it's essentially at the same location
+        if (fabs(t - tZero) < tStep * 0.01)
+        {
+          continue;
+        }
+      }
+
+      // Add subdivision point (skip the last one, we'll add the end point below)
+      if (s < numSubdivisions)
+      {
+        double scaledSub[3] = { dir[0], dir[1], dir[2] };
+        vtkMath::MultiplyScalar(scaledSub, t);
+        double subPt[3];
+        vtkMath::Add(prevPt, scaledSub, subPt);
+        outPoints->InsertNextPoint(subPt);
+        outScalars->InsertNextValue(static_cast<float>(d0 + t * dDiff));
+      }
+    }
+
+    // Add the end of the visible portion
+    double scaledEnd[3] = { dir[0], dir[1], dir[2] };
+    vtkMath::MultiplyScalar(scaledEnd, tEnd);
+    double endPt[3];
+    vtkMath::Add(prevPt, scaledEnd, endPt);
+    outPoints->InsertNextPoint(endPt);
+    outScalars->InsertNextValue(static_cast<float>(d0 + tEnd * dDiff));
+    prevAdded = (tEnd >= 1.0);
+    vtkMath::Assign(pt, prevPt);
+  }
+
+  // Build polyline cell connecting all points in order
+  vtkIdType numOutPts = outPoints->GetNumberOfPoints();
+  vtkNew<vtkCellArray> outLines;
+  if (numOutPts > 1)
+  {
+    vtkNew<vtkIdList> ids;
+    ids->SetNumberOfIds(numOutPts);
+    for (vtkIdType pointIndex = 0; pointIndex < numOutPts; pointIndex++)
+    {
+      ids->SetId(pointIndex, pointIndex);
+    }
+    outLines->InsertNextCell(ids);
+  }
+
+  outputPolyData->SetPoints(outPoints);
+  outputPolyData->SetLines(outLines);
+  outputPolyData->GetPointData()->SetScalars(outScalars);
+  outputPolyData->Modified();
+
+  // Update cached MTimes so the guard can skip recomputation next time.
+  this->FadingScalarsLastWorldDataMTime = worldMTime;
+  this->FadingScalarsLastSlicePlaneMTime = planeMTime;
+  this->FadingScalarsLastFadingEnd = fadingEnd;
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation2D::UpdateSliceIntersectionPointDisplay(double glyphSize, vtkScalarsToColors* colorMap)
+{
+  if (!this->MarkupsDisplayNode || !this->MarkupsDisplayNode->GetLineSliceIntersectionPointVisibility() || !this->MarkupsDisplayNode->GetLineDirectionVisibility()
+      || !this->MarkupsDisplayNode->GetLineDirectionVisibility2D() || !this->Renderer)
+  {
+    this->LineSliceIntersectionEnteringPipeline->Actor->SetVisibility(false);
+    this->LineSliceIntersectionExitingPipeline->Actor->SetVisibility(false);
+    return;
+  }
+
+  this->LineSliceIntersectionEnteringPipeline->DisplayPoints->Reset();
+  this->LineSliceIntersectionExitingPipeline->DisplayPoints->Reset();
+
+  // Use half of fadingEnd as scalar offset so the LUT picks a clearly
+  // distinguishable fading color from the correct side of the slice plane.
+  double fadingEnd = this->MarkupsDisplayNode->GetLineColorFadingEnd();
+  double sideOffset = fadingEnd * 0.5;
+  if (sideOffset <= 0.0)
+  {
+    sideOffset = 0.01;
+  }
+
+  for (vtkIdType pointIndex = 0; pointIndex < this->LineSliceIntersectionWorldPoints->GetNumberOfPoints(); pointIndex++)
+  {
+    double worldPos[3];
+    this->LineSliceIntersectionWorldPoints->GetPoint(pointIndex, worldPos);
+    double displayPos[4] = { 0.0 };
+    this->GetWorldToDisplayCoordinates(worldPos, displayPos);
+    double dp[3] = { displayPos[0], displayPos[1], 0.0 };
+
+    float sign = (pointIndex < this->LineSliceIntersectionApproachingSigns->GetNumberOfTuples()) ? this->LineSliceIntersectionApproachingSigns->GetValue(pointIndex) : 1.0f;
+    // When direction markers are reversed, swap entering/exiting assignment
+    if (!this->MarkupsDisplayNode->GetLineDirectionFirstToLastControlPoint())
+    {
+      sign = -sign;
+    }
+
+    // Entering: sign > 0 (curve approaches from positive side)
+    // Exiting: sign < 0 (curve approaches from negative side)
+    if (sign >= 0.0f)
+    {
+      this->LineSliceIntersectionEnteringPipeline->DisplayPoints->InsertNextPoint(dp);
+    }
+    else
+    {
+      this->LineSliceIntersectionExitingPipeline->DisplayPoints->InsertNextPoint(dp);
+    }
+  }
+
+  // Sample color from the LUT for each side and set on per-pipeline properties.
+  // Opacity is not mapped — intersection glyphs are always fully opaque.
+  if (colorMap)
+  {
+    double enteringColor[3];
+    colorMap->GetColor(+sideOffset, enteringColor);
+    this->LineSliceIntersectionEnteringPipeline->Property->SetColor(enteringColor);
+
+    double exitingColor[3];
+    colorMap->GetColor(-sideOffset, exitingColor);
+    this->LineSliceIntersectionExitingPipeline->Property->SetColor(exitingColor);
+  }
+
+  // Update entering pipeline (CircledCross)
+  this->LineSliceIntersectionEnteringPipeline->DisplayPoints->Modified();
+  this->LineSliceIntersectionEnteringPipeline->PointsPoly->Modified();
+  this->LineSliceIntersectionEnteringPipeline->Glypher->SetScaleFactor(glyphSize);
+
+  // Update exiting pipeline (CircledPoint)
+  this->LineSliceIntersectionExitingPipeline->DisplayPoints->Modified();
+  this->LineSliceIntersectionExitingPipeline->PointsPoly->Modified();
+  this->LineSliceIntersectionExitingPipeline->Glypher->SetScaleFactor(glyphSize);
+
+  this->LineSliceIntersectionEnteringPipeline->Actor->SetVisibility(this->LineSliceIntersectionEnteringPipeline->DisplayPoints->GetNumberOfPoints() > 0);
+  this->LineSliceIntersectionExitingPipeline->Actor->SetVisibility(this->LineSliceIntersectionExitingPipeline->DisplayPoints->GetNumberOfPoints() > 0);
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
@@ -35,14 +35,22 @@
 
 #include "vtkMRMLSliceNode.h"
 
+#include <memory>
+
 class vtkActor2D;
+class vtkAlgorithmOutput;
+class vtkDoubleArray;
 class vtkDiscretizableColorTransferFunction;
+class vtkFloatArray;
 class vtkGlyph2D;
 class vtkLabelPlacementMapper;
 class vtkMarkupsGlyphSource2D;
 class vtkPlane;
+class vtkPoints;
+class vtkPolyData;
 class vtkPolyDataMapper2D;
 class vtkProperty2D;
+class vtkScalarsToColors;
 
 class vtkMRMLInteractionEventData;
 
@@ -132,6 +140,26 @@ protected:
   /// Check if the representation polydata intersects the slice
   bool IsRepresentationIntersectingSlice(vtkPolyData* representation, const char* arrayName);
 
+  /// Compute fading scalars for accurate line/curve projection on the 2D slice.
+  /// 1. Clips the polydata to the fading range (|distance| <= fadingEnd), discarding
+  ///    invisible portions entirely.
+  /// 2. Inserts exact intersection points where the curve crosses the slice plane.
+  /// 3. Subdivides the visible portion into enough vertices that per-vertex opacity
+  ///    mapping accurately represents the nonlinear transfer function.
+  /// If intersectionPoints is non-null, detected zero-crossings are appended to it.
+  /// The caller is responsible for resetting intersectionPoints before the first call.
+  /// When the MTime guard triggers an early return, intersectionPoints is left untouched
+  /// (still valid from the previous computation with the same inputs).
+  virtual void ComputeIntersectionFadingScalars(vtkPolyData* worldPolyData,
+                                                vtkPlane* slicePlane,
+                                                vtkPolyData* outputPolyData,
+                                                vtkFloatArray* distanceArray = nullptr,
+                                                vtkPoints* intersectionPoints = nullptr);
+
+  /// Project accumulated SliceIntersectionWorldPoints to display coordinates and update
+  /// the intersection point glyph pipeline (actor visibility, color, scale, LUT).
+  virtual void UpdateSliceIntersectionPointDisplay(double glyphSize, vtkScalarsToColors* colorMap);
+
   class ControlPointsPipeline2D : public ControlPointsPipeline
   {
   public:
@@ -156,6 +184,73 @@ protected:
 
   vtkSmartPointer<vtkTransform> WorldToSliceTransform;
   vtkSmartPointer<vtkPlane> SlicePlane;
+
+  /// Per-glyph rendering pipeline for slice intersection points.
+  /// Each instance holds the display points, polydata, glypher, mapper, and actor
+  /// for one glyph type (entering = CircledCross, exiting = CircledPoint).
+  class LineIntersectionPointsPipeline2D
+  {
+  public:
+    LineIntersectionPointsPipeline2D(vtkAlgorithmOutput* glyphSourcePort, vtkProperty2D* property);
+    ~LineIntersectionPointsPipeline2D() = default;
+
+    vtkSmartPointer<vtkPoints> DisplayPoints;
+    vtkSmartPointer<vtkPolyData> PointsPoly;
+    vtkSmartPointer<vtkGlyph2D> Glypher;
+    vtkSmartPointer<vtkPolyDataMapper2D> Mapper;
+    vtkSmartPointer<vtkProperty2D> Property;
+    vtkSmartPointer<vtkActor2D> Actor;
+  };
+
+  /// Per-glyph rendering pipeline for direction arrow markers (2D).
+  /// Holds the display-space points, normals, slice-distance scalars, polydata,
+  /// glyph2D, mapper, and actor for cone-shaped direction markers.
+  /// The mapper's lookup table is not set here — callers must configure it after
+  /// construction via LineDirectionArrowPipeline->Mapper->SetLookupTable(...).
+  class LineDirectionArrowPipeline2D
+  {
+  public:
+    LineDirectionArrowPipeline2D();
+    ~LineDirectionArrowPipeline2D() = default;
+
+    vtkSmartPointer<vtkPoints> Points;
+    vtkSmartPointer<vtkDoubleArray> Normals;
+    vtkSmartPointer<vtkFloatArray> SliceDistances; ///< signed distance to slice per marker, drives opacity fading
+    vtkSmartPointer<vtkPolyData> PointsPoly;
+    vtkSmartPointer<vtkGlyph2D> Glypher;
+    vtkSmartPointer<vtkPolyDataMapper2D> Mapper;
+    vtkSmartPointer<vtkActor2D> Actor;
+  };
+
+  /// Direction arrow glyph pipeline (2D).
+  std::unique_ptr<LineDirectionArrowPipeline2D> LineDirectionArrowPipeline;
+
+  /// Cached BuildLineDirectionMarkers output; rebuilt only when spacing or geometry changes.
+  /// The view-dependent projection loop (world -> display) always runs.
+  vtkSmartPointer<vtkPoints> LineDirectionMarkerCachedWorldPositions;
+  vtkSmartPointer<vtkDoubleArray> LineDirectionMarkerCachedWorldTangents;
+  double LineDirectionMarkerLastSpacing = -1.0;
+  vtkMTimeType LineDirectionMarkerLastGeometryMTime = 0;
+  vtkMTimeType LineDirectionMarkerLastSlicePlaneMTime = 0;
+  vtkMTimeType LineDirectionMarkerLastMarkupsDisplayMTime = 0;
+  bool LineDirectionFirstToLastControlPoint = true;
+
+  // Line slice intersection point glyph pipelines (2D).
+  // Mark the exact positions where a curve/line crosses the slice plane.
+  // Entering (CircledCross) and exiting (CircledPoint) are driven by
+  // SliceIntersectionApproachingSigns.
+  vtkSmartPointer<vtkPoints> LineSliceIntersectionWorldPoints;
+  vtkSmartPointer<vtkFloatArray> LineSliceIntersectionApproachingSigns;
+  vtkSmartPointer<vtkProperty2D> LineSliceIntersectionProperty;
+  std::unique_ptr<LineIntersectionPointsPipeline2D> LineSliceIntersectionEnteringPipeline;
+  std::unique_ptr<LineIntersectionPointsPipeline2D> LineSliceIntersectionExitingPipeline;
+
+  /// Cached input timestamps for ComputeIntersectionFadingScalars MTime guard.
+  /// Avoids expensive polyline walking when neither curve geometry, slice plane,
+  /// nor fading range have changed.
+  vtkMTimeType FadingScalarsLastWorldDataMTime = 0;
+  vtkMTimeType FadingScalarsLastSlicePlaneMTime = 0;
+  double FadingScalarsLastFadingEnd = -1.0;
 
   virtual void UpdateAllPointsAndLabelsFromMRML(double labelsOffset);
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -20,17 +20,20 @@
 #include "vtkCallbackCommand.h"
 #include "vtkCamera.h"
 #include "vtkCellPicker.h"
+#include "vtkConeSource.h"
+#include "vtkDoubleArray.h"
 #include "vtkLabelPlacementMapper.h"
 #include "vtkLine.h"
 #include "vtkFloatArray.h"
 #include "vtkGlyph3DMapper.h"
 #include "vtkMarkupsGlyphSource2D.h"
 #include "vtkMath.h"
-#include "vtkMatrix4x4.h"
 #include "vtkObjectFactory.h"
 #include "vtkPointData.h"
 #include "vtkPointSetToLabelHierarchy.h"
 #include "vtkPolyDataMapper.h"
+#include "vtkPoints.h"
+#include "vtkPolyData.h"
 #include "vtkProperty.h"
 #include "vtkRenderer.h"
 #include "vtkRenderWindow.h"
@@ -40,8 +43,6 @@
 #include "vtkStringArray.h"
 #include "vtkTextActor.h"
 #include "vtkTextProperty.h"
-#include "vtkTransform.h"
-#include "vtkTransformPolyDataFilter.h"
 
 // MRML includes
 #include <vtkMRMLAbstractThreeDViewDisplayableManager.h>
@@ -173,6 +174,41 @@ vtkSlicerMarkupsWidgetRepresentation3D::ControlPointsPipeline3D::ControlPointsPi
 vtkSlicerMarkupsWidgetRepresentation3D::ControlPointsPipeline3D::~ControlPointsPipeline3D() = default;
 
 //----------------------------------------------------------------------
+vtkSlicerMarkupsWidgetRepresentation3D::LineDirectionArrowPipeline3D::LineDirectionArrowPipeline3D()
+{
+  // 'coneSource' is a local variable; VTK's pipeline keeps it alive as needed.
+  vtkNew<vtkConeSource> coneSource;
+  coneSource->SetHeight(1.0);
+  coneSource->SetRadius(0.4);
+  coneSource->SetResolution(6);
+  coneSource->SetDirection(1, 0, 0);
+
+  this->Normals = vtkSmartPointer<vtkDoubleArray>::New();
+  this->Normals->SetNumberOfComponents(3);
+  this->Normals->SetName("Normals");
+
+  this->Points = vtkSmartPointer<vtkPoints>::New();
+
+  this->PointsPoly = vtkSmartPointer<vtkPolyData>::New();
+  this->PointsPoly->SetPoints(this->Points);
+  this->PointsPoly->GetPointData()->AddArray(this->Normals);
+  this->PointsPoly->GetPointData()->SetActiveNormals("Normals");
+
+  this->Mapper = vtkSmartPointer<vtkGlyph3DMapper>::New();
+  this->Mapper->SetSourceConnection(coneSource->GetOutputPort());
+  this->Mapper->SetInputData(this->PointsPoly);
+  this->Mapper->SetOrientationArray("Normals");
+  this->Mapper->SetOrientationModeToDirection();
+  this->Mapper->SetScaleModeToNoDataScaling();
+  this->Mapper->ScalarVisibilityOff();
+  this->Mapper->SetScaleFactor(1.0); // updated dynamically in subclass UpdateFromMRMLInternal
+
+  this->Actor = vtkSmartPointer<vtkActor>::New();
+  this->Actor->SetMapper(this->Mapper);
+  this->Actor->SetVisibility(false);
+}
+
+//----------------------------------------------------------------------
 vtkSlicerMarkupsWidgetRepresentation3D::vtkSlicerMarkupsWidgetRepresentation3D()
 {
   for (int i = 0; i < NumberOfControlPointTypes; i++)
@@ -212,6 +248,9 @@ vtkSlicerMarkupsWidgetRepresentation3D::vtkSlicerMarkupsWidgetRepresentation3D()
   this->RenderCompletedCallback = vtkSmartPointer<vtkCallbackCommand>::New();
   this->RenderCompletedCallback->SetClientData(this);
   this->RenderCompletedCallback->SetCallback(vtkSlicerMarkupsWidgetRepresentation3D::OnRenderCompleted);
+
+  // Direction arrow glyph pipeline (3D)
+  this->LineDirectionArrowPipeline = std::make_unique<LineDirectionArrowPipeline3D>();
 }
 
 //----------------------------------------------------------------------
@@ -668,6 +707,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::GetActors(vtkPropCollection* pc)
     controlPoints->LabelsOccludedActor->GetActors(pc);
   }
   this->TextActor->GetActors(pc);
+  this->LineDirectionArrowPipeline->Actor->GetActors(pc);
 }
 
 //----------------------------------------------------------------------
@@ -683,6 +723,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::ReleaseGraphicsResources(vtkWindow*
     controlPoints->LabelsOccludedActor->ReleaseGraphicsResources(win);
   }
   this->TextActor->ReleaseGraphicsResources(win);
+  this->LineDirectionArrowPipeline->Actor->ReleaseGraphicsResources(win);
 }
 
 //----------------------------------------------------------------------
@@ -765,6 +806,10 @@ int vtkSlicerMarkupsWidgetRepresentation3D::RenderOverlay(vtkViewport* viewport)
     {
       count += this->TextActor->RenderOverlay(viewport);
     }
+  }
+  if (this->LineDirectionArrowPipeline->Actor->GetVisibility())
+  {
+    count += this->LineDirectionArrowPipeline->Actor->RenderOverlay(viewport);
   }
   return count;
 }
@@ -903,7 +948,43 @@ int vtkSlicerMarkupsWidgetRepresentation3D::RenderOpaqueGeometry(vtkViewport* vi
     }
     count += this->TextActor->RenderOpaqueGeometry(viewport);
   }
-
+  if (this->LineDirectionArrowPipeline->Actor->GetVisibility())
+  {
+    if (this->MarkupsDisplayNode)
+    {
+      // ControlPointSize may have been recalculated by the base class due to camera zoom/pan.
+      // Propagate the updated size to the direction arrow scale factor immediately.
+      double lineDiameter =
+        (this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ? this->MarkupsDisplayNode->GetLineDiameter()
+                                                                                                        : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness());
+      double markerSizeWorld = vtkMRMLMarkupsDisplayNode::LineDirectionMarkerBaseScaleFactor * this->MarkupsDisplayNode->GetLineDirectionMarkerScale() * lineDiameter;
+      double markerSpacingWorld = this->MarkupsDisplayNode->GetLineDirectionMarkerSpacingScale() * markerSizeWorld;
+      this->LineDirectionArrowPipeline->Mapper->SetScaleFactor(markerSizeWorld);
+      // Rebuild marker positions only when spacing or curve geometry changed.
+      vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
+      vtkPolyData* curveWorld = markupsNode ? markupsNode->GetCurveWorld() : nullptr;
+      if (curveWorld && curveWorld->GetNumberOfPoints() >= 2)
+      {
+        vtkMTimeType curveMTime = curveWorld->GetMTime();
+        bool lineDirectionFirstToLastControlPoint = this->MarkupsDisplayNode->GetLineDirectionFirstToLastControlPoint();
+        if (markerSpacingWorld != this->LineDirectionMarkerLastSpacing || curveMTime != this->LineDirectionMarkerLastGeometryMTime
+            || lineDirectionFirstToLastControlPoint != this->LineDirectionFirstToLastControlPoint)
+        {
+          vtkMRMLMarkupsNode::BuildLineDirectionMarkers(curveWorld->GetPoints(),
+                                                        this->CurveClosed,
+                                                        markerSpacingWorld,
+                                                        this->LineDirectionArrowPipeline->Points,
+                                                        this->LineDirectionArrowPipeline->Normals,
+                                                        lineDirectionFirstToLastControlPoint);
+          this->LineDirectionArrowPipeline->PointsPoly->Modified();
+          this->LineDirectionMarkerLastSpacing = markerSpacingWorld;
+          this->LineDirectionMarkerLastGeometryMTime = curveMTime;
+          this->LineDirectionFirstToLastControlPoint = lineDirectionFirstToLastControlPoint;
+        }
+      }
+    }
+    count += this->LineDirectionArrowPipeline->Actor->RenderOpaqueGeometry(viewport);
+  }
   return count;
 }
 
@@ -939,6 +1020,10 @@ int vtkSlicerMarkupsWidgetRepresentation3D::RenderTranslucentPolygonalGeometry(v
   {
     count += this->TextActor->RenderTranslucentPolygonalGeometry(viewport);
   }
+  if (this->LineDirectionArrowPipeline->Actor->GetVisibility())
+  {
+    count += this->LineDirectionArrowPipeline->Actor->RenderTranslucentPolygonalGeometry(viewport);
+  }
   return count;
 }
 
@@ -973,6 +1058,10 @@ vtkTypeBool vtkSlicerMarkupsWidgetRepresentation3D::HasTranslucentPolygonalGeome
   {
     return true;
   }
+  if (this->LineDirectionArrowPipeline->Actor->GetVisibility() && this->LineDirectionArrowPipeline->Actor->HasTranslucentPolygonalGeometry())
+  {
+    return true;
+  }
   return false;
 }
 
@@ -982,7 +1071,8 @@ double* vtkSlicerMarkupsWidgetRepresentation3D::GetBounds()
   vtkBoundingBox boundingBox;
   const std::vector<vtkProp*> actors({ reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[Unselected])->Actor,
                                        reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[Selected])->Actor,
-                                       reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[Active])->Actor });
+                                       reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[Active])->Actor,
+                                       this->LineDirectionArrowPipeline->Actor });
   this->AddActorsBounds(boundingBox, actors, Superclass::GetBounds());
   boundingBox.GetBounds(this->Bounds);
   return this->Bounds;
@@ -1030,6 +1120,14 @@ void vtkSlicerMarkupsWidgetRepresentation3D::PrintSelf(ostream& os, vtkIndent in
   else
   {
     os << indent << "Text Visibility: (none)\n";
+  }
+  if (this->LineDirectionArrowPipeline->Actor)
+  {
+    os << indent << "Arrow Actor Visibility: " << this->LineDirectionArrowPipeline->Actor->GetVisibility() << "\n";
+  }
+  else
+  {
+    os << indent << "Arrow Actor: (none)\n";
   }
 }
 
@@ -1114,12 +1212,12 @@ bool vtkSlicerMarkupsWidgetRepresentation3D::AccuratePick(int x, int y, double p
   this->Renderer->GetActiveCamera()->GetPosition(cameraPosition);
   pickPositions->GetPoint(0, pickPoint);
   double minDist2 = vtkMath::Distance2BetweenPoints(pickPoint, cameraPosition);
-  for (vtkIdType i = 1; i < numberOfPickedPositions; i++)
+  for (vtkIdType pointIndex = 1; pointIndex < numberOfPickedPositions; pointIndex++)
   {
-    double currentMinDist2 = vtkMath::Distance2BetweenPoints(pickPositions->GetPoint(i), cameraPosition);
+    double currentMinDist2 = vtkMath::Distance2BetweenPoints(pickPositions->GetPoint(pointIndex), cameraPosition);
     if (currentMinDist2 < minDist2)
     {
-      pickPositions->GetPoint(i, pickPoint);
+      pickPositions->GetPoint(pointIndex, pickPoint);
       minDist2 = currentMinDist2;
     }
   }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -31,13 +31,18 @@
 #include "vtkSlicerMarkupsWidgetRepresentation.h"
 
 #include <map>
+#include <memory>
 
 class vtkActor;
 class vtkActor2D;
 class vtkCellPicker;
+class vtkConeSource;
+class vtkDoubleArray;
 class vtkFastSelectVisiblePoints;
 class vtkGlyph3DMapper;
 class vtkLabelPlacementMapper;
+class vtkPoints;
+class vtkPolyData;
 class vtkPolyDataMapper;
 class vtkProperty;
 
@@ -137,6 +142,29 @@ protected:
   virtual void UpdateNthPointAndLabelFromMRML(int n);
 
   virtual void UpdateAllPointsAndLabelsFromMRML();
+
+  /// Per-glyph rendering pipeline for direction arrow markers (3D).
+  /// Holds the cone source, world-space points, normals, polydata, Glyph3DMapper, and actor.
+  class LineDirectionArrowPipeline3D
+  {
+  public:
+    LineDirectionArrowPipeline3D();
+    ~LineDirectionArrowPipeline3D() = default;
+
+    vtkSmartPointer<vtkPoints> Points;
+    vtkSmartPointer<vtkDoubleArray> Normals;
+    vtkSmartPointer<vtkPolyData> PointsPoly;
+    vtkSmartPointer<vtkGlyph3DMapper> Mapper;
+    vtkSmartPointer<vtkActor> Actor;
+  };
+
+  /// Direction arrow glyph pipeline (3D).
+  std::unique_ptr<LineDirectionArrowPipeline3D> LineDirectionArrowPipeline;
+
+  /// Cached marker spacing/geometry MTime/reversed flag for BuildLineDirectionMarkers guard.
+  double LineDirectionMarkerLastSpacing = -1.0;
+  vtkMTimeType LineDirectionMarkerLastGeometryMTime = 0;
+  bool LineDirectionFirstToLastControlPoint = true;
 
   /// Update the occluded relative offsets for an occluded mapper
   /// Allows occluded regions to be rendered on top.

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
@@ -544,6 +544,197 @@
         </property>
        </widget>
       </item>
+      <item row="15" column="0" colspan="2">
+       <widget class="ctkCollapsibleGroupBox" name="LineDirectionMarkersCollapsibleGroupBox">
+        <property name="title">
+         <string>Direction Markers</string>
+        </property>
+        <property name="collapsed">
+         <bool>true</bool>
+        </property>
+        <layout class="QGridLayout" name="LineDirectionMarkersGridLayout">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>5</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="LineDirectionVisibilityLabel">
+           <property name="text">
+            <string>Show Direction Markers:</string>
+           </property>
+           <property name="toolTip">
+            <string>Show or hide directional arrow markers along curve and line markups.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QCheckBox" name="LineDirectionVisibilityCheckBox">
+           <property name="toolTip">
+            <string>Show or hide directional arrow markers along curve and line markups.</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="LineDirectionVisibility3DLabel">
+           <property name="text">
+            <string>3D Visibility:</string>
+           </property>
+           <property name="toolTip">
+            <string>Show direction markers in 3D views. Requires &quot;Show Direction Markers&quot; to be enabled.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="LineDirectionVisibility3DCheckBox">
+           <property name="toolTip">
+            <string>Show direction markers in 3D views. Requires &quot;Show Direction Markers&quot; to be enabled.</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="LineDirectionVisibility2DLabel">
+           <property name="text">
+            <string>2D Visibility:</string>
+           </property>
+           <property name="toolTip">
+            <string>Show direction markers in 2D slice views. Requires &quot;Show Direction Markers&quot; to be enabled.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QCheckBox" name="LineDirectionVisibility2DCheckBox">
+           <property name="toolTip">
+            <string>Show direction markers in 2D slice views. Requires &quot;Show Direction Markers&quot; to be enabled.</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="LineSliceIntersectionPointVisibilityLabel">
+           <property name="text">
+            <string>Slice Intersection Points:</string>
+           </property>
+           <property name="toolTip">
+            <string>Show markers at positions where the curve/line crosses the current slice plane.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QCheckBox" name="LineSliceIntersectionPointVisibilityCheckBox">
+           <property name="toolTip">
+            <string>Show markers at positions where the curve/line crosses the current slice plane.</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="LineDirectionMarkerReversedLabel">
+           <property name="text">
+            <string>Reverse Direction:</string>
+           </property>
+           <property name="toolTip">
+            <string>Reverse the direction of the arrow markers so they point in the opposite direction along the curve or line.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QCheckBox" name="LineDirectionMarkerReversedCheckBox">
+           <property name="toolTip">
+            <string>Reverse the direction of the arrow markers so they point in the opposite direction along the curve or line.</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="LineDirectionMarkerSizeLabel">
+           <property name="text">
+            <string>Marker Size:</string>
+           </property>
+           <property name="toolTip">
+            <string>Size of each direction marker relative to the physical line thickness.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="ctkSliderWidget" name="LineDirectionMarkerScaleSliderWidget">
+           <property name="toolTip">
+            <string>Size of each direction marker relative to the physical line thickness.</string>
+           </property>
+           <property name="minimum">
+            <double>10.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>1000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>10.000000000000000</double>
+           </property>
+           <property name="pageStep">
+            <double>100.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>150.000000000000000</double>
+           </property>
+           <property name="suffix">
+            <string> %</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="LineDirectionMarkerSpacingLabel">
+           <property name="text">
+            <string>Marker Spacing:</string>
+           </property>
+           <property name="toolTip">
+            <string>Distance between direction markers relative to the marker height.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="ctkSliderWidget" name="LineDirectionMarkerSpacingScaleSliderWidget">
+           <property name="toolTip">
+            <string>Distance between consecutive direction markers relative to the marker height. 100% = markers touch, 200% = one gap, 300% = two gaps.</string>
+           </property>
+           <property name="minimum">
+            <double>100.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>2000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>50.000000000000000</double>
+           </property>
+           <property name="pageStep">
+            <double>100.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>200.000000000000000</double>
+           </property>
+           <property name="suffix">
+            <string> %</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
@@ -29,7 +29,9 @@
 #include <vtkMRMLScene.h>
 #include <vtkMRMLColorTableNode.h>
 #include <vtkMRMLMarkupsDisplayNode.h>
+#include <vtkMRMLMarkupsCurveNode.h>
 #include <vtkMRMLMarkupsFiducialNode.h>
+#include <vtkMRMLMarkupsLineNode.h>
 #include <vtkMRMLMarkupsNode.h>
 #include <vtkMRMLSelectionNode.h>
 
@@ -107,6 +109,14 @@ void qMRMLMarkupsDisplayNodeWidgetPrivate::init()
   QObject::connect(this->OccludedOpacitySliderWidget, SIGNAL(valueChanged(double)), q, SLOT(setOccludedOpacity(double)));
 
   QObject::connect(this->OccludedVisibilityCheckBox, SIGNAL(toggled(bool)), q, SLOT(setOccludedVisibility(bool)));
+
+  QObject::connect(this->LineDirectionVisibilityCheckBox, SIGNAL(toggled(bool)), q, SLOT(setLineDirectionVisibility(bool)));
+  QObject::connect(this->LineDirectionVisibility3DCheckBox, SIGNAL(toggled(bool)), q, SLOT(setLineDirectionVisibility3D(bool)));
+  QObject::connect(this->LineDirectionVisibility2DCheckBox, SIGNAL(toggled(bool)), q, SLOT(setLineDirectionVisibility2D(bool)));
+  QObject::connect(this->LineDirectionMarkerScaleSliderWidget, SIGNAL(valueChanged(double)), q, SLOT(onLineDirectionMarkerScaleChanged(double)));
+  QObject::connect(this->LineDirectionMarkerSpacingScaleSliderWidget, SIGNAL(valueChanged(double)), q, SLOT(onLineDirectionMarkerSpacingScaleChanged(double)));
+  QObject::connect(this->LineDirectionMarkerReversedCheckBox, SIGNAL(toggled(bool)), q, SLOT(setLineDirectionMarkerReversed(bool)));
+  QObject::connect(this->LineSliceIntersectionPointVisibilityCheckBox, SIGNAL(toggled(bool)), q, SLOT(setLineSliceIntersectionPointVisibility(bool)));
 
   this->TextFontFamilyComboBox->addItem(vtkTextProperty::GetFontFamilyAsString(VTK_ARIAL), VTK_ARIAL);
   this->TextFontFamilyComboBox->addItem(vtkTextProperty::GetFontFamilyAsString(VTK_COURIER), VTK_COURIER);
@@ -204,7 +214,6 @@ void qMRMLMarkupsDisplayNodeWidget::setMRMLMarkupsDisplayNode(vtkMRMLNode* node)
 //-----------------------------------------------------------------------------
 void qMRMLMarkupsDisplayNodeWidget::setMRMLMarkupsNode(vtkMRMLMarkupsNode* node)
 {
-  Q_D(qMRMLMarkupsDisplayNodeWidget);
   this->setMRMLMarkupsDisplayNode(node ? vtkMRMLMarkupsDisplayNode::SafeDownCast(node->GetDisplayNode()) : nullptr);
 }
 
@@ -388,6 +397,39 @@ void qMRMLMarkupsDisplayNodeWidget::updateWidgetFromMRML()
   property->GetBackgroundColor(textBackgroundColorF);
   d->TextBackgroundColorPickerButton->setColor(QColor::fromRgbF(textBackgroundColorF[0], textBackgroundColorF[1], textBackgroundColorF[2]));
   d->TextBackgroundColorPickerButton->blockSignals(wasBlocking);
+
+  // Direction markers: only visible for Line and Curve nodes
+  vtkMRMLNode* displayableNode = d->MarkupsDisplayNode ? d->MarkupsDisplayNode->GetDisplayableNode() : nullptr;
+  bool isLineOrCurve = (vtkMRMLMarkupsLineNode::SafeDownCast(displayableNode) != nullptr || vtkMRMLMarkupsCurveNode::SafeDownCast(displayableNode) != nullptr);
+  d->LineDirectionMarkersCollapsibleGroupBox->setVisible(isLineOrCurve);
+
+  wasBlocking = d->LineDirectionVisibilityCheckBox->blockSignals(true);
+  d->LineDirectionVisibilityCheckBox->setChecked(markupsDisplayNode->GetLineDirectionVisibility());
+  d->LineDirectionVisibilityCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->LineDirectionVisibility3DCheckBox->blockSignals(true);
+  d->LineDirectionVisibility3DCheckBox->setChecked(markupsDisplayNode->GetLineDirectionVisibility3D());
+  d->LineDirectionVisibility3DCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->LineDirectionVisibility2DCheckBox->blockSignals(true);
+  d->LineDirectionVisibility2DCheckBox->setChecked(markupsDisplayNode->GetLineDirectionVisibility2D());
+  d->LineDirectionVisibility2DCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->LineDirectionMarkerScaleSliderWidget->blockSignals(true);
+  d->LineDirectionMarkerScaleSliderWidget->setValue(markupsDisplayNode->GetLineDirectionMarkerScale() * 100.0);
+  d->LineDirectionMarkerScaleSliderWidget->blockSignals(wasBlocking);
+
+  wasBlocking = d->LineDirectionMarkerSpacingScaleSliderWidget->blockSignals(true);
+  d->LineDirectionMarkerSpacingScaleSliderWidget->setValue(markupsDisplayNode->GetLineDirectionMarkerSpacingScale() * 100.0);
+  d->LineDirectionMarkerSpacingScaleSliderWidget->blockSignals(wasBlocking);
+
+  wasBlocking = d->LineDirectionMarkerReversedCheckBox->blockSignals(true);
+  d->LineDirectionMarkerReversedCheckBox->setChecked(!markupsDisplayNode->GetLineDirectionFirstToLastControlPoint());
+  d->LineDirectionMarkerReversedCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->LineSliceIntersectionPointVisibilityCheckBox->blockSignals(true);
+  d->LineSliceIntersectionPointVisibilityCheckBox->setChecked(markupsDisplayNode->GetLineSliceIntersectionPointVisibility());
+  d->LineSliceIntersectionPointVisibilityCheckBox->blockSignals(wasBlocking);
 
   // Scalars
   d->ScalarsDisplayWidget->updateWidgetFromMRML();
@@ -738,6 +780,83 @@ void qMRMLMarkupsDisplayNodeWidget::onTextPropertyWidgetsChanged()
   textProperty->SetShadow(textShadow);
   textProperty->SetBackgroundOpacity(backgroundOpacity);
   textProperty->SetBackgroundColor(backgroundColorF);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::setLineDirectionVisibility(bool visible)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+  {
+    return;
+  }
+  d->MarkupsDisplayNode->SetLineDirectionVisibility(visible);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::setLineDirectionVisibility3D(bool visible)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+  {
+    return;
+  }
+  d->MarkupsDisplayNode->SetLineDirectionVisibility3D(visible);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::setLineDirectionVisibility2D(bool visible)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+  {
+    return;
+  }
+  d->MarkupsDisplayNode->SetLineDirectionVisibility2D(visible);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::onLineDirectionMarkerScaleChanged(double value)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+  {
+    return;
+  }
+  d->MarkupsDisplayNode->SetLineDirectionMarkerScale(value * 0.01);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::onLineDirectionMarkerSpacingScaleChanged(double value)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+  {
+    return;
+  }
+  d->MarkupsDisplayNode->SetLineDirectionMarkerSpacingScale(value * 0.01);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::setLineDirectionMarkerReversed(bool reversed)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+  {
+    return;
+  }
+  d->MarkupsDisplayNode->SetLineDirectionFirstToLastControlPoint(!reversed);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::setLineSliceIntersectionPointVisibility(bool visible)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+  {
+    return;
+  }
+  d->MarkupsDisplayNode->SetLineSliceIntersectionPointVisibility(visible);
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
@@ -91,6 +91,14 @@ public slots:
   void setOccludedVisibility(bool visibility);
   void setOccludedOpacity(double OccludedOpacity);
 
+  void setLineDirectionVisibility(bool visible);
+  void onLineDirectionMarkerScaleChanged(double value);
+  void onLineDirectionMarkerSpacingScaleChanged(double value);
+  void setLineDirectionVisibility3D(bool visible);
+  void setLineDirectionVisibility2D(bool visible);
+  void setLineDirectionMarkerReversed(bool reversed);
+  void setLineSliceIntersectionPointVisibility(bool visible);
+
 protected slots:
   void updateWidgetFromMRML();
   vtkMRMLSelectionNode* getSelectionNode(vtkMRMLScene* mrmlScene);


### PR DESCRIPTION
ENH: Add directional arrow glyphs to line and curve markup nodes
Add configurable directional arrow glyphs (markers) that can be displayed
along curve and line markup nodes to indicate directionality. The arrows
are rendered in both 2D slice views and 3D views.

Changes include:
- Add DirectionMarkerVisibility and DirectionMarkerSize properties to
  vtkMRMLMarkupsDisplayNode for controlling glyph appearance
- Add helper methods in vtkMRMLMarkupsNode to compute tangent directions
  along curves for glyph orientation
- Implement direction marker rendering in 2D and 3D representations for
  line and curve widgets using cone glyphs
- Add projection support for direction markers in 2D slice views
- Add UI controls in qMRMLMarkupsDisplayNodeWidget for toggling
  direction marker visibility and adjusting size

BUG: Fix line projection on slice views for line, angle, and curve nodes