### PR TITLE
Add DICOM SEG/PM/SR/M3D plugins to Slicer core

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -465,6 +465,7 @@ if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
   # add as unit test for use at build/test time
   slicer_add_python_unittest(SCRIPT AtlasTests.py)
   slicer_add_python_unittest(SCRIPT DICOMReaders.py)
+  slicer_add_python_unittest(SCRIPT DICOMPluginTests.py)
   slicer_add_python_unittest(SCRIPT KneeAtlasTest.py)
   slicer_add_python_unittest(SCRIPT sceneImport2428.py)
   slicer_add_python_unittest(SCRIPT SlicerDisplayNodeSequenceTest.py)

--- a/Applications/SlicerApp/Testing/Python/DICOMPluginTests.py
+++ b/Applications/SlicerApp/Testing/Python/DICOMPluginTests.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import shutil
 import tempfile

--- a/Applications/SlicerApp/Testing/Python/DICOMPluginTests.py
+++ b/Applications/SlicerApp/Testing/Python/DICOMPluginTests.py
@@ -1,0 +1,264 @@
+import logging
+import os
+import shutil
+import tempfile
+import urllib.request
+
+import slicer
+from slicer.ScriptedLoadableModule import *
+from DICOMLib import DICOMUtils
+
+
+#
+# DICOMPluginTests
+#
+
+
+class DICOMPluginTests(ScriptedLoadableModule):
+    def __init__(self, parent):
+        ScriptedLoadableModule.__init__(self, parent)
+        parent.title = "DICOMPluginTests"
+        parent.categories = ["DICOMPluginTests"]
+        parent.dependencies = []
+        parent.contributors = ["Andrey Fedorov (SPL, BWH)"]
+        parent.helpText = """
+    Integration tests for DICOM plugins added in Slicer core: DICOMSegmentationPlugin,
+    DICOMTID1500Plugin, and DICOMM3DPlugin. Each test downloads a small (~5-32 KB) reference
+    DICOM file from the NCI Imaging Data Commons (IDC, https://portal.imaging.datacommons.cancer.gov/)
+    public GCS bucket, imports it into a temporary DICOM database, and verifies that the plugin
+    correctly examines and loads the object into the MRML scene.
+    """
+        parent.acknowledgementText = (
+            "Test data sourced from the NCI Imaging Data Commons (IDC). "
+            "SEG and SR samples created by the QIICR project (NIH U24 CA180918). "
+            "M3D sample from the Prostate MRI US Biopsy collection."
+        )
+
+
+#
+# DICOMPluginTestsWidget
+#
+
+
+class DICOMPluginTestsWidget(ScriptedLoadableModuleWidget):
+    def setup(self):
+        ScriptedLoadableModuleWidget.setup(self)
+        self.layout.addStretch(1)
+
+
+#
+# DICOMPluginTestsTest
+#
+
+
+class DICOMPluginTestsTest(ScriptedLoadableModuleTest):
+    """Integration tests for DICOMSegmentationPlugin, DICOMTID1500Plugin, and DICOMM3DPlugin."""
+
+    def setUp(self):
+        self.delayDisplay("Closing the scene")
+        slicer.mrmlScene.Clear(0)
+
+    def runTest(self):
+        self.setUp()
+        self.test_DICOMSegmentationPlugin()
+        self.setUp()
+        self.test_DICOMTID1500Plugin()
+        self.setUp()
+        self.test_DICOMM3DPlugin()
+
+    # -------------------------------------------------------------------------
+    # Helpers
+    # -------------------------------------------------------------------------
+
+    def _downloadDICOMFile(self, url, destDir):
+        """Download a single DICOM file via HTTPS into destDir. Returns the local path."""
+        filename = url.split("/")[-1]
+        destPath = os.path.join(destDir, filename)
+        self.delayDisplay(f"Downloading {filename} ...")
+        urllib.request.urlretrieve(url, destPath)
+        return destPath
+
+    # -------------------------------------------------------------------------
+    # Test: DICOMSegmentationPlugin
+    # -------------------------------------------------------------------------
+
+    def test_DICOMSegmentationPlugin(self):
+        """Test loading a DICOM SEG object via DICOMSegmentationPlugin.
+
+        Test data: ReMIND collection, patient ReMIND-004, tumor segmentation
+        (QIICR/dcmqi-generated, Manufacturer: QIICR).
+        SeriesInstanceUID: 1.3.6.1.4.1.14519.5.2.1.27661008822762431370973483522020876264
+        License: CC BY 4.0
+
+        IDC viewer:
+          https://viewer.imaging.datacommons.cancer.gov/v3/viewer/?StudyInstanceUIDs=
+          1.3.6.1.4.1.14519.5.2.1.21953915370182127679153341817124092346
+          &initialSeriesInstanceUID=
+          1.3.6.1.4.1.14519.5.2.1.27661008822762431370973483522020876264
+
+        Acknowledgment:
+          Juvekar, P., et al. (2023). ReMIND: The Brain Resection Multimodal Imaging Database.
+          The Cancer Imaging Archive. https://doi.org/10.7937/3RAG-D070
+        """
+        self.delayDisplay("Starting test_DICOMSegmentationPlugin")
+
+        SEG_URL = (
+            "https://storage.googleapis.com/idc-open-data/"
+            "8676c8bb-3bdd-4106-be09-97223b5126e7/"
+            "6936cea9-f0ac-49bd-91c4-86904f5c3650.dcm"
+        )
+        SEG_SERIES_UID = "1.3.6.1.4.1.14519.5.2.1.27661008822762431370973483522020876264"
+
+        tmpDir = tempfile.mkdtemp()
+        try:
+            self._downloadDICOMFile(SEG_URL, tmpDir)
+
+            with DICOMUtils.TemporaryDICOMDatabase() as db:
+                self.assertTrue(db.isOpen, "Temporary DICOM database failed to open")
+
+                DICOMUtils.importDicom(tmpDir, db)
+
+                files = slicer.dicomDatabase.filesForSeries(SEG_SERIES_UID)
+                self.assertGreater(len(files), 0, "SEG series was not indexed into the DICOM database")
+
+                plugin = slicer.modules.dicomPlugins["DICOMSegmentationPlugin"]()
+                loadables = plugin.examineFiles(files)
+                self.assertGreater(len(loadables), 0,
+                                   "DICOMSegmentationPlugin.examineFiles() returned no loadables")
+
+                self.assertTrue(plugin.load(loadables[0]),
+                                "DICOMSegmentationPlugin.load() returned False")
+
+                segNodes = slicer.util.getNodesByClass("vtkMRMLSegmentationNode")
+                self.assertEqual(len(segNodes), 1,
+                                 f"Expected 1 vtkMRMLSegmentationNode, got {len(segNodes)}")
+                self.assertGreater(segNodes[0].GetSegmentation().GetNumberOfSegments(), 0,
+                                   "Loaded segmentation node contains no segments")
+
+        finally:
+            shutil.rmtree(tmpDir)
+
+        self.delayDisplay("test_DICOMSegmentationPlugin passed!")
+
+    # -------------------------------------------------------------------------
+    # Test: DICOMTID1500Plugin
+    # -------------------------------------------------------------------------
+
+    def test_DICOMTID1500Plugin(self):
+        """Test loading a DICOM SR TID1500 structured report via DICOMTID1500Plugin.
+
+        Test data: QIN-PROSTATE-Repeatability collection, patient PCAMPMRI-00001,
+        DCE Subtraction Measurements report (QIICR/dcmqi-generated, Manufacturer: QIICR).
+        SeriesInstanceUID: 1.2.276.0.7230010.3.1.3.3166326398.17020.1513205119.297
+        SOPClassUID: 1.2.840.10008.5.1.4.1.1.88.22 (Comprehensive SR Storage)
+        License: CC BY 4.0
+
+        IDC viewer:
+          https://viewer.imaging.datacommons.cancer.gov/v3/viewer/?StudyInstanceUIDs=
+          1.3.6.1.4.1.14519.5.2.1.3671.4754.288848219213026850354055725664
+          &initialSeriesInstanceUID=
+          1.2.276.0.7230010.3.1.3.3166326398.17020.1513205119.297
+
+        Acknowledgment:
+          Fedorov, A., Tempany, C., & Fennessy, F. (2019). Data From QIN-PROSTATE-Repeatability
+          (Version 2). The Cancer Imaging Archive. https://doi.org/10.7937/K9/TCIA.2018.MR1CKGND
+        """
+        self.delayDisplay("Starting test_DICOMTID1500Plugin")
+
+        SR_URL = (
+            "https://storage.googleapis.com/idc-open-data/"
+            "72555341-016b-4483-a4e9-928e03a12b17/"
+            "6cfb33f2-65a7-413f-9e01-d06aaf38f2ef.dcm"
+        )
+        SR_SERIES_UID = "1.2.276.0.7230010.3.1.3.3166326398.17020.1513205119.297"
+
+        tmpDir = tempfile.mkdtemp()
+        try:
+            self._downloadDICOMFile(SR_URL, tmpDir)
+
+            with DICOMUtils.TemporaryDICOMDatabase() as db:
+                self.assertTrue(db.isOpen, "Temporary DICOM database failed to open")
+
+                DICOMUtils.importDicom(tmpDir, db)
+
+                files = slicer.dicomDatabase.filesForSeries(SR_SERIES_UID)
+                self.assertGreater(len(files), 0, "SR series was not indexed into the DICOM database")
+
+                plugin = slicer.modules.dicomPlugins["DICOMTID1500Plugin"]()
+                loadables = plugin.examineFiles(files)
+                self.assertGreater(len(loadables), 0,
+                                   "DICOMTID1500Plugin.examineFiles() returned no loadables")
+
+                self.assertTrue(plugin.load(loadables[0]),
+                                "DICOMTID1500Plugin.load() returned False")
+
+                tableNodes = slicer.util.getNodesByClass("vtkMRMLTableNode")
+                self.assertGreater(len(tableNodes), 0,
+                                   "Expected at least one vtkMRMLTableNode after loading TID1500 SR")
+
+        finally:
+            shutil.rmtree(tmpDir)
+
+        self.delayDisplay("test_DICOMTID1500Plugin passed!")
+
+    # -------------------------------------------------------------------------
+    # Test: DICOMM3DPlugin
+    # -------------------------------------------------------------------------
+
+    def test_DICOMM3DPlugin(self):
+        """Test loading a DICOM M3D object (encapsulated STL) via DICOMM3DPlugin.
+
+        Test data: Prostate-MRI-US-Biopsy collection, patient Prostate-MRI-US-Biopsy-0293,
+        STL surface of lesion 2 (DICOM annotations by Ciausu, Clunie, Fedorov).
+        SeriesInstanceUID: 1.3.6.1.4.1.5962.99.1.1972223737.1083348708.1694189371129.3.0
+        SOPClassUID: 1.2.840.10008.5.1.4.1.1.104.3
+        License: CC BY 4.0
+
+        IDC viewer:
+          https://viewer.imaging.datacommons.cancer.gov/v3/viewer/?StudyInstanceUIDs=
+          1.3.6.1.4.1.14519.5.2.1.298134725212789995817164419725804739814
+          &initialSeriesInstanceUID=
+          1.3.6.1.4.1.5962.99.1.1972223737.1083348708.1694189371129.3.0
+
+        Acknowledgment:
+          Ciausu, C., Clunie, D., & Fedorov, A. (2023). DICOM converted annotations for the
+          Prostate-MRI-US-Biopsy collection [Data set]. Zenodo.
+          https://doi.org/10.5281/ZENODO.10069910
+        """
+        self.delayDisplay("Starting test_DICOMM3DPlugin")
+
+        M3D_URL = (
+            "https://storage.googleapis.com/idc-open-data/"
+            "e5db2185-8d0a-4e35-aa63-231ad7aa6e1b/"
+            "c9a91b1e-0bb4-4f35-98b9-c55aa6217e22.dcm"
+        )
+        M3D_SERIES_UID = "1.3.6.1.4.1.5962.99.1.1972223737.1083348708.1694189371129.3.0"
+
+        tmpDir = tempfile.mkdtemp()
+        try:
+            self._downloadDICOMFile(M3D_URL, tmpDir)
+
+            with DICOMUtils.TemporaryDICOMDatabase() as db:
+                self.assertTrue(db.isOpen, "Temporary DICOM database failed to open")
+
+                DICOMUtils.importDicom(tmpDir, db)
+
+                files = slicer.dicomDatabase.filesForSeries(M3D_SERIES_UID)
+                self.assertGreater(len(files), 0, "M3D series was not indexed into the DICOM database")
+
+                plugin = slicer.modules.dicomPlugins["DICOMM3DPlugin"]()
+                loadables = plugin.examineFiles(files)
+                self.assertGreater(len(loadables), 0,
+                                   "DICOMM3DPlugin.examineFiles() returned no loadables")
+
+                self.assertTrue(plugin.load(loadables[0]),
+                                "DICOMM3DPlugin.load() returned False")
+
+                segNodes = slicer.util.getNodesByClass("vtkMRMLSegmentationNode")
+                self.assertEqual(len(segNodes), 1,
+                                 f"Expected 1 vtkMRMLSegmentationNode, got {len(segNodes)}")
+
+        finally:
+            shutil.rmtree(tmpDir)
+
+        self.delayDisplay("test_DICOMM3DPlugin passed!")

--- a/Applications/SlicerApp/Testing/Python/DICOMPluginTests.py
+++ b/Applications/SlicerApp/Testing/Python/DICOMPluginTests.py
@@ -1,7 +1,5 @@
-import os
 import shutil
 import tempfile
-import urllib.request
 
 import slicer
 from slicer.ScriptedLoadableModule import *
@@ -66,18 +64,6 @@ class DICOMPluginTestsTest(ScriptedLoadableModuleTest):
         self.test_DICOMM3DPlugin()
 
     # -------------------------------------------------------------------------
-    # Helpers
-    # -------------------------------------------------------------------------
-
-    def _downloadDICOMFile(self, url, destDir):
-        """Download a single DICOM file via HTTPS into destDir. Returns the local path."""
-        filename = url.split("/")[-1]
-        destPath = os.path.join(destDir, filename)
-        self.delayDisplay(f"Downloading {filename} ...")
-        urllib.request.urlretrieve(url, destPath)
-        return destPath
-
-    # -------------------------------------------------------------------------
     # Test: DICOMSegmentationPlugin
     # -------------------------------------------------------------------------
 
@@ -101,16 +87,20 @@ class DICOMPluginTestsTest(ScriptedLoadableModuleTest):
         """
         self.delayDisplay("Starting test_DICOMSegmentationPlugin")
 
+        import SampleData
         SEG_URL = (
             "https://storage.googleapis.com/idc-open-data/"
             "8676c8bb-3bdd-4106-be09-97223b5126e7/"
             "6936cea9-f0ac-49bd-91c4-86904f5c3650.dcm"
         )
+        SEG_FILENAME = "6936cea9-f0ac-49bd-91c4-86904f5c3650.dcm"
+        SEG_CHECKSUM = "SHA256:27b2132aad76a2c1fed06aef62b9a1cdfcf774ca588012a3b7a4789328ec2f64"
         SEG_SERIES_UID = "1.3.6.1.4.1.14519.5.2.1.27661008822762431370973483522020876264"
 
+        cachedPath = SampleData.SampleDataLogic().downloadFileIntoCache(SEG_URL, SEG_FILENAME, SEG_CHECKSUM)
         tmpDir = tempfile.mkdtemp()
         try:
-            self._downloadDICOMFile(SEG_URL, tmpDir)
+            shutil.copy(cachedPath, tmpDir)
 
             with DICOMUtils.TemporaryDICOMDatabase() as db:
                 self.assertTrue(db.isOpen, "Temporary DICOM database failed to open")
@@ -164,16 +154,20 @@ class DICOMPluginTestsTest(ScriptedLoadableModuleTest):
         """
         self.delayDisplay("Starting test_DICOMTID1500Plugin")
 
+        import SampleData
         SR_URL = (
             "https://storage.googleapis.com/idc-open-data/"
             "72555341-016b-4483-a4e9-928e03a12b17/"
             "6cfb33f2-65a7-413f-9e01-d06aaf38f2ef.dcm"
         )
+        SR_FILENAME = "6cfb33f2-65a7-413f-9e01-d06aaf38f2ef.dcm"
+        SR_CHECKSUM = "SHA256:b5584fc2df0a3e0f88948a02301f5e22f1aadb7fc152398a32a5df7fb4baa4d3"
         SR_SERIES_UID = "1.2.276.0.7230010.3.1.3.3166326398.17020.1513205119.297"
 
+        cachedPath = SampleData.SampleDataLogic().downloadFileIntoCache(SR_URL, SR_FILENAME, SR_CHECKSUM)
         tmpDir = tempfile.mkdtemp()
         try:
-            self._downloadDICOMFile(SR_URL, tmpDir)
+            shutil.copy(cachedPath, tmpDir)
 
             with DICOMUtils.TemporaryDICOMDatabase() as db:
                 self.assertTrue(db.isOpen, "Temporary DICOM database failed to open")
@@ -226,16 +220,20 @@ class DICOMPluginTestsTest(ScriptedLoadableModuleTest):
         """
         self.delayDisplay("Starting test_DICOMM3DPlugin")
 
+        import SampleData
         M3D_URL = (
             "https://storage.googleapis.com/idc-open-data/"
             "e5db2185-8d0a-4e35-aa63-231ad7aa6e1b/"
             "c9a91b1e-0bb4-4f35-98b9-c55aa6217e22.dcm"
         )
+        M3D_FILENAME = "c9a91b1e-0bb4-4f35-98b9-c55aa6217e22.dcm"
+        M3D_CHECKSUM = "SHA256:7b22fd756a35dddd8ea72c0bb34f9f8f19fd41541ad42a42e7d9270242c90824"
         M3D_SERIES_UID = "1.3.6.1.4.1.5962.99.1.1972223737.1083348708.1694189371129.3.0"
 
+        cachedPath = SampleData.SampleDataLogic().downloadFileIntoCache(M3D_URL, M3D_FILENAME, M3D_CHECKSUM)
         tmpDir = tempfile.mkdtemp()
         try:
-            self._downloadDICOMFile(M3D_URL, tmpDir)
+            shutil.copy(cachedPath, tmpDir)
 
             with DICOMUtils.TemporaryDICOMDatabase() as db:
                 self.assertTrue(db.isOpen, "Temporary DICOM database failed to open")

--- a/Modules/Scripted/DICOM/DICOMExtensions.json
+++ b/Modules/Scripted/DICOM/DICOMExtensions.json
@@ -12,40 +12,6 @@
       }
     },
     {
-      "name": "QuantitativeReporting",
-      "repository": "https://github.com/QIICR/QuantitativeReporting.git",
-      "typeDescription": "Segmentation Objects",
-      "tagValues": {
-        "Modality": [
-          "SEG"
-        ]
-      }
-    },
-    {
-      "name": "QuantitativeReporting",
-      "repository": "https://github.com/QIICR/QuantitativeReporting.git",
-      "typeDescription": "Parametric Map Objects",
-      "tagValues": {
-        "SOPClassUID": [
-          "1.2.840.10008.5.1.4.1.1.30"
-        ]
-      }
-    },
-    {
-      "name": "QuantitativeReporting",
-      "repository": "https://github.com/QIICR/QuantitativeReporting.git",
-      "typeDescription": "Structured Report Objects",
-      "tagValues": {
-        "Modality": [
-          "SR"
-        ],
-        "SOPClassUID": [
-          "1.2.840.10008.5.1.4.1.1.88.22",
-          "1.2.840.10008.5.1.4.1.1.88.33"
-        ]
-      }
-    },
-    {
       "name": "SlicerHeart",
       "repository": "https://github.com/SlicerHeart/SlicerHeart.git",
       "typeDescription": "4D Ultrasound",

--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -1,5 +1,9 @@
 import logging
+import os
+import shutil
+from datetime import datetime
 
+import pydicom
 import slicer
 
 #########################################################
@@ -89,6 +93,79 @@ class DICOMPlugin:
         self.tags["seriesDescription"] = "0008,103E"
         self.tags["seriesNumber"] = "0020,0011"
         self.tags["frameOfReferenceUID"] = "0020,0052"
+        self.tags["seriesInstanceUID"] = "0020,000E"
+        self.tags["modality"] = "0008,0060"
+        self.tags["instanceUID"] = "0008,0018"
+        self.tags["classUID"] = "0008,0016"
+        # Temporary directory used during loading; cleaned up by cleanup()
+        self.tempDir = None
+
+    @property
+    def currentDateTime(self):
+        """Return a timestamp string suitable for temporary directory names."""
+        try:
+            return self._currentDateTime
+        except AttributeError:
+            self._currentDateTime = datetime.now().strftime('%Y-%m-%d_%H%M%S')
+        return self._currentDateTime
+
+    def cleanup(self):
+        """Remove the temporary directory created during loading, if any."""
+        if not self.tempDir:
+            return
+        try:
+            logging.debug("Cleaning up temporary directory %s" % self.tempDir)
+            shutil.rmtree(self.tempDir)
+            self.tempDir = None
+        except OSError:
+            pass
+
+    def addReferences(self, loadable):
+        """Populate loadable.referencedInstanceUIDs and loadable.referencedSeriesUID
+        by reading referenced series/image sequences from the first DICOM file.
+        """
+        dcm = pydicom.dcmread(loadable.files[0])
+        loadable.referencedInstanceUIDs = []
+        self._addReferencedSeries(loadable, dcm)
+        self._addReferencedImages(loadable, dcm)
+        loadable.referencedInstanceUIDs = list(set(loadable.referencedInstanceUIDs))
+
+    def _addReferencedSeries(self, loadable, dcm):
+        if hasattr(dcm, "ReferencedSeriesSequence"):
+            if hasattr(dcm.ReferencedSeriesSequence[0], "SeriesInstanceUID"):
+                for f in slicer.dicomDatabase.filesForSeries(dcm.ReferencedSeriesSequence[0].SeriesInstanceUID):
+                    refDCM = pydicom.dcmread(f)
+                    loadable.referencedInstanceUIDs.append(refDCM.SOPInstanceUID)
+                loadable.referencedSeriesUID = dcm.ReferencedSeriesSequence[0].SeriesInstanceUID
+
+    def _addReferencedImages(self, loadable, dcm):
+        if hasattr(dcm, "ReferencedImageSequence"):
+            for item in dcm.ReferencedImageSequence:
+                if hasattr(item, "ReferencedSOPInstanceUID"):
+                    loadable.referencedInstanceUIDs.append(item.ReferencedSOPInstanceUID)
+
+    @staticmethod
+    def _dcmqi_binary(name):
+        """Return the path to a dcmqi binary installed via the pip 'dcmqi' package.
+
+        Slicer adds its bin directory to PATH, so console_scripts installed in
+        Slicer's embedded Python environment are discoverable via shutil.which().
+        Raises RuntimeError if the binary cannot be found.
+        """
+        path = shutil.which(name)
+        if path is None:
+            # Fallback: look in same directory as the Python executable
+            import sys
+            candidate = os.path.join(os.path.dirname(sys.executable), name)
+            if os.path.isfile(candidate):
+                path = candidate
+            elif os.path.isfile(candidate + ".exe"):
+                path = candidate + ".exe"
+        if path is None:
+            raise RuntimeError(
+                "dcmqi binary '%s' not found. "
+                "Ensure the 'dcmqi' pip package is installed." % name)
+        return path
 
     def findPrivateTag(self, ds, group, element, privateCreator):
         """Helper function to get private tag from private creator name.
@@ -145,8 +222,26 @@ class DICOMPlugin:
 
     def examineForImport(self, fileList):
         """Look at the list of lists of filenames and return
-        a list of DICOMLoadables that are options for loading
-        Virtual: should be overridden by the subclass
+        a list of DICOMLoadables that are options for loading.
+        Default implementation calls examineFiles() for each file group with caching.
+        Subclasses may override either examineForImport() (bypasses caching) or
+        examineFiles() (uses inherited caching).
+        """
+        loadables = []
+        for files in fileList:
+            cachedLoadables = self.getCachedLoadables(files)
+            if cachedLoadables is not None:
+                loadables += cachedLoadables
+            else:
+                loadablesForFiles = self.examineFiles(files)
+                loadables += loadablesForFiles
+                self.cacheLoadables(files, loadablesForFiles)
+        return loadables
+
+    def examineFiles(self, files):
+        """Examine a single group of files and return a list of DICOMLoadables.
+        Virtual: should be overridden by the subclass when using the default
+        examineForImport() caching wrapper.
         """
         return []
 

--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -96,7 +96,7 @@ class DICOMPlugin:
         self.tags["seriesInstanceUID"] = "0020,000E"
         self.tags["modality"] = "0008,0060"
         self.tags["instanceUID"] = "0008,0018"
-        self.tags["classUID"] = "0008,0016"
+        self.tags["sopClassUID"] = "0008,0016"
         # Temporary directory used during loading; cleaned up by cleanup()
         self.tempDir = None
 
@@ -148,24 +148,33 @@ class DICOMPlugin:
     def _dcmqi_binary(name):
         """Return the path to a dcmqi binary installed via the pip 'dcmqi' package.
 
-        Slicer adds its bin directory to PATH, so console_scripts installed in
-        Slicer's embedded Python environment are discoverable via shutil.which().
+        Uses sysconfig to locate the pip scripts directory for Slicer's embedded
+        Python environment, avoiding accidental resolution of a system-installed
+        binary via PATH. On Windows, pip installs console_scripts into a Scripts/
+        subdirectory separate from sys.executable, so sysconfig is more correct
+        than os.path.dirname(sys.executable) on all platforms.
         Raises RuntimeError if the binary cannot be found.
         """
-        path = shutil.which(name)
-        if path is None:
-            # Fallback: look in same directory as the Python executable
-            import sys
-            candidate = os.path.join(os.path.dirname(sys.executable), name)
-            if os.path.isfile(candidate):
-                path = candidate
-            elif os.path.isfile(candidate + ".exe"):
-                path = candidate + ".exe"
-        if path is None:
-            raise RuntimeError(
-                "dcmqi binary '%s' not found. "
-                "Ensure the 'dcmqi' pip package is installed." % name)
-        return path
+        import sys
+        import sysconfig
+
+        scripts_dir = sysconfig.get_path("scripts")
+        candidate = os.path.join(scripts_dir, name)
+        if os.name == "nt":
+            candidate += ".exe"
+        if os.path.isfile(candidate):
+            return candidate
+
+        # Fallback: same directory as sys.executable (equivalent on Linux/macOS).
+        candidate = os.path.join(os.path.dirname(sys.executable), name)
+        if os.name == "nt" and not candidate.endswith(".exe"):
+            candidate += ".exe"
+        if os.path.isfile(candidate):
+            return candidate
+
+        raise RuntimeError(
+            f"dcmqi binary '{name}' not found. "
+            "Ensure the 'dcmqi' pip package is installed.")
 
     def findPrivateTag(self, ds, group, element, privateCreator):
         """Helper function to get private tag from private creator name.
@@ -321,7 +330,7 @@ class DICOMPlugin:
         tags["patientSex"] = "0010,0040"
         tags["patientBirthDate"] = "0010,0030"
         tags["patientComments"] = "0010,4000"
-        tags["classUID"] = "0008,0016"
+        tags["sopClassUID"] = "0008,0016"
         tags["instanceUID"] = "0008,0018"
 
         # Import and check dependencies

--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -106,7 +106,7 @@ class DICOMPlugin:
         try:
             return self._currentDateTime
         except AttributeError:
-            self._currentDateTime = datetime.now().strftime('%Y-%m-%d_%H%M%S')
+            self._currentDateTime = datetime.now().strftime("%Y-%m-%d_%H%M%S")
         return self._currentDateTime
 
     def cleanup(self):

--- a/Modules/Scripted/DICOMPlugins/CMakeLists.txt
+++ b/Modules/Scripted/DICOMPlugins/CMakeLists.txt
@@ -10,6 +10,10 @@ set(MODULE_PYTHON_SCRIPTS
   DICOMScalarVolumePlugin.py
   DICOMVolumeSequencePlugin.py
   DICOMSlicerDataBundlePlugin.py
+  DICOMSegmentationPlugin.py
+  DICOMParametricMapPlugin.py
+  DICOMTID1500Plugin.py
+  DICOMM3DPlugin.py
   )
 
 set(MODULE_PYTHON_RESOURCES

--- a/Modules/Scripted/DICOMPlugins/DICOMM3DPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMM3DPlugin.py
@@ -1,8 +1,4 @@
-from __future__ import absolute_import
-import glob
 import os
-import json
-import vtk
 import io
 import shutil
 import vtkSegmentationCorePython as vtkSegmentationCore
@@ -21,11 +17,11 @@ from DICOMLib import DICOMLoadable, DICOMPlugin
 class DICOMM3DPluginClass(DICOMPlugin):
 
   def __init__(self):
-    super(DICOMM3DPluginClass, self).__init__()
+    super().__init__()
     self.loadType = "DICOMM3D"
 
   def examineFiles(self, files):
-    """ Returns a list of DICOMLoadable instances
+    """Returns a list of DICOMLoadable instances
     corresponding to ways of interpreting the
     files parameter.
     """
@@ -33,26 +29,26 @@ class DICOMM3DPluginClass(DICOMPlugin):
 
     for candidateFile in files:
       #read modality type to flag M3D object.
-      isDicomM3D = (slicer.dicomDatabase.fileValue(candidateFile, self.tags['modality']) == 'M3D')
+      isDicomM3D = (slicer.dicomDatabase.fileValue(candidateFile, self.tags["modality"]) == "M3D")
       if isDicomM3D:
-        uid = slicer.dicomDatabase.fileValue(candidateFile, self.tags['instanceUID'])
-        if uid == '':
+        uid = slicer.dicomDatabase.fileValue(candidateFile, self.tags["instanceUID"])
+        if uid == "":
           return []
 
-        desc = slicer.dicomDatabase.fileValue(candidateFile, self.tags['seriesDescription'])
-        if desc == '':
+        desc = slicer.dicomDatabase.fileValue(candidateFile, self.tags["seriesDescription"])
+        if desc == "":
           desc = "Unknown"
 
         loadable = DICOMLoadable()
         loadable.files = [candidateFile]
         loadable.name = desc
-        loadable.tooltip = loadable.name + ' - as a DICOM M3D object'
+        loadable.tooltip = loadable.name + " - as a DICOM M3D object"
         loadable.selected = True
         loadable.confidence = 0.95
         loadable.uid = uid
         loadables.append(loadable)
 
-        logging.debug('DICOM M3D modality found')
+        logging.debug("DICOM M3D modality found")
 
     return loadables
 
@@ -62,11 +58,11 @@ class DICOMM3DPluginClass(DICOMPlugin):
     if hasattr(dcm, "FrameOfReferenceUID"):
       return dcm.FrameOfReferenceUID
     else:
-      return 'Unnamed FrameOfReferenceUID'
+      return "Unnamed FrameOfReferenceUID"
 
   def getEncapsulatedDocumentAttributes(self, candidateFile):
     dcm = pydicom.dcmread(candidateFile)
-    encapsulatedDocument = b''
+    encapsulatedDocument = b""
     encapsulatedDocumentLength = 0
     if hasattr(dcm, "EncapsulatedDocument"):
       encapsulatedDocument = dcm.EncapsulatedDocument
@@ -75,12 +71,11 @@ class DICOMM3DPluginClass(DICOMPlugin):
     return encapsulatedDocument, encapsulatedDocumentLength
 
   def load(self, loadable):
-    """ Load the DICOM M3D object
-    """
-    logging.debug('DICOM M3D load()')
+    """Load the DICOM M3D object"""
+    logging.debug("DICOM M3D load()")
     if hasattr(loadable, "uid"):
       uid = loadable.uid
-      logging.debug('in load(): uid = ' + uid)
+      logging.debug("in load(): uid = " + uid)
     else:
       return False
 
@@ -92,7 +87,7 @@ class DICOMM3DPluginClass(DICOMPlugin):
 
     stlFileName = slicer.dicomDatabase.fileForInstance(uid)
     if stlFileName is None:
-      logging.error('Failed to get the filename from the DICOM database for ' + uid)
+      logging.error("Failed to get the filename from the DICOM database for " + uid)
       self.cleanup()
       return False
 
@@ -111,7 +106,7 @@ class DICOMM3DPluginClass(DICOMPlugin):
 
     # Save processed binary IO buffer into a temporary .STL file
     stlFilePath = os.path.join(self.tempDir, "temp.STL")
-    with open(stlFilePath, 'wb') as file:
+    with open(stlFilePath, "wb") as file:
       shutil.copyfileobj(read_buffer, file)
     assert os.path.exists(stlFilePath)
     file.close()
@@ -176,6 +171,7 @@ class DICOMM3DPlugin:
   This class is the 'hook' for slicer to detect and recognize the plugin
   as a loadable scripted module
   """
+
   def __init__(self, parent):
     parent.title = "DICOM M3D Object Import Plugin"
     parent.categories = ["Developer Tools.DICOM Plugins"]
@@ -184,7 +180,7 @@ class DICOMM3DPlugin:
     Plugin to the DICOM Module to parse and load DICOM M3D modality.
     No module interface here, only in the DICOM module
     """
