### PR TITLE
COMP: Fix CTKAppLauncherLib add-qt6-support commit hash

### DIFF
--- a/SuperBuild/External_CTKAppLauncherLib.cmake
+++ b/SuperBuild/External_CTKAppLauncherLib.cmake
@@ -24,19 +24,11 @@ if(NOT DEFINED CTKAppLauncherLib_DIR AND NOT Slicer_USE_SYSTEM_${proj})
     QUIET
     )
 
-  if(Slicer_REQUIRED_QT_VERSION VERSION_GREATER_EQUAL "6")
-    ExternalProject_SetIfNotDefined(
-      Slicer_${proj}_GIT_TAG
-      "9635b987dedfc3cb7c397baaf67bb00d640f5be6" # add-qt6-support
-      QUIET
-      )
-  else()
-    ExternalProject_SetIfNotDefined(
-      Slicer_${proj}_GIT_TAG
-      "a2c2f83401eddc72f30a1a6dd6769eb17a46fd41"
-      QUIET
-      )
-  endif()
+  ExternalProject_SetIfNotDefined(
+    Slicer_${proj}_GIT_TAG
+    "a37ad37c06e6fb4fc203434787f8bbffb52749bb"
+    QUIET
+    )
 
   set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
   if(Slicer_REQUIRED_QT_VERSION VERSION_GREATER_EQUAL "6")


### PR DESCRIPTION
This closes #9090.

The commit hash previously used to refer to the `add-qt6-support` branch in CTKAppLauncherLib is now not available anymore due to rebase/force push. Therefore, a Qt6-based Slicer build currently fails to fetch [CTK/AppLauncher](https://github.com/commontk/AppLauncher).

This PR updates the commit hash reference to the latest (and now only) commit on the `add-qt6-support` branch to fix the build.

- [x] https://github.com/commontk/AppLauncher/pull/181 should be integrated first