### PR TITLE
Add dcmtk JPEG2000 support

### DIFF
--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -2,7 +2,7 @@
 set(proj DCMTK)
 
 # Set dependency list
-set(${proj}_DEPENDENCIES "zlib")
+set(${proj}_DEPENDENCIES "zlib" "OpenJPEG" "DCMTKcs")
 if(DCMTK_WITH_OPENSSL)
   if(NOT Slicer_USE_SYSTEM_${proj})
     list(APPEND ${proj}_DEPENDENCIES OpenSSL)
@@ -62,15 +62,23 @@ if(NOT DEFINED DCMTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       )
   endif()
 
+  list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+    -DDCMTK_EXTERNAL_MODULES:STRING=${DCMTKcs_SOURCE_DIR}/dcmjp2kcs
+    -DDCMTK_WITH_OPENJPEG:BOOL=ON
+    -DOpenJPEG_DIR:PATH=${OpenJPEG_DIR}
+    )
+
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/DCMTK/DCMTK.git"
+    #"${EP_GIT_PROTOCOL}://github.com/DCMTK/DCMTK.git"
+    "${EP_GIT_PROTOCOL}://github.com/lassoan/DCMTK.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "a7369385d91f40e19a9b2d4ef922c61370dfc5b1" # DCMTK 3.7.0++ 2026-01-22
+    #"a7369385d91f40e19a9b2d4ef922c61370dfc5b1" # DCMTK 3.7.0++ 2026-01-22
+    "improve-external-module-support"
     QUIET
     )
 

--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -70,7 +70,7 @@ if(NOT DEFINED DCMTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "a7369385d91f40e19a9b2d4ef922c61370dfc5b1" # DCMTK 3.7.0++ 2026-01-22
+    "2dd54ca1c28100b820ccf1383a0948e889246f96" # DCMTK 3.7.0++ 2026-05-08
     QUIET
     )
 

--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -2,7 +2,7 @@
 set(proj DCMTK)
 
 # Set dependency list
-set(${proj}_DEPENDENCIES "zlib")
+set(${proj}_DEPENDENCIES "zlib" "OpenJPEG" "DCMTKcs")
 if(DCMTK_WITH_OPENSSL)
   if(NOT Slicer_USE_SYSTEM_${proj})
     list(APPEND ${proj}_DEPENDENCIES OpenSSL)
@@ -61,6 +61,12 @@ if(NOT DEFINED DCMTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       -DDCMTK_WITH_WRAP:BOOL=OFF   # CTK does not build on Mac with this option turned ON due to library dependencies missing
       )
   endif()
+
+  list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+    -DDCMTK_EXTERNAL_MODULES:STRING=${DCMTKcs_SOURCE_DIR}/dcmjp2kcs
+    -DDCMTK_WITH_OPENJPEG:BOOL=ON
+    -DOpenJPEG_DIR:PATH=${OpenJPEG_DIR}
+    )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY

--- a/SuperBuild/External_DCMTKcs.cmake
+++ b/SuperBuild/External_DCMTKcs.cmake
@@ -1,0 +1,60 @@
+
+set(proj DCMTKcs)
+
+# DCMTKcs provides community-supported external modules for DCMTK.
+# It is a source-only download: the dcmjp2kcs module is built as part of the
+# DCMTK build by copying the source into DCMTK's ExternalModules directory.
+# See External_DCMTK.cmake for how this source is used.
+
+# Set dependency list
+set(${proj}_DEPENDENCIES "")
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+# Sanity checks
+if(DEFINED DCMTKcs_SOURCE_DIR AND NOT EXISTS ${DCMTKcs_SOURCE_DIR})
+  message(FATAL_ERROR "DCMTKcs_SOURCE_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(NOT DEFINED DCMTKcs_SOURCE_DIR AND NOT Slicer_USE_SYSTEM_${proj})
+
+  ExternalProject_SetIfNotDefined(
+    Slicer_${proj}_GIT_REPOSITORY
+    "${EP_GIT_PROTOCOL}://github.com/lassoan/DCMTKcs.git"
+    QUIET
+    )
+
+  ExternalProject_SetIfNotDefined(
+    Slicer_${proj}_GIT_TAG
+    "416bc63e929dd17d629a9952d93295dc239e8e9d" # main 2026-04-01
+    QUIET
+    )
+
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+
+  # Source-only download: DCMTKcs modules are built as part of DCMTK,
+  # not as a standalone ExternalProject.
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY "${Slicer_${proj}_GIT_REPOSITORY}"
+    GIT_TAG "${Slicer_${proj}_GIT_TAG}"
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    DEPENDS
+      ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
+  set(DCMTKcs_SOURCE_DIR ${EP_SOURCE_DIR})
+
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDENCIES})
+endif()
+
+mark_as_superbuild(
+  VARS DCMTKcs_SOURCE_DIR:PATH
+  )