-    parent.dependencies = ['DICOM', 'Colors']
+    parent.dependencies = ["DICOM", "Colors"]
     parent.acknowledgementText = """
     This DICOM Plugin was developed by
     Cosmin Ciausu, BWH.
@@ -197,4 +193,4 @@ class DICOMM3DPlugin:
       slicer.modules.dicomPlugins
     except AttributeError:
       slicer.modules.dicomPlugins = {}
-    slicer.modules.dicomPlugins['DICOMM3DPlugin'] = DICOMM3DPluginClass
+    slicer.modules.dicomPlugins["DICOMM3DPlugin"] = DICOMM3DPluginClass

--- a/Modules/Scripted/DICOMPlugins/DICOMM3DPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMM3DPlugin.py
@@ -1,0 +1,200 @@
+from __future__ import absolute_import
+import glob
+import os
+import json
+import vtk
+import io
+import shutil
+import vtkSegmentationCorePython as vtkSegmentationCore
+import logging
+import pydicom
+
+import slicer
+from DICOMLib import DICOMLoadable, DICOMPlugin
+
+
+#
+# This is the plugin to handle translation of DICOM M3D objects
+# M3D stands for Model for 3D Manufacturing.
+# DICOM M3D objects can be for example .STL files encoded into a DICOM M3D object.
+#
+class DICOMM3DPluginClass(DICOMPlugin):
+
+  def __init__(self):
+    super(DICOMM3DPluginClass, self).__init__()
+    self.loadType = "DICOMM3D"
+
+  def examineFiles(self, files):
+    """ Returns a list of DICOMLoadable instances
+    corresponding to ways of interpreting the
+    files parameter.
+    """
+    loadables = []
+
+    for candidateFile in files:
+      #read modality type to flag M3D object.
+      isDicomM3D = (slicer.dicomDatabase.fileValue(candidateFile, self.tags['modality']) == 'M3D')
+      if isDicomM3D:
+        uid = slicer.dicomDatabase.fileValue(candidateFile, self.tags['instanceUID'])
+        if uid == '':
+          return []
+
+        desc = slicer.dicomDatabase.fileValue(candidateFile, self.tags['seriesDescription'])
+        if desc == '':
+          desc = "Unknown"
+
+        loadable = DICOMLoadable()
+        loadable.files = [candidateFile]
+        loadable.name = desc
+        loadable.tooltip = loadable.name + ' - as a DICOM M3D object'
+        loadable.selected = True
+        loadable.confidence = 0.95
+        loadable.uid = uid
+        loadables.append(loadable)
+
+        logging.debug('DICOM M3D modality found')
+
+    return loadables
+
+  def getFrameOfReferenceUID(self, candidateFile):
+    """Returns the frame of referenceUID for the given loadable"""
+    dcm = pydicom.dcmread(candidateFile)
+    if hasattr(dcm, "FrameOfReferenceUID"):
+      return dcm.FrameOfReferenceUID
+    else:
+      return 'Unnamed FrameOfReferenceUID'
+
+  def getEncapsulatedDocumentAttributes(self, candidateFile):
+    dcm = pydicom.dcmread(candidateFile)
+    encapsulatedDocument = b''
+    encapsulatedDocumentLength = 0
+    if hasattr(dcm, "EncapsulatedDocument"):
+      encapsulatedDocument = dcm.EncapsulatedDocument
+    if hasattr(dcm, "EncapsulatedDocumentLength"):
+      encapsulatedDocumentLength = dcm.EncapsulatedDocumentLength
+    return encapsulatedDocument, encapsulatedDocumentLength
+
+  def load(self, loadable):
+    """ Load the DICOM M3D object
+    """
+    logging.debug('DICOM M3D load()')
+    if hasattr(loadable, "uid"):
+      uid = loadable.uid
+      logging.debug('in load(): uid = ' + uid)
+    else:
+      return False
+
+    self.tempDir = slicer.util.tempDirectory()
+    try:
+      os.makedirs(self.tempDir)
+    except OSError:
+      pass
+
+    stlFileName = slicer.dicomDatabase.fileForInstance(uid)
+    if stlFileName is None:
+      logging.error('Failed to get the filename from the DICOM database for ' + uid)
+      self.cleanup()
+      return False
+
+    #Retrieve EncapsulatedDocument and EncapsulatedDocumentLength for candidateFile
+    docFile, docLengthFile = self.getEncapsulatedDocumentAttributes(loadable.files[0])
+
+    # Read Encapsulated Document attribute into binary IO buffer
+    read_buffer = io.BytesIO(docFile)
+
+    # Take care of trailing padding in Encapsulated Document
+    # If EncapsulatedDocumentLength is odd,
+    # the EncapsulatedDocument was padded to even length, otherwise it was already of even length.
+    buffer_view = read_buffer.getbuffer()
+    if (int(docLengthFile) % 2) != 0:
+      buffer_view = buffer_view[0:(read_buffer.getbuffer().nbytes - 1)]
+
+    # Save processed binary IO buffer into a temporary .STL file
+    stlFilePath = os.path.join(self.tempDir, "temp.STL")
+    with open(stlFilePath, 'wb') as file:
+      shutil.copyfileobj(read_buffer, file)
+    assert os.path.exists(stlFilePath)
+    file.close()
+
+    # Create Segmentation Node based on .STL file
+    self._createSegmentationNode(loadable, stlFilePath)
+
+    self.cleanup()
+
+    return True
+
+  def _createSegmentationNode(self, loadable, stlFilePath):
+    #create modelNode
+    modelNode = slicer.util.loadModel(stlFilePath)
+
+    # Initialize Segmentation Node
+    segmentationNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
+    segmentationNode.SetName(loadable.name)
+
+    # Initialize Segmentation Display Node
+    segmentationDisplayNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationDisplayNode")
+    segmentationNode.SetAndObserveDisplayNodeID(segmentationDisplayNode.GetID())
+
+    #Setup converters for further export to labelmap or model representations
+    vtkSegConverter = vtkSegmentationCore.vtkSegmentationConverter
+    segmentation = vtkSegmentationCore.vtkSegmentation()
+    segmentation.SetSourceRepresentationName(vtkSegConverter.GetSegmentationClosedSurfaceRepresentationName())
+    segmentation.CreateRepresentation(vtkSegConverter.GetSegmentationBinaryLabelmapRepresentationName(), True)
+    segmentationNode.SetAndObserveSegmentation(segmentation)
+
+    #Load Model Node into Segmentation Node
+    self._importModelToSegAndRemoveModel(modelNode, segmentationNode)
+    self.addSeriesInSubjectHierarchy(loadable, segmentationNode)
+    return segmentationNode
+
+  def _importModelToSegAndRemoveModel(self, ModelNode, segmentationNode):
+    segmentationsLogic = slicer.modules.segmentations.logic()
+    segmentation = segmentationNode.GetSegmentation()
+    numberOfSegmentsBeforeImport = segmentation.GetNumberOfSegments()
+    success = segmentationsLogic.ImportModelToSegmentationNode(ModelNode, segmentationNode)
+    if segmentation.GetNumberOfSegments() == 0:
+      logging.warning("Empty segment loaded from DICOM SEG!")
+    if segmentation.GetNumberOfSegments() - numberOfSegmentsBeforeImport > 1:
+      logging.warning("Multiple segments were loaded from DICOM SEG labelmap. Only one label was expected.")
+    if success and segmentation.GetNumberOfSegments() > 0:
+      segment = segmentation.GetNthSegment(segmentation.GetNumberOfSegments() - 1)
+      segment.SetName("Segment 1")
+      segment.SetNameAutoGenerated(False)
+      self._removeModelNode(ModelNode)
+    return segmentation
+
+  def _removeModelNode(self, modelNode):
+    #Model Node being temporary, we remove here the node from the scene
+    dNode = modelNode.GetDisplayNode()
+    if dNode is not None:
+      slicer.mrmlScene.RemoveNode(dNode)
+    slicer.mrmlScene.RemoveNode(modelNode)
+
+
+class DICOMM3DPlugin:
+  """
+  This class is the 'hook' for slicer to detect and recognize the plugin
+  as a loadable scripted module
+  """
+  def __init__(self, parent):
+    parent.title = "DICOM M3D Object Import Plugin"
+    parent.categories = ["Developer Tools.DICOM Plugins"]
+    parent.contributors = ["Cosmin Ciausu, BWH"]
+    parent.helpText = """
+    Plugin to the DICOM Module to parse and load DICOM M3D modality.
+    No module interface here, only in the DICOM module
+    """
+    parent.dependencies = ['DICOM', 'Colors']
+    parent.acknowledgementText = """
+    This DICOM Plugin was developed by
+    Cosmin Ciausu, BWH.
+    """
+
+    # Add this extension to the DICOM module's list for discovery when the module
+    # is created.  Since this module may be discovered before DICOM itself,
+    # create the list if it doesn't already exist.
+    try:
+      slicer.modules.dicomPlugins
+    except AttributeError:
+      slicer.modules.dicomPlugins = {}
+    slicer.modules.dicomPlugins['DICOMM3DPlugin'] = DICOMM3DPluginClass

--- a/Modules/Scripted/DICOMPlugins/DICOMParametricMapPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMParametricMapPlugin.py
@@ -1,0 +1,155 @@
+import json
+import logging
+import os
+import subprocess
+
+import slicer
+from DICOMLib import DICOMLoadable, DICOMPlugin
+
+
+#
+# This is the plugin to handle translation of DICOM Parametric Map objects
+#
+
+class DICOMParametricMapPluginClass(DICOMPlugin):
+
+  def __init__(self):
+    super(DICOMParametricMapPluginClass, self).__init__()
+    self.loadType = "DICOMParametricMap"
+
+  def examineFiles(self, files):
+
+    """ Returns a list of DICOMLoadable instances
+    corresponding to ways of interpreting the
+    files parameter.
+    """
+    loadables = []
+
+    for cFile in files:
+
+      uid = slicer.dicomDatabase.fileValue(cFile, self.tags['instanceUID'])
+      if uid == '':
+        return []
+
+      desc = slicer.dicomDatabase.fileValue(cFile, self.tags['seriesDescription'])
+      if desc == '':
+        desc = "Unknown"
+
+      isDicomPM = (slicer.dicomDatabase.fileValue(cFile, self.tags['classUID']) == '1.2.840.10008.5.1.4.1.1.30')
+
+      if isDicomPM:
+        loadable = DICOMLoadable()
+        loadable.files = [cFile]
+        loadable.name = desc + ' - as a DICOM Parametric Map object'
+        loadable.tooltip = loadable.name
+        loadable.selected = True
+        loadable.confidence = 0.95
+        loadable.uid = uid
+        self.addReferences(loadable)
+        refName = self.referencedSeriesName(loadable)
+        if refName != "":
+          loadable.name = refName + " " + desc + " - ParametricMap"
+
+        loadables.append(loadable)
+
+        logging.debug('DICOM Parametric Map found')
+
+    return loadables
+
+  def referencedSeriesName(self, loadable):
+    """Returns the default series name for the given loadable"""
+    referencedName = "Unnamed Reference"
+    if hasattr(loadable, "referencedSeriesUID"):
+      referencedName = self.defaultSeriesNodeName(loadable.referencedSeriesUID)
+    return referencedName
+
+  def load(self, loadable):
+    """ Load the DICOM PM object
+    """
+    logging.debug('DICOM PM load()')
+    try:
+      uid = loadable.uid
+      logging.debug('in load(): uid = %s' % uid)
+    except AttributeError:
+      return False
+
+    self.tempDir = os.path.join(slicer.app.temporaryPath, "QIICR", "PM", self.currentDateTime, loadable.uid)
+    try:
+      os.makedirs(self.tempDir)
+    except OSError:
+      pass
+
+    pmFileName = slicer.dicomDatabase.fileForInstance(uid)
+    if pmFileName is None:
+      logging.debug('Failed to get the filename from the DICOM database for %s' % uid)
+      self.cleanup()
+      return False
+
+    result = subprocess.run(
+        [self._dcmqi_binary('paramap2itkimage'),
+         '--inputFileName', pmFileName,
+         '--outputDirName', self.tempDir],
+        capture_output=True, text=True)
+    if result.returncode != 0:
+      logging.debug('paramap2itkimage failed, unable to load DICOM ParametricMap:\n' + result.stderr)
+      self.cleanup()
+      return False
+
+    pmNode = slicer.util.loadVolume(os.path.join(self.tempDir, "pmap.nrrd"))
+
+    # load the metadata JSON to retrieve volume semantics (quantity stored and units)
+    with open(os.path.join(self.tempDir, "meta.json")) as metafile:
+      meta = json.load(metafile)
+      qJson = meta["QuantityValueCode"]
+      uJson = meta["MeasurementUnitsCode"]
+
+      quantity = slicer.vtkCodedEntry()
+      quantity.SetValueSchemeMeaning(qJson["CodeValue"], qJson["CodingSchemeDesignator"], qJson["CodeMeaning"])
+
+      units = slicer.vtkCodedEntry()
+      units.SetValueSchemeMeaning(uJson["CodeValue"], uJson["CodingSchemeDesignator"], uJson["CodeMeaning"])
+
+      pmNode.SetVoxelValueQuantity(quantity)
+      pmNode.SetVoxelValueUnits(units)
+
+      pmNode.SetAttribute("DICOM.instanceUIDs", uid)
+
+    # create Subject hierarchy nodes for the loaded series
+    self.addSeriesInSubjectHierarchy(loadable, pmNode)
+
+    self.cleanup()
+    return True
+
+
+#
+# DICOMParametricMapPlugin
+#
+
+class DICOMParametricMapPlugin:
+  """
+  This class is the 'hook' for slicer to detect and recognize the plugin
+  as a loadable scripted module
+  """
+  def __init__(self, parent):
+    parent.title = "DICOM ParametricMap Object Import Plugin"
+    parent.categories = ["Developer Tools.DICOM Plugins"]
+    parent.contributors = ["Andrey Fedorov, BWH"]
+    parent.helpText = """
+    Plugin to the DICOM Module to parse and load DICOM Parametric Map modality.
+    No module interface here, only in the DICOM module
+    """
+    parent.dependencies = ['DICOM', 'Colors']
+    parent.acknowledgementText = """
+    This DICOM Plugin was developed by
+    Andrey Fedorov, BWH.
+    and was partially funded by NIH grant U01CA151261.
+    """
+
+    # Add this extension to the DICOM module's list for discovery when the module
+    # is created.  Since this module may be discovered before DICOM itself,
+    # create the list if it doesn't already exist.
+    try:
+      slicer.modules.dicomPlugins
+    except AttributeError:
+      slicer.modules.dicomPlugins = {}
+    slicer.modules.dicomPlugins['DICOMParametricMapPlugin'] = DICOMParametricMapPluginClass

--- a/Modules/Scripted/DICOMPlugins/DICOMParametricMapPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMParametricMapPlugin.py
@@ -34,7 +34,7 @@ class DICOMParametricMapPluginClass(DICOMPlugin):
       if desc == "":
         desc = "Unknown"
 
-      isDicomPM = (slicer.dicomDatabase.fileValue(cFile, self.tags["classUID"]) == "1.2.840.10008.5.1.4.1.1.30")
+      isDicomPM = (slicer.dicomDatabase.fileValue(cFile, self.tags["sopClassUID"]) == "1.2.840.10008.5.1.4.1.1.30")
 
       if isDicomPM:
         loadable = DICOMLoadable()

--- a/Modules/Scripted/DICOMPlugins/DICOMParametricMapPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMParametricMapPlugin.py
@@ -87,8 +87,8 @@ class DICOMParametricMapPluginClass(DICOMPlugin):
 
     result = subprocess.run(
         [self._dcmqi_binary('paramap2itkimage'),
-         '--inputFileName', pmFileName,
-         '--outputDirName', self.tempDir],
+         '--inputDICOM', pmFileName,
+         '--outputDirectory', self.tempDir],
         capture_output=True, text=True)
     if result.returncode != 0:
       logging.debug('paramap2itkimage failed, unable to load DICOM ParametricMap:\n' + result.stderr)

--- a/Modules/Scripted/DICOMPlugins/DICOMParametricMapPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMParametricMapPlugin.py
@@ -14,12 +14,11 @@ from DICOMLib import DICOMLoadable, DICOMPlugin
 class DICOMParametricMapPluginClass(DICOMPlugin):
 
   def __init__(self):
-    super(DICOMParametricMapPluginClass, self).__init__()
+    super().__init__()
     self.loadType = "DICOMParametricMap"
 
   def examineFiles(self, files):
-
-    """ Returns a list of DICOMLoadable instances
+    """Returns a list of DICOMLoadable instances
     corresponding to ways of interpreting the
     files parameter.
     """
@@ -27,20 +26,20 @@ class DICOMParametricMapPluginClass(DICOMPlugin):
 
     for cFile in files:
 
-      uid = slicer.dicomDatabase.fileValue(cFile, self.tags['instanceUID'])
-      if uid == '':
+      uid = slicer.dicomDatabase.fileValue(cFile, self.tags["instanceUID"])
+      if uid == "":
         return []
 
-      desc = slicer.dicomDatabase.fileValue(cFile, self.tags['seriesDescription'])
-      if desc == '':
+      desc = slicer.dicomDatabase.fileValue(cFile, self.tags["seriesDescription"])
+      if desc == "":
         desc = "Unknown"
 
-      isDicomPM = (slicer.dicomDatabase.fileValue(cFile, self.tags['classUID']) == '1.2.840.10008.5.1.4.1.1.30')
+      isDicomPM = (slicer.dicomDatabase.fileValue(cFile, self.tags["classUID"]) == "1.2.840.10008.5.1.4.1.1.30")
 
       if isDicomPM:
         loadable = DICOMLoadable()
         loadable.files = [cFile]
-        loadable.name = desc + ' - as a DICOM Parametric Map object'
+        loadable.name = desc + " - as a DICOM Parametric Map object"
         loadable.tooltip = loadable.name
         loadable.selected = True
         loadable.confidence = 0.95
@@ -52,7 +51,7 @@ class DICOMParametricMapPluginClass(DICOMPlugin):
 
         loadables.append(loadable)
 
-        logging.debug('DICOM Parametric Map found')
+        logging.debug("DICOM Parametric Map found")
 
     return loadables
 
@@ -64,12 +63,11 @@ class DICOMParametricMapPluginClass(DICOMPlugin):
     return referencedName
 
   def load(self, loadable):
-    """ Load the DICOM PM object
-    """
-    logging.debug('DICOM PM load()')
+    """Load the DICOM PM object"""
+    logging.debug("DICOM PM load()")
     try:
       uid = loadable.uid
-      logging.debug('in load(): uid = %s' % uid)
+      logging.debug("in load(): uid = %s" % uid)
     except AttributeError:
       return False
 
@@ -81,17 +79,17 @@ class DICOMParametricMapPluginClass(DICOMPlugin):
 
     pmFileName = slicer.dicomDatabase.fileForInstance(uid)
     if pmFileName is None:
-      logging.debug('Failed to get the filename from the DICOM database for %s' % uid)
+      logging.debug("Failed to get the filename from the DICOM database for %s" % uid)
       self.cleanup()
       return False
 
     result = subprocess.run(
-        [self._dcmqi_binary('paramap2itkimage'),
-         '--inputDICOM', pmFileName,
-         '--outputDirectory', self.tempDir],
-        capture_output=True, text=True)
+        [self._dcmqi_binary("paramap2itkimage"),
+         "--inputDICOM", pmFileName,
+         "--outputDirectory", self.tempDir],
+        capture_output=True, text=True, check=False)
     if result.returncode != 0:
-      logging.debug('paramap2itkimage failed, unable to load DICOM ParametricMap:\n' + result.stderr)
+      logging.debug("paramap2itkimage failed, unable to load DICOM ParametricMap:\n" + result.stderr)
       self.cleanup()
       return False
 
@@ -130,6 +128,7 @@ class DICOMParametricMapPlugin:
   This class is the 'hook' for slicer to detect and recognize the plugin
   as a loadable scripted module
   """
+
   def __init__(self, parent):
     parent.title = "DICOM ParametricMap Object Import Plugin"
     parent.categories = ["Developer Tools.DICOM Plugins"]
@@ -138,7 +137,7 @@ class DICOMParametricMapPlugin:
     Plugin to the DICOM Module to parse and load DICOM Parametric Map modality.
     No module interface here, only in the DICOM module
     """
-    parent.dependencies = ['DICOM', 'Colors']
+    parent.dependencies = ["DICOM", "Colors"]
     parent.acknowledgementText = """
     This DICOM Plugin was developed by
     Andrey Fedorov, BWH.
@@ -152,4 +151,4 @@ class DICOMParametricMapPlugin:
       slicer.modules.dicomPlugins
     except AttributeError:
       slicer.modules.dicomPlugins = {}
-    slicer.modules.dicomPlugins['DICOMParametricMapPlugin'] = DICOMParametricMapPluginClass
+    slicer.modules.dicomPlugins["DICOMParametricMapPlugin"] = DICOMParametricMapPluginClass

--- a/Modules/Scripted/DICOMPlugins/DICOMSegmentationPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMSegmentationPlugin.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import glob
 import json
 import logging
@@ -19,11 +18,11 @@ from DICOMLib import DICOMLoadable, DICOMPlugin
 class DICOMSegmentationPluginClass(DICOMPlugin):
 
   def __init__(self):
-    super(DICOMSegmentationPluginClass, self).__init__()
+    super().__init__()
     self.loadType = "DICOMSegmentation"
 
   def examineFiles(self, files):
-    """ Returns a list of DICOMLoadable instances
+    """Returns a list of DICOMLoadable instances
     corresponding to ways of interpreting the
     files parameter.
     """
@@ -31,21 +30,21 @@ class DICOMSegmentationPluginClass(DICOMPlugin):
 
     for cFile in files:
 
-      uid = slicer.dicomDatabase.fileValue(cFile, self.tags['instanceUID'])
-      if uid == '':
+      uid = slicer.dicomDatabase.fileValue(cFile, self.tags["instanceUID"])
+      if uid == "":
         return []
 
-      desc = slicer.dicomDatabase.fileValue(cFile, self.tags['seriesDescription'])
-      if desc == '':
+      desc = slicer.dicomDatabase.fileValue(cFile, self.tags["seriesDescription"])
+      if desc == "":
         desc = "Unknown"
 
-      isDicomSeg = (slicer.dicomDatabase.fileValue(cFile, self.tags['modality']) == 'SEG')
+      isDicomSeg = (slicer.dicomDatabase.fileValue(cFile, self.tags["modality"]) == "SEG")
 
       if isDicomSeg:
         loadable = DICOMLoadable()
         loadable.files = [cFile]
         loadable.name = desc
-        loadable.tooltip = loadable.name + ' - as a DICOM SEG object'
+        loadable.tooltip = loadable.name + " - as a DICOM SEG object"
         loadable.selected = True
         loadable.confidence = 0.95
         loadable.uid = uid
@@ -53,7 +52,7 @@ class DICOMSegmentationPluginClass(DICOMPlugin):
 
         loadables.append(loadable)
 
-        logging.debug('DICOM SEG modality found')
+        logging.debug("DICOM SEG modality found")
 
     return loadables
 
@@ -69,15 +68,14 @@ class DICOMSegmentationPluginClass(DICOMPlugin):
       cs = segment[codeSequenceName]
       return cs["CodeValue"], cs["CodingSchemeDesignator"], cs["CodeMeaning"]
     except KeyError:
-      return defaults if defaults else ['', '', '']
+      return defaults if defaults else ["", "", ""]
 
   def load(self, loadable):
-    """ Load the DICOM SEG object
-    """
-    logging.debug('DICOM SEG load()')
+    """Load the DICOM SEG object"""
+    logging.debug("DICOM SEG load()")
     try:
       uid = loadable.uid
-      logging.debug('in load(): uid = ' + uid)
+      logging.debug("in load(): uid = " + uid)
     except AttributeError:
       return False
 
@@ -91,22 +89,22 @@ class DICOMSegmentationPluginClass(DICOMPlugin):
     # the terminology information for each segment
     segFileName = slicer.dicomDatabase.fileForInstance(uid)
     if segFileName is None:
-      logging.error('Failed to get the filename from the DICOM database for ' + uid)
+      logging.error("Failed to get the filename from the DICOM database for " + uid)
       self.cleanup()
       return False
 
     result = subprocess.run(
-        [self._dcmqi_binary('segimage2itkimage'),
-         '--inputDICOM', segFileName,
-         '--outputDirectory', self.tempDir,
-         '--mergeSegments'],
-        capture_output=True, text=True)
+        [self._dcmqi_binary("segimage2itkimage"),
+         "--inputDICOM", segFileName,
+         "--outputDirectory", self.tempDir,
+         "--mergeSegments"],
+        capture_output=True, text=True, check=False)
     if result.returncode != 0:
-      logging.error('segimage2itkimage failed, unable to load DICOM Segmentation:\n' + result.stderr)
+      logging.error("segimage2itkimage failed, unable to load DICOM Segmentation:\n" + result.stderr)
       self.cleanup()
       return False
 
-    numberOfSegmentations = len(glob.glob(os.path.join(self.tempDir, '*.nrrd')))
+    numberOfSegmentations = len(glob.glob(os.path.join(self.tempDir, "*.nrrd")))
 
     # resize the color table to include the segments plus 0 for the background
 
@@ -132,11 +130,11 @@ class DICOMSegmentationPluginClass(DICOMPlugin):
 
     with open(metaFileName) as metaFile:
       data = json.load(metaFile)
-      logging.debug('Loaded segmentation metadata from ' + metaFileName)
+      logging.debug("Loaded segmentation metadata from " + metaFileName)
 
-      logging.debug('number of segmentation files = ' + str(numberOfSegmentations))
+      logging.debug("number of segmentation files = " + str(numberOfSegmentations))
       if numberOfSegmentations != len(data["segmentAttributes"]):
-        logging.error('Loading failed: Inconsistent number of segments in the descriptor file and on disk')
+        logging.error("Loading failed: Inconsistent number of segments in the descriptor file and on disk")
         return
 
       for segmentationId, segmentAttributes in enumerate(data["segmentAttributes"]):
@@ -144,7 +142,7 @@ class DICOMSegmentationPluginClass(DICOMPlugin):
         labelFileName = os.path.join(self.tempDir, str(segmentationId + 1) + ".nrrd")
         # The temporary folder contains 1.nrrd, 2.nrrd,... files. We must specify singleFile=True to ensure
         # they are not loaded as an image stack (could happen if each image file has a single slice only).
-        labelNode = slicer.util.loadLabelVolume(labelFileName, {'singleFile': True})
+        labelNode = slicer.util.loadLabelVolume(labelFileName, {"singleFile": True})
 
         labelNode.labelAttributes = []
 
@@ -299,7 +297,7 @@ class DICOMSegmentationPluginClass(DICOMPlugin):
           matches.append(shn.GetItemDataNode(childID))
 
     reference = None
-    if len(matches):
+    if matches:
       if any(x.GetAttribute("DICOM.RWV.instanceUID") is not None for x in matches):
         for x in matches:
           if x.GetAttribute("DICOM.RWV.instanceUID") is not None:
@@ -320,16 +318,16 @@ class DICOMSegmentationPluginClass(DICOMPlugin):
   def _examineExportableForSegmentationNode(self, shNode, subjectHierarchyItemID):
     dataNode = shNode.GetItemDataNode(subjectHierarchyItemID)
     exportable = None
-    if dataNode and dataNode.IsA('vtkMRMLSegmentationNode'):
+    if dataNode and dataNode.IsA("vtkMRMLSegmentationNode"):
       # Check to make sure all referenced UIDs exist in the database.
       instanceUIDs = shNode.GetItemAttribute(subjectHierarchyItemID, "DICOM.ReferencedInstanceUIDs").split()
       if instanceUIDs != "" and all(slicer.dicomDatabase.fileForInstance(uid) != "" for uid in instanceUIDs):
         exportable = slicer.qSlicerDICOMExportable()
         exportable.confidence = 1.0
         # Define common required tags and default values
-        exportable.setTag('Modality', 'SEG')
-        exportable.setTag('SeriesDescription', dataNode.GetName())
-        exportable.setTag('SeriesNumber', '100')
+        exportable.setTag("Modality", "SEG")
+        exportable.setTag("SeriesDescription", dataNode.GetName())
+        exportable.setTag("SeriesNumber", "100")
     return exportable
 
   def _setupExportable(self, exportable, subjectHierarchyItemID):
@@ -383,14 +381,14 @@ class DICOMSegmentationPluginClass(DICOMPlugin):
         # Generic error
         import traceback
         traceback.print_exc()
-        return "Segmentation object export failed.\n{0}".format(str(exc))
+        return "Segmentation object export failed.\n{}".format(str(exc))
       finally:
         exporter.cleanup()
     return ""
 
 
 class DICOMSegmentationExporter:
-  """This class can be used for exporting a segmentation into DICOM """
+  """This class can be used for exporting a segmentation into DICOM"""
 
   class EmptySegmentsFoundError(ValueError):
     pass
@@ -412,7 +410,7 @@ class DICOMSegmentationExporter:
 
   @staticmethod
   def saveJSON(data, destination):
-    with open(os.path.join(destination), 'w') as outfile:
+    with open(os.path.join(destination), "w") as outfile:
       json.dump(data, outfile, indent=2)
     return destination
 
@@ -460,7 +458,7 @@ class DICOMSegmentationExporter:
   @property
   def currentDateTime(self):
     from datetime import datetime
-    return datetime.now().strftime('%Y-%m-%d_%H%M%S')
+    return datetime.now().strftime("%Y-%m-%d_%H%M%S")
 
   def __init__(self, segmentationNode, contentCreatorName=None):
     self.segmentationNode = segmentationNode
@@ -544,12 +542,12 @@ class DICOMSegmentationExporter:
       shutil.copyfile(inputFilePath, destFile)
 
     result = subprocess.run(
-        [DICOMPlugin._dcmqi_binary('itkimage2segimage'),
-         '--inputDICOMDirectory', cliTempDir,
-         '--inputImageList', ','.join(segmentFiles),
-         '--inputMetadata', metaFilePath,
-         '--outputDICOM', segFilePath],
-        capture_output=True, text=True)
+        [DICOMPlugin._dcmqi_binary("itkimage2segimage"),
+         "--inputDICOMDirectory", cliTempDir,
+         "--inputImageList", ",".join(segmentFiles),
+         "--inputMetadata", metaFilePath,
+         "--outputDICOM", segFilePath],
+        capture_output=True, text=True, check=False)
 
     shutil.rmtree(cliTempDir)
 
@@ -571,7 +569,7 @@ class DICOMSegmentationExporter:
     if instanceUIDs:
       seriesNumber = slicer.dicomDatabase.fileValue(
           slicer.dicomDatabase.fileForInstance(instanceUIDs.split()[0]), "0020,0011")
-    attributes["SeriesNumber"] = "100" if seriesNumber in [None, ''] else str(int(seriesNumber) + 100)
+    attributes["SeriesNumber"] = "100" if seriesNumber in [None, ""] else str(int(seriesNumber) + 100)
     attributes["InstanceNumber"] = "1"
     return attributes
 
@@ -603,7 +601,7 @@ class DICOMSegmentationExporter:
     attributeName = "DICOM.instanceUIDs"
     instanceUIDs = volumeNode.GetAttribute(attributeName)
     if not instanceUIDs:
-      raise ValueError("VolumeNode {0} has no attribute {1}".format(volumeNode.GetName(), attributeName))
+      raise ValueError("VolumeNode {} has no attribute {}".format(volumeNode.GetName(), attributeName))
     fileList = []
     rootDir = None
     for uid in instanceUIDs.split():
@@ -623,7 +621,7 @@ class DICOMSegmentationExporter:
     for segmentID in segmentIDs:
       segmentData = self._createSegmentData(segmentID)
       segmentsData.append([segmentData])
-    if not len(segmentsData):
+    if not segmentsData:
       raise ValueError("No segments with pixel data found.")
     return segmentsData
 
@@ -635,13 +633,13 @@ class DICOMSegmentationExporter:
     category = terminologyEntry.GetCategoryObject()
     segmentData["SegmentLabel"] = segment.GetName()
     segmentData["SegmentDescription"] = category.GetCodeMeaning()
-    algorithmType = vtk.mutable('')
+    algorithmType = vtk.mutable("")
     if not segment.GetTag("DICOM.SegmentAlgorithmType", algorithmType):
       algorithmType = "MANUAL"
     if algorithmType not in ["MANUAL", "SEMIAUTOMATIC", "AUTOMATIC"]:
       raise ValueError("Segment {} has invalid attribute for SegmentAlgorithmType."
         "Should be one of (MANUAL,SEMIAUTOMATIC,AUTOMATIC).".format(segment.GetName()))
-    algorithmName = vtk.mutable('')
+    algorithmName = vtk.mutable("")
     if not segment.GetTag("DICOM.SegmentAlgorithmName", algorithmName):
       algorithmName = None
     if algorithmType != "MANUAL" and not algorithmName:
@@ -734,6 +732,7 @@ class DICOMSegmentationPlugin:
   This class is the 'hook' for slicer to detect and recognize the plugin
   as a loadable scripted module
   """
+
   def __init__(self, parent):
     parent.title = "DICOM Segmentation Object Import Plugin"
     parent.categories = ["Developer Tools.DICOM Plugins"]
@@ -742,7 +741,7 @@ class DICOMSegmentationPlugin:
     Plugin to the DICOM Module to parse and load DICOM SEG modality.
     No module interface here, only in the DICOM module
     """
