### PR TITLE
BUG: Disable touch events on macOS Qt6 to fix stuck 3D rotation

### DIFF
--- a/Libs/MRML/Widgets/qMRMLSliceView.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceView.cxx
@@ -62,6 +62,7 @@
 #include <vtkRenderWindowInteractor.h>
 #include <vtkInteractorStyleUser.h>
 #include <vtkSmartPointer.h>
+#include <vtkVersionMacros.h>
 
 //--------------------------------------------------------------------------
 // qMRMLSliceViewPrivate methods
@@ -96,6 +97,16 @@ void qMRMLSliceViewPrivate::init()
   Q_Q(qMRMLSliceView);
 
   this->ctkVTKSliceViewPrivate::init();
+
+  // Disable touch event processing on macOS with Qt6 to prevent spurious
+  // LeftButtonPressEvent from trackpad touch events without matching releases.
+  // See https://github.com/Slicer/Slicer/issues/9068
+#if defined(Q_OS_MACOS) && (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)) && (VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 0))
+  if (q->VTKWidget() != nullptr)
+  {
+    q->VTKWidget()->setEnableTouchEventProcessing(false);
+  }
+#endif
 
   q->setRenderEnabled(this->MRMLScene != nullptr);
 

--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -58,6 +58,7 @@
 #include <vtkRenderer.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkSmartPointer.h>
+#include <vtkVersionMacros.h>
 
 //--------------------------------------------------------------------------
 // qMRMLThreeDViewPrivate methods
@@ -95,6 +96,18 @@ void qMRMLThreeDViewPrivate::init()
   Q_Q(qMRMLThreeDView);
 
   this->ctkVTKRenderViewPrivate::init();
+
+  // Disable touch event processing on macOS with Qt6 to prevent the 3D view from
+  // getting stuck in rotation mode. On macOS, trackpad touch events generate
+  // LeftButtonPressEvent in VTK without matching release events, causing the
+  // interactor style to remain in ROTATE state permanently.
+  // See https://github.com/Slicer/Slicer/issues/9068
+#if defined(Q_OS_MACOS) && (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)) && (VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 0))
+  if (q->VTKWidget() != nullptr)
+  {
+    q->VTKWidget()->setEnableTouchEventProcessing(false);
+  }
+#endif
 
   q->setRenderEnabled(this->MRMLScene != nullptr);
 


### PR DESCRIPTION
On macOS with Qt6, trackpad touch events (TouchBegin) are converted by VTK's QVTKInteractorAdapter into LeftButtonPressEvent without matching LeftButtonReleaseEvent from TouchEnd, leaving the interactor style permanently stuck in ROTATE state.

Disable WA_AcceptTouchEvents on the VTK widget for both 3D and slice views on macOS Qt6 builds to prevent this.

Fixes https://github.com/Slicer/Slicer/issues/9068