--- a/SuperBuild/External_DCMTKcs.cmake
+++ b/SuperBuild/External_DCMTKcs.cmake
@@ -1,0 +1,60 @@
+
+set(proj DCMTKcs)
+
+# DCMTKcs provides community-supported external modules for DCMTK.
+# It is a source-only download: the dcmjp2kcs module is built as part of the
+# DCMTK build by copying the source into DCMTK's ExternalModules directory.
+# See External_DCMTK.cmake for how this source is used.
+
+# Set dependency list
+set(${proj}_DEPENDENCIES "")
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+# Sanity checks
+if(DEFINED DCMTKcs_SOURCE_DIR AND NOT EXISTS ${DCMTKcs_SOURCE_DIR})
+  message(FATAL_ERROR "DCMTKcs_SOURCE_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(NOT DEFINED DCMTKcs_SOURCE_DIR AND NOT Slicer_USE_SYSTEM_${proj})
+
+  ExternalProject_SetIfNotDefined(
+    Slicer_${proj}_GIT_REPOSITORY
+    "${EP_GIT_PROTOCOL}://github.com/Slicer/DCMTKcs.git"
+    QUIET
+    )
+
+  ExternalProject_SetIfNotDefined(
+    Slicer_${proj}_GIT_TAG
+    "fbfd93318d32fabc86704cdd279bcb3e9028dd41" # main 2026-05-11
+    QUIET
+    )
+
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+
+  # Source-only download: DCMTKcs modules are built as part of DCMTK,
+  # not as a standalone ExternalProject.
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY "${Slicer_${proj}_GIT_REPOSITORY}"
+    GIT_TAG "${Slicer_${proj}_GIT_TAG}"
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    DEPENDS
+      ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
+  set(DCMTKcs_SOURCE_DIR ${EP_SOURCE_DIR})
+
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDENCIES})
+endif()
+
+mark_as_superbuild(
+  VARS DCMTKcs_SOURCE_DIR:PATH
+  )

--- a/SuperBuild/External_OpenJPEG.cmake
+++ b/SuperBuild/External_OpenJPEG.cmake
@@ -1,0 +1,87 @@
+
+set(proj OpenJPEG)
+
+# Set dependency list
+set(${proj}_DEPENDENCIES "")
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+if(Slicer_USE_SYSTEM_${proj})
+  unset(OpenJPEG_DIR CACHE)
+  find_package(OpenJPEG REQUIRED)
+endif()
+
+# Sanity checks
+if(DEFINED OpenJPEG_DIR AND NOT EXISTS ${OpenJPEG_DIR})
+  message(FATAL_ERROR "OpenJPEG_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(NOT DEFINED OpenJPEG_DIR AND NOT Slicer_USE_SYSTEM_${proj})
+
+  ExternalProject_SetIfNotDefined(
+    Slicer_${proj}_GIT_REPOSITORY
+    "${EP_GIT_PROTOCOL}://github.com/uclouvain/openjpeg.git"
+    QUIET
+    )
+
+  ExternalProject_SetIfNotDefined(
+    Slicer_${proj}_GIT_TAG
+    "v2.5.3"
+    QUIET
+    )
+
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY "${Slicer_${proj}_GIT_REPOSITORY}"
+    GIT_TAG "${Slicer_${proj}_GIT_TAG}"
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    BINARY_DIR ${EP_BINARY_DIR}
+    INSTALL_DIR ${EP_INSTALL_DIR}
+    CMAKE_CACHE_ARGS
+      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+      -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
+      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+      -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+      -DBUILD_SHARED_LIBS:BOOL=ON
+      -DBUILD_TESTING:BOOL=OFF
+      -DBUILD_CODEC:BOOL=OFF
+      # Install directories
+      -DCMAKE_INSTALL_LIBDIR:STRING=lib  # Override value set in GNUInstallDirs CMake module
+      -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+    DEPENDS
+      ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
+  # OpenJPEG installs its cmake config to lib/cmake/openjpeg-<MAJOR>.<MINOR>
+  set(OpenJPEG_DIR ${EP_INSTALL_DIR}/lib/cmake/openjpeg-2.5)
+
+  set(_lib_subdir lib)
+  if(WIN32)
+    set(_lib_subdir bin)
+  endif()
+
+  #-----------------------------------------------------------------------------
+  # Launcher setting specific to build tree
+
+  set(${proj}_LIBRARY_PATHS_LAUNCHER_BUILD ${EP_INSTALL_DIR}/${_lib_subdir})
+  mark_as_superbuild(
+    VARS ${proj}_LIBRARY_PATHS_LAUNCHER_BUILD
+    LABELS "LIBRARY_PATHS_LAUNCHER_BUILD"
+    )
+
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDENCIES})
+endif()
+
+mark_as_superbuild(
+  VARS OpenJPEG_DIR:PATH
+  LABELS "FIND_PACKAGE"
+  )