-    parent.dependencies = ['DICOM', 'Colors']
+    parent.dependencies = ["DICOM", "Colors"]
     parent.acknowledgementText = """
     This DICOM Plugin was developed by
     Andrey Fedorov, BWH.
@@ -756,4 +755,4 @@ class DICOMSegmentationPlugin:
       slicer.modules.dicomPlugins
     except AttributeError:
       slicer.modules.dicomPlugins = {}
-    slicer.modules.dicomPlugins['DICOMSegmentationPlugin'] = DICOMSegmentationPluginClass
+    slicer.modules.dicomPlugins["DICOMSegmentationPlugin"] = DICOMSegmentationPluginClass

--- a/Modules/Scripted/DICOMPlugins/DICOMSegmentationPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMSegmentationPlugin.py
@@ -97,8 +97,8 @@ class DICOMSegmentationPluginClass(DICOMPlugin):
 
     result = subprocess.run(
         [self._dcmqi_binary('segimage2itkimage'),
-         '--inputSEGFileName', segFileName,
-         '--outputDirName', self.tempDir,
+         '--inputDICOM', segFileName,
+         '--outputDirectory', self.tempDir,
          '--mergeSegments'],
         capture_output=True, text=True)
     if result.returncode != 0:
@@ -547,8 +547,8 @@ class DICOMSegmentationExporter:
         [DICOMPlugin._dcmqi_binary('itkimage2segimage'),
          '--inputDICOMDirectory', cliTempDir,
          '--inputImageList', ','.join(segmentFiles),
-         '--metaDataFileName', metaFilePath,
-         '--outputSEGFileName', segFilePath],
+         '--inputMetadata', metaFilePath,
+         '--outputDICOM', segFilePath],
         capture_output=True, text=True)
 
     shutil.rmtree(cliTempDir)

--- a/Modules/Scripted/DICOMPlugins/DICOMSegmentationPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMSegmentationPlugin.py
@@ -1,0 +1,759 @@
+from __future__ import absolute_import
+import glob
+import json
+import logging
+import os
+import subprocess
+import tempfile
+import shutil
+import vtk
+import vtkSegmentationCorePython as vtkSegmentationCore
+
+import slicer
+from DICOMLib import DICOMLoadable, DICOMPlugin
+
+
+#
+# This is the plugin to handle translation of DICOM SEG objects
+#
+class DICOMSegmentationPluginClass(DICOMPlugin):
+
+  def __init__(self):
+    super(DICOMSegmentationPluginClass, self).__init__()
+    self.loadType = "DICOMSegmentation"
+
+  def examineFiles(self, files):
+    """ Returns a list of DICOMLoadable instances
+    corresponding to ways of interpreting the
+    files parameter.
+    """
+    loadables = []
+
+    for cFile in files:
+
+      uid = slicer.dicomDatabase.fileValue(cFile, self.tags['instanceUID'])
+      if uid == '':
+        return []
+
+      desc = slicer.dicomDatabase.fileValue(cFile, self.tags['seriesDescription'])
+      if desc == '':
+        desc = "Unknown"
+
+      isDicomSeg = (slicer.dicomDatabase.fileValue(cFile, self.tags['modality']) == 'SEG')
+
+      if isDicomSeg:
+        loadable = DICOMLoadable()
+        loadable.files = [cFile]
+        loadable.name = desc
+        loadable.tooltip = loadable.name + ' - as a DICOM SEG object'
+        loadable.selected = True
+        loadable.confidence = 0.95
+        loadable.uid = uid
+        self.addReferences(loadable)
+
+        loadables.append(loadable)
+
+        logging.debug('DICOM SEG modality found')
+
+    return loadables
+
+  def referencedSeriesName(self, loadable):
+    """Returns the default series name for the given loadable"""
+    referencedName = "Unnamed Reference"
+    if hasattr(loadable, "referencedSeriesUID"):
+      referencedName = self.defaultSeriesNodeName(loadable.referencedSeriesUID)
+    return referencedName
+
+  def getValuesFromCodeSequence(self, segment, codeSequenceName, defaults=None):
+    try:
+      cs = segment[codeSequenceName]
+      return cs["CodeValue"], cs["CodingSchemeDesignator"], cs["CodeMeaning"]
+    except KeyError:
+      return defaults if defaults else ['', '', '']
+
+  def load(self, loadable):
+    """ Load the DICOM SEG object
+    """
+    logging.debug('DICOM SEG load()')
+    try:
+      uid = loadable.uid
+      logging.debug('in load(): uid = ' + uid)
+    except AttributeError:
+      return False
+
+    self.tempDir = os.path.join(slicer.app.temporaryPath, "QIICR", "SEG", self.currentDateTime, loadable.uid)
+    try:
+      os.makedirs(self.tempDir)
+    except OSError:
+      pass
+
+    # produces output label map files, one per segment, and information files with
+    # the terminology information for each segment
+    segFileName = slicer.dicomDatabase.fileForInstance(uid)
+    if segFileName is None:
+      logging.error('Failed to get the filename from the DICOM database for ' + uid)
+      self.cleanup()
+      return False
+
+    result = subprocess.run(
+        [self._dcmqi_binary('segimage2itkimage'),
+         '--inputSEGFileName', segFileName,
+         '--outputDirName', self.tempDir,
+         '--mergeSegments'],
+        capture_output=True, text=True)
+    if result.returncode != 0:
+      logging.error('segimage2itkimage failed, unable to load DICOM Segmentation:\n' + result.stderr)
+      self.cleanup()
+      return False
+
+    numberOfSegmentations = len(glob.glob(os.path.join(self.tempDir, '*.nrrd')))
+
+    # resize the color table to include the segments plus 0 for the background
+
+    seriesName = self.referencedSeriesName(loadable)
+    segmentLabelNodes = []
+    metaFileName = os.path.join(self.tempDir, "meta.json")
+
+    # Load terminology in the metafile into context
+    terminologiesLogic = slicer.modules.terminologies.logic()
+
+    categoryContextName = loadable.name
+    if not terminologiesLogic.LoadTerminologyFromSegmentDescriptorFile(categoryContextName, metaFileName):
+      categoryContextName = "Segmentation category and type - DICOM master list"
+
+    anatomicContextName = loadable.name
+    try:
+      if not terminologiesLogic.LoadRegionContextFromSegmentDescriptorFile(anatomicContextName, metaFileName):
+        anatomicContextName = "Anatomic codes - DICOM master list"
+    except AttributeError:
+      # backward compatibility with Slicer 5.8.1
+      if not terminologiesLogic.LoadAnatomicContextFromSegmentDescriptorFile(anatomicContextName, metaFileName):
+        anatomicContextName = "Anatomic codes - DICOM master list"
+
+    with open(metaFileName) as metaFile:
+      data = json.load(metaFile)
+      logging.debug('Loaded segmentation metadata from ' + metaFileName)
+
+      logging.debug('number of segmentation files = ' + str(numberOfSegmentations))
+      if numberOfSegmentations != len(data["segmentAttributes"]):
+        logging.error('Loading failed: Inconsistent number of segments in the descriptor file and on disk')
+        return
+
+      for segmentationId, segmentAttributes in enumerate(data["segmentAttributes"]):
+
+        labelFileName = os.path.join(self.tempDir, str(segmentationId + 1) + ".nrrd")
+        # The temporary folder contains 1.nrrd, 2.nrrd,... files. We must specify singleFile=True to ensure
+        # they are not loaded as an image stack (could happen if each image file has a single slice only).
+        labelNode = slicer.util.loadLabelVolume(labelFileName, {'singleFile': True})
+
+        labelNode.labelAttributes = []
+
+        for segment in segmentAttributes:
+          try:
+            rgb255 = segment["recommendedDisplayRGBValue"]
+            rgb = [float(c) / 255. for c in rgb255]
+          except KeyError:
+            rgb = (150., 150., 0.)
+
+          segmentId = segment["labelID"]
+
+          categoryCode, categoryCodingScheme, categoryCodeMeaning = \
+            self.getValuesFromCodeSequence(segment, "SegmentedPropertyCategoryCodeSequence")
+
+          typeCode, typeCodingScheme, typeCodeMeaning = \
+            self.getValuesFromCodeSequence(segment, "SegmentedPropertyTypeCodeSequence")
+
+          typeModCode, typeModCodingScheme, typeModCodeMeaning = \
+            self.getValuesFromCodeSequence(segment, "SegmentedPropertyTypeModifierCodeSequence")
+
+          regionCode, regionCodingScheme, regionCodeMeaning = \
+            self.getValuesFromCodeSequence(segment, "AnatomicRegionSequence")
+
+          regionModCode, regionModCodingScheme, regionModCodeMeaning = \
+            self.getValuesFromCodeSequence(segment, "AnatomicRegionModifierSequence")
+
+          segmentTerminologyTag = terminologiesLogic.SerializeTerminologyEntry(
+                                    categoryContextName,
+                                    categoryCode, categoryCodingScheme, categoryCodeMeaning,
+                                    typeCode, typeCodingScheme, typeCodeMeaning,
+                                    typeModCode, typeModCodingScheme, typeModCodeMeaning,
+                                    anatomicContextName,
+                                    regionCode, regionCodingScheme, regionCodeMeaning,
+                                    regionModCode, regionModCodingScheme, regionModCodeMeaning)
+
+          # Set terminology properties as attributes to the label node (which is a temporary node)
+          segmentNameAutoGenerated = False  # automatically generated from terminology
+          if segment["SegmentLabel"]:
+            segmentName = segment["SegmentLabel"]
+          elif segment["SegmentDescription"]:
+            segmentName = segment["SegmentDescription"]
+          else:
+            segmentName = typeCodeMeaning
+            segmentNameAutoGenerated = True
+
+          labelAttributes = {}
+          labelAttributes["Name"] = segmentName
+          labelAttributes["NameAutoGenerated"] = segmentNameAutoGenerated
+          labelAttributes["Description"] = segment["SegmentDescription"]
+          labelAttributes["Terminology"] = segmentTerminologyTag
+          labelAttributes["ColorR"] = rgb[0]
+          labelAttributes["ColorG"] = rgb[1]
+          labelAttributes["ColorB"] = rgb[2]
+          labelAttributes["DICOM.SegmentAlgorithmType"] = segment["SegmentAlgorithmType"] if "SegmentAlgorithmType" in segment else None
+          labelAttributes["DICOM.SegmentAlgorithmName"] = segment["SegmentAlgorithmName"] if "SegmentAlgorithmName" in segment else None
+
+          labelNode.labelAttributes.append(labelAttributes)
+
+        segmentLabelNodes.append(labelNode)
+
+    self.cleanup()
+
+    self._createSegmentationNode(loadable, segmentLabelNodes)
+
+    return True
+
+  def _createSegmentationNode(self, loadable, segmentLabelNodes):
+    segmentationNode = self._initializeSegmentation(loadable)
+
+    for segmentLabelNode in segmentLabelNodes:
+      self._importSegmentAndRemoveLabel(segmentLabelNode, segmentationNode)
+
+    self.addSeriesInSubjectHierarchy(loadable, segmentationNode)
+    if hasattr(loadable, "referencedSeriesUID"):
+      self._findAndSetGeometryReference(loadable.referencedSeriesUID, segmentationNode)
+
+    segmentationNode.SetAttribute("DICOM.instanceUIDs", loadable.uid)
+
+  def _importSegmentAndRemoveLabel(self, segmentLabelNode, segmentationNode):
+    segmentationsLogic = slicer.modules.segmentations.logic()
+    segmentation = segmentationNode.GetSegmentation()
+    numberOfSegmentsBeforeImport = segmentation.GetNumberOfSegments()
+    success = segmentationsLogic.ImportLabelmapToSegmentationNode(segmentLabelNode, segmentationNode)
+
+    if not success:
+      logging.error("Failed to import segment from labelmap!")
+      return
+
+    if segmentation.GetNumberOfSegments() == 0:
+      logging.warning("Empty segment loaded from DICOM SEG!")
+
+    thisLabelSegmentID = 0
+    for segmentId in range(numberOfSegmentsBeforeImport, segmentation.GetNumberOfSegments()):
+      logging.info("Setting attributes for segment %d ..." % segmentId)
+
+      segment = segmentation.GetNthSegment(segmentId)
+      segment.SetName(segmentLabelNode.labelAttributes[thisLabelSegmentID]["Name"])
+      segment.SetNameAutoGenerated(segmentLabelNode.labelAttributes[thisLabelSegmentID]["NameAutoGenerated"])
+      segment.SetTag("Description", segmentLabelNode.labelAttributes[thisLabelSegmentID]["Description"])
+      segment.SetColor([float(segmentLabelNode.labelAttributes[thisLabelSegmentID]["ColorR"]),
+                        float(segmentLabelNode.labelAttributes[thisLabelSegmentID]["ColorG"]),
+                        float(segmentLabelNode.labelAttributes[thisLabelSegmentID]["ColorB"])])
+      segment.SetTag(vtkSegmentationCore.vtkSegment.GetTerminologyEntryTagName(),
+                     segmentLabelNode.labelAttributes[thisLabelSegmentID]["Terminology"])
+      algorithmName = segmentLabelNode.labelAttributes[thisLabelSegmentID]["DICOM.SegmentAlgorithmName"]
+      if algorithmName is not None:
+        segment.SetTag("DICOM.SegmentAlgorithmName", algorithmName)
+      algorithmType = segmentLabelNode.labelAttributes[thisLabelSegmentID]["DICOM.SegmentAlgorithmType"]
+      if algorithmType is not None:
+        segment.SetTag("DICOM.SegmentAlgorithmType", algorithmType)
+      thisLabelSegmentID += 1
+
+    self._removeLabelNode(segmentLabelNode)
+
+    return segmentation
+
+  def _removeLabelNode(self, labelNode):
+    dNode = labelNode.GetDisplayNode()
+    if dNode is not None:
+      slicer.mrmlScene.RemoveNode(dNode)
+    slicer.mrmlScene.RemoveNode(labelNode)
+
+  def _initializeSegmentation(self, loadable):
+    segmentationNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
+    segmentationNode.SetName(loadable.name)
+
+    segmentationDisplayNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationDisplayNode")
+    segmentationNode.SetAndObserveDisplayNodeID(segmentationDisplayNode.GetID())
+
+    vtkSegConverter = vtkSegmentationCore.vtkSegmentationConverter
+    segmentation = vtkSegmentationCore.vtkSegmentation()
+    segmentation.SetSourceRepresentationName(vtkSegConverter.GetSegmentationBinaryLabelmapRepresentationName())
+    segmentation.CreateRepresentation(vtkSegConverter.GetSegmentationClosedSurfaceRepresentationName(), True)
+    segmentationNode.SetAndObserveSegmentation(segmentation)
+
+    return segmentationNode
+
+  def _findAndSetGeometryReference(self, referencedSeriesUID, segmentationNode):
+    shn = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)
+    segID = shn.GetItemByDataNode(segmentationNode)
+    parentID = shn.GetItemParent(segID)
+    childIDs = vtk.vtkIdList()
+    shn.GetItemChildren(parentID, childIDs)
+    uidName = slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMUIDName()
+    matches = []
+    for childID in reversed([childIDs.GetId(id) for id in range(childIDs.GetNumberOfIds()) if segID]):
+      if childID == segID:
+        continue
+      if shn.GetItemUID(childID, uidName) == referencedSeriesUID:
+        if shn.GetItemDataNode(childID):
+          matches.append(shn.GetItemDataNode(childID))
+
+    reference = None
+    if len(matches):
+      if any(x.GetAttribute("DICOM.RWV.instanceUID") is not None for x in matches):
+        for x in matches:
+          if x.GetAttribute("DICOM.RWV.instanceUID") is not None:
+            reference = x
+            break
+      else:
+        reference = matches[0]
+
+    if reference:
+      segmentationNode.SetReferenceImageGeometryParameterFromVolumeNode(reference)
+
+  def examineForExport(self, subjectHierarchyItemID):
+    shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)
+
+    exportable = self._examineExportableForSegmentationNode(shNode, subjectHierarchyItemID)
+    return self._setupExportable(exportable, subjectHierarchyItemID)
+
+  def _examineExportableForSegmentationNode(self, shNode, subjectHierarchyItemID):
+    dataNode = shNode.GetItemDataNode(subjectHierarchyItemID)
+    exportable = None
+    if dataNode and dataNode.IsA('vtkMRMLSegmentationNode'):
+      # Check to make sure all referenced UIDs exist in the database.
+      instanceUIDs = shNode.GetItemAttribute(subjectHierarchyItemID, "DICOM.ReferencedInstanceUIDs").split()
+      if instanceUIDs != "" and all(slicer.dicomDatabase.fileForInstance(uid) != "" for uid in instanceUIDs):
+        exportable = slicer.qSlicerDICOMExportable()
+        exportable.confidence = 1.0
+        # Define common required tags and default values
+        exportable.setTag('Modality', 'SEG')
+        exportable.setTag('SeriesDescription', dataNode.GetName())
+        exportable.setTag('SeriesNumber', '100')
+    return exportable
+
+  def _setupExportable(self, exportable, subjectHierarchyItemID):
+    if not exportable:
+      return []
+    exportable.name = self.loadType
+    exportable.tooltip = "Create DICOM files from segmentation"
+    exportable.subjectHierarchyItemID = subjectHierarchyItemID
+    exportable.pluginClass = self.__module__
+    return [exportable]
+
+  def export(self, exportables):
+    try:
+      slicer.modules.segmentations
+    except AttributeError as exc:
+      return str(exc)
+
+    shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)
+    if shNode is None:
+      error = "Invalid subject hierarchy"
+      logging.error(error)
+      return error
+
+    for exportable in exportables:
+      subjectHierarchyItemID = exportable.subjectHierarchyItemID
+      segmentationNode = shNode.GetItemDataNode(subjectHierarchyItemID)
+
+      exporter = DICOMSegmentationExporter(segmentationNode)
+
+      metadata = {}
+      for attr in ["SeriesNumber", "SeriesDescription", "ContentCreatorName", "ClinicalTrialSeriesID", "ClinicalTrialTimePointID",
+        "ClinicalTrialCoordinatingCenterName"]:
+        if exportable.tag(attr) != "":
+          metadata[attr] = exportable.tag(attr)
+
+      try:
+        segFileName = "subject_hierarchy_export.SEG" + exporter.currentDateTime + ".dcm"
+        segFilePath = os.path.join(exportable.directory, segFileName)
+        try:
+          exporter.export(exportable.directory, segFileName, metadata)
+        except DICOMSegmentationExporter.EmptySegmentsFoundError as exc:
+          if slicer.util.confirmYesNoDisplay(str(exc)):
+            exporter.export(exportable.directory, segFileName, metadata, skipEmpty=True)
+          else:
+            raise ValueError("Export canceled")
+        slicer.dicomDatabase.insert(segFilePath)
+        logging.info("Added segmentation to DICOM database (" + segFilePath + ")")
+      except (DICOMSegmentationExporter.NoNonEmptySegmentsFoundError, ValueError) as exc:
+        return str(exc)
+      except Exception as exc:
+        # Generic error
+        import traceback
+        traceback.print_exc()
+        return "Segmentation object export failed.\n{0}".format(str(exc))
+      finally:
+        exporter.cleanup()
+    return ""
+
+
+class DICOMSegmentationExporter:
+  """This class can be used for exporting a segmentation into DICOM """
+
+  class EmptySegmentsFoundError(ValueError):
+    pass
+
+  class NoNonEmptySegmentsFoundError(ValueError):
+    pass
+
+  class MissingAttributeError(ValueError):
+    pass
+
+  @staticmethod
+  def getDeserializedTerminologyEntry(vtkSegment):
+    terminologyEntry = slicer.vtkSlicerTerminologyEntry()
+    tag = vtk.mutable("")
+    vtkSegment.GetTag(vtkSegment.GetTerminologyEntryTagName(), tag)
+    terminologyLogic = slicer.modules.terminologies.logic()
+    terminologyLogic.DeserializeTerminologyEntry(tag, terminologyEntry)
+    return terminologyEntry
+
+  @staticmethod
+  def saveJSON(data, destination):
+    with open(os.path.join(destination), 'w') as outfile:
+      json.dump(data, outfile, indent=2)
+    return destination
+
+  @staticmethod
+  def vtkStringArrayFromList(listToConvert):
+    stringArray = vtk.vtkStringArray()
+    for listElement in listToConvert:
+      stringArray.InsertNextValue(listElement)
+    return stringArray
+
+  @staticmethod
+  def createLabelNodeFromSegment(segmentationNode, segmentID):
+    labelNode = slicer.vtkMRMLLabelMapVolumeNode()
+    slicer.mrmlScene.AddNode(labelNode)
+    segmentationsLogic = slicer.modules.segmentations.logic()
+
+    mergedImageData = vtkSegmentationCore.vtkOrientedImageData()
+    segmentationNode.GenerateMergedLabelmapForAllSegments(mergedImageData, 0, None,
+                                                          DICOMSegmentationExporter.vtkStringArrayFromList([segmentID]))
+    if not segmentationsLogic.CreateLabelmapVolumeFromOrientedImageData(mergedImageData, labelNode):
+      slicer.mrmlScene.RemoveNode(labelNode)
+      return None
+    labelNode.SetName("{}_label".format(segmentID))
+    return labelNode
+
+  @staticmethod
+  def getSegmentIDs(segmentationNode, visibleOnly=False):
+    if not segmentationNode:
+      raise AttributeError("SegmentationNode must not be None!")
+    segmentIDs = vtk.vtkStringArray()
+    segmentation = segmentationNode.GetSegmentation()
+    command = segmentationNode.GetDisplayNode().GetVisibleSegmentIDs if visibleOnly else segmentation.GetSegmentIDs
+    command(segmentIDs)
+    return [segmentIDs.GetValue(idx) for idx in range(segmentIDs.GetNumberOfValues())]
+
+  @staticmethod
+  def getReferencedVolumeFromSegmentationNode(segmentationNode):
+    if not segmentationNode:
+      raise ValueError("Invalid segmentation node")
+    referencedVolumeNode = segmentationNode.GetNodeReference(segmentationNode.GetReferenceImageGeometryReferenceRole())
+    if not referencedVolumeNode:
+      raise ValueError("Referenced volume is not found for the segmentation. Specify segmentation geometry using a volume node as source.")
+    return referencedVolumeNode
+
+  @property
+  def currentDateTime(self):
+    from datetime import datetime
+    return datetime.now().strftime('%Y-%m-%d_%H%M%S')
+
+  def __init__(self, segmentationNode, contentCreatorName=None):
+    self.segmentationNode = segmentationNode
+    self.contentCreatorName = contentCreatorName if contentCreatorName else "Slicer"
+
+    self.tempDir = slicer.util.tempDirectory()
+
+  def cleanup(self):
+    try:
+      logging.debug("Cleaning up temporarily created directory {}".format(self.tempDir))
+      shutil.rmtree(self.tempDir)
+    except AttributeError:
+      pass
+
+  def formatMetaDataDICOMConform(self, metadata):
+    metadata["ContentCreatorName"] = "^".join(metadata["ContentCreatorName"].split(" ")[::-1])
+
+  def export(self, outputDirectory, segFileName, metadata, segmentIDs=None, skipEmpty=False):
+    data = self.getSeriesAttributes()
+    data.update(metadata)
+
+    metadataDefaults = {}
+    metadataDefaults["SeriesNumber"] = "100"
+    metadataDefaults["SeriesDescription"] = "Segmentation"
+    metadataDefaults["ContentCreatorName"] = self.contentCreatorName
+    metadataDefaults["ClinicalTrialSeriesID"] = "1"
+    metadataDefaults["ClinicalTrialTimePointID"] = "1"
+    metadataDefaults["ClinicalTrialCoordinatingCenterName"] = "QIICR"
+
+    for attr in ["SeriesNumber", "SeriesDescription", "ContentCreatorName", "ClinicalTrialSeriesID", "ClinicalTrialTimePointID",
+                   "ClinicalTrialCoordinatingCenterName"]:
+      try:
+        if data[attr] == "":
+          data[attr] = metadataDefaults[attr]
+      except KeyError:
+        data[attr] = metadataDefaults[attr]
+
+    self.formatMetaDataDICOMConform(data)
+
+    segmentIDs = segmentIDs if segmentIDs else self.getSegmentIDs(self.segmentationNode)
+
+    nonEmptySegmentIDs = self.getNonEmptySegmentIDs(segmentIDs)
+
+    if skipEmpty is False and len(nonEmptySegmentIDs) and len(segmentIDs) != len(nonEmptySegmentIDs):
+      raise self.EmptySegmentsFoundError("Empty segments found in segmentation. Currently the export of empty segments "
+                                         "is not supported. Do you want to skip empty segments and proceed exporting?")
+
+    segmentIDs = nonEmptySegmentIDs
+
+    if not len(segmentIDs):
+      raise self.NoNonEmptySegmentsFoundError("No non empty segments found.")
+
+    data["segmentAttributes"] = self.generateJSON4DcmSEGExport(segmentIDs)
+
+    logging.debug("DICOM SEG Metadata output:")
+    logging.debug(data)
+
+    metaFilePath = self.saveJSON(data, os.path.join(self.tempDir, "seg_meta.json"))
+
+    segmentFiles = self.createAndGetLabelMapsFromSegments(segmentIDs)
+    inputDICOMImageFileNames = self.getDICOMFileList(self.getReferencedVolumeFromSegmentationNode(self.segmentationNode),
+                                                     absolutePaths=True)
+
+    # Check if referenced image files are found and raise exception with a descriptive message in case of an error.
+    numberOfImageFilesNotFound = 0
+    for inputDICOMImageFileName in inputDICOMImageFileNames:
+      if not inputDICOMImageFileName:
+        numberOfImageFilesNotFound += 1
+    if numberOfImageFilesNotFound > 0:
+      numberOfImageFilesTotal = len(inputDICOMImageFileNames)
+      raise ValueError("Referenced volume files were not found in the DICOM database (missing %d files out of %d)." %
+                       (numberOfImageFilesNotFound, numberOfImageFilesTotal))
+
+    segFilePath = os.path.join(outputDirectory, segFileName)
+
+    # copy files to a temp location, since otherwise the command line can easily exceed
+    #  the maximum on Windows (~8k characters)
+    cliTempDir = tempfile.mkdtemp()
+    for inputFilePath in inputDICOMImageFileNames:
+      destFile = os.path.join(cliTempDir, os.path.split(inputFilePath)[1])
+      shutil.copyfile(inputFilePath, destFile)
+
+    result = subprocess.run(
+        [DICOMPlugin._dcmqi_binary('itkimage2segimage'),
+         '--inputDICOMDirectory', cliTempDir,
+         '--inputImageList', ','.join(segmentFiles),
+         '--metaDataFileName', metaFilePath,
+         '--outputSEGFileName', segFilePath],
+        capture_output=True, text=True)
+
+    shutil.rmtree(cliTempDir)
+
+    if result.returncode != 0:
+      raise RuntimeError("itkimage2segimage failed:\n%s" % result.stderr)
+
+    if not os.path.exists(segFilePath):
+      raise RuntimeError("DICOM Segmentation was not created. Check Error Log for further information.")
+
+    logging.debug("Saved DICOM Segmentation to {}".format(segFilePath))
+    return True
+
+  def getSeriesAttributes(self):
+    attributes = dict()
+    volumeNode = self.getReferencedVolumeFromSegmentationNode(self.segmentationNode)
+    # Get series number from DICOM database for the referenced volume
+    instanceUIDs = volumeNode.GetAttribute("DICOM.instanceUIDs") if volumeNode else ""
+    seriesNumber = ""
+    if instanceUIDs:
+      seriesNumber = slicer.dicomDatabase.fileValue(
+          slicer.dicomDatabase.fileForInstance(instanceUIDs.split()[0]), "0020,0011")
+    attributes["SeriesNumber"] = "100" if seriesNumber in [None, ''] else str(int(seriesNumber) + 100)
+    attributes["InstanceNumber"] = "1"
+    return attributes
+
+  def getNonEmptySegmentIDs(self, segmentIDs):
+    segmentation = self.segmentationNode.GetSegmentation()
+    return [segmentID for segmentID in segmentIDs if not self.isSegmentEmpty(segmentation.GetSegment(segmentID))]
+
+  def isSegmentEmpty(self, segment):
+    vtkSegConverter = vtkSegmentationCore.vtkSegmentationConverter
+    r = segment.GetRepresentation(vtkSegConverter.GetSegmentationBinaryLabelmapRepresentationName())
+    imagescalars = r.GetPointData().GetArray("ImageScalars")
+
+    if imagescalars is None:
+      return True
+    else:
+      return imagescalars.GetValueRange() == (0, 0)
+
+  def createAndGetLabelMapsFromSegments(self, segmentIDs):
+    segmentFiles = []
+    for segmentID in segmentIDs:
+      segmentLabelmap = self.createLabelNodeFromSegment(self.segmentationNode, segmentID)
+      filename = os.path.join(self.tempDir, "{}.nrrd".format(segmentLabelmap.GetName()))
+      slicer.util.saveNode(segmentLabelmap, filename)
+      slicer.mrmlScene.RemoveNode(segmentLabelmap)
+      segmentFiles.append(filename)
+    return segmentFiles
+
+  def getDICOMFileList(self, volumeNode, absolutePaths=False):
+    attributeName = "DICOM.instanceUIDs"
+    instanceUIDs = volumeNode.GetAttribute(attributeName)
+    if not instanceUIDs:
+      raise ValueError("VolumeNode {0} has no attribute {1}".format(volumeNode.GetName(), attributeName))
+    fileList = []
+    rootDir = None
+    for uid in instanceUIDs.split():
+      rootDir, filename = self.getInstanceUIDDirectoryAndFileName(uid)
+      fileList.append(str(filename if not absolutePaths else os.path.join(rootDir, filename)))
+    if not absolutePaths:
+      return rootDir, fileList
+    return fileList
+
+  def getInstanceUIDDirectoryAndFileName(self, uid):
+    path = slicer.dicomDatabase.fileForInstance(uid)
+    return os.path.dirname(path), os.path.basename(path)
+
+  def generateJSON4DcmSEGExport(self, segmentIDs):
+    self.checkTerminologyOfSegments(segmentIDs)
+    segmentsData = []
+    for segmentID in segmentIDs:
+      segmentData = self._createSegmentData(segmentID)
+      segmentsData.append([segmentData])
+    if not len(segmentsData):
+      raise ValueError("No segments with pixel data found.")
+    return segmentsData
+
+  def _createSegmentData(self, segmentID):
+    segmentData = dict()
+    segmentData["labelID"] = 1
+    segment = self.segmentationNode.GetSegmentation().GetSegment(segmentID)
+    terminologyEntry = self.getDeserializedTerminologyEntry(segment)
+    category = terminologyEntry.GetCategoryObject()
+    segmentData["SegmentLabel"] = segment.GetName()
+    segmentData["SegmentDescription"] = category.GetCodeMeaning()
+    algorithmType = vtk.mutable('')
+    if not segment.GetTag("DICOM.SegmentAlgorithmType", algorithmType):
+      algorithmType = "MANUAL"
+    if algorithmType not in ["MANUAL", "SEMIAUTOMATIC", "AUTOMATIC"]:
+      raise ValueError("Segment {} has invalid attribute for SegmentAlgorithmType."
+        "Should be one of (MANUAL,SEMIAUTOMATIC,AUTOMATIC).".format(segment.GetName()))
+    algorithmName = vtk.mutable('')
+    if not segment.GetTag("DICOM.SegmentAlgorithmName", algorithmName):
+      algorithmName = None
+    if algorithmType != "MANUAL" and not algorithmName:
+      raise ValueError("Segment {} has missing SegmentAlgorithmName, which"
+        "should be specified for non-manual segmentations.".format(segment.GetName()))
+    segmentData["SegmentAlgorithmType"] = str(algorithmType)
+    if algorithmName:
+      segmentData["SegmentAlgorithmName"] = str(algorithmName)
+    rgb = segment.GetColor()
+    segmentData["recommendedDisplayRGBValue"] = [rgb[0] * 255, rgb[1] * 255, rgb[2] * 255]
+    segmentData.update(self.createJSONFromTerminologyContext(terminologyEntry))
+    segmentData.update(self.createJSONFromRegionContext(terminologyEntry))
+    return segmentData
+
+  def checkTerminologyOfSegments(self, segmentIDs):
+    for segmentID in segmentIDs:
+      segment = self.segmentationNode.GetSegmentation().GetSegment(segmentID)
+      terminologyEntry = self.getDeserializedTerminologyEntry(segment)
+      category = terminologyEntry.GetCategoryObject()
+      propType = terminologyEntry.GetTypeObject()
+      if any(v is None for v in [category, propType]):
+        raise ValueError("Segment {} has missing attributes. Make sure to set terminology.".format(segment.GetName()))
+
+  def createJSONFromTerminologyContext(self, terminologyEntry):
+    segmentData = dict()
+
+    categoryObject = terminologyEntry.GetCategoryObject()
+    categoryObject_invalid = categoryObject is None or not self.isTerminologyInformationValid(categoryObject)
+
+    typeObject = terminologyEntry.GetTypeObject()
+    typeObject_invalid = typeObject is None or not self.isTerminologyInformationValid(typeObject)
+
+    if categoryObject_invalid or typeObject_invalid:
+      logging.warning("Terminology information invalid or unset! This might lead to crashes during the conversion to "
+                      "SEG objects. Make sure to select a terminology class for all segments in the Slicer scene.")
+      return {}
+
+    segmentData["SegmentedPropertyCategoryCodeSequence"] = self.getJSONFromVtkSlicerTerminology(categoryObject)
+    segmentData["SegmentedPropertyTypeCodeSequence"] = self.getJSONFromVtkSlicerTerminology(typeObject)
+
+    modifierObject = terminologyEntry.GetTypeModifierObject()
+    if modifierObject is not None and self.isTerminologyInformationValid(modifierObject):
+      segmentData["SegmentedPropertyTypeModifierCodeSequence"] = self.getJSONFromVtkSlicerTerminology(modifierObject)
+
+    return segmentData
+
+  def createJSONFromRegionContext(self, terminologyEntry):
+    segmentData = dict()
+
+    try:
+      regionObject = terminologyEntry.GetRegionObject()
+    except AttributeError:
+      # backward compatibility with Slicer 5.8.1
+      regionObject = terminologyEntry.GetAnatomicRegionObject()
+
+    if regionObject is None or not self.isTerminologyInformationValid(regionObject):
+      return {}
+    segmentData["AnatomicRegionSequence"] = self.getJSONFromVtkSlicerTerminology(regionObject)
+
+    try:
+      regionModifierObject = terminologyEntry.GetRegionModifierObject()
+    except AttributeError:
+      # backward compatibility with Slicer 5.8.1
+      regionModifierObject = terminologyEntry.GetAnatomicRegionModifierObject()
+
+    if regionModifierObject is not None and self.isTerminologyInformationValid(regionModifierObject):
+      segmentData["AnatomicRegionModifierSequence"] = self.getJSONFromVtkSlicerTerminology(regionModifierObject)
+    return segmentData
+
+  def isTerminologyInformationValid(self, termTypeObject):
+    return all(t is not None for t in [termTypeObject.GetCodeValue(), termTypeObject.GetCodingSchemeDesignator(),
+                                       termTypeObject.GetCodeMeaning()])
+
+  def getJSONFromVtkSlicerTerminology(self, termTypeObject):
+    return self.createCodeSequence(termTypeObject.GetCodeValue(), termTypeObject.GetCodingSchemeDesignator(),
+                                   termTypeObject.GetCodeMeaning())
+
+  def createCodeSequence(self, value, designator, meaning):
+    return {"CodeValue": value,
+            "CodingSchemeDesignator": designator,
+            "CodeMeaning": meaning}
+
+
+#
+# DICOMSegmentationPlugin
+#
+
+class DICOMSegmentationPlugin:
+  """
+  This class is the 'hook' for slicer to detect and recognize the plugin
+  as a loadable scripted module
+  """
+  def __init__(self, parent):
+    parent.title = "DICOM Segmentation Object Import Plugin"
+    parent.categories = ["Developer Tools.DICOM Plugins"]
+    parent.contributors = ["Andrey Fedorov, BWH"]
+    parent.helpText = """
+    Plugin to the DICOM Module to parse and load DICOM SEG modality.
+    No module interface here, only in the DICOM module
+    """
+    parent.dependencies = ['DICOM', 'Colors']
+    parent.acknowledgementText = """
+    This DICOM Plugin was developed by
+    Andrey Fedorov, BWH.
+    and was partially funded by NIH grant U01CA151261.
+    """
+
+    # Add this extension to the DICOM module's list for discovery when the module
+    # is created.  Since this module may be discovered before DICOM itself,
+    # create the list if it doesn't already exist.
+    try:
+      slicer.modules.dicomPlugins
+    except AttributeError:
+      slicer.modules.dicomPlugins = {}
+    slicer.modules.dicomPlugins['DICOMSegmentationPlugin'] = DICOMSegmentationPluginClass

--- a/Modules/Scripted/DICOMPlugins/DICOMSegmentationPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMSegmentationPlugin.py
@@ -381,7 +381,7 @@ class DICOMSegmentationPluginClass(DICOMPlugin):
         # Generic error
         import traceback
         traceback.print_exc()
-        return "Segmentation object export failed.\n{}".format(str(exc))
+        return f"Segmentation object export failed.\n{str(exc)}"
       finally:
         exporter.cleanup()
     return ""
@@ -433,7 +433,7 @@ class DICOMSegmentationExporter:
     if not segmentationsLogic.CreateLabelmapVolumeFromOrientedImageData(mergedImageData, labelNode):
       slicer.mrmlScene.RemoveNode(labelNode)
       return None
-    labelNode.SetName("{}_label".format(segmentID))
+    labelNode.SetName(f"{segmentID}_label")
     return labelNode
 
   @staticmethod
@@ -468,7 +468,7 @@ class DICOMSegmentationExporter:
 
   def cleanup(self):
     try:
-      logging.debug("Cleaning up temporarily created directory {}".format(self.tempDir))
+      logging.debug(f"Cleaning up temporarily created directory {self.tempDir}")
       shutil.rmtree(self.tempDir)
     except AttributeError:
       pass
@@ -557,7 +557,7 @@ class DICOMSegmentationExporter:
     if not os.path.exists(segFilePath):
       raise RuntimeError("DICOM Segmentation was not created. Check Error Log for further information.")
 
-    logging.debug("Saved DICOM Segmentation to {}".format(segFilePath))
+    logging.debug(f"Saved DICOM Segmentation to {segFilePath}")
     return True
 
   def getSeriesAttributes(self):
@@ -591,7 +591,7 @@ class DICOMSegmentationExporter:
     segmentFiles = []
     for segmentID in segmentIDs:
       segmentLabelmap = self.createLabelNodeFromSegment(self.segmentationNode, segmentID)
-      filename = os.path.join(self.tempDir, "{}.nrrd".format(segmentLabelmap.GetName()))
+      filename = os.path.join(self.tempDir, f"{segmentLabelmap.GetName()}.nrrd")
       slicer.util.saveNode(segmentLabelmap, filename)
       slicer.mrmlScene.RemoveNode(segmentLabelmap)
       segmentFiles.append(filename)
@@ -601,7 +601,7 @@ class DICOMSegmentationExporter:
     attributeName = "DICOM.instanceUIDs"
     instanceUIDs = volumeNode.GetAttribute(attributeName)
     if not instanceUIDs:
-      raise ValueError("VolumeNode {} has no attribute {}".format(volumeNode.GetName(), attributeName))
+      raise ValueError(f"VolumeNode {volumeNode.GetName()} has no attribute {attributeName}")
     fileList = []
     rootDir = None
     for uid in instanceUIDs.split():
@@ -661,7 +661,7 @@ class DICOMSegmentationExporter:
       category = terminologyEntry.GetCategoryObject()
       propType = terminologyEntry.GetTypeObject()
       if any(v is None for v in [category, propType]):
-        raise ValueError("Segment {} has missing attributes. Make sure to set terminology.".format(segment.GetName()))
+        raise ValueError(f"Segment {segment.GetName()} has missing attributes. Make sure to set terminology.")
 
   def createJSONFromTerminologyContext(self, terminologyEntry):
     segmentData = dict()

--- a/Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py
@@ -9,6 +9,7 @@ from collections import Counter
 import numpy
 import numpy as np
 import random
+import highdicom as hd
 import pydicom
 from pydicom.sr.codedict import codes
 
@@ -63,7 +64,6 @@ class DICOMTID1500PluginClass(DICOMPlugin):
 
   def examineFiles(self, files):
 
-    import pydicom
     loadables = []
 
     for cFile in files:
@@ -100,14 +100,6 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     This function checks if the dataset is a TID1500 or not. 
     """
 
