### PR TITLE
COMP: Update CTK to latest (3b3f9eff)

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -78,7 +78,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "935c4e0413a2e074175a8e015a95c3475940142e"
+    "3b3f9eff550b5b8d2a207a575b0f40f54e850169"
     QUIET
     )
 


### PR DESCRIPTION
Update CTK external project GIT_TAG to commontk/CTK master `3b3f9eff` (2026-04-23) and rebase onto latest `Slicer/main`.

<details>
<summary>CTK commits since Slicer stock (935c4e04)</summary>

Adds 1 new commit beyond previous proposal `7cb63253`:

- `3b3f9eff` COMP: Fix Windows dllimport build error
- `7cb63253` BUG: Stop executeFile from leaving its script directory on sys.path
- `80b051fb` BUG: Fix lupdate error in ctkMessageBox
- `9ce17b4a` COMP: Need full definitions not forward declarations

Plus the prior 76 commits previously summarized (Qt6 compat, clazy fixes,
QRegExp->QRegularExpression migration, VTK8 removal, DICOM SEGFAULT fix,
test suite fixes, etc.). Full log: `git log 935c4e04..3b3f9eff` in the CTK repo.

</details>

<details>
<summary>Validation summary (prior baseline at 7cb63253)</summary>

Last full validation run was at CTK `7cb63253`:
- CTK Qt5/Qt6 build: 0 errors, 0 warnings
- Slicer SuperBuild incremental: 0 CTK-related errors/warnings
- CTK tests: Qt5 267/280, Qt6 245/255 (failures are known pre-existing OpenGL/modal/locale)
- Slicer tests: 661/670 (0 CTK-related failures)

The new commit `3b3f9eff` is a Windows-only `dllimport` compile fix —
no behavior change on Linux/macOS. Cross-platform re-validation pending.

</details>

## Test plan

- [x] Linux SuperBuild + Slicer test run at prior baseline (`7cb63253`)
- [ ] Re-validate at `3b3f9eff` on Linux
- [ ] macOS / Windows validation

<!--
provenance: claude-code session 2026-04-23 (gh-triage-pr)
key_facts: rebased branch onto Slicer/main (22 commits caught up); CTK hash bumped 7cb63253 -> 3b3f9eff (1 new commit, Windows dllimport fix); CI on prior HEAD was fully green
related_files: SuperBuild/External_CTK.cmake:81
post_merge_action: re-run /validate-ctk-pr at 3b3f9eff once Windows runner is available
-->