--- a/SuperBuild/External_OpenJPEG.cmake
+++ b/SuperBuild/External_OpenJPEG.cmake
@@ -1,0 +1,88 @@
+
+set(proj OpenJPEG)
+
+# Set dependency list
+set(${proj}_DEPENDENCIES "")
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+if(Slicer_USE_SYSTEM_${proj})
+  unset(OpenJPEG_DIR CACHE)
+  find_package(OpenJPEG REQUIRED)
+endif()
+
+# Sanity checks
+if(DEFINED OpenJPEG_DIR AND NOT EXISTS ${OpenJPEG_DIR})
+  message(FATAL_ERROR "OpenJPEG_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(NOT DEFINED OpenJPEG_DIR AND NOT Slicer_USE_SYSTEM_${proj})
+
+  ExternalProject_SetIfNotDefined(
+    Slicer_${proj}_GIT_REPOSITORY
+    "${EP_GIT_PROTOCOL}://github.com/uclouvain/openjpeg.git"
+    QUIET
+    )
+
+  ExternalProject_SetIfNotDefined(
+    Slicer_${proj}_GIT_TAG
+    "v2.5.4"
+    QUIET
+    )
+
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY "${Slicer_${proj}_GIT_REPOSITORY}"
+    GIT_TAG "${Slicer_${proj}_GIT_TAG}"
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    BINARY_DIR ${EP_BINARY_DIR}
+    INSTALL_DIR ${EP_INSTALL_DIR}
+    CMAKE_CACHE_ARGS
+      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+      -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
+      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+      -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+      -DBUILD_SHARED_LIBS:BOOL=ON
+      -DBUILD_STATIC_LIBS:BOOL=OFF  # Remove static OpenJPEG library target to avoid conflict with ITK GDCM OpenJPEG
+      -DBUILD_TESTING:BOOL=OFF
+      -DBUILD_CODEC:BOOL=OFF
+      # Install directories
+      -DCMAKE_INSTALL_LIBDIR:STRING=lib  # Override value set in GNUInstallDirs CMake module
+      -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+    DEPENDS
+      ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
+  # OpenJPEG installs its cmake config to lib/cmake/openjpeg-<MAJOR>.<MINOR>
+  set(OpenJPEG_DIR ${EP_INSTALL_DIR}/lib/cmake/openjpeg-2.5)
+
+  set(_lib_subdir lib)
+  if(WIN32)
+    set(_lib_subdir bin)
+  endif()
+
+  #-----------------------------------------------------------------------------
+  # Launcher setting specific to build tree
+
+  set(${proj}_LIBRARY_PATHS_LAUNCHER_BUILD ${EP_INSTALL_DIR}/${_lib_subdir})
+  mark_as_superbuild(
+    VARS ${proj}_LIBRARY_PATHS_LAUNCHER_BUILD
+    LABELS "LIBRARY_PATHS_LAUNCHER_BUILD"
+    )
+
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDENCIES})
+endif()
+
+mark_as_superbuild(
+  VARS OpenJPEG_DIR:PATH
+  LABELS "FIND_PACKAGE"
+  )


### PR DESCRIPTION
This PR adds JPEG2000 support to DCMTK.

Prerequisites:
- [x] DCMTKcs: Review the new community-supported DCMTK external modules repository: https://github.com/lassoan/DCMTKcs - If it looks like a good approach then I would transfer it to the commontk or Slicer organization.
- [x] DCMTK: Make it easy to add external modules to DCMTK. We just need a small commit that allows cleanly adding external modules from folders outside the DCMTK repository: https://github.com/lassoan/DCMTK/tree/improve-external-module-support - It would be preferable if DCMTK maintainers accept this change in DCMTK upstream. Otherwise we'll switch back to our DCMTK fork in the commontk organization.
- [x] CTK: Enable the JPEG2000 codec in CTK by merging https://github.com/commontk/CTK/pull/1406
- [x] Update github URLs based on the final location of the repositories