-    # Install/import highdicom 
-    try:
-      import highdicom as hd
-    except ModuleNotFoundError:
-      if slicer.util.confirmOkCancelDisplay("This module requires 'highdicom' Python package. Click OK to install it now."):
-        slicer.util.pip_install("highdicom") 
-        import highdicom as hd
-
     try:
       isDicomTID1500 = self.getDICOMValue(dataset, "Modality") == 'SR' and \
                        (self.getDICOMValue(dataset, "SOPClassUID") == self.UID_EnhancedSRStorage or
@@ -133,9 +125,6 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     This function takes as input a standardized string, and returns 
     the highdicom code, either using pydicom or defining it.
     """
-
-    import highdicom as hd 
-    from pydicom.sr.codedict import codes
 
     if (code_meaning == "Image Region"): 
       highdicom_code = codes.DCM.ImageRegion # instead of using hd.sr.value_types.Code(value='111030',scheme_designator='DCM',meaning='Image Region')
@@ -174,10 +163,6 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     """
     Main function to create the loadable and add the necessary references. 
     """
-
-    import highdicom as hd
-    import pydicom 
-    from pydicom.sr.codedict import codes
 
     loadable = DICOMLoadable()
     loadable.selected = True
@@ -353,7 +338,6 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     return sorted(uids, key=lambda uid: self.getDateTime(uid))
 
   def getDateTime(self, uid):
-    import pydicom 
     filename = slicer.dicomDatabase.fileForInstance(uid)
     dataset = pydicom.dcmread(filename)
     if hasattr(dataset, 'SeriesDate') and hasattr(dataset, "SeriesTime"):
@@ -397,9 +381,6 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     Checks if the SR contains a bbox, polyline, or point3D.
     """
 
-    import highdicom as hd 
-    from pydicom.sr.codedict import codes
-
     # If SR contains a bounding box 
     if (geometry_type == "bbox2D"):
       for group in sr.content.get_planar_roi_measurement_groups(reference_type=codes.DCM.ImageRegion, graphic_type=hd.sr.GraphicTypeValues.POLYLINE):
@@ -432,10 +413,8 @@ class DICOMTID1500PluginClass(DICOMPlugin):
   def getIPPFromSOP(self, referenced_sop_instance_uid, referenced_series_instance_uid):
     """
     In order to display the bounding box markups in Slicer, we need the IPP corresponding 
-    to the referenced SOPInstanceUID. We get this from the Slicer DICOM database. 
+    to the referenced SOPInstanceUID. We get this from the Slicer DICOM database.
     """
-
-    import pydicom 
 
     # Get the dicom database 
     db = slicer.dicomDatabase 
@@ -699,15 +678,12 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     and creates a table node. 
     """
 
-    import highdicom as hd
-    from pydicom.sr.codedict import codes
-
     # We use the SeriesNumber and the SeriesDescription of the SR to name the table
     SeriesNumber = sr.SeriesNumber
     SeriesDescription = sr.SeriesDescription
     table_name = str(SeriesNumber) + ": " + SeriesDescription
 
-    # get image region code 
+    # get image region code
     image_region_code = self.getSRCode("Image Region")
 
     # will store the info needed for table too. 
@@ -778,17 +754,15 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     and creates a table node. 
     """
 
-    import highdicom as hd
-
     # We use the SeriesNumber and the SeriesDescription of the SR to name the table
     SeriesNumber = sr.SeriesNumber
     SeriesDescription = sr.SeriesDescription
     table_name = str(SeriesNumber) + ": " + SeriesDescription
 
-    # get the referenced SeriesInstanceUID 
+    # get the referenced SeriesInstanceUID
     referenced_series_instance_uid = str(sr.CurrentRequestedProcedureEvidenceSequence[0].ReferencedSeriesSequence[0].SeriesInstanceUID)
 
-    # will store the info needed for table too. 
+    # will store the info needed for table too.
     line_infos = [] 
 
     # First get the planar roi measurement groups 
@@ -1106,7 +1080,6 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     Loads the SR and checks for planar annotations. 
     """
 
-    import highdicom as hd
     logging.debug('DICOM SR TID1500 load()')
 
     logging.debug("before sorting: %s" % loadable.uids)
@@ -1376,7 +1349,6 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     Loads length measements as annotation rulers
     TODO: need to generalize to other report contents
     """
-    import pydicom 
     srFilePath = slicer.dicomDatabase.fileForInstance(srUID)
     sr = pydicom.dcmread(srFilePath)
 
@@ -1454,7 +1426,6 @@ class DICOMLongitudinalTID1500PluginClass(DICOMTID1500PluginClass):
     self.loadType = "Longitudinal DICOM Structured Report TID1500"
 
   def examineFiles(self, files):
-    import pydicom 
     loadables = []
 
     for cFile in files:
@@ -1488,7 +1459,6 @@ class DICOMLongitudinalTID1500PluginClass(DICOMTID1500PluginClass):
     return loadables
 
   def getRelatedSRs(self, dataset):
-    import pydicom 
     otherSRFiles = []
     otherSRDatasets = []
     studyInstanceUID = self.getDICOMValue(dataset, "StudyInstanceUID")

--- a/Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py
@@ -8,7 +8,6 @@ from collections import Counter
 
 import numpy
 import numpy as np
-import random
 import highdicom as hd
 import pydicom
 from pydicom.sr.codedict import codes
@@ -26,7 +25,7 @@ class DICOMTID1500PluginClass(DICOMPlugin):
   UID_RealWorldValueMappingStorage = pydicom.uid.RealWorldValueMappingStorage
 
   def __init__(self):
-    super(DICOMTID1500PluginClass, self).__init__()
+    super().__init__()
     self.loadType = "DICOM Structured Report TID1500"
 
     self.codings = {
@@ -40,7 +39,7 @@ class DICOMTID1500PluginClass(DICOMPlugin):
       "length": { "scheme": "SRT", "value": "G-D7FE" },
     }
 
-    self.tags = {} 
+    self.tags = {}
     self.tags["PatientID"] = "0010,0020"
     self.tags["StudyDate"] = "0008,0020"
     self.tags["StudyInstanceUID"] = "0020,000D"
@@ -80,7 +79,7 @@ class DICOMTID1500PluginClass(DICOMPlugin):
       if isDicomTID1500:
         loadable = self.createLoadableAndAddReferences([dataset])
         loadable.files = [cFile]
-        loadable.name = seriesDescription + ' - as a DICOM SR TID1500 object'
+        loadable.name = seriesDescription + " - as a DICOM SR TID1500 object"
         loadable.tooltip = loadable.name
         loadable.selected = True
         loadable.confidence = 0.95
@@ -91,78 +90,72 @@ class DICOMTID1500PluginClass(DICOMPlugin):
 
         loadables.append(loadable)
 
-        logging.debug('DICOM SR TID1500 modality found')
-      
+        logging.debug("DICOM SR TID1500 modality found")
+
     return loadables
 
   def isDICOMTID1500(self, dataset):
     """"
-    This function checks if the dataset is a TID1500 or not. 
+    This function checks if the dataset is a TID1500 or not.
     """
 
     try:
-      isDicomTID1500 = self.getDICOMValue(dataset, "Modality") == 'SR' and \
+      isDicomTID1500 = self.getDICOMValue(dataset, "Modality") == "SR" and \
                        (self.getDICOMValue(dataset, "SOPClassUID") == self.UID_EnhancedSRStorage or
-                        self.getDICOMValue(dataset, "SOPClassUID") == self.UID_ComprehensiveSRStorage or 
+                        self.getDICOMValue(dataset, "SOPClassUID") == self.UID_ComprehensiveSRStorage or
                         self.getDICOMValue(dataset, "SOPClassUID") == self.UID_Comprehensive3DSRStorage) and \
-                       self.getDICOMValue(dataset, "ContentTemplateSequence")[0].TemplateIdentifier == '1500'
+                       self.getDICOMValue(dataset, "ContentTemplateSequence")[0].TemplateIdentifier == "1500"
     except (AttributeError, IndexError):
       isDicomTID1500 = False
     return isDicomTID1500
 
   def referencedSeriesName(self, loadable):
-    """
-    Returns the default series name for the given loadable.
-    """
+    """Returns the default series name for the given loadable."""
 
     referencedName = "Unnamed Reference"
     if hasattr(loadable, "referencedSOPInstanceUID"):
       referencedName = self.defaultSeriesNodeName(loadable.referencedSOPInstanceUID)
     return referencedName
-  
+
   def getSRCode(self, code_meaning):
     """
-    This function takes as input a standardized string, and returns 
+    This function takes as input a standardized string, and returns
     the highdicom code, either using pydicom or defining it.
     """
 
-    if (code_meaning == "Image Region"): 
+    if (code_meaning == "Image Region"):
       highdicom_code = codes.DCM.ImageRegion # instead of using hd.sr.value_types.Code(value='111030',scheme_designator='DCM',meaning='Image Region')
-    elif (code_meaning == "Geometric purpose of region"): 
+    elif (code_meaning == "Geometric purpose of region"):
       highdicom_code = hd.sr.value_types.Code(
-                        value='130400',
-                        scheme_designator='DCM',
-                        meaning='Geometric purpose of region'
+                        value="130400",
+                        scheme_designator="DCM",
+                        meaning="Geometric purpose of region",
                       )
-    elif (code_meaning == "Bounded by"): 
+    elif (code_meaning == "Bounded by"):
       highdicom_code = hd.sr.value_types.Code(
-                        value='75958009',
-                        scheme_designator='SCT',
-                        meaning='Bounded by'
-                      ) # codes.SCT.BoundedBy from pydicom does not exist. 
-    else: 
+                        value="75958009",
+                        scheme_designator="SCT",
+                        meaning="Bounded by",
+                      ) # codes.SCT.BoundedBy from pydicom does not exist.
+    else:
       highdicom_code = ""
 
     return highdicom_code
 
   def getSOPInstanceUIDsForSeries(self, SeriesInstanceUID):
-    """
-    Gets the list of SOPInstanceUIDs from a SeriesInstanceUID. 
-    """
+    """Gets the list of SOPInstanceUIDs from a SeriesInstanceUID."""
 
     db = slicer.dicomDatabase
-    SOPInstanceUIDs = [] 
-    fileList = db.filesForSeries(SeriesInstanceUID) 
-    for file in fileList: 
+    SOPInstanceUIDs = []
+    fileList = db.filesForSeries(SeriesInstanceUID)
+    for file in fileList:
       SOPInstanceUID = db.fileValue(file, self.tags["SOPInstanceUID"])
-      SOPInstanceUIDs.append(SOPInstanceUID) 
+      SOPInstanceUIDs.append(SOPInstanceUID)
 
     return SOPInstanceUIDs
-  
+
   def createLoadableAndAddReferences(self, datasets):
-    """
-    Main function to create the loadable and add the necessary references. 
-    """
+    """Main function to create the loadable and add the necessary references."""
 
     loadable = DICOMLoadable()
     loadable.selected = True
@@ -196,11 +189,11 @@ class DICOMTID1500PluginClass(DICOMPlugin):
         logging.error(f"Cannot create SR from dataset. Unsupported SOP Class UID: {sop_class_uid}")
 
       ### First we check if the SR contains planar annotations ###
-      containsPlanarAnnotations = self.containsPlanarAnnotations(sr) 
+      containsPlanarAnnotations = self.containsPlanarAnnotations(sr)
 
-      ### If it doesn't contain planar annotations, and instead references a seg, we use the original code ### 
-      if not containsPlanarAnnotations: 
-        
+      ### If it doesn't contain planar annotations, and instead references a seg, we use the original code ###
+      if not containsPlanarAnnotations:
+
         uid = self.getDICOMValue(dataset, "SOPInstanceUID")
         loadable.ReferencedSegmentationInstanceUIDs[uid] = []
         if hasattr(dataset, "CurrentRequestedProcedureEvidenceSequence"):
@@ -217,13 +210,13 @@ class DICOMTID1500PluginClass(DICOMPlugin):
                 else:
                   # TODO: those are not used at all
                   logging.debug( "Found other reference")
-                  loadable.ReferencedOtherInstanceUIDs.append(refSOPSequence.ReferencedSOPInstanceUID) 
+                  loadable.ReferencedOtherInstanceUIDs.append(refSOPSequence.ReferencedSOPInstanceUID)
 
         for segSeriesInstanceUID in loadable.ReferencedSegmentationInstanceUIDs[uid]:
           segLoadables = segPlugin.examine([slicer.dicomDatabase.filesForSeries(segSeriesInstanceUID)])
           for segLoadable in segLoadables:
             loadable.referencedInstanceUIDs += segLoadable.referencedInstanceUIDs
-        
+
         if len(loadable.ReferencedSegmentationInstanceUIDs[uid])>1:
           logging.warning("SR references more than one SEG. This has not been tested!")
         for segUID in loadable.ReferencedSegmentationInstanceUIDs:
@@ -232,162 +225,160 @@ class DICOMTID1500PluginClass(DICOMPlugin):
         if len(loadable.ReferencedRWVMSeriesInstanceUIDs)>1:
           logging.warning("SR references more than one RWVM. This has not been tested!")
             # not adding RWVM instances to referencedSeriesInstanceUIDs
-      
-      ### Additions for handling planar annotations ### 
+
+      ### Additions for handling planar annotations ###
       else:
-        
-        #### Then we check if the SR contains a point3d, line, or bbox ### 
-        checkIfSRContainsBbox = self.checkIfSRContainsGeometry(sr, geometry_type='bbox2D')
-        checkIfSRContains3DPoint = self.checkIfSRContainsGeometry(sr, geometry_type='point3D')
-        checkIfSRContainsPolyline = self.checkIfSRContainsGeometry(sr, geometry_type='polyline2D')
+
+        #### Then we check if the SR contains a point3d, line, or bbox ###
+        checkIfSRContainsBbox = self.checkIfSRContainsGeometry(sr, geometry_type="bbox2D")
+        checkIfSRContains3DPoint = self.checkIfSRContainsGeometry(sr, geometry_type="point3D")
+        checkIfSRContainsPolyline = self.checkIfSRContainsGeometry(sr, geometry_type="polyline2D")
 
         ### checkIfSRContains3DPoint ###
         # We only check for FrameOfReferenceUID for 3Dpoint
-        # We check for FrameOfReferenceUID, and add to the list of loadable.referencedInstanceUIDs 
+        # We check for FrameOfReferenceUID, and add to the list of loadable.referencedInstanceUIDs
         # Please refer to David Clunie's paper for more information about searching for the FrameOfReferenceUIDs
-        # http://dx.doi.org/10.13140/RG.2.2.34520.62725 
-        if checkIfSRContains3DPoint: 
+        # http://dx.doi.org/10.13140/RG.2.2.34520.62725
+        if checkIfSRContains3DPoint:
 
-          # print('In checkIfSRContains3DPoint - check for FrameOfReferenceUID')     
-          # get the ImageRegion code 
+          # print('In checkIfSRContains3DPoint - check for FrameOfReferenceUID')
+          # get the ImageRegion code
           image_region_code = self.getSRCode("Image Region")
-          # First get the planar roi measurement groups 
+          # First get the planar roi measurement groups
           groups = sr.content.get_planar_roi_measurement_groups(
                     graphic_type=hd.sr.GraphicTypeValues3D.POINT,
                     reference_type=codes.DCM.ImageRegion,
           )
 
-          # Iterate through the groups, and get unique list of FrameOfReferenceUIDs 
-          FrameOfReferenceUIDs = [] 
-          for group in groups: 
+          # Iterate through the groups, and get unique list of FrameOfReferenceUIDs
+          FrameOfReferenceUIDs = []
+          for group in groups:
             FrameOfReferenceUIDs.append(group.roi.frame_of_reference_uid)
           FrameOfReferenceUIDs = list(set(FrameOfReferenceUIDs))
 
-          # Now we get the SeriesInstanceUIDs in the dicom database that have these FrameOfReferenceUIDs 
-          # We know that the StudyInstanceUID must be the same, so we only check those patients. 
-          StudyInstanceUID = dataset.StudyInstanceUID 
-          # Get the list of possible series in the database for this study 
+          # Now we get the SeriesInstanceUIDs in the dicom database that have these FrameOfReferenceUIDs
+          # We know that the StudyInstanceUID must be the same, so we only check those patients.
+          StudyInstanceUID = dataset.StudyInstanceUID
+          # Get the list of possible series in the database for this study
           SeriesInstanceUIDs = slicer.dicomDatabase.seriesForStudy(StudyInstanceUID)
 
-          # Now make sure that the modality of these possible_SeriesInstanceUIDs are not SR or SEG.  
-          # Don't want them included in the list 
-          possible_SeriesInstanceUIDs = [] 
-          db = slicer.dicomDatabase 
-          for series in SeriesInstanceUIDs: 
-            modality = slicer.dicomDatabase.fileValue(  
-              slicer.dicomDatabase.filesForSeries(series)[0], self.tags["Modality"]
+          # Now make sure that the modality of these possible_SeriesInstanceUIDs are not SR or SEG.
+          # Don't want them included in the list
+          possible_SeriesInstanceUIDs = []
+          db = slicer.dicomDatabase
+          for series in SeriesInstanceUIDs:
+            modality = slicer.dicomDatabase.fileValue(
+              slicer.dicomDatabase.filesForSeries(series)[0], self.tags["Modality"],
             )
-            if (modality != "SR") and (modality != "SEG"): 
+            if (modality != "SR") and (modality != "SEG"):
               possible_SeriesInstanceUIDs.append(series)
 
           # Now, we don't need to check if possible_SeriesInstanceUIDs are actually in the DICOM database
           # We know they are, because we retrieved the list of series using slicer.dicomDatabase.seriesForStudy(StudyInstanceUID)
-          # However, we do need to make sure that possible_SeriesInstanceUIDs is not empty. 
-          # If empty, then display a popup 
-          if not possible_SeriesInstanceUIDs: 
+          # However, we do need to make sure that possible_SeriesInstanceUIDs is not empty.
+          # If empty, then display a popup
+          if not possible_SeriesInstanceUIDs:
             logging.error("ERROR: no referenced series found in the DICOM database, cannot load any associated image data")
             slicer.util.errorDisplay("No referenced series found in the DICOM database, cannot load any associated image data")
 
-          else: 
-        
-            # Now get the FrameOfReferenceUIDs for these SeriesInstanceUIDs 
-            FrameOfReferenceUIDs_forSeries = [] 
-            for SeriesInstanceUID in possible_SeriesInstanceUIDs: 
+          else:
+
+            # Now get the FrameOfReferenceUIDs for these SeriesInstanceUIDs
+            FrameOfReferenceUIDs_forSeries = []
+            for SeriesInstanceUID in possible_SeriesInstanceUIDs:
               FrameOfReferenceUID_forSeries = slicer.dicomDatabase.fileValue(
-                                                        slicer.dicomDatabase.filesForSeries(SeriesInstanceUID)[0], self.tags["FrameOfReferenceUID"]) 
+                                                        slicer.dicomDatabase.filesForSeries(SeriesInstanceUID)[0], self.tags["FrameOfReferenceUID"])
               FrameOfReferenceUIDs_forSeries.append(FrameOfReferenceUID_forSeries)
-              
-            # iterate over the list of FrameOfReferenceUIDs_forSeries and see if any are in the actual SR. 
-            keep_SeriesInstanceUIDs = [] 
-            for SeriesInstanceUID,FrameOfReferenceUID_forSeries in zip(possible_SeriesInstanceUIDs,FrameOfReferenceUIDs_forSeries):
-              if FrameOfReferenceUID_forSeries in FrameOfReferenceUIDs: 
+
+            # iterate over the list of FrameOfReferenceUIDs_forSeries and see if any are in the actual SR.
+            keep_SeriesInstanceUIDs = []
+            for SeriesInstanceUID,FrameOfReferenceUID_forSeries in zip(possible_SeriesInstanceUIDs,FrameOfReferenceUIDs_forSeries, strict=False):
+              if FrameOfReferenceUID_forSeries in FrameOfReferenceUIDs:
                 keep_SeriesInstanceUIDs.append(SeriesInstanceUID)
 
-            # Get the unique list of possible series 
+            # Get the unique list of possible series
             keep_SeriesInstanceUIDs = list(set(keep_SeriesInstanceUIDs))
 
             SOPInstanceUIDs = [self.getSOPInstanceUIDsForSeries(series) for series in keep_SeriesInstanceUIDs]
             SOPInstanceUIDs = [item for sublist in SOPInstanceUIDs for item in sublist]
-            # Now add to the loadable.referencedInstanceUIDs 
+            # Now add to the loadable.referencedInstanceUIDs
             if (SOPInstanceUIDs):
-              loadable.referencedInstanceUIDs += SOPInstanceUIDs 
+              loadable.referencedInstanceUIDs += SOPInstanceUIDs
 
 
-        #### checkIfSRContainsBbox or checkIfSRContainsPolyline ### 
-        # Here we get the referenced SeriesInstanceUID 
-        if (checkIfSRContainsBbox or checkIfSRContainsPolyline): 
+        #### checkIfSRContainsBbox or checkIfSRContainsPolyline ###
+        # Here we get the referenced SeriesInstanceUID
+        if (checkIfSRContainsBbox or checkIfSRContainsPolyline):
 
-          # print('In checkIfSRContainsBbox/checkIfSRContainsPolyline - get referenced series')     
-          # Get the referenced SeriesInstanceUID 
+          # print('In checkIfSRContainsBbox/checkIfSRContainsPolyline - get referenced series')
+          # Get the referenced SeriesInstanceUID
           referenced_series_instance_uid = str(sr.CurrentRequestedProcedureEvidenceSequence[0].ReferencedSeriesSequence[0].SeriesInstanceUID)
-          # Now we get all of the SOPInstanceUIDs of this series 
+          # Now we get all of the SOPInstanceUIDs of this series
           db = slicer.dicomDatabase
           fileList = db.filesForSeries(referenced_series_instance_uid)
-          if not fileList: 
+          if not fileList:
             logging.error("ERROR: no referenced series found in the DICOM database, cannot load any associated image data")
             slicer.util.errorDisplay("No referenced series found in the DICOM database, cannot load any associated image data")
-          else: 
+          else:
             SOPInstanceUIDs = [db.fileValue(file, self.tags["SOPInstanceUID"]) for file in fileList]
             if (SOPInstanceUIDs):
-              loadable.referencedInstanceUIDs += SOPInstanceUIDs 
+              loadable.referencedInstanceUIDs += SOPInstanceUIDs
 
 
     return loadable
 
   def sortReportsByDateTime(self, uids):
-    return sorted(uids, key=lambda uid: self.getDateTime(uid))
+    return sorted(uids, key=self.getDateTime)
 
   def getDateTime(self, uid):
     filename = slicer.dicomDatabase.fileForInstance(uid)
     dataset = pydicom.dcmread(filename)
-    if hasattr(dataset, 'SeriesDate') and hasattr(dataset, "SeriesTime"):
+    if hasattr(dataset, "SeriesDate") and hasattr(dataset, "SeriesTime"):
       date = dataset.SeriesDate
       time = dataset.SeriesTime
-    elif hasattr(dataset, 'StudyDate') and hasattr(dataset, "StudyTime"):
+    elif hasattr(dataset, "StudyDate") and hasattr(dataset, "StudyTime"):
       date = dataset.StudyDate
       time = dataset.StudyDate
     else:
       date = ""
       time = ""
     try:
-      dateTime = datetime.datetime.strptime(date+time, '%Y%m%d%H%M%S')
+      dateTime = datetime.datetime.strptime(date+time, "%Y%m%d%H%M%S")
     except ValueError:
       dateTime = ""
     return dateTime
-  
+
   def containsPlanarAnnotations(self, sr):
-    """ 
-    Checks if the original plugin should be used (tid1500reader) to read the SR, or if specialized 
+    """
+    Checks if the original plugin should be used (tid1500reader) to read the SR, or if specialized
     highdicom code should be utilized for reading planar annotations, in the case of point,
-    bounding box, etc. 
+    bounding box, etc.
     """
 
-    # default to use the plugin 
+    # default to use the plugin
     containsPlanarAnnotations = False
 
-    # get the image region code 
+    # get the image region code
     image_region_code = self.getSRCode("Image Region")
 
     planar_roi_measurement_groups = sr.content.get_planar_roi_measurement_groups()
-    for planar_roi_measurement_group in planar_roi_measurement_groups: 
-      # Here we check if it is an Image Region 
+    for planar_roi_measurement_group in planar_roi_measurement_groups:
+      # Here we check if it is an Image Region
       if (planar_roi_measurement_group.reference_type == image_region_code):
           containsPlanarAnnotations = True
 
     return containsPlanarAnnotations
-  
-  def checkIfSRContainsGeometry(self, sr, geometry_type='bbox'):
-    """ 
-    Checks if the SR contains a bbox, polyline, or point3D.
-    """
 
-    # If SR contains a bounding box 
+  def checkIfSRContainsGeometry(self, sr, geometry_type="bbox"):
+    """Checks if the SR contains a bbox, polyline, or point3D."""
+
+    # If SR contains a bounding box
     if (geometry_type == "bbox2D"):
       for group in sr.content.get_planar_roi_measurement_groups(reference_type=codes.DCM.ImageRegion, graphic_type=hd.sr.GraphicTypeValues.POLYLINE):
         for eval in group.get_qualitative_evaluations(
               name=self.getSRCode("Geometric purpose of region"),
         ):
-            if eval.value == self.getSRCode("Bounded by"): 
+            if eval.value == self.getSRCode("Bounded by"):
                 return True
       return False
 
@@ -395,54 +386,52 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     elif (geometry_type == "polyline2D"):
       groups = sr.content.get_planar_roi_measurement_groups(
         reference_type=self.getSRCode("Image Region"),
-        graphic_type=hd.sr.GraphicTypeValues.POLYLINE, 
-      )  
+        graphic_type=hd.sr.GraphicTypeValues.POLYLINE,
+      )
       return len(groups) >= 1
 
-    # If SR contains SCOORD3D 
+    # If SR contains SCOORD3D
     elif (geometry_type == "point3D"):
       groups = sr.content.get_planar_roi_measurement_groups(reference_type=codes.DCM.ImageRegion,graphic_type=hd.sr.GraphicTypeValues3D.POINT)
       return len(groups) >= 1
-    
-    # If SR contains unknown geometry 
+
+    # If SR contains unknown geometry
     else:
-      logging.info('Cannot read SR with geometry: ' + str(geometry_type))
+      logging.info("Cannot read SR with geometry: " + str(geometry_type))
 
     return False
-  
+
   def getIPPFromSOP(self, referenced_sop_instance_uid, referenced_series_instance_uid):
     """
