### PR TITLE
COMP: Update VTK to 9.6.1

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -148,8 +148,8 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "08210fbecda09bea2544dbb80777d634e1bfea25") # slicer-v9.5.2-2025-09-16-7c0494a68
     set(vtk_dist_info_version "9.5.2")
   elseif("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.6")
-    set(_git_tag "dcfd7686e33e6fbc195620008936b5f604681dba") # slicer-v9.6.0-2026-02-09-edd2a192d
-    set(vtk_dist_info_version "9.6.0")
+    set(_git_tag "a0bea7a6f58008e3599142594d9f9c8845618645") # slicer-v9.6.1-2026-03-24-d3ad22cd8
+    set(vtk_dist_info_version "9.6.1")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR.Slicer_VTK_VERSION_MINOR: ${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}")
   endif()


### PR DESCRIPTION
VTK 9.6.1 has been announced: https://discourse.vtk.org/t/vtk-9-6-1-release/16356/1

This follows-up on previous comment at https://github.com/Slicer/Slicer/pull/8928#discussion_r2921222534 regarding creating a new branch based on latest VTK patch release following previous backports on an earlier branch.

```
Slicer/VTK:
$ git shortlog dcfd768..a0bea7a --no-merges
Alexy Pellegrini (2):
      wheel-sdk: Update entry point name to a meaningful value
      ci: Update vtk-sdk upload rules to include missing Python 3.14 versions

Ben Boeckel (2):
      FindEXPAT: sync with CMake
      OpenMP/vtkSMPToolsImpl: restore support for OpenMP pre-5.0

Cory Quammen (1):
      vtkOpenGLGlyph3DMapper: prevent excessive memory usage

David Gobbi (1):
      Add missing keyboard mappings for PyQt/PySide

Drew Parsons (2):
      check for null image pointer in Matplotlib RenderOneCell
      add doc dev .md entry

ElkCl0ner (1):
      vtkPLYReader: Return in case we cannot read the geometry.

James Butler (1):
      vtkOpenGLState: Skip blit to avoid errors with not ready framebuffers

Jaswant Panchumarti (9):
      ci: disable wasm in test-ext stage
      Fix OpenGL initialization error handling and version check
      Rename SSAAProgram to SSAAHelper
      Fix vtkSSAAPass null program error when changing renderers
      Ensure focal point is fixed in vtkCameraOrientationWidget
      Fix GL_INVALID_OPERATION in vtkFramebufferPass under GLES 3.0
      Add surface filter and update abort/reset functionality in WrappedAsyncClipper
      do not force -sPROXY_TO_PTHREAD on dependents of vtk modules
      remove unused GL_POINT_SPRITE enabling code in vtkEGLRenderWindow

Jean-Christophe Fillion-Robin (3):
      [Slicer] COMP: Remove custom FindOpenGL to ensure OpenGL_GL_PREFERENCE is considered
      [Slicer] BUG: Update vtkPythonUtil to disable relative import causing crash for Slicer modules
      [Slicer] COMP: Remove FindTBB and expect VTK to be configured with TBB_DIR

Jose M Pozo (1):
      Fix nearest-neighbour interpolation: maxWeight type to double

Kenneth Moreland (2):
      Convert constant arrays to Viskores
      Convert vtkAffineArray to Viskores array handles

Lucas GOTTAR (4):
      Fix generate fields crash
      Update testsfor HTG Generate Fields
      Fix tuple insertion if index is out of range
      Add empty volume test for vtkHyperTreeGridGenerateFields

Lucas Givord (5):
      Fix ordering dependent rendering bug in composite polydata cell mapping
      BatchPolyDataMapper: add test for a sliced composite data
      Batch rendering bug fix: add release note
      TestBatchOrderRendering : disable scalar visibility
      BatchPolyDataMapper: take in account dummy offset for edges

LunaNebula L (3):
      Fix divide-by-zero in vtkSpanSpace for constant scalar fields
      Add test for contouring constant scalar fields
      update test use the _NO_VALID suffix.

Mathieu Westphal (2):
      vtkHDFReader: Set block names for PDC
      vtkHDFReader: properly close open datasets after reading

Quinn Powell (3):
      vtkPython.h: add preprocessor check for MSVC
      vtkStringFormatter: add macros to wrap format calls in try-catch
      Use macros with try-catch for format calls with possibly user-provided formats

Sankhesh Jhaveri (6):
      Fix segfault when processing selector cell id high 24 bits
      Multi-scatter approximation for image-based illumination
      Add a PBR multi scattering with IBL test
      Add a documentation note for multiscattering IBL
      Guard IBL multi-scattering to avoid potential division by zero
      Wrap internal factory functions in anonymous namespaces

Sean McBride (1):
      Fix Clang -Wdocumentation warning in public header

Spiros Tsalikis (9):
      vtkExplicitStructuredGrid: Fix implementation of GetCellNeighbors
      vtkGeometryFilter: Fix Surface generation with hidden/duplicate cells
      geometryFilterGhosts: Add test
      TestEnSightGoldCombinedReader: Keep duplicate cells
      vtkUnstructuredGrid: Fix crashes in RemoveGhostCells
      vtkPolyData: Simplify RemoveGhostCells
      vtkAppendFilter/PolyData: Simplify std::transform
      vtk*EnSightReader: Fix scanning issues from b9390b84
      vtkIOSSReader: Set default for GroupAlphabeticVectorFieldComponents

Vicente Adolfo Bolea Sanchez (3):
      docs: moved dev release notes to 6.1
      docs: final edits to the 9.6.md release notes.
      Update version number to 9.6.1.
```