-    In order to display the bounding box markups in Slicer, we need the IPP corresponding 
+    In order to display the bounding box markups in Slicer, we need the IPP corresponding
     to the referenced SOPInstanceUID. We get this from the Slicer DICOM database.
     """
 
-    # Get the dicom database 
-    db = slicer.dicomDatabase 
+    # Get the dicom database
+    db = slicer.dicomDatabase
 
-    # Get the files for the series 
+    # Get the files for the series
     fileList = db.filesForSeries(referenced_series_instance_uid)
 
-    # Use pydicom to read the files, get the SOPInstanceUID and the IPP for each 
+    # Use pydicom to read the files, get the SOPInstanceUID and the IPP for each
     num_files = len(fileList)
-    SOPInstanceUID_list = [] 
-    IPP_list = [] 
-    for file in fileList: 
+    SOPInstanceUID_list = []
+    IPP_list = []
+    for file in fileList:
       ds = pydicom.dcmread(file)
       SOPInstanceUID_list.append(ds.SOPInstanceUID)
       IPP_list.append(ds.ImagePositionPatient)
 
-    # Get the index of the SOPInstanceUID we want 
+    # Get the index of the SOPInstanceUID we want
     index = SOPInstanceUID_list.index(referenced_sop_instance_uid)
 
-    # Now get the IPP for the corresponding SOPInstanceUID 
+    # Now get the IPP for the corresponding SOPInstanceUID
     ipp = IPP_list[index]
 
-    return ipp 
-  
+    return ipp
+
   def showTable(self, table):
-    """
-    Display a table in the scene. 
-    """
+    """Display a table in the scene."""
 
     currentLayout = slicer.app.layoutManager().layout
     layoutWithTable = slicer.modules.tables.logic().GetLayoutWithTable(currentLayout)
@@ -451,18 +440,16 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     slicer.app.applicationLogic().GetSelectionNode().SetActiveTableID(table.GetID())
     slicer.app.applicationLogic().PropagateTableSelection()
 
-    return 
-  
+    return
+
   def createBboxTable(self, poly_infos, table_name):
-    """
-    Create and display a table for the bbox info. 
-    """
+    """Create and display a table for the bbox info."""
 
     tableNode = slicer.vtkMRMLTableNode()
-    tableNode.SetAttribute("readonly", "Yes") 
+    tableNode.SetAttribute("readonly", "Yes")
     tableNode.SetName(table_name)
 
-    # Add columns 
+    # Add columns
     col = tableNode.AddColumn()
     col.SetName("Tracking Identifier")
     col = tableNode.AddColumn()
@@ -472,43 +459,41 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     col = tableNode.AddColumn()
     col.SetName("Bounding box points")
 
-    # Order by IPP2 
-    poly_infos = sorted(poly_infos, key=lambda x: x['center_z'])
+    # Order by IPP2
+    poly_infos = sorted(poly_infos, key=lambda x: x["center_z"])
 
     for i,p in enumerate(poly_infos):
-      # get values 
-      tracking_identifier = p['TrackingIdentifier']
-      finding_type = p['FindingType']
-      finding_site = p['FindingSite'][0] # check this later. 
-      polyline = p['polyline']
-      polyline_str = ', '.join(f"({np.round(a,2)}, {np.round(b,2)})" for a, b in polyline)
-      width = np.round(p['width'],2)
-      height = np.round(p['height'],2)
-      center_x = np.round(p['center_x'],2)
-      center_y = np.round(p['center_y'],2)
-      center_z = np.round(p['center_z'],2)
-      center = list([str(center_x), str(center_y), str(center_z)])
-      # add tracking info and finding site info 
+      # get values
+      tracking_identifier = p["TrackingIdentifier"]
+      finding_type = p["FindingType"]
+      finding_site = p["FindingSite"][0] # check this later.
+      polyline = p["polyline"]
+      polyline_str = ", ".join(f"({np.round(a,2)}, {np.round(b,2)})" for a, b in polyline)
+      width = np.round(p["width"],2)
+      height = np.round(p["height"],2)
+      center_x = np.round(p["center_x"],2)
+      center_y = np.round(p["center_y"],2)
+      center_z = np.round(p["center_z"],2)
+      center = [str(center_x), str(center_y), str(center_z)]
+      # add tracking info and finding site info
       rowIndex = tableNode.AddEmptyRow()
       tableNode.SetCellText(rowIndex, 0, tracking_identifier)
       tableNode.SetCellText(rowIndex, 1, finding_type[2])
       tableNode.SetCellText(rowIndex, 2, finding_site[2])
-      # add bbox points 
+      # add bbox points
       tableNode.SetCellText(rowIndex, 3, polyline_str)
 
-    return tableNode 
-  
-    
+    return tableNode
+
+
   def createPointTable(self, point_infos, table_name):
-    """
-    Create and display a table for the point info. 
-    """
+    """Create and display a table for the point info."""
 
     tableNode = slicer.vtkMRMLTableNode()
-    tableNode.SetAttribute("readonly", "Yes") 
+    tableNode.SetAttribute("readonly", "Yes")
     tableNode.SetName(table_name)
 
-    # Add columns 
+    # Add columns
     col = tableNode.AddColumn()
     col.SetName("Tracking Identifier")
     col = tableNode.AddColumn()
@@ -518,56 +503,54 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     col = tableNode.AddColumn()
     col.SetName("Point")
 
-    # Order by IPP2 
-    point_infos = sorted(point_infos, key=lambda x: x['point'][2])
+    # Order by IPP2
+    point_infos = sorted(point_infos, key=lambda x: x["point"][2])
 
     for i,p in enumerate(point_infos):
-      # get values 
-      tracking_identifier = p['TrackingIdentifier']
-      tracking_uid = p['TrackingUID']
-      finding_type = p['FindingType']
-      finding_site = p['FindingSite'][0] # check this later. 
+      # get values
+      tracking_identifier = p["TrackingIdentifier"]
+      tracking_uid = p["TrackingUID"]
+      finding_type = p["FindingType"]
+      finding_site = p["FindingSite"][0] # check this later.
       point = p["point"]
       point = [str(np.round(f,2)) for f in point]
       point_str = f"({', '.join(point)})"
-      content_sequence_names = p['ContentSequenceNames']
-      content_sequence_values = p['ContentSequenceValues']
-      # add tracking info and finding site info 
+      content_sequence_names = p["ContentSequenceNames"]
+      content_sequence_values = p["ContentSequenceValues"]
+      # add tracking info and finding site info
       rowIndex = tableNode.AddEmptyRow()
       tableNode.SetCellText(rowIndex, 0, tracking_identifier)
       tableNode.SetCellText(rowIndex, 1, finding_type[2]) # CodeMeaning
       tableNode.SetCellText(rowIndex, 2, finding_site[2]) # CodeMeaning
       # add point
-      tableNode.SetCellText(rowIndex, 3, point_str) 
-      # now add the names CodeMeaning as the column name, and the values CodeMeaning as the actual value 
-      # first do for qualitative evaluations 
+      tableNode.SetCellText(rowIndex, 3, point_str)
+      # now add the names CodeMeaning as the column name, and the values CodeMeaning as the actual value
+      # first do for qualitative evaluations
       num_rows = 4
       # then add for content sequence
       # num_rows = num_rows + len(qual_eval_names)
-      for j, content_sequence_name in enumerate(content_sequence_names): 
+      for j, content_sequence_name in enumerate(content_sequence_names):
         rowIndexValue = num_rows + j
         colName = str(content_sequence_name[2])
         colValue = str(content_sequence_values[j][2])
-        # can't add column each time - if there is more than 1 point. 
-        # therefore, only add column when on first point_info. 
+        # can't add column each time - if there is more than 1 point.
+        # therefore, only add column when on first point_info.
         if (i==0):
-          col = tableNode.AddColumn() 
-          col.SetName(colName) 
-        tableNode.SetCellText(rowIndex, rowIndexValue, colValue) 
+          col = tableNode.AddColumn()
+          col.SetName(colName)
+        tableNode.SetCellText(rowIndex, rowIndexValue, colValue)
 
 
-    return tableNode 
-  
+    return tableNode
+
   def createPolylineTable(self, point_infos, table_name):
-    """
-    Create and display a table for the polyline info. 
-    """
+    """Create and display a table for the polyline info."""
 
     tableNode = slicer.vtkMRMLTableNode()
-    tableNode.SetAttribute("readonly", "Yes") 
+    tableNode.SetAttribute("readonly", "Yes")
     tableNode.SetName(table_name)
 
-    # Add columns 
+    # Add columns
     col = tableNode.AddColumn()
     col.SetName("Tracking Identifier")
     col = tableNode.AddColumn()
@@ -578,28 +561,28 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     col.SetName("PolyLine")
 
     for i,p in enumerate(point_infos):
-      # get values 
-      tracking_identifier = p['TrackingIdentifier']
-      tracking_uid = p['TrackingUID']
-      finding_type = p['FindingType']
-      finding_site = p['FindingSite'][0] # check this later. 
+      # get values
+      tracking_identifier = p["TrackingIdentifier"]
+      tracking_uid = p["TrackingUID"]
+      finding_type = p["FindingType"]
+      finding_site = p["FindingSite"][0] # check this later.
       polyline = p["polyline"]
       polyline = [str(np.round(f,2)) for f in polyline]
       polyline_str = f"({', '.join(polyline)})"
-      # add tracking info and finding site info 
+      # add tracking info and finding site info
       rowIndex = tableNode.AddEmptyRow()
       tableNode.SetCellText(rowIndex, 0, tracking_identifier)
       tableNode.SetCellText(rowIndex, 1, finding_type[2]) # CodeMeaning
       tableNode.SetCellText(rowIndex, 2, finding_site[2]) # CodeMeaning
       # add polyline
-      tableNode.SetCellText(rowIndex, 3, polyline_str) 
+      tableNode.SetCellText(rowIndex, 3, polyline_str)
 
-    return tableNode 
-  
-  def extractBboxMetadataToVtkTableNode(self, sr): 
+    return tableNode
+
+  def extractBboxMetadataToVtkTableNode(self, sr):
     """
-    Extracts the bounding box metadata from the SR using highdicom, 
-    and creates a table node. 
+    Extracts the bounding box metadata from the SR using highdicom,
+    and creates a table node.
     """
 
     # We use the SeriesNumber and the SeriesDescription of the SR to name the table
@@ -607,75 +590,75 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     SeriesDescription = sr.SeriesDescription
     table_name = str(SeriesNumber) + ": " + SeriesDescription
 
-    # get the referenced SeriesInstanceUID 
+    # get the referenced SeriesInstanceUID
     referenced_series_instance_uid = str(sr.CurrentRequestedProcedureEvidenceSequence[0].ReferencedSeriesSequence[0].SeriesInstanceUID)
 
-    # get the image_region_code 
+    # get the image_region_code
     image_region_code = self.getSRCode("Image Region")
 
-    # will store the info needed for table too. 
-    poly_infos = [] 
+    # will store the info needed for table too.
+    poly_infos = []
 
-    # First get the planar roi measurement groups 
+    # First get the planar roi measurement groups
     groups = sr.content.get_planar_roi_measurement_groups()
 
-    for group in groups: 
+    for group in groups:
 
-      # Get the tracking ids 
+      # Get the tracking ids
       tracking_identifier = group.tracking_identifier
       tracking_uid = group.tracking_uid
 
-      # Get the findings and finding_sites 
+      # Get the findings and finding_sites
       finding_type = [group.finding_type.CodeValue, group.finding_type.CodingSchemeDesignator, group.finding_type.CodeMeaning]
       finding_sites = []
       for finding_site in group.finding_sites:
-        finding_sites.append([finding_site.value.CodeValue, 
-                              finding_site.value.CodingSchemeDesignator, 
+        finding_sites.append([finding_site.value.CodeValue,
+                              finding_site.value.CodingSchemeDesignator,
                               finding_site.value.CodeMeaning])
-      # Get the Image Region 
+      # Get the Image Region
       referenced_sop_instance_uid = group.roi.ContentSequence[0].referenced_sop_instance_uid
-      bbox = group.roi.value 
+      bbox = group.roi.value
 
-      # calculate the width, height and center, as these are needed for display 
+      # calculate the width, height and center, as these are needed for display
       min_x = np.min([bbox[0,0], bbox[1,0], bbox[2,0], bbox[3,0]]) # using roi.GraphicData: min_x = np.min([bbox[0], bbox[2], bbox[4], bbox[6]])
       max_x = np.max([bbox[0,0], bbox[1,0], bbox[2,0], bbox[3,0]]) # using roi.GraphicData: max_x = np.max([bbox[0], bbox[2], bbox[4], bbox[6]])
       min_y = np.min([bbox[0,1], bbox[1,1], bbox[2,1], bbox[3,1]]) # using roi.GraphicData: min_y = np.min([bbox[1], bbox[3], bbox[5], bbox[7]])
       max_y = np.max([bbox[0,1], bbox[1,1], bbox[2,1], bbox[3,1]]) # using roi.GraphicData: max_y = np.max([bbox[1], bbox[3], bbox[5], bbox[7]])
-      width = max_x - min_x 
-      height = max_y - min_y 
-      # in pixel coordinates 
+      width = max_x - min_x
+      height = max_y - min_y
+      # in pixel coordinates
       center_x = min_x + width/2
-      center_y = min_y + height/2 
-      # get ipp 
-      ipp = self.getIPPFromSOP(referenced_sop_instance_uid, 
+      center_y = min_y + height/2
+      # get ipp
+      ipp = self.getIPPFromSOP(referenced_sop_instance_uid,
                                        referenced_series_instance_uid)
-      # in mm 
-      center_z = ipp[2] 
-      
+      # in mm
+      center_z = ipp[2]
+
       # append to poly_infos
       poly_infos.append({
-                         "TrackingIdentifier": tracking_identifier, 
+                         "TrackingIdentifier": tracking_identifier,
                          "TrackingUID" : tracking_uid,
-                         "SOPInstanceUID" : referenced_sop_instance_uid, 
-                         "FindingType": finding_type, 
+                         "SOPInstanceUID" : referenced_sop_instance_uid,
+                         "FindingType": finding_type,
                          "FindingSite": finding_sites,
-                         "polyline": bbox, # using roi.GraphicData: [[bbox[0],bbox[1]], [bbox[2],bbox[3]], [bbox[4],bbox[5]], [bbox[6],bbox[7]]], 
-                         "width": width, 
+                         "polyline": bbox, # using roi.GraphicData: [[bbox[0],bbox[1]], [bbox[2],bbox[3]], [bbox[4],bbox[5]], [bbox[6],bbox[7]]],
+                         "width": width,
                          "height": height,
                          "center_x": center_x,
-                         "center_y": center_y, 
-                         "center_z": center_z
+                         "center_y": center_y,
+                         "center_z": center_z,
                         })
 
-      # create and display tableNode 
+      # create and display tableNode
       tableNode = self.createBboxTable(poly_infos, table_name)
 
-    return poly_infos, tableNode 
-  
+    return poly_infos, tableNode
+
   def extractPointMetadataToVtkTableNode(self, sr):
     """
-    Extracts the point metadata from the SR using highdicom, 
-    and creates a table node. 
+    Extracts the point metadata from the SR using highdicom,
+    and creates a table node.
     """
 
     # We use the SeriesNumber and the SeriesDescription of the SR to name the table
@@ -686,72 +669,72 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     # get image region code
     image_region_code = self.getSRCode("Image Region")
 
-    # will store the info needed for table too. 
-    point_infos = [] 
+    # will store the info needed for table too.
+    point_infos = []
 
-    # First get the planar roi measurement groups 
+    # First get the planar roi measurement groups
     groups = sr.content.get_planar_roi_measurement_groups(graphic_type=hd.sr.GraphicTypeValues3D.POINT,reference_type=codes.DCM.ImageRegion)
-  
-    # Iterate through each group 
-    for group in groups: 
 
-      # Get the tracking ids 
+    # Iterate through each group
+    for group in groups:
+
+      # Get the tracking ids
       tracking_identifier = group.tracking_identifier
       tracking_uid = group.tracking_uid
-      # Get the finding type 
-      finding_type = [group.finding_type.CodeValue, 
-                      group.finding_type.CodingSchemeDesignator, 
+      # Get the finding type
+      finding_type = [group.finding_type.CodeValue,
+                      group.finding_type.CodingSchemeDesignator,
                       group.finding_type.CodeMeaning]
-      # Get the finding sites 
-      finding_sites = [] 
+      # Get the finding sites
+      finding_sites = []
       for finding_site in group.finding_sites:
-        finding_sites.append([finding_site.value.CodeValue, 
-                              finding_site.value.CodingSchemeDesignator, 
+        finding_sites.append([finding_site.value.CodeValue,
+                              finding_site.value.CodingSchemeDesignator,
                               finding_site.value.CodeMeaning])
-        
-      # Get the point info 
+
+      # Get the point info
       referenced_frame_of_reference_uid = group.roi.ReferencedFrameOfReferenceUID
-      extracted_data = group.roi.value[0] 
-        
-      # Get the content items 
+      extracted_data = group.roi.value[0]
+
+      # Get the content items
       # if (len(group)>0):
-      code_items = hd.sr.utils.find_content_items(group[0], 
-                                                  relationship_type=hd.sr.RelationshipTypeValues.CONTAINS, 
+      code_items = hd.sr.utils.find_content_items(group[0],
+                                                  relationship_type=hd.sr.RelationshipTypeValues.CONTAINS,
                                                   value_type = hd.sr.ValueTypeValues.CODE)
-      content_sequence_names = [] 
-      content_sequence_values = [] 
-      for code_item in code_items: 
-        # Skip image region code here, will get in a different way. 
+      content_sequence_names = []
+      content_sequence_values = []
+      for code_item in code_items:
+        # Skip image region code here, will get in a different way.
         if (code_item.name == image_region_code):
           break
-        else: 
+        else:
           content_sequence_names.append([code_item.name.CodeValue,
-                                        code_item.name.CodingSchemeDesignator, 
+                                        code_item.name.CodingSchemeDesignator,
                                         code_item.name.CodeMeaning])
-          content_sequence_values.append([code_item.value.CodeValue, 
+          content_sequence_values.append([code_item.value.CodeValue,
                                           code_item.value.CodingSchemeDesignator,
                                           code_item.value.CodeMeaning])
       # append to poly_infos
       point_infos.append({
-                         "TrackingIdentifier": tracking_identifier, 
+                         "TrackingIdentifier": tracking_identifier,
                          "TrackingUID" : tracking_uid,
-                         "FindingType": finding_type, 
+                         "FindingType": finding_type,
                          "FindingSite": finding_sites,
-                         "ReferencedFrameOfReferenceUID": referenced_frame_of_reference_uid, 
-                         "ContentSequenceNames": content_sequence_names, 
+                         "ReferencedFrameOfReferenceUID": referenced_frame_of_reference_uid,
+                         "ContentSequenceNames": content_sequence_names,
                          "ContentSequenceValues": content_sequence_values,
-                         "point": extracted_data 
+                         "point": extracted_data,
                         })
-      
-    # create and display tableNode 
+
+    # create and display tableNode
     tableNode = self.createPointTable(point_infos, table_name)
 
-    return point_infos, tableNode 
-  
+    return point_infos, tableNode
+
   def extractLineMetadataToVtkTableNode(self, sr):
     """
-    Extracts the point metadata from the SR using highdicom, 
-    and creates a table node. 
+    Extracts the point metadata from the SR using highdicom,
+    and creates a table node.
     """
 
     # We use the SeriesNumber and the SeriesDescription of the SR to name the table
@@ -763,67 +746,67 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     referenced_series_instance_uid = str(sr.CurrentRequestedProcedureEvidenceSequence[0].ReferencedSeriesSequence[0].SeriesInstanceUID)
 
     # will store the info needed for table too.
-    line_infos = [] 
+    line_infos = []
 
-    # First get the planar roi measurement groups 
+    # First get the planar roi measurement groups
     groups = sr.content.get_planar_roi_measurement_groups(
         reference_type=self.getSRCode("Image Region"),
-        graphic_type=hd.sr.GraphicTypeValues.POLYLINE, 
-      )  
+        graphic_type=hd.sr.GraphicTypeValues.POLYLINE,
+      )
 
-    for group in groups: 
+    for group in groups:
 
-      # Get the tracking ids 
+      # Get the tracking ids
       tracking_identifier = group.tracking_identifier
       tracking_uid = group.tracking_uid
 
-      # Get the findings and finding_sites 
+      # Get the findings and finding_sites
       finding_type = [group.finding_type.CodeValue, group.finding_type.CodingSchemeDesignator, group.finding_type.CodeMeaning]
       finding_sites = []
       for finding_site in group.finding_sites:
-        finding_sites.append([finding_site.value.CodeValue, 
-                              finding_site.value.CodingSchemeDesignator, 
+        finding_sites.append([finding_site.value.CodeValue,
+                              finding_site.value.CodingSchemeDesignator,
                               finding_site.value.CodeMeaning])
-      
-      # Get the reference 
+
+      # Get the reference
       referenced_sop_instance_uid = group.roi.ContentSequence[0].referenced_sop_instance_uid
-      # Get the polyline 
+      # Get the polyline
       polyline = group.roi.value
-      # get the points 
+      # get the points
       num_points = np.int32(len(polyline))
-      point_line = [] 
-      for n in range(0,num_points): 
+      point_line = []
+      for n in range(0,num_points):
         pointx = polyline[n,0] # pixel coord space
         pointy = polyline[n,1] # pixel coord space
         pointz = self.getIPPFromSOP(referenced_sop_instance_uid,
-                                    referenced_series_instance_uid)[2] # mm space 
+                                    referenced_series_instance_uid)[2] # mm space
         point_line.append([pointx, pointy, pointz])
       # append to poly_infos
       line_infos.append({
-                        "TrackingIdentifier": tracking_identifier, 
+                        "TrackingIdentifier": tracking_identifier,
                         "TrackingUID" : tracking_uid,
-                        "SOPInstanceUID" : referenced_sop_instance_uid, 
-                        "FindingType": finding_type, 
+                        "SOPInstanceUID" : referenced_sop_instance_uid,
+                        "FindingType": finding_type,
                         "FindingSite": finding_sites,
-                        "polyline": point_line
+                        "polyline": point_line,
                         })
-      
+
     tableNode = self.createPolylineTable(line_infos, table_name)
 
-    return line_infos, tableNode 
-   
+    return line_infos, tableNode
+
   def create_2d_roi(self, loadable, center_ras, width, height, slice_normal=(0, 0, 1), thickness=1.0, bbox_name="2D_BoundingBox"):
     """
     Create a Markups ROI as a thin 2D bounding box on a specified slice plane.
-    
+
     Args:
-        loadable             - loadable of the corresponding SR 
+        loadable             - loadable of the corresponding SR
         center_ras (tuple)   - (x, y, z) center in RAS coordinates.
         width (float)        - Width of the box (in mm).
         height (float)       - Height of the box (in mm).
         slice_normal (tuple) - Normal vector of the slice plane (e.g., (0,0,1) for axial).
         thickness (float)    - Depth of the box (in mm), small for a 2D box.
-    
+
     Returns:
         vtkMRMLMarkupsROINode - The ROI node created.
     """
@@ -831,17 +814,17 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     roi_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsROINode", bbox_name)
     # Do not lock the node
     roi_node.SetLocked(False)
-    
+
     # Set the size (width, height, thickness)
     size = [width, height, thickness]
     roi_node.SetSize(size)
-    
+
     # Set the center position
     roi_node.SetCenter(center_ras)
-    
+
     # Align ROI orientation to slice normal
     transform_matrix = vtk.vtkMatrix4x4()
-    
+
     # Build a local coordinate system with normal as Z
     z = np.array(slice_normal)
     z = z / np.linalg.norm(z)
@@ -857,44 +840,42 @@ class DICOMTID1500PluginClass(DICOMPlugin):
         transform_matrix.SetElement(i, 2, z[i])
         transform_matrix.SetElement(i, 3, center_ras[i])
     roi_node.SetAndObserveObjectToNodeMatrix(transform_matrix)
-    
+
     display_node = roi_node.GetDisplayNode()
     if (display_node):
       # Change size of glyph
       display_node.SetGlyphScale(1.3)
-      # Change size of interaction handles 
+      # Change size of interaction handles
       display_node.SetInteractionHandleScale(1)
-      # Reduce the opacity of the box 
+      # Reduce the opacity of the box
       display_node.SetFillOpacity(0)
 
     roi_node.GetDisplayNode().SetHandlesInteractive(False)
     for controlPointIndex in range(roi_node.GetNumberOfControlPoints()):
       roi_node.SetNthControlPointLocked(controlPointIndex, True)
-    
-    return roi_node 
 
-  def displayBboxMarkups(self, sr, loadable, poly_infos): 
-    """
-    Displays the bounding box markups. 
-    """
+    return roi_node
+
+  def displayBboxMarkups(self, sr, loadable, poly_infos):
+    """Displays the bounding box markups."""
 
     # Get the subject hierarchy
     shNode = slicer.modules.subjecthierarchy.logic().GetSubjectHierarchyNode()
 
-    # We use the SeriesNumber and the SeriesDescription of the SR to name the folder 
+    # We use the SeriesNumber and the SeriesDescription of the SR to name the folder
     SeriesNumber = sr.SeriesNumber
     SeriesDescription = sr.SeriesDescription
 
     # We get the StudyInstanceUID for creating nodes in the subject hierarchy
-    StudyInstanceUID = sr.StudyInstanceUID 
+    StudyInstanceUID = sr.StudyInstanceUID
 
-    # Get the studyNode 
+    # Get the studyNode
     studyNode = shNode.GetItemByUID(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMUIDName(), StudyInstanceUID)
-    # Now create the folder and set the name 
-    bboxFolderID = shNode.CreateFolderItem(studyNode, str(SeriesNumber) + ': ' + SeriesDescription)
+    # Now create the folder and set the name
+    bboxFolderID = shNode.CreateFolderItem(studyNode, str(SeriesNumber) + ": " + SeriesDescription)
 
-    # Order by IPP2 
-    poly_infos = sorted(poly_infos, key=lambda x: x['center_z'])
+    # Order by IPP2
+    poly_infos = sorted(poly_infos, key=lambda x: x["center_z"])
 
     # We need the pixel spacing, in order to convert the coordinates from pixel space to mm space
     referenced_series_instance_uid = str(sr.CurrentRequestedProcedureEvidenceSequence[0].ReferencedSeriesSequence[0].SeriesInstanceUID)
@@ -907,121 +888,115 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     num_columns = np.float32(db.fileValue(fileList[0], self.tags["Columns"]))
 
     for i,p in enumerate(poly_infos):
-      # get values 
-      polyline = p['polyline']
-      tracking_identifier = p['TrackingIdentifier']
-      width = p['width'] # in pixel coord
-      height = p['height'] # in pixel coord
-      center_x = p['center_x'] # in pixel coord
-      center_y = p['center_y'] # in pixel coord
-      center_z = p['center_z'] # in mm 
-      # convert pixel coordinates to mm 
-      referenced_sop_instance_uid = p['SOPInstanceUID']
-      ipp = self.getIPPFromSOP(referenced_sop_instance_uid, 
+      # get values
+      polyline = p["polyline"]
+      tracking_identifier = p["TrackingIdentifier"]
+      width = p["width"] # in pixel coord
+      height = p["height"] # in pixel coord
+      center_x = p["center_x"] # in pixel coord
+      center_y = p["center_y"] # in pixel coord
+      center_z = p["center_z"] # in mm
+      # convert pixel coordinates to mm
+      referenced_sop_instance_uid = p["SOPInstanceUID"]
+      ipp = self.getIPPFromSOP(referenced_sop_instance_uid,
                                referenced_series_instance_uid)
-      ipp_0 = ipp[0] 
-      ipp_1 = ipp[1] 
+      ipp_0 = ipp[0]
+      ipp_1 = ipp[1]
       center_x_mm = -((center_x * pixel_spacing_x) + ipp_0)
       center_y_mm = -((center_y * pixel_spacing_y) + ipp_1)
       center_ras = np.asarray([center_x_mm, center_y_mm, center_z])
       width_mm = width * pixel_spacing_x
       height_mm = height * pixel_spacing_y
-      bbox_name = tracking_identifier # for now 
-      # create roi 
-      bboxNode = self.create_2d_roi(loadable, center_ras, width_mm, height_mm, slice_normal=(0, 0, 1), thickness=0.01, bbox_name=bbox_name) 
+      bbox_name = tracking_identifier # for now
+      # create roi
+      bboxNode = self.create_2d_roi(loadable, center_ras, width_mm, height_mm, slice_normal=(0, 0, 1), thickness=0.01, bbox_name=bbox_name)
       markupItemID = shNode.GetItemByDataNode(bboxNode)
       # Set the parent to the folder
       shNode.SetItemParent(markupItemID, bboxFolderID)
       if (i==0):
         slicer.modules.markups.logic().JumpSlicesToLocation(center_x_mm, center_y_mm, center_z, True)
 
-    return 
-  
-  
-  def create_3d_point(self, loadable, point_index, point_x, point_y, point_z, point_text): 
-    """
-    Create the point markup 
-    """
+    return
+
+
+  def create_3d_point(self, loadable, point_index, point_x, point_y, point_z, point_text):
+    """Create the point markup"""
 
     markupsNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", point_text)
     markupsNode.CreateDefaultDisplayNodes()
-    # if markupsNode.SetLocked(True) - cannot move, edit, or delete points, but also cannot jump between control points. 
-    # if markupsNode.SetLocked(False) - can move, edit, delete and jump between control points. 
-    markupsNode.SetLocked(False) 
+    # if markupsNode.SetLocked(True) - cannot move, edit, or delete points, but also cannot jump between control points.
+    # if markupsNode.SetLocked(False) - can move, edit, delete and jump between control points.
+    markupsNode.SetLocked(False)
     markupsNode.AddControlPoint([point_x, point_y, point_z])
     markupsNode.SetName(point_text)
     markupsNode.SetNthControlPointLabel(point_index, point_text)
 
-    # Make sure control points are locked and cannot be moved 
+    # Make sure control points are locked and cannot be moved
     markupsNode.GetDisplayNode().SetHandlesInteractive(False)
     for controlPointIndex in range(markupsNode.GetNumberOfControlPoints()):
       markupsNode.SetNthControlPointLocked(controlPointIndex, True)
 
     return markupsNode
-  
-  def displayPointMarkups(self, sr, loadable, point_infos): 
-    """
-    Display the point markups. 
-    """
+
+  def displayPointMarkups(self, sr, loadable, point_infos):
+    """Display the point markups."""
 
     # Get the subject hierarchy
     shNode = slicer.modules.subjecthierarchy.logic().GetSubjectHierarchyNode()
 
-    # We use the SeriesNumber and the SeriesDescription of the SR to name the folder 
-    SeriesNumber = sr.SeriesNumber 
+    # We use the SeriesNumber and the SeriesDescription of the SR to name the folder
+    SeriesNumber = sr.SeriesNumber
     SeriesDescription = sr.SeriesDescription
 
     # We get the StudyInstanceUID for creating nodes in the subject hierarchy
-    StudyInstanceUID = sr.StudyInstanceUID 
+    StudyInstanceUID = sr.StudyInstanceUID
 
-    # Get the studyNode 
+    # Get the studyNode
     studyNode = shNode.GetItemByUID(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMUIDName(), StudyInstanceUID)
-    # Now create the folder and set the name 
-    pointsFolderID = shNode.CreateFolderItem(studyNode, str(SeriesNumber) + ': ' + SeriesDescription)
+    # Now create the folder and set the name
+    pointsFolderID = shNode.CreateFolderItem(studyNode, str(SeriesNumber) + ": " + SeriesDescription)
 
     for i,p in enumerate(point_infos):
-      point_text = p['TrackingIdentifier']
-      point_x = -p['point'][0]
-      point_y = -p['point'][1] 
-      point_z = p['point'][2]
-      # index should always be 0. not i. 
+      point_text = p["TrackingIdentifier"]
+      point_x = -p["point"][0]
+      point_y = -p["point"][1]
+      point_z = p["point"][2]
+      # index should always be 0. not i.
       pointsNode = self.create_3d_point(loadable, 0, point_x, point_y, point_z, point_text)
-      # change size of glyph 
-      display_node = pointsNode.GetDisplayNode() 
+      # change size of glyph
+      display_node = pointsNode.GetDisplayNode()
       if (display_node):
         display_node.SetGlyphScale(0.75)
 
       markupItemID = shNode.GetItemByDataNode(pointsNode)
       # Set the parent to the folder
       shNode.SetItemParent(markupItemID, pointsFolderID)
-      # jump to the first point 
+      # jump to the first point
       if (i==0):
         slicer.modules.markups.logic().JumpSlicesToLocation(point_x, point_y, point_z, True)
-    
-    return 
-  
+
+    return
+
   def displayLineMarkups(self, sr, loadable, line_infos):
-    """
-    Display the line markups. 
-    """
+    """Display the line markups."""
 
     # Get the subject hierarchy
     shNode = slicer.modules.subjecthierarchy.logic().GetSubjectHierarchyNode()
 
-    # We use the SeriesNumber and the SeriesDescription of the SR to name the folder 
-    SeriesNumber = sr.SeriesNumber 
+    # We use the SeriesNumber and the SeriesDescription of the SR to name the folder
+    SeriesNumber = sr.SeriesNumber
     SeriesDescription = sr.SeriesDescription
 
     # We get the StudyInstanceUID for creating nodes in the subject hierarchy
-    StudyInstanceUID = sr.StudyInstanceUID 
+    StudyInstanceUID = sr.StudyInstanceUID
 
-    # Get the studyNode 
+    # Get the studyNode
     studyNode = shNode.GetItemByUID(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMUIDName(), StudyInstanceUID)
-    # Now create the folder and set the name 
-    linesFolderID = shNode.CreateFolderItem(studyNode, str(SeriesNumber) + ': ' + SeriesDescription)
+    # Now create the folder and set the name
+    linesFolderID = shNode.CreateFolderItem(studyNode, str(SeriesNumber) + ": " + SeriesDescription)
 
-    # Get the referenced series instance uid 
-    # Needed for later getting the IPP 
+    # Get the referenced series instance uid
+    # Needed for later getting the IPP
     referenced_series_instance_uid = str(sr.CurrentRequestedProcedureEvidenceSequence[0].ReferencedSeriesSequence[0].SeriesInstanceUID)
     db = slicer.dicomDatabase
     fileList = db.filesForSeries(referenced_series_instance_uid)
@@ -1029,38 +1004,38 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     pixel_spacing_x = np.float32(pixel_spacing.split("\\")[0])
     pixel_spacing_y = np.float32(pixel_spacing.split("\\")[1])
 
-    # Create all the line nodes 
+    # Create all the line nodes
     for i,p in enumerate(line_infos):
-      line_text = p['TrackingIdentifier']
-      polyline = p['polyline']
-      # add new node 
+      line_text = p["TrackingIdentifier"]
+      polyline = p["polyline"]
+      # add new node
       lineNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode", line_text)
       # Do not lock node
       lineNode.SetLocked(False)
-      # get number of points 
+      # get number of points
       num_points = len(polyline)
-      # add each as a control point 
-      for n in range(0,num_points): 
-        point_x = polyline[n][0] # pixel coord space 
+      # add each as a control point
+      for n in range(0,num_points):
+        point_x = polyline[n][0] # pixel coord space
         point_y = polyline[n][1] # pixel coord space
-        # convert pixel coordinates to mm 
-        referenced_sop_instance_uid = p['SOPInstanceUID']
-        ipp = self.getIPPFromSOP(referenced_sop_instance_uid, 
+        # convert pixel coordinates to mm
+        referenced_sop_instance_uid = p["SOPInstanceUID"]
+        ipp = self.getIPPFromSOP(referenced_sop_instance_uid,
                                  referenced_series_instance_uid)
-        ipp_0 = ipp[0] 
-        ipp_1 = ipp[1] 
+        ipp_0 = ipp[0]
+        ipp_1 = ipp[1]
         point_x_mm = -((point_x * pixel_spacing_x) + ipp_0)
         point_y_mm = -((point_y * pixel_spacing_y) + ipp_1)
         point_z = polyline[n][2]
         lineNode.AddControlPoint(point_x_mm, point_y_mm, point_z)
-        # jump to the first line 
+        # jump to the first line
         if (i==0 and n==0):
           slicer.modules.markups.logic().JumpSlicesToLocation(point_x_mm, point_y_mm, point_z, True)
-      # do not display the length measurement 
-      lineNode.GetMeasurement('length').SetEnabled(False)
-      # change size of glyph 
-      display_node = lineNode.GetDisplayNode() 
-      # lock the display 
+      # do not display the length measurement
+      lineNode.GetMeasurement("length").SetEnabled(False)
+      # change size of glyph
+      display_node = lineNode.GetDisplayNode()
+      # lock the display
       lineNode.GetDisplayNode().SetHandlesInteractive(False)
       for controlPointIndex in range(lineNode.GetNumberOfControlPoints()):
           lineNode.SetNthControlPointLocked(controlPointIndex, True)
@@ -1073,14 +1048,12 @@ class DICOMTID1500PluginClass(DICOMPlugin):
       # Set the parent to the folder
       shNode.SetItemParent(markupItemID, linesFolderID)
 
-    return 
-  
-  def load(self, loadable):
-    """
-    Loads the SR and checks for planar annotations. 
-    """
+    return
 
-    logging.debug('DICOM SR TID1500 load()')
+  def load(self, loadable):
+    """Loads the SR and checks for planar annotations."""
+
+    logging.debug("DICOM SR TID1500 load()")
 
     logging.debug("before sorting: %s" % loadable.uids)
     sortedUIDs = self.sortReportsByDateTime(loadable.uids)
@@ -1091,26 +1064,26 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     # referencedSeriesUID from the image series, but load using the RWVM plugin
     segPlugin = slicer.modules.dicomPlugins["DICOMSegmentationPlugin"]()
 
-    ### Iterate over the uids ### 
+    ### Iterate over the uids ###
     for idx, uid in enumerate(sortedUIDs):
 
-      # Get SR filename 
+      # Get SR filename
       srFileName = slicer.dicomDatabase.fileForInstance(uid)
       if srFileName is None:
-        logging.debug('Failed to get the filename from the DICOM database for ', uid)
+        logging.debug("Failed to get the filename from the DICOM database for %s", uid)
         return False
-      
+
       # Read the SR once
       sr = hd.sr.srread(srFileName)
-        
+
       # Check if the plugin (tid1500reader) should be used or specialized highdicom code
-      # to read the planar annotations 
-      # sets the self.containsPlanarAnnotations = True or False 
-      containsPlanarAnnotations = self.containsPlanarAnnotations(sr) 
-      logging.info('containsPlanarAnnotations: ' + str(containsPlanarAnnotations))
+      # to read the planar annotations
+      # sets the self.containsPlanarAnnotations = True or False
+      containsPlanarAnnotations = self.containsPlanarAnnotations(sr)
+      logging.info("containsPlanarAnnotations: " + str(containsPlanarAnnotations))
 
       ### If it does not contain planar annotations ###
-      if not containsPlanarAnnotations: 
+      if not containsPlanarAnnotations:
 
         tables = []
 
@@ -1138,25 +1111,25 @@ class DICOMTID1500PluginClass(DICOMPlugin):
           }
 
         result = subprocess.run(
-            [self._dcmqi_binary('tid1500reader'),
-             '--inputDICOM', param['inputSRFileName'],
-             '--outputMetadata', param['metaDataFileName']],
-            capture_output=True, text=True)
+            [self._dcmqi_binary("tid1500reader"),
+             "--inputDICOM", param["inputSRFileName"],
+             "--outputMetadata", param["metaDataFileName"]],
+            capture_output=True, text=True, check=False)
         if result.returncode != 0:
-          logging.debug('tid1500reader failed, unable to load DICOM SR TID1500:\n' + result.stderr)
+          logging.debug("tid1500reader failed, unable to load DICOM SR TID1500:\n" + result.stderr)
           self.cleanup()
           return False
 
         table = self.metadata2vtkTableNode(outputFile)
         if table:
           self.addSeriesInSubjectHierarchy(loadable, table)
-          with open(outputFile, 'r') as srMetadataFile:
+          with open(outputFile) as srMetadataFile:
             srMetadataJSON = json.loads(srMetadataFile.read())
             table.SetName(srMetadataJSON["SeriesDescription"])
 
           # TODO: think about the following...
-          if len(slicer.util.getNodesByClass('vtkMRMLSegmentationNode')) > 0:
-            segmentationNode = slicer.util.getNodesByClass('vtkMRMLSegmentationNode')[-1]
+          if len(slicer.util.getNodesByClass("vtkMRMLSegmentationNode")) > 0:
+            segmentationNode = slicer.util.getNodesByClass("vtkMRMLSegmentationNode")[-1]
             segmentationNodeID = segmentationNode.GetID()
             table.SetAttribute("ReferencedSegmentationNodeID", segmentationNodeID)
 
@@ -1174,36 +1147,36 @@ class DICOMTID1500PluginClass(DICOMPlugin):
         self.cleanup()
 
       ### If it does contains planar annotations - use highdicom code to read the SR ###
-      else: 
+      else:
 
-        # check if contains a point, bbox, polyline 
-        checkIfSRContainsBbox = self.checkIfSRContainsGeometry(sr, geometry_type='bbox2D')
-        checkIfSRContains3DPoint = self.checkIfSRContainsGeometry(sr, geometry_type='point3D')
-        checkIfSRContainsPolyline = self.checkIfSRContainsGeometry(sr, geometry_type='polyline2D')
+        # check if contains a point, bbox, polyline
+        checkIfSRContainsBbox = self.checkIfSRContainsGeometry(sr, geometry_type="bbox2D")
+        checkIfSRContains3DPoint = self.checkIfSRContainsGeometry(sr, geometry_type="point3D")
+        checkIfSRContainsPolyline = self.checkIfSRContainsGeometry(sr, geometry_type="polyline2D")
 
-        tables = [] 
+        tables = []
 
-        # if bbox 
-        if (checkIfSRContainsBbox): 
-          logging.info('SR contains 2D bounding box')
+        # if bbox
+        if (checkIfSRContainsBbox):
+          logging.info("SR contains 2D bounding box")
           bboxInfo, bboxTableNode = self.extractBboxMetadataToVtkTableNode(sr)
           self.showTable(bboxTableNode)
           self.addSeriesInSubjectHierarchy(loadable, bboxTableNode)
           self.displayBboxMarkups(sr, loadable, bboxInfo)
           tables.append(bboxTableNode)
-          
-        # if point 
+
+        # if point
         if (checkIfSRContains3DPoint):
-            logging.info('SR contains 3D point')
+            logging.info("SR contains 3D point")
             pointInfo, pointTableNode = self.extractPointMetadataToVtkTableNode(sr)
             self.showTable(pointTableNode)
             self.addSeriesInSubjectHierarchy(loadable, pointTableNode)
             self.displayPointMarkups(sr, loadable, pointInfo)
             tables.append(pointTableNode)
 
-        # if polyline but not bbox 
+        # if polyline but not bbox
         if (checkIfSRContainsPolyline and not checkIfSRContainsBbox):
-            logging.info('SR contains a 2D polyline, but not a bbox')
+            logging.info("SR contains a 2D polyline, but not a bbox")
             lineInfo, lineTableNode = self.extractLineMetadataToVtkTableNode(sr)
             self.showTable(lineTableNode)
             self.addSeriesInSubjectHierarchy(loadable, lineTableNode)
@@ -1319,7 +1292,7 @@ class DICOMTID1500PluginClass(DICOMPlugin):
       else:
         description = measurementItem["quantity"]["CodeMeaning"]
 
-      crntInfo["name"] = "%s [%s]" % (description, unit.replace("[", "").replace("]", ""))
+      crntInfo["name"] = "{} [{}]".format(description, unit.replace("[", "").replace("]", ""))
       crntInfo["description"] = description
 
       infoItems.append(crntInfo)
@@ -1332,7 +1305,7 @@ class DICOMTID1500PluginClass(DICOMPlugin):
 
     for i in reversed(range(len(names))):
       item = names[i]
-      if item in counts and counts[item]:
+      if counts.get(item):
         nameListCopy[i] += " (%s)" % str(counts[item])
         counts[item] -= 1
 
@@ -1357,52 +1330,52 @@ class DICOMTID1500PluginClass(DICOMPlugin):
 
     contents = {}
     measurements = []
-    contents['measurements'] = measurements
+    contents["measurements"] = measurements
     for item in sr.ContentSequence:
       if self.isConcept(item, "personObserver"):
-        contents['personObserver'] = item.PersonName
+        contents["personObserver"] = item.PersonName
       if self.isConcept(item, "imagingMeasurements"):
         for contentItem in item.ContentSequence:
           if self.isConcept(contentItem, "measurementGroup"):
             measurement = {}
             for measurementItem in contentItem.ContentSequence:
               if self.isConcept(measurementItem, "trackingIdentifier"):
-                measurement['trackingIdentifier'] = measurementItem.TextValue
+                measurement["trackingIdentifier"] = measurementItem.TextValue
               if self.isConcept(measurementItem, "trackingUniqueIdentifier"):
-                measurement['trackingUniqueIdentifier'] = measurementItem.UID
+                measurement["trackingUniqueIdentifier"] = measurementItem.UID
               if self.isConcept(measurementItem, "findingSite"):
-                measurement['findingSite'] = measurementItem.ConceptCodeSequence[0].CodeMeaning
+                measurement["findingSite"] = measurementItem.ConceptCodeSequence[0].CodeMeaning
               if self.isConcept(measurementItem, "length"):
                 for lengthItem in measurementItem.ContentSequence:
-                  measurement['polyline'] = lengthItem.GraphicData
+                  measurement["polyline"] = lengthItem.GraphicData
                   for selectionItem in lengthItem.ContentSequence:
                     if selectionItem.RelationshipType == "SELECTED FROM":
                       for reference in selectionItem.ReferencedSOPSequence:
-                        measurement['referencedSOPInstanceUID'] = reference.ReferencedSOPInstanceUID
+                        measurement["referencedSOPInstanceUID"] = reference.ReferencedSOPInstanceUID
                         if hasattr(reference, "ReferencedFrameNumber") and reference.ReferencedFrameNumber != "1":
-                          print('Error - only single frame references supported')
+                          print("Error - only single frame references supported")
             measurements.append(measurement)
 
-    for measurement in contents['measurements']:
-      if not 'polyline' in measurement:
+    for measurement in contents["measurements"]:
+      if not "polyline" in measurement:
         # only polyline measurements are loaded as nodes
         continue
 
       markupsNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode")
-      markupsNode.SetName(str(contents['personObserver']))
+      markupsNode.SetName(str(contents["personObserver"]))
       self.addSeriesInSubjectHierarchy(loadable, markupsNode)
 
       # Instead of calling markupsNode.SetLocked(True), lock each control point.
       # This allows interacting with the points but not change their position.
       slicer.modules.markups.logic().SetAllMarkupsLocked(markupsNode, True)
 
-      colorIndex = 1 + slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLMarkupsLineNode')
+      colorIndex = 1 + slicer.mrmlScene.GetNumberOfNodesByClass("vtkMRMLMarkupsLineNode")
       colorNode = slicer.mrmlScene.GetNodeByID("vtkMRMLColorTableNodeFileGenericAnatomyColors.txt")
       color = numpy.zeros(4)
       colorNode.GetColor(colorIndex, color)
       markupsNode.GetDisplayNode().SetSelectedColor(*color[:3])
 
-      referenceFilePath = slicer.dicomDatabase.fileForInstance(measurement['referencedSOPInstanceUID'])
+      referenceFilePath = slicer.dicomDatabase.fileForInstance(measurement["referencedSOPInstanceUID"])
       if not referenceFilePath:
         raise Exception(f"Referenced image is not found in the database (referencedSOPInstanceUID={measurement['referencedSOPInstanceUID']}). Polyline point positions cannot be determined in 3D.")
 
@@ -1412,7 +1385,7 @@ class DICOMTID1500PluginClass(DICOMPlugin):
       alongRowVector = numpy.array(reference.ImageOrientationPatient[3:])
       alongColumnVector *= reference.PixelSpacing[1]
       alongRowVector *= reference.PixelSpacing[0]
-      col1,row1,col2,row2 = measurement['polyline']
+      col1,row1,col2,row2 = measurement["polyline"]
       lpsToRAS = numpy.array([-1,-1,1])
       p1 = (origin + col1 * alongColumnVector + row1 * alongRowVector) * lpsToRAS
       p2 = (origin + col2 * alongColumnVector + row2 * alongRowVector) * lpsToRAS
@@ -1422,7 +1395,7 @@ class DICOMTID1500PluginClass(DICOMPlugin):
 class DICOMLongitudinalTID1500PluginClass(DICOMTID1500PluginClass):
 
   def __init__(self):
-    super(DICOMLongitudinalTID1500PluginClass, self).__init__()
+    super().__init__()
     self.loadType = "Longitudinal DICOM Structured Report TID1500"
 
   def examineFiles(self, files):
@@ -1443,7 +1416,7 @@ class DICOMLongitudinalTID1500PluginClass(DICOMTID1500PluginClass):
           loadable = self.createLoadableAndAddReferences(allDatasets)
           loadable.files = [cFile]+otherSRFiles
           seriesDescription = self.getDICOMValue(dataset, "SeriesDescription", "Unknown")
-          loadable.name = seriesDescription + ' - as a Longitudinal DICOM SR TID1500 object'
+          loadable.name = seriesDescription + " - as a Longitudinal DICOM SR TID1500 object"
           loadable.tooltip = loadable.name
           loadable.selected = True
           loadable.confidence = 0.96
@@ -1454,7 +1427,7 @@ class DICOMLongitudinalTID1500PluginClass(DICOMTID1500PluginClass):
 
           loadables.append(loadable)
 
-          logging.debug('DICOM SR Longitudinal TID1500 modality found')
+          logging.debug("DICOM SR Longitudinal TID1500 modality found")
 
     return loadables
 
@@ -1489,6 +1462,7 @@ class DICOMTID1500Plugin:
   This class is the 'hook' for slicer to detect and recognize the plugin
   as a loadable scripted module
   """
+
   def __init__(self, parent):
     parent.title = "DICOM SR TID1500 Object Import Plugin"
     parent.categories = ["Developer Tools.DICOM Plugins"]
@@ -1497,7 +1471,7 @@ class DICOMTID1500Plugin:
     Plugin to the DICOM Module to parse and load DICOM SR TID1500 instances.
     No module interface here, only in the DICOM module
     """
-    parent.dependencies = ['DICOM', 'Colors']
+    parent.dependencies = ["DICOM", "Colors"]
     parent.acknowledgementText = """
     This DICOM Plugin was developed by
     Christian Herz and Andrey Fedorov, BWH.
@@ -1511,5 +1485,5 @@ class DICOMTID1500Plugin:
       slicer.modules.dicomPlugins
     except AttributeError:
       slicer.modules.dicomPlugins = {}
-    slicer.modules.dicomPlugins['DICOMTID1500Plugin'] = DICOMTID1500PluginClass
+    slicer.modules.dicomPlugins["DICOMTID1500Plugin"] = DICOMTID1500PluginClass
     # slicer.modules.dicomPlugins['DICOMLongitudinalTID1500Plugin'] = DICOMLongitudinalTID1500PluginClass

--- a/Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py
@@ -637,7 +637,7 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     # will store the info needed for table too. 
     poly_infos = [] 
 
-    # First get the planar roi measurement gorups 
+    # First get the planar roi measurement groups 
     groups = sr.content.get_planar_roi_measurement_groups()
 
     for group in groups: 
@@ -791,7 +791,7 @@ class DICOMTID1500PluginClass(DICOMPlugin):
     # will store the info needed for table too. 
     line_infos = [] 
 
-    # First get the planar roi measurement gorups 
+    # First get the planar roi measurement groups 
     groups = sr.content.get_planar_roi_measurement_groups(
         reference_type=self.getSRCode("Image Region"),
         graphic_type=hd.sr.GraphicTypeValues.POLYLINE, 
@@ -1086,7 +1086,7 @@ class DICOMTID1500PluginClass(DICOMPlugin):
       lineNode.GetMeasurement('length').SetEnabled(False)
       # change size of glyph 
       display_node = lineNode.GetDisplayNode() 
-      # lock the dispay 
+      # lock the display 
       lineNode.GetDisplayNode().SetHandlesInteractive(False)
       for controlPointIndex in range(lineNode.GetNumberOfControlPoints()):
           lineNode.SetNthControlPointLocked(controlPointIndex, True)
@@ -1166,8 +1166,8 @@ class DICOMTID1500PluginClass(DICOMPlugin):
 
         result = subprocess.run(
             [self._dcmqi_binary('tid1500reader'),
-             '--inputSRFileName', param['inputSRFileName'],
-             '--metaDataFileName', param['metaDataFileName']],
+             '--inputDICOM', param['inputSRFileName'],
+             '--outputMetadata', param['metaDataFileName']],
             capture_output=True, text=True)
         if result.returncode != 0:
           logging.debug('tid1500reader failed, unable to load DICOM SR TID1500:\n' + result.stderr)

--- a/Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py
@@ -1204,7 +1204,7 @@ class DICOMTID1500PluginClass(DICOMPlugin):
         trackingUID = measurement[tagName]
         segment = segments[idx]
         segment.SetTag(tagName, trackingUID)
-        logging.debug("Setting tag '{}' to {} for segment with name {}".format(tagName, trackingUID, segment.GetName()))
+        logging.debug(f"Setting tag '{tagName}' to {trackingUID} for segment with name {segment.GetName()}")
 
   def determineAndApplyRWVMToReferencedSeries(self, loadable, segLoadable):
     rwvmUID = loadable.ReferencedRWVMSeriesInstanceUIDs[0]

--- a/Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py
@@ -6,7 +6,6 @@ import vtk
 import datetime
 from collections import Counter
 
-import numpy
 import numpy as np
 import highdicom as hd
 import pydicom
@@ -1371,7 +1370,7 @@ class DICOMTID1500PluginClass(DICOMPlugin):
 
       colorIndex = 1 + slicer.mrmlScene.GetNumberOfNodesByClass("vtkMRMLMarkupsLineNode")
       colorNode = slicer.mrmlScene.GetNodeByID("vtkMRMLColorTableNodeFileGenericAnatomyColors.txt")
-      color = numpy.zeros(4)
+      color = np.zeros(4)
       colorNode.GetColor(colorIndex, color)
       markupsNode.GetDisplayNode().SetSelectedColor(*color[:3])
 
@@ -1380,13 +1379,13 @@ class DICOMTID1500PluginClass(DICOMPlugin):
         raise Exception(f"Referenced image is not found in the database (referencedSOPInstanceUID={measurement['referencedSOPInstanceUID']}). Polyline point positions cannot be determined in 3D.")
 
       reference = pydicom.dcmread(referenceFilePath)
-      origin = numpy.array(reference.ImagePositionPatient)
-      alongColumnVector = numpy.array(reference.ImageOrientationPatient[:3])
-      alongRowVector = numpy.array(reference.ImageOrientationPatient[3:])
+      origin = np.array(reference.ImagePositionPatient)
+      alongColumnVector = np.array(reference.ImageOrientationPatient[:3])
+      alongRowVector = np.array(reference.ImageOrientationPatient[3:])
       alongColumnVector *= reference.PixelSpacing[1]
       alongRowVector *= reference.PixelSpacing[0]
       col1,row1,col2,row2 = measurement["polyline"]
-      lpsToRAS = numpy.array([-1,-1,1])
+      lpsToRAS = np.array([-1,-1,1])
       p1 = (origin + col1 * alongColumnVector + row1 * alongRowVector) * lpsToRAS
       p2 = (origin + col2 * alongColumnVector + row2 * alongRowVector) * lpsToRAS
       markupsNode.AddControlPoint(vtk.vtkVector3d(p1))

--- a/Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py
@@ -1,0 +1,1545 @@
+import json
+import logging
+import os
+import subprocess
+import vtk
+import datetime
+from collections import Counter
+
+import numpy
+import numpy as np
+import random
+import pydicom
+from pydicom.sr.codedict import codes
+
+import slicer
+from DICOMLib import DICOMLoadable, DICOMPlugin
+
+
+class DICOMTID1500PluginClass(DICOMPlugin):
+
+  UID_EnhancedSRStorage = pydicom.uid.EnhancedSRStorage
+  UID_ComprehensiveSRStorage = pydicom.uid.ComprehensiveSRStorage
+  UID_Comprehensive3DSRStorage = pydicom.uid.Comprehensive3DSRStorage
+  UID_SegmentationStorage = pydicom.uid.SegmentationStorage
+  UID_RealWorldValueMappingStorage = pydicom.uid.RealWorldValueMappingStorage
+
+  def __init__(self):
+    super(DICOMTID1500PluginClass, self).__init__()
+    self.loadType = "DICOM Structured Report TID1500"
+
+    self.codings = {
+      "imagingMeasurementReport": { "scheme": "DCM", "value": "126000" },
+      "personObserver": { "scheme": "DCM", "value": "121008" },
+      "imagingMeasurements": { "scheme": "DCM", "value": "126010" },
+      "measurementGroup": { "scheme": "DCM", "value": "125007" },
+      "trackingIdentifier": { "scheme": "DCM", "value": "112039" },
+      "trackingUniqueIdentifier": { "scheme": "DCM", "value": "112040" },
+      "findingSite": { "scheme": "SRT", "value": "G-C0E3" },
+      "length": { "scheme": "SRT", "value": "G-D7FE" },
+    }
+
+    self.tags = {} 
+    self.tags["PatientID"] = "0010,0020"
+    self.tags["StudyDate"] = "0008,0020"
+    self.tags["StudyInstanceUID"] = "0020,000D"
+    self.tags["SeriesInstanceUID"] = "0020,000E"
+    self.tags["SeriesNumber"] = "0020,0011"
+    self.tags["SeriesDescription"] = "0008,103E"
+    self.tags["SOPInstanceUID"] = "0008,0018"
+    self.tags["ReferencedSeriesSequence"] = "0008,1115"
+    self.tags["Modality"] = "0008,0060"
+    self.tags["FrameOfReferenceUID"] = "0020,0052"
+    self.tags["PixelSpacing"] = "0028,0030"
+    self.tags["Rows"] = "0028,0010"
+    self.tags["Columns"] = "0028,0011"
+
+  def getDICOMValue(self, dataset, attribute, default=""):
+    """Get an attribute value from a pydicom Dataset, returning default if not present."""
+    try:
+      return getattr(dataset, attribute)
+    except AttributeError:
+      return default
+
+  def examineFiles(self, files):
+
+    import pydicom
+    loadables = []
+
+    for cFile in files:
+      dataset = pydicom.dcmread(cFile)
+
+      uid = self.getDICOMValue(dataset, "SOPInstanceUID")
+      if uid == "":
+        return []
+
+      seriesDescription = self.getDICOMValue(dataset, "SeriesDescription", "Unknown")
+
+      isDicomTID1500 = self.isDICOMTID1500(dataset)
+
+      if isDicomTID1500:
+        loadable = self.createLoadableAndAddReferences([dataset])
+        loadable.files = [cFile]
+        loadable.name = seriesDescription + ' - as a DICOM SR TID1500 object'
+        loadable.tooltip = loadable.name
+        loadable.selected = True
+        loadable.confidence = 0.95
+        loadable.uids = [uid]
+        refName = self.referencedSeriesName(loadable)
+        if refName != "":
+          loadable.name = refName + " " + seriesDescription + " - SR TID1500"
+
+        loadables.append(loadable)
+
+        logging.debug('DICOM SR TID1500 modality found')
+      
+    return loadables
+
+  def isDICOMTID1500(self, dataset):
+    """"
+    This function checks if the dataset is a TID1500 or not. 
+    """
+
+    # Install/import highdicom 
+    try:
+      import highdicom as hd
+    except ModuleNotFoundError:
+      if slicer.util.confirmOkCancelDisplay("This module requires 'highdicom' Python package. Click OK to install it now."):
+        slicer.util.pip_install("highdicom") 
+        import highdicom as hd
+
+    try:
+      isDicomTID1500 = self.getDICOMValue(dataset, "Modality") == 'SR' and \
+                       (self.getDICOMValue(dataset, "SOPClassUID") == self.UID_EnhancedSRStorage or
+                        self.getDICOMValue(dataset, "SOPClassUID") == self.UID_ComprehensiveSRStorage or 
+                        self.getDICOMValue(dataset, "SOPClassUID") == self.UID_Comprehensive3DSRStorage) and \
+                       self.getDICOMValue(dataset, "ContentTemplateSequence")[0].TemplateIdentifier == '1500'
+    except (AttributeError, IndexError):
+      isDicomTID1500 = False
+    return isDicomTID1500
+
+  def referencedSeriesName(self, loadable):
+    """
+    Returns the default series name for the given loadable.
+    """
+
+    referencedName = "Unnamed Reference"
+    if hasattr(loadable, "referencedSOPInstanceUID"):
+      referencedName = self.defaultSeriesNodeName(loadable.referencedSOPInstanceUID)
+    return referencedName
+  
+  def getSRCode(self, code_meaning):
+    """
+    This function takes as input a standardized string, and returns 
+    the highdicom code, either using pydicom or defining it.
+    """
+
+    import highdicom as hd 
+    from pydicom.sr.codedict import codes
+
+    if (code_meaning == "Image Region"): 
+      highdicom_code = codes.DCM.ImageRegion # instead of using hd.sr.value_types.Code(value='111030',scheme_designator='DCM',meaning='Image Region')
+    elif (code_meaning == "Geometric purpose of region"): 
+      highdicom_code = hd.sr.value_types.Code(
+                        value='130400',
+                        scheme_designator='DCM',
+                        meaning='Geometric purpose of region'
+                      )
+    elif (code_meaning == "Bounded by"): 
+      highdicom_code = hd.sr.value_types.Code(
+                        value='75958009',
+                        scheme_designator='SCT',
+                        meaning='Bounded by'
+                      ) # codes.SCT.BoundedBy from pydicom does not exist. 
+    else: 
+      highdicom_code = ""
+
+    return highdicom_code
+
+  def getSOPInstanceUIDsForSeries(self, SeriesInstanceUID):
+    """
+    Gets the list of SOPInstanceUIDs from a SeriesInstanceUID. 
+    """
+
+    db = slicer.dicomDatabase
+    SOPInstanceUIDs = [] 
+    fileList = db.filesForSeries(SeriesInstanceUID) 
+    for file in fileList: 
+      SOPInstanceUID = db.fileValue(file, self.tags["SOPInstanceUID"])
+      SOPInstanceUIDs.append(SOPInstanceUID) 
+
+    return SOPInstanceUIDs
+  
+  def createLoadableAndAddReferences(self, datasets):
+    """
+    Main function to create the loadable and add the necessary references. 
+    """
+
+    import highdicom as hd
+    import pydicom 
+    from pydicom.sr.codedict import codes
+
+    loadable = DICOMLoadable()
+    loadable.selected = True
+    loadable.confidence = 0.95
+
+    loadable.referencedSegInstanceUIDs = []
+    # store lists of UIDs separately to avoid re-parsing later
+    loadable.ReferencedSegmentationInstanceUIDs = {}
+    loadable.ReferencedRWVMSeriesInstanceUIDs = []
+    loadable.ReferencedOtherInstanceUIDs = []
+    loadable.referencedInstanceUIDs = []
+
+    segPlugin = slicer.modules.dicomPlugins["DICOMSegmentationPlugin"]()
+
+    for dataset in datasets:
+
+      ### First we convert from dataset to sr ###
+      sr_class_map = {
+          pydicom.uid.EnhancedSRStorage: hd.sr.EnhancedSR,
+          pydicom.uid.ComprehensiveSRStorage: hd.sr.ComprehensiveSR,
+          pydicom.uid.Comprehensive3DSRStorage: hd.sr.Comprehensive3DSR,
+      }
+      # Get the SOP Class UID from the dataset
+      sop_class_uid = dataset.SOPClassUID
+      # Retrieve the correct SR class from the dictionary
+      sr_class = sr_class_map.get(sop_class_uid)
+      # Instantiate the correct SR object
+      if sr_class is not None:
+        sr = sr_class.from_dataset(dataset, copy=True)
+      else:
+        logging.error(f"Cannot create SR from dataset. Unsupported SOP Class UID: {sop_class_uid}")
+
+      ### First we check if the SR contains planar annotations ###
+      containsPlanarAnnotations = self.containsPlanarAnnotations(sr) 
+
+      ### If it doesn't contain planar annotations, and instead references a seg, we use the original code ### 
+      if not containsPlanarAnnotations: 
+        
+        uid = self.getDICOMValue(dataset, "SOPInstanceUID")
+        loadable.ReferencedSegmentationInstanceUIDs[uid] = []
+        if hasattr(dataset, "CurrentRequestedProcedureEvidenceSequence"):
+          for refSeriesSequence in dataset.CurrentRequestedProcedureEvidenceSequence:
+            for referencedSeriesSequence in refSeriesSequence.ReferencedSeriesSequence:
+              for refSOPSequence in referencedSeriesSequence.ReferencedSOPSequence:
+                if refSOPSequence.ReferencedSOPClassUID == self.UID_SegmentationStorage:
+                  logging.debug("Found referenced segmentation")
+                  loadable.ReferencedSegmentationInstanceUIDs[uid].append(referencedSeriesSequence.SeriesInstanceUID)
+
+                elif refSOPSequence.ReferencedSOPClassUID == self.UID_RealWorldValueMappingStorage: # handle SUV mapping
+                  logging.debug("Found referenced RWVM")
+                  loadable.ReferencedRWVMSeriesInstanceUIDs.append(referencedSeriesSequence.SeriesInstanceUID)
+                else:
+                  # TODO: those are not used at all
+                  logging.debug( "Found other reference")
+                  loadable.ReferencedOtherInstanceUIDs.append(refSOPSequence.ReferencedSOPInstanceUID) 
+
+        for segSeriesInstanceUID in loadable.ReferencedSegmentationInstanceUIDs[uid]:
+          segLoadables = segPlugin.examine([slicer.dicomDatabase.filesForSeries(segSeriesInstanceUID)])
+          for segLoadable in segLoadables:
+            loadable.referencedInstanceUIDs += segLoadable.referencedInstanceUIDs
+        
+        if len(loadable.ReferencedSegmentationInstanceUIDs[uid])>1:
+          logging.warning("SR references more than one SEG. This has not been tested!")
+        for segUID in loadable.ReferencedSegmentationInstanceUIDs:
+          loadable.referencedSegInstanceUIDs.append(segUID)
+
+        if len(loadable.ReferencedRWVMSeriesInstanceUIDs)>1:
+          logging.warning("SR references more than one RWVM. This has not been tested!")
+            # not adding RWVM instances to referencedSeriesInstanceUIDs
+      
+      ### Additions for handling planar annotations ### 
+      else:
+        
+        #### Then we check if the SR contains a point3d, line, or bbox ### 
+        checkIfSRContainsBbox = self.checkIfSRContainsGeometry(sr, geometry_type='bbox2D')
+        checkIfSRContains3DPoint = self.checkIfSRContainsGeometry(sr, geometry_type='point3D')
+        checkIfSRContainsPolyline = self.checkIfSRContainsGeometry(sr, geometry_type='polyline2D')
+
+        ### checkIfSRContains3DPoint ###
+        # We only check for FrameOfReferenceUID for 3Dpoint
+        # We check for FrameOfReferenceUID, and add to the list of loadable.referencedInstanceUIDs 
+        # Please refer to David Clunie's paper for more information about searching for the FrameOfReferenceUIDs
+        # http://dx.doi.org/10.13140/RG.2.2.34520.62725 
+        if checkIfSRContains3DPoint: 
+
+          # print('In checkIfSRContains3DPoint - check for FrameOfReferenceUID')     
+          # get the ImageRegion code 
+          image_region_code = self.getSRCode("Image Region")
+          # First get the planar roi measurement groups 
+          groups = sr.content.get_planar_roi_measurement_groups(
+                    graphic_type=hd.sr.GraphicTypeValues3D.POINT,
+                    reference_type=codes.DCM.ImageRegion,
+          )
+
+          # Iterate through the groups, and get unique list of FrameOfReferenceUIDs 
+          FrameOfReferenceUIDs = [] 
+          for group in groups: 
+            FrameOfReferenceUIDs.append(group.roi.frame_of_reference_uid)
+          FrameOfReferenceUIDs = list(set(FrameOfReferenceUIDs))
+
+          # Now we get the SeriesInstanceUIDs in the dicom database that have these FrameOfReferenceUIDs 
+          # We know that the StudyInstanceUID must be the same, so we only check those patients. 
+          StudyInstanceUID = dataset.StudyInstanceUID 
+          # Get the list of possible series in the database for this study 
+          SeriesInstanceUIDs = slicer.dicomDatabase.seriesForStudy(StudyInstanceUID)
+
+          # Now make sure that the modality of these possible_SeriesInstanceUIDs are not SR or SEG.  
+          # Don't want them included in the list 
+          possible_SeriesInstanceUIDs = [] 
+          db = slicer.dicomDatabase 
+          for series in SeriesInstanceUIDs: 
+            modality = slicer.dicomDatabase.fileValue(  
+              slicer.dicomDatabase.filesForSeries(series)[0], self.tags["Modality"]
+            )
+            if (modality != "SR") and (modality != "SEG"): 
+              possible_SeriesInstanceUIDs.append(series)
+
+          # Now, we don't need to check if possible_SeriesInstanceUIDs are actually in the DICOM database
+          # We know they are, because we retrieved the list of series using slicer.dicomDatabase.seriesForStudy(StudyInstanceUID)
+          # However, we do need to make sure that possible_SeriesInstanceUIDs is not empty. 
+          # If empty, then display a popup 
+          if not possible_SeriesInstanceUIDs: 
+            logging.error("ERROR: no referenced series found in the DICOM database, cannot load any associated image data")
+            slicer.util.errorDisplay("No referenced series found in the DICOM database, cannot load any associated image data")
+
+          else: 
+        
+            # Now get the FrameOfReferenceUIDs for these SeriesInstanceUIDs 
+            FrameOfReferenceUIDs_forSeries = [] 
+            for SeriesInstanceUID in possible_SeriesInstanceUIDs: 
+              FrameOfReferenceUID_forSeries = slicer.dicomDatabase.fileValue(
+                                                        slicer.dicomDatabase.filesForSeries(SeriesInstanceUID)[0], self.tags["FrameOfReferenceUID"]) 
+              FrameOfReferenceUIDs_forSeries.append(FrameOfReferenceUID_forSeries)
+              
+            # iterate over the list of FrameOfReferenceUIDs_forSeries and see if any are in the actual SR. 
+            keep_SeriesInstanceUIDs = [] 
+            for SeriesInstanceUID,FrameOfReferenceUID_forSeries in zip(possible_SeriesInstanceUIDs,FrameOfReferenceUIDs_forSeries):
+              if FrameOfReferenceUID_forSeries in FrameOfReferenceUIDs: 
+                keep_SeriesInstanceUIDs.append(SeriesInstanceUID)
+
+            # Get the unique list of possible series 
+            keep_SeriesInstanceUIDs = list(set(keep_SeriesInstanceUIDs))
+
+            SOPInstanceUIDs = [self.getSOPInstanceUIDsForSeries(series) for series in keep_SeriesInstanceUIDs]
+            SOPInstanceUIDs = [item for sublist in SOPInstanceUIDs for item in sublist]
+            # Now add to the loadable.referencedInstanceUIDs 
+            if (SOPInstanceUIDs):
+              loadable.referencedInstanceUIDs += SOPInstanceUIDs 
+
+
+        #### checkIfSRContainsBbox or checkIfSRContainsPolyline ### 
+        # Here we get the referenced SeriesInstanceUID 
+        if (checkIfSRContainsBbox or checkIfSRContainsPolyline): 
+
+          # print('In checkIfSRContainsBbox/checkIfSRContainsPolyline - get referenced series')     
+          # Get the referenced SeriesInstanceUID 
+          referenced_series_instance_uid = str(sr.CurrentRequestedProcedureEvidenceSequence[0].ReferencedSeriesSequence[0].SeriesInstanceUID)
+          # Now we get all of the SOPInstanceUIDs of this series 
+          db = slicer.dicomDatabase
+          fileList = db.filesForSeries(referenced_series_instance_uid)
+          if not fileList: 
+            logging.error("ERROR: no referenced series found in the DICOM database, cannot load any associated image data")
+            slicer.util.errorDisplay("No referenced series found in the DICOM database, cannot load any associated image data")
+          else: 
+            SOPInstanceUIDs = [db.fileValue(file, self.tags["SOPInstanceUID"]) for file in fileList]
+            if (SOPInstanceUIDs):
+              loadable.referencedInstanceUIDs += SOPInstanceUIDs 
+
+
+    return loadable
+
+  def sortReportsByDateTime(self, uids):
+    return sorted(uids, key=lambda uid: self.getDateTime(uid))
+
+  def getDateTime(self, uid):
+    import pydicom 
+    filename = slicer.dicomDatabase.fileForInstance(uid)
+    dataset = pydicom.dcmread(filename)
+    if hasattr(dataset, 'SeriesDate') and hasattr(dataset, "SeriesTime"):
+      date = dataset.SeriesDate
+      time = dataset.SeriesTime
+    elif hasattr(dataset, 'StudyDate') and hasattr(dataset, "StudyTime"):
+      date = dataset.StudyDate
+      time = dataset.StudyDate
+    else:
+      date = ""
+      time = ""
+    try:
+      dateTime = datetime.datetime.strptime(date+time, '%Y%m%d%H%M%S')
+    except ValueError:
+      dateTime = ""
+    return dateTime
+  
+  def containsPlanarAnnotations(self, sr):
+    """ 
+    Checks if the original plugin should be used (tid1500reader) to read the SR, or if specialized 
+    highdicom code should be utilized for reading planar annotations, in the case of point,
+    bounding box, etc. 
+    """
+
+    # default to use the plugin 
+    containsPlanarAnnotations = False
+
+    # get the image region code 
+    image_region_code = self.getSRCode("Image Region")
+
+    planar_roi_measurement_groups = sr.content.get_planar_roi_measurement_groups()
+    for planar_roi_measurement_group in planar_roi_measurement_groups: 
+      # Here we check if it is an Image Region 
+      if (planar_roi_measurement_group.reference_type == image_region_code):
+          containsPlanarAnnotations = True
+
+    return containsPlanarAnnotations
+  
+  def checkIfSRContainsGeometry(self, sr, geometry_type='bbox'):
+    """ 
+    Checks if the SR contains a bbox, polyline, or point3D.
+    """
+
+    import highdicom as hd 
+    from pydicom.sr.codedict import codes
+
+    # If SR contains a bounding box 
+    if (geometry_type == "bbox2D"):
+      for group in sr.content.get_planar_roi_measurement_groups(reference_type=codes.DCM.ImageRegion, graphic_type=hd.sr.GraphicTypeValues.POLYLINE):
+        for eval in group.get_qualitative_evaluations(
+              name=self.getSRCode("Geometric purpose of region"),
+        ):
+            if eval.value == self.getSRCode("Bounded by"): 
+                return True
+      return False
+
+    # If SR contains a POLYLINE
+    elif (geometry_type == "polyline2D"):
+      groups = sr.content.get_planar_roi_measurement_groups(
+        reference_type=self.getSRCode("Image Region"),
+        graphic_type=hd.sr.GraphicTypeValues.POLYLINE, 
+      )  
+      return len(groups) >= 1
+
+    # If SR contains SCOORD3D 
+    elif (geometry_type == "point3D"):
+      groups = sr.content.get_planar_roi_measurement_groups(reference_type=codes.DCM.ImageRegion,graphic_type=hd.sr.GraphicTypeValues3D.POINT)
+      return len(groups) >= 1
+    
+    # If SR contains unknown geometry 
+    else:
+      logging.info('Cannot read SR with geometry: ' + str(geometry_type))
+
+    return False
+  
+  def getIPPFromSOP(self, referenced_sop_instance_uid, referenced_series_instance_uid):
+    """
+    In order to display the bounding box markups in Slicer, we need the IPP corresponding 
+    to the referenced SOPInstanceUID. We get this from the Slicer DICOM database. 
+    """
+
+    import pydicom 
+
+    # Get the dicom database 
+    db = slicer.dicomDatabase 
+
+    # Get the files for the series 
+    fileList = db.filesForSeries(referenced_series_instance_uid)
+
+    # Use pydicom to read the files, get the SOPInstanceUID and the IPP for each 
+    num_files = len(fileList)
+    SOPInstanceUID_list = [] 
+    IPP_list = [] 
+    for file in fileList: 
+      ds = pydicom.dcmread(file)
+      SOPInstanceUID_list.append(ds.SOPInstanceUID)
+      IPP_list.append(ds.ImagePositionPatient)
+
+    # Get the index of the SOPInstanceUID we want 
+    index = SOPInstanceUID_list.index(referenced_sop_instance_uid)
+
+    # Now get the IPP for the corresponding SOPInstanceUID 
+    ipp = IPP_list[index]
+
+    return ipp 
+  
+  def showTable(self, table):
+    """
+    Display a table in the scene. 
+    """
+
+    currentLayout = slicer.app.layoutManager().layout
+    layoutWithTable = slicer.modules.tables.logic().GetLayoutWithTable(currentLayout)
+    slicer.mrmlScene.AddNode(table)
+    slicer.app.layoutManager().setLayout(layoutWithTable)
+    slicer.app.applicationLogic().GetSelectionNode().SetActiveTableID(table.GetID())
+    slicer.app.applicationLogic().PropagateTableSelection()
+
+    return 
+  
+  def createBboxTable(self, poly_infos, table_name):
+    """
+    Create and display a table for the bbox info. 
+    """
+
+    tableNode = slicer.vtkMRMLTableNode()
+    tableNode.SetAttribute("readonly", "Yes") 
+    tableNode.SetName(table_name)
+
+    # Add columns 
+    col = tableNode.AddColumn()
+    col.SetName("Tracking Identifier")
+    col = tableNode.AddColumn()
+    col.SetName("FindingType")
+    col = tableNode.AddColumn()
+    col.SetName("FindingSite")
+    col = tableNode.AddColumn()
+    col.SetName("Bounding box points")
+
+    # Order by IPP2 
+    poly_infos = sorted(poly_infos, key=lambda x: x['center_z'])
+
+    for i,p in enumerate(poly_infos):
+      # get values 
+      tracking_identifier = p['TrackingIdentifier']
+      finding_type = p['FindingType']
+      finding_site = p['FindingSite'][0] # check this later. 
+      polyline = p['polyline']
+      polyline_str = ', '.join(f"({np.round(a,2)}, {np.round(b,2)})" for a, b in polyline)
+      width = np.round(p['width'],2)
+      height = np.round(p['height'],2)
+      center_x = np.round(p['center_x'],2)
+      center_y = np.round(p['center_y'],2)
+      center_z = np.round(p['center_z'],2)
+      center = list([str(center_x), str(center_y), str(center_z)])
+      # add tracking info and finding site info 
+      rowIndex = tableNode.AddEmptyRow()
+      tableNode.SetCellText(rowIndex, 0, tracking_identifier)
+      tableNode.SetCellText(rowIndex, 1, finding_type[2])
+      tableNode.SetCellText(rowIndex, 2, finding_site[2])
+      # add bbox points 
+      tableNode.SetCellText(rowIndex, 3, polyline_str)
+
+    return tableNode 
+  
+    
+  def createPointTable(self, point_infos, table_name):
+    """
+    Create and display a table for the point info. 
+    """
+
+    tableNode = slicer.vtkMRMLTableNode()
+    tableNode.SetAttribute("readonly", "Yes") 
+    tableNode.SetName(table_name)
+
+    # Add columns 
+    col = tableNode.AddColumn()
+    col.SetName("Tracking Identifier")
+    col = tableNode.AddColumn()
+    col.SetName("FindingType")
+    col = tableNode.AddColumn()
+    col.SetName("FindingSite")
+    col = tableNode.AddColumn()
+    col.SetName("Point")
+
+    # Order by IPP2 
+    point_infos = sorted(point_infos, key=lambda x: x['point'][2])
+
+    for i,p in enumerate(point_infos):
+      # get values 
+      tracking_identifier = p['TrackingIdentifier']
+      tracking_uid = p['TrackingUID']
+      finding_type = p['FindingType']
+      finding_site = p['FindingSite'][0] # check this later. 
+      point = p["point"]
+      point = [str(np.round(f,2)) for f in point]
+      point_str = f"({', '.join(point)})"
+      content_sequence_names = p['ContentSequenceNames']
+      content_sequence_values = p['ContentSequenceValues']
+      # add tracking info and finding site info 
+      rowIndex = tableNode.AddEmptyRow()
+      tableNode.SetCellText(rowIndex, 0, tracking_identifier)
+      tableNode.SetCellText(rowIndex, 1, finding_type[2]) # CodeMeaning
+      tableNode.SetCellText(rowIndex, 2, finding_site[2]) # CodeMeaning
+      # add point
+      tableNode.SetCellText(rowIndex, 3, point_str) 
+      # now add the names CodeMeaning as the column name, and the values CodeMeaning as the actual value 
+      # first do for qualitative evaluations 
+      num_rows = 4
+      # then add for content sequence
+      # num_rows = num_rows + len(qual_eval_names)
+      for j, content_sequence_name in enumerate(content_sequence_names): 
+        rowIndexValue = num_rows + j
+        colName = str(content_sequence_name[2])
+        colValue = str(content_sequence_values[j][2])
+        # can't add column each time - if there is more than 1 point. 
+        # therefore, only add column when on first point_info. 
+        if (i==0):
+          col = tableNode.AddColumn() 
+          col.SetName(colName) 
+        tableNode.SetCellText(rowIndex, rowIndexValue, colValue) 
+
+
+    return tableNode 
+  
+  def createPolylineTable(self, point_infos, table_name):
+    """
+    Create and display a table for the polyline info. 
+    """
+
+    tableNode = slicer.vtkMRMLTableNode()
+    tableNode.SetAttribute("readonly", "Yes") 
+    tableNode.SetName(table_name)
+
+    # Add columns 
+    col = tableNode.AddColumn()
+    col.SetName("Tracking Identifier")
+    col = tableNode.AddColumn()
+    col.SetName("FindingType")
+    col = tableNode.AddColumn()
+    col.SetName("FindingSite")
+    col = tableNode.AddColumn()
+    col.SetName("PolyLine")
+
+    for i,p in enumerate(point_infos):
+      # get values 
+      tracking_identifier = p['TrackingIdentifier']
+      tracking_uid = p['TrackingUID']
+      finding_type = p['FindingType']
+      finding_site = p['FindingSite'][0] # check this later. 
+      polyline = p["polyline"]
+      polyline = [str(np.round(f,2)) for f in polyline]
+      polyline_str = f"({', '.join(polyline)})"
+      # add tracking info and finding site info 
+      rowIndex = tableNode.AddEmptyRow()
+      tableNode.SetCellText(rowIndex, 0, tracking_identifier)
+      tableNode.SetCellText(rowIndex, 1, finding_type[2]) # CodeMeaning
+      tableNode.SetCellText(rowIndex, 2, finding_site[2]) # CodeMeaning
+      # add polyline
+      tableNode.SetCellText(rowIndex, 3, polyline_str) 
+
+    return tableNode 
+  
+  def extractBboxMetadataToVtkTableNode(self, sr): 
+    """
+    Extracts the bounding box metadata from the SR using highdicom, 
+    and creates a table node. 
+    """
+
+    # We use the SeriesNumber and the SeriesDescription of the SR to name the table
+    SeriesNumber = sr.SeriesNumber
+    SeriesDescription = sr.SeriesDescription
+    table_name = str(SeriesNumber) + ": " + SeriesDescription
+
+    # get the referenced SeriesInstanceUID 
+    referenced_series_instance_uid = str(sr.CurrentRequestedProcedureEvidenceSequence[0].ReferencedSeriesSequence[0].SeriesInstanceUID)
+
+    # get the image_region_code 
+    image_region_code = self.getSRCode("Image Region")
+
+    # will store the info needed for table too. 
+    poly_infos = [] 
+
+    # First get the planar roi measurement gorups 
+    groups = sr.content.get_planar_roi_measurement_groups()
+
+    for group in groups: 
+
+      # Get the tracking ids 
+      tracking_identifier = group.tracking_identifier
+      tracking_uid = group.tracking_uid
+
+      # Get the findings and finding_sites 
+      finding_type = [group.finding_type.CodeValue, group.finding_type.CodingSchemeDesignator, group.finding_type.CodeMeaning]
+      finding_sites = []
+      for finding_site in group.finding_sites:
+        finding_sites.append([finding_site.value.CodeValue, 
+                              finding_site.value.CodingSchemeDesignator, 
+                              finding_site.value.CodeMeaning])
+      # Get the Image Region 
+      referenced_sop_instance_uid = group.roi.ContentSequence[0].referenced_sop_instance_uid
+      bbox = group.roi.value 
+
+      # calculate the width, height and center, as these are needed for display 
+      min_x = np.min([bbox[0,0], bbox[1,0], bbox[2,0], bbox[3,0]]) # using roi.GraphicData: min_x = np.min([bbox[0], bbox[2], bbox[4], bbox[6]])
+      max_x = np.max([bbox[0,0], bbox[1,0], bbox[2,0], bbox[3,0]]) # using roi.GraphicData: max_x = np.max([bbox[0], bbox[2], bbox[4], bbox[6]])
+      min_y = np.min([bbox[0,1], bbox[1,1], bbox[2,1], bbox[3,1]]) # using roi.GraphicData: min_y = np.min([bbox[1], bbox[3], bbox[5], bbox[7]])
+      max_y = np.max([bbox[0,1], bbox[1,1], bbox[2,1], bbox[3,1]]) # using roi.GraphicData: max_y = np.max([bbox[1], bbox[3], bbox[5], bbox[7]])
+      width = max_x - min_x 
+      height = max_y - min_y 
+      # in pixel coordinates 
+      center_x = min_x + width/2
+      center_y = min_y + height/2 
+      # get ipp 
+      ipp = self.getIPPFromSOP(referenced_sop_instance_uid, 
+                                       referenced_series_instance_uid)
+      # in mm 
+      center_z = ipp[2] 
+      
+      # append to poly_infos
+      poly_infos.append({
+                         "TrackingIdentifier": tracking_identifier, 
+                         "TrackingUID" : tracking_uid,
+                         "SOPInstanceUID" : referenced_sop_instance_uid, 
+                         "FindingType": finding_type, 
+                         "FindingSite": finding_sites,
+                         "polyline": bbox, # using roi.GraphicData: [[bbox[0],bbox[1]], [bbox[2],bbox[3]], [bbox[4],bbox[5]], [bbox[6],bbox[7]]], 
+                         "width": width, 
+                         "height": height,
+                         "center_x": center_x,
+                         "center_y": center_y, 
+                         "center_z": center_z
+                        })
+
+      # create and display tableNode 
+      tableNode = self.createBboxTable(poly_infos, table_name)
+
+    return poly_infos, tableNode 
+  
+  def extractPointMetadataToVtkTableNode(self, sr):
+    """
+    Extracts the point metadata from the SR using highdicom, 
+    and creates a table node. 
+    """
+
+    import highdicom as hd
+    from pydicom.sr.codedict import codes
+
+    # We use the SeriesNumber and the SeriesDescription of the SR to name the table
+    SeriesNumber = sr.SeriesNumber
+    SeriesDescription = sr.SeriesDescription
+    table_name = str(SeriesNumber) + ": " + SeriesDescription
+
+    # get image region code 
+    image_region_code = self.getSRCode("Image Region")
+
+    # will store the info needed for table too. 
+    point_infos = [] 
+
+    # First get the planar roi measurement groups 
+    groups = sr.content.get_planar_roi_measurement_groups(graphic_type=hd.sr.GraphicTypeValues3D.POINT,reference_type=codes.DCM.ImageRegion)
+  
+    # Iterate through each group 
+    for group in groups: 
+
+      # Get the tracking ids 
+      tracking_identifier = group.tracking_identifier
+      tracking_uid = group.tracking_uid
+      # Get the finding type 
+      finding_type = [group.finding_type.CodeValue, 
+                      group.finding_type.CodingSchemeDesignator, 
+                      group.finding_type.CodeMeaning]
+      # Get the finding sites 
+      finding_sites = [] 
+      for finding_site in group.finding_sites:
+        finding_sites.append([finding_site.value.CodeValue, 
+                              finding_site.value.CodingSchemeDesignator, 
+                              finding_site.value.CodeMeaning])
+        
+      # Get the point info 
+      referenced_frame_of_reference_uid = group.roi.ReferencedFrameOfReferenceUID
+      extracted_data = group.roi.value[0] 
+        
+      # Get the content items 
+      # if (len(group)>0):
+      code_items = hd.sr.utils.find_content_items(group[0], 
+                                                  relationship_type=hd.sr.RelationshipTypeValues.CONTAINS, 
+                                                  value_type = hd.sr.ValueTypeValues.CODE)
+      content_sequence_names = [] 
+      content_sequence_values = [] 
+      for code_item in code_items: 
+        # Skip image region code here, will get in a different way. 
+        if (code_item.name == image_region_code):
+          break
+        else: 
+          content_sequence_names.append([code_item.name.CodeValue,
+                                        code_item.name.CodingSchemeDesignator, 
+                                        code_item.name.CodeMeaning])
+          content_sequence_values.append([code_item.value.CodeValue, 
+                                          code_item.value.CodingSchemeDesignator,
+                                          code_item.value.CodeMeaning])
+      # append to poly_infos
+      point_infos.append({
+                         "TrackingIdentifier": tracking_identifier, 
+                         "TrackingUID" : tracking_uid,
+                         "FindingType": finding_type, 
+                         "FindingSite": finding_sites,
+                         "ReferencedFrameOfReferenceUID": referenced_frame_of_reference_uid, 
+                         "ContentSequenceNames": content_sequence_names, 
+                         "ContentSequenceValues": content_sequence_values,
+                         "point": extracted_data 
+                        })
+      
+    # create and display tableNode 
+    tableNode = self.createPointTable(point_infos, table_name)
+
+    return point_infos, tableNode 
+  
+  def extractLineMetadataToVtkTableNode(self, sr):
+    """
+    Extracts the point metadata from the SR using highdicom, 
+    and creates a table node. 
+    """
+
+    import highdicom as hd
+
+    # We use the SeriesNumber and the SeriesDescription of the SR to name the table
+    SeriesNumber = sr.SeriesNumber
+    SeriesDescription = sr.SeriesDescription
+    table_name = str(SeriesNumber) + ": " + SeriesDescription
+
+    # get the referenced SeriesInstanceUID 
+    referenced_series_instance_uid = str(sr.CurrentRequestedProcedureEvidenceSequence[0].ReferencedSeriesSequence[0].SeriesInstanceUID)
+
+    # will store the info needed for table too. 
+    line_infos = [] 
+
+    # First get the planar roi measurement gorups 
+    groups = sr.content.get_planar_roi_measurement_groups(
+        reference_type=self.getSRCode("Image Region"),
+        graphic_type=hd.sr.GraphicTypeValues.POLYLINE, 
+      )  
+
+    for group in groups: 
+
+      # Get the tracking ids 
+      tracking_identifier = group.tracking_identifier
+      tracking_uid = group.tracking_uid
+
+      # Get the findings and finding_sites 
+      finding_type = [group.finding_type.CodeValue, group.finding_type.CodingSchemeDesignator, group.finding_type.CodeMeaning]
+      finding_sites = []
+      for finding_site in group.finding_sites:
+        finding_sites.append([finding_site.value.CodeValue, 
+                              finding_site.value.CodingSchemeDesignator, 
+                              finding_site.value.CodeMeaning])
+      
+      # Get the reference 
+      referenced_sop_instance_uid = group.roi.ContentSequence[0].referenced_sop_instance_uid
+      # Get the polyline 
+      polyline = group.roi.value
+      # get the points 
+      num_points = np.int32(len(polyline))
+      point_line = [] 
+      for n in range(0,num_points): 
+        pointx = polyline[n,0] # pixel coord space
+        pointy = polyline[n,1] # pixel coord space
+        pointz = self.getIPPFromSOP(referenced_sop_instance_uid,
+                                    referenced_series_instance_uid)[2] # mm space 
+        point_line.append([pointx, pointy, pointz])
+      # append to poly_infos
+      line_infos.append({
+                        "TrackingIdentifier": tracking_identifier, 
+                        "TrackingUID" : tracking_uid,
+                        "SOPInstanceUID" : referenced_sop_instance_uid, 
+                        "FindingType": finding_type, 
+                        "FindingSite": finding_sites,
+                        "polyline": point_line
+                        })
+      
+    tableNode = self.createPolylineTable(line_infos, table_name)
+
+    return line_infos, tableNode 
+   
+  def create_2d_roi(self, loadable, center_ras, width, height, slice_normal=(0, 0, 1), thickness=1.0, bbox_name="2D_BoundingBox"):
+    """
+    Create a Markups ROI as a thin 2D bounding box on a specified slice plane.
+    
+    Args:
+        loadable             - loadable of the corresponding SR 
+        center_ras (tuple)   - (x, y, z) center in RAS coordinates.
+        width (float)        - Width of the box (in mm).
+        height (float)       - Height of the box (in mm).
+        slice_normal (tuple) - Normal vector of the slice plane (e.g., (0,0,1) for axial).
+        thickness (float)    - Depth of the box (in mm), small for a 2D box.
+    
+    Returns:
+        vtkMRMLMarkupsROINode - The ROI node created.
+    """
+    # Create ROI node
+    roi_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsROINode", bbox_name)
+    # Do not lock the node
+    roi_node.SetLocked(False)
+    
+    # Set the size (width, height, thickness)
+    size = [width, height, thickness]
+    roi_node.SetSize(size)
+    
+    # Set the center position
+    roi_node.SetCenter(center_ras)
+    
+    # Align ROI orientation to slice normal
+    transform_matrix = vtk.vtkMatrix4x4()
+    
+    # Build a local coordinate system with normal as Z
+    z = np.array(slice_normal)
+    z = z / np.linalg.norm(z)
+    x = np.cross([0, 1, 0], z)
+    if np.linalg.norm(x) < 1e-3:
+        x = np.cross([1, 0, 0], z)
+    x = x / np.linalg.norm(x)
+    y = np.cross(z, x)
+
+    for i in range(3):
+        transform_matrix.SetElement(i, 0, x[i])
+        transform_matrix.SetElement(i, 1, y[i])
+        transform_matrix.SetElement(i, 2, z[i])
+        transform_matrix.SetElement(i, 3, center_ras[i])
+    roi_node.SetAndObserveObjectToNodeMatrix(transform_matrix)
+    
+    display_node = roi_node.GetDisplayNode()
+    if (display_node):
+      # Change size of glyph
+      display_node.SetGlyphScale(1.3)
+      # Change size of interaction handles 
+      display_node.SetInteractionHandleScale(1)
+      # Reduce the opacity of the box 
+      display_node.SetFillOpacity(0)
+
+    roi_node.GetDisplayNode().SetHandlesInteractive(False)
+    for controlPointIndex in range(roi_node.GetNumberOfControlPoints()):
+      roi_node.SetNthControlPointLocked(controlPointIndex, True)
+    
+    return roi_node 
+
+  def displayBboxMarkups(self, sr, loadable, poly_infos): 
+    """
+    Displays the bounding box markups. 
+    """
+
+    # Get the subject hierarchy
+    shNode = slicer.modules.subjecthierarchy.logic().GetSubjectHierarchyNode()
+
+    # We use the SeriesNumber and the SeriesDescription of the SR to name the folder 
+    SeriesNumber = sr.SeriesNumber
+    SeriesDescription = sr.SeriesDescription
+
+    # We get the StudyInstanceUID for creating nodes in the subject hierarchy
+    StudyInstanceUID = sr.StudyInstanceUID 
+
+    # Get the studyNode 
+    studyNode = shNode.GetItemByUID(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMUIDName(), StudyInstanceUID)
+    # Now create the folder and set the name 
+    bboxFolderID = shNode.CreateFolderItem(studyNode, str(SeriesNumber) + ': ' + SeriesDescription)
+
+    # Order by IPP2 
+    poly_infos = sorted(poly_infos, key=lambda x: x['center_z'])
+
+    # We need the pixel spacing, in order to convert the coordinates from pixel space to mm space
+    referenced_series_instance_uid = str(sr.CurrentRequestedProcedureEvidenceSequence[0].ReferencedSeriesSequence[0].SeriesInstanceUID)
+    db = slicer.dicomDatabase
+    fileList = db.filesForSeries(referenced_series_instance_uid)
+    pixel_spacing = db.fileValue(fileList[0], self.tags["PixelSpacing"])
+    pixel_spacing_x = np.float32(pixel_spacing.split("\\")[0])
+    pixel_spacing_y = np.float32(pixel_spacing.split("\\")[1])
+    num_rows = np.float32(db.fileValue(fileList[0], self.tags["Rows"]))
+    num_columns = np.float32(db.fileValue(fileList[0], self.tags["Columns"]))
+
+    for i,p in enumerate(poly_infos):
+      # get values 
+      polyline = p['polyline']
+      tracking_identifier = p['TrackingIdentifier']
+      width = p['width'] # in pixel coord
+      height = p['height'] # in pixel coord
+      center_x = p['center_x'] # in pixel coord
+      center_y = p['center_y'] # in pixel coord
+      center_z = p['center_z'] # in mm 
+      # convert pixel coordinates to mm 
+      referenced_sop_instance_uid = p['SOPInstanceUID']
+      ipp = self.getIPPFromSOP(referenced_sop_instance_uid, 
+                               referenced_series_instance_uid)
+      ipp_0 = ipp[0] 
+      ipp_1 = ipp[1] 
+      center_x_mm = -((center_x * pixel_spacing_x) + ipp_0)
+      center_y_mm = -((center_y * pixel_spacing_y) + ipp_1)
+      center_ras = np.asarray([center_x_mm, center_y_mm, center_z])
+      width_mm = width * pixel_spacing_x
+      height_mm = height * pixel_spacing_y
+      bbox_name = tracking_identifier # for now 
+      # create roi 
+      bboxNode = self.create_2d_roi(loadable, center_ras, width_mm, height_mm, slice_normal=(0, 0, 1), thickness=0.01, bbox_name=bbox_name) 
+      markupItemID = shNode.GetItemByDataNode(bboxNode)
+      # Set the parent to the folder
+      shNode.SetItemParent(markupItemID, bboxFolderID)
+      if (i==0):
+        slicer.modules.markups.logic().JumpSlicesToLocation(center_x_mm, center_y_mm, center_z, True)
+
+    return 
+  
+  
+  def create_3d_point(self, loadable, point_index, point_x, point_y, point_z, point_text): 
+    """
+    Create the point markup 
+    """
+
+    markupsNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", point_text)
+    markupsNode.CreateDefaultDisplayNodes()
+    # if markupsNode.SetLocked(True) - cannot move, edit, or delete points, but also cannot jump between control points. 
+    # if markupsNode.SetLocked(False) - can move, edit, delete and jump between control points. 
+    markupsNode.SetLocked(False) 
+    markupsNode.AddControlPoint([point_x, point_y, point_z])
+    markupsNode.SetName(point_text)
+    markupsNode.SetNthControlPointLabel(point_index, point_text)
+
+    # Make sure control points are locked and cannot be moved 
+    markupsNode.GetDisplayNode().SetHandlesInteractive(False)
+    for controlPointIndex in range(markupsNode.GetNumberOfControlPoints()):
+      markupsNode.SetNthControlPointLocked(controlPointIndex, True)
+
+    return markupsNode
+  
+  def displayPointMarkups(self, sr, loadable, point_infos): 
+    """
+    Display the point markups. 
+    """
+
+    # Get the subject hierarchy
+    shNode = slicer.modules.subjecthierarchy.logic().GetSubjectHierarchyNode()
+
+    # We use the SeriesNumber and the SeriesDescription of the SR to name the folder 
+    SeriesNumber = sr.SeriesNumber 
+    SeriesDescription = sr.SeriesDescription
+
+    # We get the StudyInstanceUID for creating nodes in the subject hierarchy
+    StudyInstanceUID = sr.StudyInstanceUID 
+
+    # Get the studyNode 
+    studyNode = shNode.GetItemByUID(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMUIDName(), StudyInstanceUID)
+    # Now create the folder and set the name 
+    pointsFolderID = shNode.CreateFolderItem(studyNode, str(SeriesNumber) + ': ' + SeriesDescription)
+
+    for i,p in enumerate(point_infos):
+      point_text = p['TrackingIdentifier']
+      point_x = -p['point'][0]
+      point_y = -p['point'][1] 
+      point_z = p['point'][2]
+      # index should always be 0. not i. 
+      pointsNode = self.create_3d_point(loadable, 0, point_x, point_y, point_z, point_text)
+      # change size of glyph 
+      display_node = pointsNode.GetDisplayNode() 
+      if (display_node):
+        display_node.SetGlyphScale(0.75)
+
+      markupItemID = shNode.GetItemByDataNode(pointsNode)
+      # Set the parent to the folder
+      shNode.SetItemParent(markupItemID, pointsFolderID)
+      # jump to the first point 
+      if (i==0):
+        slicer.modules.markups.logic().JumpSlicesToLocation(point_x, point_y, point_z, True)
+    
+    return 
+  
+  def displayLineMarkups(self, sr, loadable, line_infos):
+    """
+    Display the line markups. 
+    """
+
+    # Get the subject hierarchy
+    shNode = slicer.modules.subjecthierarchy.logic().GetSubjectHierarchyNode()
+
+    # We use the SeriesNumber and the SeriesDescription of the SR to name the folder 
+    SeriesNumber = sr.SeriesNumber 
+    SeriesDescription = sr.SeriesDescription
+
+    # We get the StudyInstanceUID for creating nodes in the subject hierarchy
+    StudyInstanceUID = sr.StudyInstanceUID 
+
+    # Get the studyNode 
+    studyNode = shNode.GetItemByUID(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMUIDName(), StudyInstanceUID)
+    # Now create the folder and set the name 
+    linesFolderID = shNode.CreateFolderItem(studyNode, str(SeriesNumber) + ': ' + SeriesDescription)
+
+    # Get the referenced series instance uid 
+    # Needed for later getting the IPP 
+    referenced_series_instance_uid = str(sr.CurrentRequestedProcedureEvidenceSequence[0].ReferencedSeriesSequence[0].SeriesInstanceUID)
+    db = slicer.dicomDatabase
+    fileList = db.filesForSeries(referenced_series_instance_uid)
+    pixel_spacing = db.fileValue(fileList[0], self.tags["PixelSpacing"])
+    pixel_spacing_x = np.float32(pixel_spacing.split("\\")[0])
+    pixel_spacing_y = np.float32(pixel_spacing.split("\\")[1])
+
+    # Create all the line nodes 
+    for i,p in enumerate(line_infos):
+      line_text = p['TrackingIdentifier']
+      polyline = p['polyline']
+      # add new node 
+      lineNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode", line_text)
+      # Do not lock node
+      lineNode.SetLocked(False)
+      # get number of points 
+      num_points = len(polyline)
+      # add each as a control point 
+      for n in range(0,num_points): 
+        point_x = polyline[n][0] # pixel coord space 
+        point_y = polyline[n][1] # pixel coord space
+        # convert pixel coordinates to mm 
+        referenced_sop_instance_uid = p['SOPInstanceUID']
+        ipp = self.getIPPFromSOP(referenced_sop_instance_uid, 
+                                 referenced_series_instance_uid)
+        ipp_0 = ipp[0] 
+        ipp_1 = ipp[1] 
+        point_x_mm = -((point_x * pixel_spacing_x) + ipp_0)
+        point_y_mm = -((point_y * pixel_spacing_y) + ipp_1)
+        point_z = polyline[n][2]
+        lineNode.AddControlPoint(point_x_mm, point_y_mm, point_z)
+        # jump to the first line 
+        if (i==0 and n==0):
+          slicer.modules.markups.logic().JumpSlicesToLocation(point_x_mm, point_y_mm, point_z, True)
+      # do not display the length measurement 
+      lineNode.GetMeasurement('length').SetEnabled(False)
+      # change size of glyph 
+      display_node = lineNode.GetDisplayNode() 
+      # lock the dispay 
+      lineNode.GetDisplayNode().SetHandlesInteractive(False)
+      for controlPointIndex in range(lineNode.GetNumberOfControlPoints()):
+          lineNode.SetNthControlPointLocked(controlPointIndex, True)
+
+      if (display_node):
+        display_node.SetGlyphScale(0.75)
+      # Add to subject hierarchy
+      # Get the Subject Hierarchy item ID for the markup node
+      markupItemID = shNode.GetItemByDataNode(lineNode)
+      # Set the parent to the folder
+      shNode.SetItemParent(markupItemID, linesFolderID)
+
+    return 
+  
+  def load(self, loadable):
+    """
+    Loads the SR and checks for planar annotations. 
+    """
+
+    import highdicom as hd
+    logging.debug('DICOM SR TID1500 load()')
+
+    logging.debug("before sorting: %s" % loadable.uids)
+    sortedUIDs = self.sortReportsByDateTime(loadable.uids)
+    logging.debug("after sorting: %s" % sortedUIDs)
+
+    # if there is a RWVM object referenced from SEG, assume it contains the
+    # scaling that needs to be applied to the referenced series. Assign
+    # referencedSeriesUID from the image series, but load using the RWVM plugin
+    segPlugin = slicer.modules.dicomPlugins["DICOMSegmentationPlugin"]()
+
+    ### Iterate over the uids ### 
+    for idx, uid in enumerate(sortedUIDs):
+
+      # Get SR filename 
+      srFileName = slicer.dicomDatabase.fileForInstance(uid)
+      if srFileName is None:
+        logging.debug('Failed to get the filename from the DICOM database for ', uid)
+        return False
+      
+      # Read the SR once
+      sr = hd.sr.srread(srFileName)
+        
+      # Check if the plugin (tid1500reader) should be used or specialized highdicom code
+      # to read the planar annotations 
+      # sets the self.containsPlanarAnnotations = True or False 
+      containsPlanarAnnotations = self.containsPlanarAnnotations(sr) 
+      logging.info('containsPlanarAnnotations: ' + str(containsPlanarAnnotations))
+
+      ### If it does not contain planar annotations ###
+      if not containsPlanarAnnotations: 
+
+        tables = []
+
+        for segSeriesInstanceUID in loadable.ReferencedSegmentationInstanceUIDs[uid]:
+          segLoadables = segPlugin.examine([slicer.dicomDatabase.filesForSeries(segSeriesInstanceUID)])
+          for segLoadable in segLoadables:
+            if hasattr(segLoadable, "referencedSegInstanceUIDs"):
+              segLoadable.referencedSegInstanceUIDs = list(set(segLoadable.referencedSegInstanceUIDs) -
+                                                          set(loadable.referencedInstanceUIDs))
+            segPlugin.load(segLoadable)
+            if hasattr(segLoadable, "referencedSeriesUID") and len(loadable.ReferencedRWVMSeriesInstanceUIDs) > 0:
+              self.determineAndApplyRWVMToReferencedSeries(loadable, segLoadable)
+
+        self.tempDir = os.path.join(slicer.app.temporaryPath, "QIICR", "SR", self.currentDateTime, uid)
+        try:
+          os.makedirs(self.tempDir)
+        except OSError:
+          pass
+
+        outputFile = os.path.join(self.tempDir, uid+".json")
+
+        param = {
+          "inputSRFileName": srFileName,
+          "metaDataFileName": outputFile,
+          }
+
+        result = subprocess.run(
+            [self._dcmqi_binary('tid1500reader'),
+             '--inputSRFileName', param['inputSRFileName'],
+             '--metaDataFileName', param['metaDataFileName']],
+            capture_output=True, text=True)
+        if result.returncode != 0:
+          logging.debug('tid1500reader failed, unable to load DICOM SR TID1500:\n' + result.stderr)
+          self.cleanup()
+          return False
+
+        table = self.metadata2vtkTableNode(outputFile)
+        if table:
+          self.addSeriesInSubjectHierarchy(loadable, table)
+          with open(outputFile, 'r') as srMetadataFile:
+            srMetadataJSON = json.loads(srMetadataFile.read())
+            table.SetName(srMetadataJSON["SeriesDescription"])
+
+          # TODO: think about the following...
+          if len(slicer.util.getNodesByClass('vtkMRMLSegmentationNode')) > 0:
+            segmentationNode = slicer.util.getNodesByClass('vtkMRMLSegmentationNode')[-1]
+            segmentationNodeID = segmentationNode.GetID()
+            table.SetAttribute("ReferencedSegmentationNodeID", segmentationNodeID)
+
+            # TODO: think about a better solution for finding related reports
+            if idx-1 > -1:
+              table.SetAttribute("PriorReportUID", sortedUIDs[idx-1])
+              tables[idx-1].SetAttribute("FollowUpReportUID", uid)
+            table.SetAttribute("SOPInstanceUID", uid)
+            self.assignTrackingUniqueIdentifier(outputFile, segmentationNode)
+
+        tables.append(table)
+
+        self.loadAdditionalMeasurements(uid, loadable)
+
+        self.cleanup()
+
+      ### If it does contains planar annotations - use highdicom code to read the SR ###
+      else: 
+
+        # check if contains a point, bbox, polyline 
+        checkIfSRContainsBbox = self.checkIfSRContainsGeometry(sr, geometry_type='bbox2D')
+        checkIfSRContains3DPoint = self.checkIfSRContainsGeometry(sr, geometry_type='point3D')
+        checkIfSRContainsPolyline = self.checkIfSRContainsGeometry(sr, geometry_type='polyline2D')
+
+        tables = [] 
+
+        # if bbox 
+        if (checkIfSRContainsBbox): 
+          logging.info('SR contains 2D bounding box')
+          bboxInfo, bboxTableNode = self.extractBboxMetadataToVtkTableNode(sr)
+          self.showTable(bboxTableNode)
+          self.addSeriesInSubjectHierarchy(loadable, bboxTableNode)
+          self.displayBboxMarkups(sr, loadable, bboxInfo)
+          tables.append(bboxTableNode)
+          
+        # if point 
+        if (checkIfSRContains3DPoint):
+            logging.info('SR contains 3D point')
+            pointInfo, pointTableNode = self.extractPointMetadataToVtkTableNode(sr)
+            self.showTable(pointTableNode)
+            self.addSeriesInSubjectHierarchy(loadable, pointTableNode)
+            self.displayPointMarkups(sr, loadable, pointInfo)
+            tables.append(pointTableNode)
+
+        # if polyline but not bbox 
+        if (checkIfSRContainsPolyline and not checkIfSRContainsBbox):
+            logging.info('SR contains a 2D polyline, but not a bbox')
+            lineInfo, lineTableNode = self.extractLineMetadataToVtkTableNode(sr)
+            self.showTable(lineTableNode)
+            self.addSeriesInSubjectHierarchy(loadable, lineTableNode)
+            self.displayLineMarkups(sr, loadable, lineInfo)
+            tables.append(lineTableNode)
+
+    return len(tables) > 0
+
+  def getSegmentIDs(self, segmentationNode):
+    segmentIDs = vtk.vtkStringArray()
+    segmentation = segmentationNode.GetSegmentation()
+    segmentation.GetSegmentIDs(segmentIDs)
+    return [segmentIDs.GetValue(idx) for idx in range(segmentIDs.GetNumberOfValues())]
+
+  def assignTrackingUniqueIdentifier(self, metafile, segmentationNode):
+
+    with open(metafile) as datafile:
+      data = json.load(datafile)
+
+      segmentation = segmentationNode.GetSegmentation()
+      segments = [segmentation.GetSegment(segmentID) for segmentID in self.getSegmentIDs(segmentationNode)]
+
+      for idx, measurement in enumerate(data["Measurements"]):
+        tagName = "TrackingUniqueIdentifier"
+        trackingUID = measurement[tagName]
+        segment = segments[idx]
+        segment.SetTag(tagName, trackingUID)
+        logging.debug("Setting tag '{}' to {} for segment with name {}".format(tagName, trackingUID, segment.GetName()))
+
+  def determineAndApplyRWVMToReferencedSeries(self, loadable, segLoadable):
+    rwvmUID = loadable.ReferencedRWVMSeriesInstanceUIDs[0]
+    logging.debug("Looking up series %s from database" % rwvmUID)
+    rwvmFiles = slicer.dicomDatabase.filesForSeries(rwvmUID)
+    if len(rwvmFiles) > 0:
+      # consider only the first item on the list - there should be only
+      # one anyway, for the cases we are handling at the moment
+      rwvmPlugin = slicer.modules.dicomPlugins["DICOMRWVMPlugin"]()
+      rwvmFile = rwvmFiles[0]
+      logging.debug("Reading RWVM from " + rwvmFile)
+      rwvmDataset = pydicom.dcmread(rwvmFile)
+      if hasattr(rwvmDataset, "ReferencedSeriesSequence"):
+        if hasattr(rwvmDataset.ReferencedSeriesSequence[0], "SeriesInstanceUID"):
+          if rwvmDataset.ReferencedSeriesSequence[0].SeriesInstanceUID == segLoadable.referencedSeriesUID:
+            logging.debug("SEG references the same image series that is referenced by the RWVM series referenced from "
+                          "SR. Will load via RWVM.")
+            logging.debug("Examining " + rwvmFile)
+            rwvmLoadables = rwvmPlugin.examine([[rwvmFile]])
+            rwvmPlugin.load(rwvmLoadables[0])
+    else:
+      logging.warning("RWVM is referenced from SR, but is not found in the DICOM database!")
+
+  def metadata2vtkTableNode(self, metafile):
+    with open(metafile) as datafile:
+      data = json.load(datafile)
+      if "Measurements" not in data:
+        # Invalid file, just return instead of throw an exception to allow loading
+        # other data.
+        return None
+
+      measurement = data["Measurements"][0]
+
+      table = self.createAndConfigureTable()
+
+      tableWasModified = table.StartModify()
+      self.setupTableInformation(measurement, table)
+      self.addMeasurementsToTable(data, table)
+      table.EndModify(tableWasModified)
+
+      slicer.app.applicationLogic().GetSelectionNode().SetReferenceActiveTableID(table.GetID())
+      slicer.app.applicationLogic().PropagateTableSelection()
+    return table
+
+  def addMeasurementsToTable(self, data, table):
+    for measurement in data["Measurements"]:
+      name = measurement["TrackingIdentifier"]
+      rowIndex = table.AddEmptyRow()
+      table.SetCellText(rowIndex, 0, name)
+      for columnIndex, measurementItem in enumerate(measurement["measurementItems"]):
+        table.SetCellText(rowIndex, columnIndex + 1, measurementItem["value"])
+
+  def createAndConfigureTable(self):
+    table = slicer.vtkMRMLTableNode()
+    slicer.mrmlScene.AddNode(table)
+    table.SetAttribute("QuantitativeReporting", "Yes")
+    table.SetAttribute("readonly", "Yes")
+    table.SetUseColumnNameAsColumnHeader(True)
+    return table
+
+  def setupTableInformation(self, measurement, table):
+    col = table.AddColumn()
+    col.SetName("Tracking Identifier")
+
+    infoItems = self.enumerateDuplicateNames(self.generateMeasurementInformation(measurement["measurementItems"]))
+
+    for info in infoItems:
+      col = table.AddColumn()
+      col.SetName(info["name"])
+      table.SetColumnLongName(info["name"], info["name"])
+      table.SetColumnUnitLabel(info["name"], info["unit"])
+      table.SetColumnDescription(info["name"], info["description"])
+
+  def generateMeasurementInformation(self, measurementItems):
+    infoItems = []
+    for measurementItem in measurementItems:
+
+      crntInfo = dict()
+
+      unit = measurementItem["units"]["CodeValue"]
+      crntInfo["unit"] = measurementItem["units"]["CodeMeaning"]
+
+      if "derivationModifier" in measurementItem.keys():
+        description = crntInfo["name"] = measurementItem["derivationModifier"]["CodeMeaning"]
+      else:
+        description = measurementItem["quantity"]["CodeMeaning"]
+
+      crntInfo["name"] = "%s [%s]" % (description, unit.replace("[", "").replace("]", ""))
+      crntInfo["description"] = description
+
+      infoItems.append(crntInfo)
+    return infoItems
+
+  def enumerateDuplicateNames(self, items):
+    names = [item["name"] for item in items]
+    counts = {k: v for k, v in Counter(names).items() if v > 1}
+    nameListCopy = names[:]
+
+    for i in reversed(range(len(names))):
+      item = names[i]
+      if item in counts and counts[item]:
+        nameListCopy[i] += " (%s)" % str(counts[item])
+        counts[item] -= 1
+
+    for idx, item in enumerate(nameListCopy):
+      items[idx]["name"] = item
+    return items
+
+  def isConcept(self, item, coding):
+    code = item.ConceptNameCodeSequence[0]
+    return code.CodingSchemeDesignator == self.codings[coding]["scheme"] and code.CodeValue == self.codings[coding]["value"]
+
+  def loadAdditionalMeasurements(self, srUID, loadable):
+    """
+    Loads length measements as annotation rulers
+    TODO: need to generalize to other report contents
+    """
+    import pydicom 
+    srFilePath = slicer.dicomDatabase.fileForInstance(srUID)
+    sr = pydicom.dcmread(srFilePath)
+
+    if not self.isConcept(sr, "imagingMeasurementReport"):
+      return sr
+
+    contents = {}
+    measurements = []
+    contents['measurements'] = measurements
+    for item in sr.ContentSequence:
+      if self.isConcept(item, "personObserver"):
+        contents['personObserver'] = item.PersonName
+      if self.isConcept(item, "imagingMeasurements"):
+        for contentItem in item.ContentSequence:
+          if self.isConcept(contentItem, "measurementGroup"):
+            measurement = {}
+            for measurementItem in contentItem.ContentSequence:
+              if self.isConcept(measurementItem, "trackingIdentifier"):
+                measurement['trackingIdentifier'] = measurementItem.TextValue
+              if self.isConcept(measurementItem, "trackingUniqueIdentifier"):
+                measurement['trackingUniqueIdentifier'] = measurementItem.UID
+              if self.isConcept(measurementItem, "findingSite"):
+                measurement['findingSite'] = measurementItem.ConceptCodeSequence[0].CodeMeaning
+              if self.isConcept(measurementItem, "length"):
+                for lengthItem in measurementItem.ContentSequence:
+                  measurement['polyline'] = lengthItem.GraphicData
+                  for selectionItem in lengthItem.ContentSequence:
+                    if selectionItem.RelationshipType == "SELECTED FROM":
+                      for reference in selectionItem.ReferencedSOPSequence:
+                        measurement['referencedSOPInstanceUID'] = reference.ReferencedSOPInstanceUID
+                        if hasattr(reference, "ReferencedFrameNumber") and reference.ReferencedFrameNumber != "1":
+                          print('Error - only single frame references supported')
+            measurements.append(measurement)
+
+    for measurement in contents['measurements']:
+      if not 'polyline' in measurement:
+        # only polyline measurements are loaded as nodes
+        continue
+
+      markupsNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode")
+      markupsNode.SetName(str(contents['personObserver']))
+      self.addSeriesInSubjectHierarchy(loadable, markupsNode)
+
+      # Instead of calling markupsNode.SetLocked(True), lock each control point.
+      # This allows interacting with the points but not change their position.
+      slicer.modules.markups.logic().SetAllMarkupsLocked(markupsNode, True)
+
+      colorIndex = 1 + slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLMarkupsLineNode')
+      colorNode = slicer.mrmlScene.GetNodeByID("vtkMRMLColorTableNodeFileGenericAnatomyColors.txt")
+      color = numpy.zeros(4)
+      colorNode.GetColor(colorIndex, color)
+      markupsNode.GetDisplayNode().SetSelectedColor(*color[:3])
+
+      referenceFilePath = slicer.dicomDatabase.fileForInstance(measurement['referencedSOPInstanceUID'])
+      if not referenceFilePath:
+        raise Exception(f"Referenced image is not found in the database (referencedSOPInstanceUID={measurement['referencedSOPInstanceUID']}). Polyline point positions cannot be determined in 3D.")
+
+      reference = pydicom.dcmread(referenceFilePath)
+      origin = numpy.array(reference.ImagePositionPatient)
+      alongColumnVector = numpy.array(reference.ImageOrientationPatient[:3])
+      alongRowVector = numpy.array(reference.ImageOrientationPatient[3:])
+      alongColumnVector *= reference.PixelSpacing[1]
+      alongRowVector *= reference.PixelSpacing[0]
+      col1,row1,col2,row2 = measurement['polyline']
+      lpsToRAS = numpy.array([-1,-1,1])
+      p1 = (origin + col1 * alongColumnVector + row1 * alongRowVector) * lpsToRAS
+      p2 = (origin + col2 * alongColumnVector + row2 * alongRowVector) * lpsToRAS
+      markupsNode.AddControlPoint(vtk.vtkVector3d(p1))
+      markupsNode.AddControlPoint(vtk.vtkVector3d(p2))
+
+class DICOMLongitudinalTID1500PluginClass(DICOMTID1500PluginClass):
+
+  def __init__(self):
+    super(DICOMLongitudinalTID1500PluginClass, self).__init__()
+    self.loadType = "Longitudinal DICOM Structured Report TID1500"
+
+  def examineFiles(self, files):
+    import pydicom 
+    loadables = []
+
+    for cFile in files:
+      dataset = pydicom.dcmread(cFile)
+
+      uid = self.getDICOMValue(dataset, "SOPInstanceUID")
+      if uid == "":
+        return []
+
+      if self.isDICOMTID1500(dataset):
+        otherSRDatasets, otherSRFiles = self.getRelatedSRs(dataset)
+
+        if len(otherSRFiles):
+          allDatasets = otherSRDatasets + [dataset]
+          loadable = self.createLoadableAndAddReferences(allDatasets)
+          loadable.files = [cFile]+otherSRFiles
+          seriesDescription = self.getDICOMValue(dataset, "SeriesDescription", "Unknown")
+          loadable.name = seriesDescription + ' - as a Longitudinal DICOM SR TID1500 object'
+          loadable.tooltip = loadable.name
+          loadable.selected = True
+          loadable.confidence = 0.96
+          loadable.uids = [self.getDICOMValue(d, "SOPInstanceUID") for d in allDatasets]
+          refName = self.referencedSeriesName(loadable)
+          if refName != "":
+            loadable.name = refName + " " + seriesDescription + " - SR TID1500"
+
+          loadables.append(loadable)
+
+          logging.debug('DICOM SR Longitudinal TID1500 modality found')
+
+    return loadables
+
+  def getRelatedSRs(self, dataset):
+    import pydicom 
+    otherSRFiles = []
+    otherSRDatasets = []
+    studyInstanceUID = self.getDICOMValue(dataset, "StudyInstanceUID")
+    patient = slicer.dicomDatabase.patientForStudy(studyInstanceUID)
+    studies = [s for s in slicer.dicomDatabase.studiesForPatient(patient) if studyInstanceUID not in s]
+    for study in studies:
+      series = slicer.dicomDatabase.seriesForStudy(study)
+      foundSRs = []
+      for s in series:
+        srFile = self.fileForSeries(s)
+        tempDCM = pydicom.dcmread(srFile)
+        if self.isDICOMTID1500(tempDCM):
+          foundSRs.append(srFile)
+          otherSRDatasets.append(tempDCM)
+
+      if len(foundSRs) > 1:
+        logging.warn("Found more than one SR per study!! This is not supported right now")
+      otherSRFiles += foundSRs
+    return otherSRDatasets, otherSRFiles
+
+  def fileForSeries(self, series):
+    instance = slicer.dicomDatabase.instancesForSeries(series)
+    return slicer.dicomDatabase.fileForInstance(instance[0])
+
+
+class DICOMTID1500Plugin:
+  """
+  This class is the 'hook' for slicer to detect and recognize the plugin
+  as a loadable scripted module
+  """
+  def __init__(self, parent):
+    parent.title = "DICOM SR TID1500 Object Import Plugin"
+    parent.categories = ["Developer Tools.DICOM Plugins"]
+    parent.contributors = ["Christian Herz (BWH), Andrey Fedorov (BWH)"]
+    parent.helpText = """
+    Plugin to the DICOM Module to parse and load DICOM SR TID1500 instances.
+    No module interface here, only in the DICOM module
+    """
+    parent.dependencies = ['DICOM', 'Colors']
+    parent.acknowledgementText = """
+    This DICOM Plugin was developed by
+    Christian Herz and Andrey Fedorov, BWH.
+    and was partially funded by NIH grant U24 CA180918 (QIICR).
+    """
+
+    # Add this extension to the DICOM module's list for discovery when the module
+    # is created.  Since this module may be discovered before DICOM itself,
+    # create the list if it doesn't already exist.
+    try:
+      slicer.modules.dicomPlugins
+    except AttributeError:
+      slicer.modules.dicomPlugins = {}
+    slicer.modules.dicomPlugins['DICOMTID1500Plugin'] = DICOMTID1500PluginClass
+    # slicer.modules.dicomPlugins['DICOMLongitudinalTID1500Plugin'] = DICOMLongitudinalTID1500PluginClass

--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -75,6 +75,22 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [dicomweb-client]
   dicomweb-client==0.60.1 --hash=sha256:e128866a797b7acdcd4ad280a10ebced5af77a3ce1d1bde709389ad56583955d
   # [/dicomweb-client]
+  # [dcmqi]
+  # Binary distribution of the DCMQI tools (segimage2itkimage, itkimage2segimage,
+  # paramap2itkimage, tid1500reader, tid1500writer, etc.) used by DICOM plugins.
+  # Note: macOS wheels require macOS 13+; Linux wheel is manylinux_2_28 x86_64 only.
+  # Hashes correspond to the following packages:
+  #  - dcmqi-0.3.3-py3-none-macosx_13_0_arm64.whl
+  #  - dcmqi-0.3.3-py3-none-macosx_13_0_x86_64.whl
+  #  - dcmqi-0.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  #  - dcmqi-0.3.3-py3-none-win32.whl
+  #  - dcmqi-0.3.3-py3-none-win_amd64.whl
+  dcmqi==0.3.3 --hash=sha256:92f5f942d0349357e511c6a5d3a3703884c3f2127e822e2a204dec8021aa83c4 \
+               --hash=sha256:cb007a8991928ff09c864d4c468255f460f6457629a449ad3d52390bf11489f3 \
+               --hash=sha256:5a689b17c1163094a73468d8a624611d460ad86969d24ffd22aeccfee7cb4dc1 \
+               --hash=sha256:daf19ba9326574eb5df6bed91598e6ee55852637c277e37ff29231936526d5ab \
+               --hash=sha256:ca684f09857323389355196cba3c58fce30f4581f1d5220725e2ab08596f6e0f
+  # [/dcmqi]
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -20,6 +20,7 @@ if(Slicer_USE_SYSTEM_${proj})
   foreach(module_name IN ITEMS
     pydicom
     six
+    highdicom
     )
     ExternalProject_FindPythonPackage(
       MODULE_NAME "${module_name}"
@@ -91,6 +92,12 @@ if(NOT Slicer_USE_SYSTEM_${proj})
                --hash=sha256:daf19ba9326574eb5df6bed91598e6ee55852637c277e37ff29231936526d5ab \
                --hash=sha256:ca684f09857323389355196cba3c58fce30f4581f1d5220725e2ab08596f6e0f
   # [/dcmqi]
+  # [highdicom]
+  # Pure-Python package for creating/reading complex DICOM objects (SR, SEG, PM, etc.)
+  # Hashes correspond to the following packages:
+  #  - highdicom-0.27.0-py3-none-any.whl
+  highdicom==0.27.0 --hash=sha256:90a14ef75f67b7df2c3fd83df9c0bddd787dfdfab2b08c8c68828207389aed3f
+  # [/highdicom]
   ]===])
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
This follows up on the discussion in https://github.com/Slicer/Slicer/issues/8387#issuecomment-4230140358. So far I built and tested this branch on Linux, and confirmed SEG read, SEG write, SR TID1500 read, M3D read all work as expected.

### Overview

This branch migrates four DICOM object-type plugins from the [QuantitativeReporting](https://github.com/QIICR/QuantitativeReporting) extension into Slicer's core `DICOMPlugins` module, so that users no longer need to install a separate extension to load these common DICOM object types. The four plugins added are:

| Plugin | DICOM SOP class |
|---|---|
| `DICOMSegmentationPlugin` | SEG — DICOM Segmentation Storage |
| `DICOMParametricMapPlugin` | PM — Parametric Map Storage |
| `DICOMTID1500Plugin` | SR — Comprehensive/Enhanced SR (TID 1500 Measurement Report) |
| `DICOMM3DPlugin` | M3D — Encapsulated 3D Model (STL) |

---

### Changes

#### New plugins (`Modules/Scripted/DICOMPlugins/`)

- **[DICOMSegmentationPlugin.py](Modules/Scripted/DICOMPlugins/DICOMSegmentationPlugin.py)** — Loads DICOM SEG objects. Uses the `dcmqi` pip binary `segimage2itkimage` to convert SEG → ITK volumes, then imports them as `vtkMRMLSegmentationNode`.
- **[DICOMParametricMapPlugin.py](Modules/Scripted/DICOMPlugins/DICOMParametricMapPlugin.py)** — Loads DICOM Parametric Map objects using `dcmqi` (`paramap2itkimage`) into scalar volumes.
- **[DICOMTID1500Plugin.py](Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py)** — Parses TID 1500 Imaging Measurement Reports using `highdicom` and populates a `vtkMRMLTableNode` with the extracted measurements.
- **[DICOMM3DPlugin.py](Modules/Scripted/DICOMPlugins/DICOMM3DPlugin.py)** — Extracts the encapsulated STL payload from a DICOM M3D object and loads it as a `vtkMRMLSegmentationNode`.
- **[CMakeLists.txt](Modules/Scripted/DICOMPlugins/CMakeLists.txt)** — Registers the four new plugin scripts so they are installed.

#### Base class enhancements (`Modules/Scripted/DICOMLib/DICOMPlugin.py`)

- Added common DICOM tag shortcuts (`seriesInstanceUID`, `modality`, `instanceUID`, `classUID`).
- Added `currentDateTime` property (lazy, cached timestamp for temp directory naming).
- Added `cleanup()` method to remove the plugin's `tempDir`.
- Added `addReferences()` / `_addReferencedSeries()` / `_addReferencedImages()` helpers to populate `loadable.referencedInstanceUIDs`.
- Added `_dcmqi_binary()` static method to locate dcmqi console-script binaries via `shutil.which` with a fallback to the Python `bin/` directory.
- Refactored `examineForImport()` into a caching wrapper that calls a new virtual method `examineFiles()`, reducing boilerplate in subclasses.

#### Dependency changes (`SuperBuild/External_python-dicom-requirements.cmake`)

- Added `dcmqi==0.3.3` with per-platform SHA-256 hashes (macOS arm64/x86_64, Linux manylinux2014, Windows 32/64).
- Added `highdicom==0.27.0` with SHA-256 hash.

#### Extension registry (`Modules/Scripted/DICOM/DICOMExtensions.json`)

- Removed the three QuantitativeReporting entries for SEG, PM, and SR — these object types are now handled natively and no longer prompt the user to install the extension.

#### Integration tests (`Applications/SlicerApp/Testing/Python/DICOMPluginTests.py`)

- Added `DICOMPluginTestsTest` with three end-to-end tests:
  - `test_DICOMSegmentationPlugin` — downloads a ReMIND SEG file from IDC, imports it, and asserts a `vtkMRMLSegmentationNode` with ≥1 segment is created.
  - `test_DICOMTID1500Plugin` — downloads a QIN-PROSTATE SR file from IDC, imports it, and asserts ≥1 `vtkMRMLTableNode` is created.
  - `test_DICOMM3DPlugin` — downloads a Prostate-MRI-US-Biopsy M3D file from IDC, imports it, and asserts a `vtkMRMLSegmentationNode` is created.
- Registered the test module in `Applications/SlicerApp/Testing/Python/CMakeLists.txt`.

---

### Notes for reviewers

- The `dcmqi` pip package ships pre-built platform binaries (macOS 13+, Linux manylinux_2_28 x86_64, Windows). Older macOS versions and non-x86_64 Linux builds will not be able to install it — this is documented in inline comments in the cmake file.
- Integration tests download files from the public IDC GCS bucket at test time; they require network access and are not hermetic.
