### PR TITLE
ENH: Add auto-trim of file cache at application startup

### DIFF
--- a/Base/Logic/vtkDataIOManagerLogic.cxx
+++ b/Base/Logic/vtkDataIOManagerLogic.cxx
@@ -162,7 +162,6 @@ void vtkDataIOManagerLogic::DeleteDataTransferFromCache(vtkDataTransfer* dt)
         {
           cm->DeleteFromCache(dt->GetDestinationURI());
           dt->SetTransferCached(0);
-          cm->InvokeEvent(vtkCacheManager::CacheDeleteEvent);
         }
       }
     }
@@ -272,7 +271,7 @@ int vtkDataIOManagerLogic::QueueRead(vtkMRMLNode* node)
   }
 
   const char* source = dnode->GetNthStorageNode(storageNodeIndex)->GetURI();
-  const char* dest = cm->GetFilenameFromURI(source);
+  std::string dest = cm->GetFilenameFromURI(source);
   vtkDebugMacro("QueueRead: got the source " << source << " and dest " << dest);
 
   //--- set the destination filename in the node.
@@ -286,8 +285,8 @@ int vtkDataIOManagerLogic::QueueRead(vtkMRMLNode* node)
     const char* sourceN = dnode->GetNthStorageNode(storageNodeIndex)->GetNthURI(uriNum);
     if (sourceN)
     {
-      const char* destN = cm->GetFilenameFromURI(sourceN);
-      if (destN)
+      std::string destN = cm->GetFilenameFromURI(sourceN);
+      if (!destN.empty())
       {
         dnode->GetNthStorageNode(storageNodeIndex)->AddFileName(destN);
         vtkDebugMacro("QueueRead: set " << uriNum << " filename to " << destN << ", source uri = " << sourceN);
@@ -305,8 +304,8 @@ int vtkDataIOManagerLogic::QueueRead(vtkMRMLNode* node)
   //--- This test has been done in MRML (DataIOManager), but with asynchIO,
   //--- Cache may have become full since the remote read was queued.
   //---
-  float bufsize = (cm->GetRemoteCacheLimit() * 1000000.0) - (cm->GetRemoteCacheFreeBufferSize() * 1000000.0);
-  if ((cm->GetCurrentCacheSize() * 1000000.0) >= bufsize)
+  cm->UpdateCacheInformation();
+  if (cm->GetFreeCacheSpaceRemaining() <= 0)
   {
     //--- No space left in cache.
     if (cm->CachedFileExists(dest))

--- a/Base/QTGUI/Resources/UI/qSlicerSettingsCachePanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsCachePanel.ui
@@ -6,24 +6,63 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>329</width>
-    <height>267</height>
+    <width>365</width>
+    <height>318</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Cache</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
-   <property name="fieldGrowthPolicy">
-    <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-   </property>
-   <item row="1" column="0">
+   <item row="0" column="0">
     <widget class="QLabel" name="CachePathLabel">
      <property name="toolTip">
       <string>Cache directory for downloaded files</string>
      </property>
      <property name="text">
       <string>Cache location:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="ctkDirectoryButton" name="CachePathButton"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="CacheSizeLabel">
+     <property name="toolTip">
+      <string>Upper limit of the dedicated cache for downloaded files</string>
+     </property>
+     <property name="text">
+      <string>Cache size:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QSpinBox" name="CacheSizeSpinBox">
+     <property name="suffix">
+      <string>MB</string>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>999999999</number>
+     </property>
+     <property name="singleStep">
+      <number>10</number>
+     </property>
+     <property name="value">
+      <number>200</number>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="UsageLabel">
+     <property name="toolTip">
+      <string>Current usage of the cache</string>
+     </property>
+     <property name="text">
+      <string>Cache usage:</string>
      </property>
     </widget>
    </item>
@@ -43,74 +82,89 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QPushButton" name="updateCacheUsageInformationButton">
+       <property name="toolTip">
+        <string>Update usage of cache information</string>
+       </property>
+       <property name="text">
+        <string>Refresh</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="PruneCachePushButton">
+       <property name="toolTip">
+        <string>Remove the oldest cached files to keep the cache within the size limit.</string>
+       </property>
+       <property name="text">
+        <string>Prune cache</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="ClearCachePushButton">
+       <property name="toolTip">
+        <string>Delete all files in cache directory</string>
+       </property>
+       <property name="text">
+        <string>Clear cache</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="UsageLabel">
+   <item row="2" column="0">
+    <widget class="QLabel" name="AutoPruneLabel">
      <property name="toolTip">
-      <string>Current usage of the cache</string>
+      <string>Automatically remove oldest cached files at startup if cache directory size exceeds configured cache size</string>
      </property>
      <property name="text">
-      <string>Cache usage:</string>
+      <string>Auto-prune:</string>
      </property>
     </widget>
    </item>
    <item row="2" column="1">
-    <widget class="QSpinBox" name="CacheSizeSpinBox">
-     <property name="suffix">
-      <string>MB</string>
-     </property>
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>999999999</number>
-     </property>
-     <property name="singleStep">
-      <number>10</number>
-     </property>
-     <property name="value">
-      <number>200</number>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="CacheSizeLabel">
+    <widget class="QCheckBox" name="AutoPruneCheckBox">
      <property name="toolTip">
-      <string>Upper limit of the dedicated cache for downloaded files</string>
+      <string>Remove the oldest cached files at application startup to keep the cache within the size limit.</string>
      </property>
      <property name="text">
-      <string>Cache size:</string>
+      <string/>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
    <item row="6" column="1">
-    <widget class="QSpinBox" name="CacheFreeBufferSpinBox">
-     <property name="suffix">
-      <string>MB</string>
-     </property>
-     <property name="maximum">
-      <number>999999999</number>
-     </property>
-     <property name="singleStep">
-      <number>10</number>
-     </property>
-     <property name="value">
-      <number>10</number>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="CacheFreeBufferLabel">
+    <widget class="QPushButton" name="RemoveSelectedCachePushButton">
      <property name="toolTip">
-      <string>Amount of space that should remain free. It should be the typical size of a file to download.</string>
+      <string>Remove the selected files or folders from the cache</string>
      </property>
      <property name="text">
-      <string>Cache free buffer:</string>
+      <string>Remove selected</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="5" column="1">
+    <widget class="QTableWidget" name="FilesTableWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="FilesListLabel">
+     <property name="text">
+      <string>Files in cache:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <widget class="QLabel" name="ForceRedownloadLabel">
      <property name="toolTip">
       <string>Control whether a file must be downloaded even if it is already in the cache</string>
@@ -120,35 +174,12 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="3" column="1">
     <widget class="QCheckBox" name="ForceRedownloadCheckBox">
      <property name="text">
       <string/>
      </property>
     </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QListWidget" name="FilesListWidget"/>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="FilesListLabel">
-     <property name="text">
-      <string>Files in cache:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QPushButton" name="ClearCachePushButton">
-     <property name="toolTip">
-      <string>Delete all files in cache directory</string>
-     </property>
-     <property name="text">
-      <string>Clear cache</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="ctkDirectoryButton" name="CachePathButton"/>
    </item>
   </layout>
  </widget>

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -121,6 +121,7 @@
 #include <vtkSystemInformation.h>
 
 // MRML includes
+#include <vtkCacheManager.h>
 #include <vtkMRMLMessageCollection.h>
 #include <vtkMRMLNode.h>
 #include <vtkMRMLScene.h>
@@ -440,8 +441,19 @@ void qSlicerApplicationPrivate::init()
   this->SettingsDialog->addPanel(qSlicerApplication::tr("Extensions"), settingsExtensionsPanel);
 #endif
   qSlicerSettingsCachePanel* cachePanel = new qSlicerSettingsCachePanel;
-  cachePanel->setCacheManager(this->MRMLScene->GetCacheManager());
+  vtkCacheManager* cacheManager = this->MRMLScene->GetCacheManager();
+  cachePanel->setCacheManager(cacheManager);
   this->SettingsDialog->addPanel(qSlicerApplication::tr("Cache"), cachePanel);
+
+  // Now that cachePanel set the cache sizes from user settings, we prune the cache.
+  if (cacheManager && q->userSettings())
+  {
+    bool autoPruneEnabled = q->userSettings()->value("Cache/AutoPrune", true).toBool();
+    if (autoPruneEnabled)
+    {
+      cacheManager->PruneCache();
+    }
+  }
 
 #ifdef Slicer_BUILD_I18N_SUPPORT
   qSlicerSettingsInternationalizationPanel* qtInternationalizationPanel = new qSlicerSettingsInternationalizationPanel;

--- a/Base/QTGUI/qSlicerSettingsCachePanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsCachePanel.cxx
@@ -19,8 +19,17 @@
 ==============================================================================*/
 
 // Qt includes
+#include <QDateTime>
 #include <QDebug>
+#include <QDir>
+#include <QFileInfo>
+#include <QHeaderView>
+#include <QShowEvent>
+#include <QMessageBox>
+#include <QSignalBlocker>
 #include <QSettings>
+#include <QSet>
+#include <QTableWidgetItem>
 
 // CTK includes
 
@@ -34,6 +43,33 @@
 
 // VTK includes
 #include <vtkCommand.h>
+
+namespace
+{
+enum CacheTableColumn
+{
+  ColumnModified = 0,
+  ColumnName = 1,
+  ColumnSize = 2,
+};
+
+// QTableWidgetItem that sorts by a stored numeric value rather than display text.
+class NumericTableWidgetItem : public QTableWidgetItem
+{
+public:
+  NumericTableWidgetItem(const QString& text, double sortValue)
+    : QTableWidgetItem(text)
+    , SortValue(sortValue)
+  {
+  }
+  bool operator<(const QTableWidgetItem& other) const override
+  {
+    const auto* o = dynamic_cast<const NumericTableWidgetItem*>(&other);
+    return o ? SortValue < o->SortValue : QTableWidgetItem::operator<(other);
+  }
+  double SortValue;
+};
+} // namespace
 
 // --------------------------------------------------------------------------
 // qSlicerSettingsCachePanelPrivate
@@ -71,13 +107,25 @@ void qSlicerSettingsCachePanelPrivate::init()
   this->setupUi(q);
   QObject::connect(this->CachePathButton, SIGNAL(directoryChanged(QString)), q, SLOT(setCachePath(QString)));
   QObject::connect(this->CacheSizeSpinBox, SIGNAL(valueChanged(int)), q, SLOT(setCacheSize(int)));
-  QObject::connect(this->CacheFreeBufferSpinBox, SIGNAL(valueChanged(int)), q, SLOT(setCacheFreeBufferSize(int)));
+  QObject::connect(this->updateCacheUsageInformationButton, SIGNAL(clicked(bool)), q, SLOT(updateFromCacheManager()));
   QObject::connect(this->ForceRedownloadCheckBox, SIGNAL(toggled(bool)), q, SLOT(setForceRedownload(bool)));
+  QObject::connect(this->RemoveSelectedCachePushButton, SIGNAL(clicked()), q, SLOT(removeSelectedCacheItems()));
+  QObject::connect(this->FilesTableWidget, SIGNAL(itemSelectionChanged()), q, SLOT(updateRemoveSelectedButton()));
+  QObject::connect(this->PruneCachePushButton, SIGNAL(clicked()), q, SLOT(pruneCache()));
   QObject::connect(this->ClearCachePushButton, SIGNAL(clicked()), q, SLOT(clearCache()));
 
-  // hide for now
-  // this->FilesListLabel->setVisible(false);
-  // this->FilesListWidget->setVisible(false);
+  this->FilesTableWidget->setColumnCount(3);
+  this->FilesTableWidget->setHorizontalHeaderLabels({ qSlicerSettingsCachePanel::tr("Modified"), qSlicerSettingsCachePanel::tr("Name"), qSlicerSettingsCachePanel::tr("Size") });
+  this->FilesTableWidget->horizontalHeader()->setSectionResizeMode(ColumnModified, QHeaderView::ResizeToContents);
+  this->FilesTableWidget->horizontalHeader()->setSectionResizeMode(ColumnName, QHeaderView::Stretch);
+  this->FilesTableWidget->horizontalHeader()->setSectionResizeMode(ColumnSize, QHeaderView::ResizeToContents);
+  this->FilesTableWidget->verticalHeader()->setVisible(false);
+  this->FilesTableWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
+  this->FilesTableWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+  this->FilesTableWidget->setSelectionMode(QAbstractItemView::ExtendedSelection);
+  this->FilesTableWidget->setSortingEnabled(true);
+  this->FilesTableWidget->sortByColumn(ColumnModified, Qt::DescendingOrder);
+  this->RemoveSelectedCachePushButton->setEnabled(false);
 }
 
 // --------------------------------------------------------------------------
@@ -96,6 +144,13 @@ qSlicerSettingsCachePanel::qSlicerSettingsCachePanel(QWidget* _parent)
 qSlicerSettingsCachePanel::~qSlicerSettingsCachePanel() = default;
 
 // --------------------------------------------------------------------------
+void qSlicerSettingsCachePanel::showEvent(QShowEvent* event)
+{
+  this->Superclass::showEvent(event);
+  this->updateFromCacheManager();
+}
+
+// --------------------------------------------------------------------------
 void qSlicerSettingsCachePanel::setCacheManager(vtkCacheManager* cacheManager)
 {
   Q_D(qSlicerSettingsCachePanel);
@@ -112,7 +167,7 @@ void qSlicerSettingsCachePanel::setCacheManager(vtkCacheManager* cacheManager)
   qSlicerRelativePathMapper* relativePathMapper = new qSlicerRelativePathMapper(d->CachePathButton, "directory", SIGNAL(directoryChanged(QString)));
   this->registerProperty("Cache/Path", relativePathMapper, "relativePath", SIGNAL(relativePathChanged(QString)));
   this->registerProperty("Cache/Size", d->CacheSizeSpinBox, /*no tr*/ "value", SIGNAL(valueChanged(int)));
-  this->registerProperty("Cache/FreeBufferSize", d->CacheFreeBufferSpinBox, /*no tr*/ "value", SIGNAL(valueChanged(int)));
+  this->registerProperty("Cache/AutoPrune", d->AutoPruneCheckBox, /*no tr*/ "checked", SIGNAL(toggled(bool)));
   this->registerProperty("Cache/ForceRedownload", d->ForceRedownloadCheckBox, /*no tr*/ "checked", SIGNAL(toggled(bool)));
 }
 
@@ -128,43 +183,115 @@ void qSlicerSettingsCachePanel::updateFromCacheManager()
   d->CachePathButton->setDirectory(QString(d->CacheManager->GetRemoteCacheDirectory()));
   d->CacheSizeSpinBox->setValue(d->CacheManager->GetRemoteCacheLimit());
 
-  d->CacheManager->CacheSizeCheck();
+  d->CacheManager->UpdateCacheInformation();
   d->UsedCacheSizeLabel->setText(tr("%1MB used").arg(QString::number(qMax(d->CacheManager->GetCurrentCacheSize(), 0.f), 'f', 2)));
-  d->CacheManager->FreeCacheBufferCheck();
   d->FreeCacheSizeLabel->setText(tr("%1MB free").arg(QString::number(d->CacheManager->GetFreeCacheSpaceRemaining(), 'f', 2)));
   QPalette palette = this->palette();
   if (d->CacheManager->GetCurrentCacheSize() > d->CacheManager->GetRemoteCacheLimit())
   {
     palette.setColor(d->UsedCacheSizeLabel->foregroundRole(), Qt::red);
   }
-  else if (d->CacheManager->GetFreeCacheSpaceRemaining() < d->CacheManager->GetRemoteCacheFreeBufferSize())
-  {
-    palette.setColor(d->UsedCacheSizeLabel->foregroundRole(), QColor("orange"));
-  }
   d->UsedCacheSizeLabel->setPalette(palette);
   d->FreeCacheSizeLabel->setPalette(palette);
 
-  d->CacheFreeBufferSpinBox->setRange(0, d->CacheManager->GetRemoteCacheLimit());
-  d->CacheFreeBufferSpinBox->setValue(d->CacheManager->GetRemoteCacheFreeBufferSize());
   d->ForceRedownloadCheckBox->setChecked(d->CacheManager->GetEnableForceRedownload() == 1);
 
-  d->FilesListWidget->clear();
-  std::vector<std::string> cachedFiles = d->CacheManager->GetCachedFiles();
-  for (std::vector<std::string>::const_iterator it = cachedFiles.begin(), end = cachedFiles.end(); it != end; ++it)
+  d->FilesTableWidget->setSortingEnabled(false);
+  d->FilesTableWidget->setRowCount(0);
+  for (const vtkCacheManager::CacheEntry& entry : d->CacheManager->GetCacheEntries())
   {
-    QFileInfo file(it->c_str());
-    QListWidgetItem* fileItem = new QListWidgetItem;
-    fileItem->setText(file.fileName());
-    // fileItem->setToolTip(it->first.c_str());
-    d->FilesListWidget->addItem(fileItem);
+    const QFileInfo fi(QString::fromStdString(entry.Path));
+    const int row = d->FilesTableWidget->rowCount();
+    d->FilesTableWidget->insertRow(row);
+
+    // Modified column — yyyy-MM-dd sorts correctly as a string.
+    auto* dateItem = new NumericTableWidgetItem(QDateTime::fromSecsSinceEpoch(entry.ModifiedTime).toString("yyyy-MM-dd"), static_cast<double>(entry.ModifiedTime));
+    d->FilesTableWidget->setItem(row, ColumnModified, dateItem);
+
+    // Name column — store full path in UserRole for deletion.
+    QString nameText = fi.fileName();
+    if (entry.IsDirectory)
+    {
+      nameText += tr(" [%1 files]").arg(entry.FileCount);
+    }
+    QTableWidgetItem* nameItem = new QTableWidgetItem(nameText);
+    nameItem->setData(Qt::UserRole, fi.filePath());
+    nameItem->setToolTip(fi.filePath());
+    d->FilesTableWidget->setItem(row, ColumnName, nameItem);
+
+    // Size column — numeric sort via NumericTableWidgetItem.
+    const double sizeMB = static_cast<double>(entry.SizeBytes) / 1000000.0;
+    const QString sizeText = sizeMB >= 0.005 ? tr("%1 MB").arg(sizeMB, 0, 'f', 2) : tr("%1 KB").arg(static_cast<double>(entry.SizeBytes) / 1000.0, 0, 'f', 1);
+    auto* sizeItem = new NumericTableWidgetItem(sizeText, static_cast<double>(entry.SizeBytes));
+    sizeItem->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    sizeItem->setData(Qt::UserRole, static_cast<qulonglong>(entry.SizeBytes));
+    d->FilesTableWidget->setItem(row, ColumnSize, sizeItem);
+
+    if (entry.ExceedsCacheSize)
+    {
+      dateItem->setForeground(Qt::red);
+      nameItem->setForeground(Qt::red);
+      sizeItem->setForeground(Qt::red);
+    }
   }
+  d->FilesTableWidget->setSortingEnabled(true);
+  this->updateRemoveSelectedButton();
 }
 
 // --------------------------------------------------------------------------
 void qSlicerSettingsCachePanel::setCachePath(const QString& path)
 {
   Q_D(qSlicerSettingsCachePanel);
-  d->CacheManager->SetRemoteCacheDirectory(path.toUtf8());
+  if (d->CacheManager == nullptr)
+  {
+    return;
+  }
+
+  const QString previousPath = QString::fromUtf8(d->CacheManager->GetRemoteCacheDirectory());
+  const QString selectedPath = path;
+  if (selectedPath == previousPath)
+  {
+    return;
+  }
+
+  // Create a missing cache directory before any sentinel checks.
+  if (!QDir(selectedPath).exists())
+  {
+    QDir directory;
+    if (!directory.mkpath(selectedPath))
+    {
+      const QSignalBlocker blocker(d->CachePathButton);
+      d->CachePathButton->setDirectory(previousPath);
+      QMessageBox::warning(this,
+                           tr("Failed to create cache folder"),
+                           tr("Failed to create cache directory %1. Make sure the parent directory is writable.").arg(QDir::toNativeSeparators(selectedPath)));
+      return;
+    }
+  }
+
+  // Warn the user if the folder contains files and is not marked as a cache folder
+  // to avoid unintentional deletion of existing files in that folder later.
+  if (!d->CacheManager->IsDirectoryEmpty(selectedPath.toStdString())              //
+      && !d->CacheManager->HasSentinelFileInDirectory(selectedPath.toStdString()) //
+      && !this->confirmCacheOperationWithMissingSentinel(tr("selection of cache folder"), selectedPath))
+  {
+    const QSignalBlocker blocker(d->CachePathButton);
+    d->CachePathButton->setDirectory(previousPath);
+    return;
+  }
+
+  // Ensure sentinel creation targets the newly selected cache path.
+  d->CacheManager->SetRemoteCacheDirectory(selectedPath.toStdString());
+  if (!d->CacheManager->HasSentinelFile() && !d->CacheManager->CreateSentinelFile())
+  {
+    d->CacheManager->SetRemoteCacheDirectory(previousPath.toStdString());
+    const QSignalBlocker blocker(d->CachePathButton);
+    d->CachePathButton->setDirectory(previousPath);
+    QMessageBox::warning(this,
+                         tr("Failed to mark folder for cache use"),
+                         tr("Failed to create cache sentinel file in %1. Make sure the selected directory is writable.") //
+                           .arg(QDir::toNativeSeparators(selectedPath)));
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -172,13 +299,6 @@ void qSlicerSettingsCachePanel::setCacheSize(int sizeInMB)
 {
   Q_D(qSlicerSettingsCachePanel);
   d->CacheManager->SetRemoteCacheLimit(sizeInMB);
-}
-
-// --------------------------------------------------------------------------
-void qSlicerSettingsCachePanel::setCacheFreeBufferSize(int sizeInMB)
-{
-  Q_D(qSlicerSettingsCachePanel);
-  d->CacheManager->SetRemoteCacheFreeBufferSize(sizeInMB);
 }
 
 // --------------------------------------------------------------------------
@@ -193,6 +313,144 @@ void qSlicerSettingsCachePanel::clearCache()
 {
   Q_D(qSlicerSettingsCachePanel);
   Q_ASSERT(d->CacheManager);
+  if (!this->confirmCacheOperationWithMissingSentinel(tr("clearing the cache"), d->CacheManager->GetRemoteCacheDirectory()))
+  {
+    return;
+  }
+
   d->CacheManager->ClearCache();
-  // this->updateFromCacheManager();
+  this->updateFromCacheManager();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsCachePanel::updateRemoveSelectedButton()
+{
+  Q_D(qSlicerSettingsCachePanel);
+
+  QSet<int> selectedRows;
+  for (const QTableWidgetItem* item : d->FilesTableWidget->selectedItems())
+  {
+    selectedRows.insert(item->row());
+  }
+
+  if (selectedRows.isEmpty())
+  {
+    d->RemoveSelectedCachePushButton->setEnabled(false);
+    d->RemoveSelectedCachePushButton->setText(tr("Remove selected"));
+    return;
+  }
+
+  unsigned long long totalBytes = 0;
+  for (int row : selectedRows)
+  {
+    totalBytes += d->FilesTableWidget->item(row, ColumnSize)->data(Qt::UserRole).toULongLong();
+  }
+
+  const double sizeMB = static_cast<double>(totalBytes) / 1000000.0;
+  const QString sizeText = sizeMB >= 0.005 ? tr("%1 MB").arg(sizeMB, 0, 'f', 2) : tr("%1 KB").arg(static_cast<double>(totalBytes) / 1000.0, 0, 'f', 1);
+
+  const int count = selectedRows.size();
+  d->RemoveSelectedCachePushButton->setEnabled(true);
+  d->RemoveSelectedCachePushButton->setText(tr("Remove selected (%1 %2, %3)").arg(count).arg(count == 1 ? tr("item") : tr("items")).arg(sizeText));
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsCachePanel::removeSelectedCacheItems()
+{
+  Q_D(qSlicerSettingsCachePanel);
+  Q_ASSERT(d->CacheManager);
+
+  QSet<int> selectedRows;
+  for (const QTableWidgetItem* item : d->FilesTableWidget->selectedItems())
+  {
+    selectedRows.insert(item->row());
+  }
+  if (selectedRows.isEmpty())
+  {
+    return;
+  }
+
+  if (!this->confirmCacheOperationWithMissingSentinel(tr("removing selected items"), d->CacheManager->GetRemoteCacheDirectory()))
+  {
+    return;
+  }
+
+  for (int row : selectedRows)
+  {
+    const QString path = d->FilesTableWidget->item(row, ColumnName)->data(Qt::UserRole).toString();
+    d->CacheManager->DeleteFromCache(path.toStdString());
+  }
+  this->updateFromCacheManager();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsCachePanel::pruneCache()
+{
+  Q_D(qSlicerSettingsCachePanel);
+  Q_ASSERT(d->CacheManager);
+  if (!this->confirmCacheOperationWithMissingSentinel(tr("trimming the cache"), d->CacheManager->GetRemoteCacheDirectory()))
+  {
+    return;
+  }
+
+  d->CacheManager->PruneCache();
+  this->updateFromCacheManager();
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerSettingsCachePanel::confirmCacheOperationWithMissingSentinel(const QString& operationText, const QString& cacheDirectory)
+{
+  Q_D(qSlicerSettingsCachePanel);
+  if (!d->CacheManager || cacheDirectory.isEmpty())
+  {
+    return false;
+  }
+  if (d->CacheManager->HasSentinelFileInDirectory(cacheDirectory.toStdString()))
+  {
+    return true;
+  }
+
+  QMessageBox confirmationMessageBox(this);
+  confirmationMessageBox.setIcon(QMessageBox::Warning);
+
+  confirmationMessageBox.setWindowTitle(tr("Confirm %1").arg(operationText));
+  confirmationMessageBox.setText(tr("Folder '%1' is not marked as a cache folder. Are you sure you want to proceed?").arg(cacheDirectory));
+
+  QDir selectedDirectory(cacheDirectory);
+  const QFileInfoList directoryEntries = selectedDirectory.entryInfoList(QDir::NoDotAndDotDot | QDir::AllEntries, QDir::Name);
+  if (!directoryEntries.empty())
+  {
+    const int maxDetailedEntries = 50;
+    QStringList displayedEntries;
+    const int displayedCount = qMin(directoryEntries.size(), maxDetailedEntries);
+    for (int entryIndex = 0; entryIndex < displayedCount; ++entryIndex)
+    {
+      displayedEntries << QDir::toNativeSeparators(directoryEntries.at(entryIndex).fileName());
+    }
+
+    QString details = tr("Selected folder contents:") + "\n" + displayedEntries.join("\n");
+    if (directoryEntries.size() > maxDetailedEntries)
+    {
+      details += "\n" + tr("... and %1 more item(s).").arg(directoryEntries.size() - maxDetailedEntries);
+    }
+    confirmationMessageBox.setDetailedText(details);
+  }
+
+  confirmationMessageBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+  confirmationMessageBox.setDefaultButton(QMessageBox::No);
+
+  if (confirmationMessageBox.exec() != QMessageBox::Yes)
+  {
+    return false;
+  }
+
+  bool sentinelCreated;
+  sentinelCreated = d->CacheManager->CreateSentinelFileInDirectory(cacheDirectory.toStdString());
+  if (!sentinelCreated)
+  {
+    QMessageBox::warning(this, tr("Unable to Continue"), tr("Failed to create cache sentinel file in %1. Operation was canceled.").arg(cacheDirectory));
+    return false;
+  }
+
+  return true;
 }

--- a/Base/QTGUI/qSlicerSettingsCachePanel.h
+++ b/Base/QTGUI/qSlicerSettingsCachePanel.h
@@ -53,14 +53,19 @@ public:
 public slots:
   void setCachePath(const QString& path);
   void setCacheSize(int sizeInMB);
-  void setCacheFreeBufferSize(int sizeInMB);
   void setForceRedownload(bool force);
+  void removeSelectedCacheItems();
+  void pruneCache();
   void clearCache();
 
 protected slots:
   void updateFromCacheManager();
+  void updateRemoveSelectedButton();
 
 protected:
+  void showEvent(QShowEvent* event) override;
+  bool confirmCacheOperationWithMissingSentinel(const QString& operationText, const QString& directoryPath);
+
   QScopedPointer<qSlicerSettingsCachePanelPrivate> d_ptr;
 
 private:

--- a/Libs/MRML/Core/vtkCacheManager.cxx
+++ b/Libs/MRML/Core/vtkCacheManager.cxx
@@ -10,43 +10,295 @@
 #include <vtkCallbackCommand.h>
 #include <vtkObjectFactory.h>
 
+// STD includes
+#include <algorithm>
+#include <cstring>
+#include <numeric>
+#include <set>
+#include <utility>
+#include <vector>
+
 vtkStandardNewMacro(vtkCacheManager);
 
 #define MB 1000000.0
 
+namespace
+{
+bool IsNullOrEmpty(const char* value)
+{
+  return value == nullptr || value[0] == '\0';
+}
+
+bool IsDirectoryNavigationEntry(const char* fileName)
+{
+  return std::strcmp(fileName, ".") == 0 || std::strcmp(fileName, "..") == 0;
+}
+} // namespace
+
+//----------------------------------------------------------------------------
+std::string vtkCacheManager::CanonicalizePath(const char* path) const
+{
+  if (IsNullOrEmpty(path))
+  {
+    return std::string();
+  }
+
+  std::string canonicalPath = vtksys::SystemTools::GetRealPath(path);
+  if (canonicalPath.empty())
+  {
+    canonicalPath = vtksys::SystemTools::CollapseFullPath(path);
+  }
+  return canonicalPath;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkCacheManager::JoinPath(const std::string& directoryPath, const std::string& fileName) const
+{
+  std::vector<std::string> pathComponents;
+  vtksys::SystemTools::SplitPath(directoryPath, pathComponents);
+  pathComponents.push_back(fileName);
+  return vtksys::SystemTools::JoinPath(pathComponents);
+}
+
+//----------------------------------------------------------------------------
+bool vtkCacheManager::PathIsWithinDirectory(const std::string& directoryPath, const std::string& path) const
+{
+  if (directoryPath.empty() || path.empty())
+  {
+    return false;
+  }
+
+  std::string relativePath = vtksys::SystemTools::RelativePath(directoryPath.c_str(), path.c_str());
+  if (relativePath.empty())
+  {
+    return directoryPath == path;
+  }
+
+  if (relativePath == ".")
+  {
+    return true;
+  }
+
+  if (vtksys::SystemTools::FileIsFullPath(relativePath.c_str()))
+  {
+    return false;
+  }
+
+  return !(relativePath == ".." || relativePath.rfind("../", 0) == 0 || relativePath.rfind("..\\", 0) == 0);
+}
+
+//----------------------------------------------------------------------------
+bool vtkCacheManager::IsDirectoryEmpty(const std::string& directoryPath) const
+{
+  vtksys::Directory directory;
+  if (directoryPath.empty() || !directory.Load(directoryPath))
+  {
+    return false;
+  }
+
+  for (size_t fileNum = 0; fileNum < directory.GetNumberOfFiles(); ++fileNum)
+  {
+    const char* fileName = directory.GetFile(static_cast<unsigned long>(fileNum));
+    if (!strcmp(fileName, ".") || !strcmp(fileName, ".."))
+    {
+      continue;
+    }
+    return false;
+  }
+
+  return true;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkCacheManager::GetSentinelFilePath(const std::string& cacheDirectory) const
+{
+  if (cacheDirectory.empty())
+  {
+    return std::string();
+  }
+  return this->JoinPath(cacheDirectory, this->GetSentinelFileName());
+}
+
+//----------------------------------------------------------------------------
+std::string vtkCacheManager::GetSentinelFilePath(const char* cacheDirectory) const
+{
+  if (IsNullOrEmpty(cacheDirectory))
+  {
+    return std::string();
+  }
+  return this->JoinPath(cacheDirectory, this->GetSentinelFileName());
+}
+
+//----------------------------------------------------------------------------
+bool vtkCacheManager::HasSentinelFileInDirectory(const std::string& cacheDirectory) const
+{
+  std::string sentinelFilePath = this->GetSentinelFilePath(cacheDirectory);
+  return !sentinelFilePath.empty() && vtksys::SystemTools::FileExists(sentinelFilePath.c_str());
+}
+
+//----------------------------------------------------------------------------
+bool vtkCacheManager::CreateSentinelFileInDirectory(const std::string& cacheDirectory) const
+{
+  if (cacheDirectory.empty() || !vtksys::SystemTools::FileIsDirectory(cacheDirectory))
+  {
+    return false;
+  }
+
+  std::string sentinelFilePath = this->GetSentinelFilePath(cacheDirectory);
+  if (sentinelFilePath.empty())
+  {
+    return false;
+  }
+  if (vtksys::SystemTools::FileExists(sentinelFilePath.c_str()))
+  {
+    return true;
+  }
+
+  return vtksys::SystemTools::Touch(sentinelFilePath, true).IsSuccess();
+}
+
+//----------------------------------------------------------------------------
+bool vtkCacheManager::CanDeletePathInCache(const char* cacheDirectory, const char* pathToDelete, std::string& reason) const
+{
+  reason.clear();
+  if (IsNullOrEmpty(cacheDirectory))
+  {
+    reason = "cache directory is empty";
+    return false;
+  }
+  if (IsNullOrEmpty(pathToDelete))
+  {
+    reason = "path to delete is empty";
+    return false;
+  }
+
+  if (!this->HasSentinelFileInDirectory(cacheDirectory))
+  {
+    reason = std::string("cache sentinel file is missing (") + this->GetSentinelFileName() + ")";
+    return false;
+  }
+
+  std::string canonicalCachePath = this->CanonicalizePath(cacheDirectory);
+  std::string canonicalDeletePath = this->CanonicalizePath(pathToDelete);
+
+  if (canonicalCachePath.empty() || canonicalDeletePath.empty())
+  {
+    reason = "unable to resolve canonical path";
+    return false;
+  }
+
+  if (!this->PathIsWithinDirectory(canonicalCachePath, canonicalDeletePath))
+  {
+    reason = "path resolves outside the cache directory";
+    return false;
+  }
+
+  return true;
+}
+
+//----------------------------------------------------------------------------
+bool vtkCacheManager::CollectCachedFilesRecursively(const std::string& directoryPath,
+                                                    const std::string& rootDirectoryPath,
+                                                    std::vector<vtkCacheManagerCachedFile>& cachedFiles) const
+{
+  if (!vtksys::SystemTools::FileIsDirectory(directoryPath.c_str()))
+  {
+    return false;
+  }
+
+  std::string canonicalRootDirectory;
+  if (!rootDirectoryPath.empty())
+  {
+    canonicalRootDirectory = this->CanonicalizePath(rootDirectoryPath.c_str());
+  }
+
+  std::set<std::string> visitedCanonicalDirectories;
+  std::vector<std::string> pendingDirectories;
+  pendingDirectories.push_back(directoryPath);
+
+  while (!pendingDirectories.empty())
+  {
+    const std::string currentDirectoryPath = pendingDirectories.back();
+    pendingDirectories.pop_back();
+
+    if (!vtksys::SystemTools::FileIsDirectory(currentDirectoryPath.c_str()))
+    {
+      continue;
+    }
+
+    std::string canonicalCurrentDirectory = this->CanonicalizePath(currentDirectoryPath.c_str());
+    if (!canonicalCurrentDirectory.empty())
+    {
+      if (!visitedCanonicalDirectories.insert(canonicalCurrentDirectory).second)
+      {
+        // Skipping already visited cache directory (possible symlink/junction cycle)
+        continue;
+      }
+    }
+
+    vtksys::Directory directory;
+    if (!directory.Load(currentDirectoryPath.c_str()))
+    {
+      continue;
+    }
+
+    for (size_t fileNum = 0; fileNum < directory.GetNumberOfFiles(); ++fileNum)
+    {
+      const char* fileName = directory.GetFile(static_cast<unsigned long>(fileNum));
+      if (IsDirectoryNavigationEntry(fileName))
+      {
+        continue;
+      }
+
+      if (this->GetSentinelFileName() == fileName)
+      {
+        continue;
+      }
+
+      std::string fullPath = this->JoinPath(currentDirectoryPath, fileName);
+
+      std::string canonicalPath = this->CanonicalizePath(fullPath.c_str());
+
+      if (!canonicalPath.empty() && !canonicalRootDirectory.empty() && !this->PathIsWithinDirectory(canonicalRootDirectory, canonicalPath))
+      {
+        vtkWarningMacro("Skipping cache entry outside of traversal root: " << fullPath);
+        continue;
+      }
+
+      if (vtksys::SystemTools::FileIsDirectory(fullPath.c_str()))
+      {
+        pendingDirectories.push_back(fullPath);
+        continue;
+      }
+
+      vtkCacheManagerCachedFile cachedFile;
+      cachedFile.Path = fullPath;
+      cachedFile.ModifiedTime = static_cast<long long>(vtksys::SystemTools::ModifiedTime(fullPath));
+      cachedFiles.push_back(cachedFile);
+    }
+  }
+
+  return true;
+}
+
 //----------------------------------------------------------------------------
 vtkCacheManager::vtkCacheManager()
 {
-  this->MRMLScene = nullptr;
   this->CallbackCommand = vtkCallbackCommand::New();
-  this->CachedFileList.clear();
-  //--- what seem reasonable default values here?
-  this->RemoteCacheLimit = 200;
-  this->RemoteCacheFreeBufferSize = 10;
-  this->CurrentCacheSize = 0;
+  this->RemoteCacheLimit = 1000; // MB (a 3D image is around a few hundred MB, so this allows at least a few files to be cached)
+  this->CurrentCacheSize = 0;    // MB
   this->EnableForceRedownload = 0;
   this->InsufficientFreeBufferNotificationFlag = 0;
-  // this->EnableRemoteCacheOverwriting = 1;
-  this->uriMap.clear();
+  this->UpdatingCacheInformation = false;
 }
 
 //----------------------------------------------------------------------------
 vtkCacheManager::~vtkCacheManager()
 {
-
-  this->MRMLScene = nullptr;
-  this->uriMap.clear();
   if (this->CallbackCommand)
   {
     this->CallbackCommand->Delete();
   }
-  this->CachedFileList.clear();
-  this->RemoteCacheLimit = 0;
-  this->CurrentCacheSize = 0;
-  this->RemoteCacheFreeBufferSize = 0;
-  this->EnableForceRedownload = 0;
-  this->InsufficientFreeBufferNotificationFlag = 0;
-  //  this->EnableRemoteCacheOverwriting = 1;
 }
 
 //----------------------------------------------------------------------------
@@ -55,8 +307,8 @@ const char* vtkCacheManager::GetFileFromURIMap(const char* uri)
   std::string uriString(uri);
 
   //--- URI is first, local name is second
-  std::map<std::string, std::string>::iterator iter = this->uriMap.find(uriString);
-  if (iter != this->uriMap.end())
+  std::map<std::string, std::string>::iterator iter = this->UriMap.find(uriString);
+  if (iter != this->UriMap.end())
   {
     return iter->second.c_str();
   }
@@ -76,22 +328,14 @@ void vtkCacheManager::MapFileToURI(const char* uri, const char* fname)
   std::string remote(uri);
   std::string local(fname);
 
-  std::map<std::string, std::string>::iterator iter;
-  //--- see if it's already here and update if so.
-
-  //--- URI is first, local name is second
-  int added = 0;
-  for (iter = this->uriMap.begin(); iter != this->uriMap.end(); iter++)
+  std::map<std::string, std::string>::iterator iter = this->UriMap.find(remote);
+  if (iter != this->UriMap.end())
   {
-    if (iter->first == remote)
-    {
-      iter->second = local;
-      added = 1;
-    }
+    iter->second = local;
   }
-  if (!added)
+  else
   {
-    this->uriMap.insert(std::make_pair(remote, local));
+    this->UriMap.insert(std::make_pair(remote, local));
     this->Modified();
   }
 }
@@ -99,36 +343,73 @@ void vtkCacheManager::MapFileToURI(const char* uri, const char* fname)
 //----------------------------------------------------------------------------
 void vtkCacheManager::SetRemoteCacheDirectory(const char* dir)
 {
-  std::string dirstring = dir;
-  size_t len = (int)dirstring.size();
-
-  if (len == 0)
+  if (dir == nullptr)
   {
-    vtkWarningMacro("Setting RemoteCacheDirectory to be a null string.");
+    vtkWarningMacro("Setting RemoteCacheDirectory from null pointer is not allowed.");
+    return;
   }
-  else
+
+  std::string dirstring = dir;
+  if (!dirstring.empty())
   {
-    //---
-    //--- make sure to remove backslash on the end of the dirstring.
-    //---
-    const char lastChar = dirstring.at(len - 1);
+    // make sure to remove backslash on the end of the dirstring.
+    const char lastChar = dirstring.at(dirstring.length() - 1);
     if (lastChar == '/' || lastChar == '\\')
     {
-      dirstring = dirstring.substr(0, len - 1);
+      dirstring = dirstring.substr(0, dirstring.length() - 1);
+    }
+    std::string canonicalDirectory = this->CanonicalizePath(dirstring.c_str());
+    if (!canonicalDirectory.empty())
+    {
+      dirstring = canonicalDirectory;
     }
   }
 
   if (this->RemoteCacheDirectory == dirstring)
   {
+    // no change
     return;
   }
 
   this->RemoteCacheDirectory = dirstring;
-  if (!vtksys::SystemTools::FileExists(this->RemoteCacheDirectory.c_str()))
+
+  if (!dirstring.empty())
   {
-    vtksys::SystemTools::MakeDirectory(this->RemoteCacheDirectory.c_str());
+    if (!vtksys::SystemTools::FileExists(this->RemoteCacheDirectory.c_str()))
+    {
+      if (!vtksys::SystemTools::MakeDirectory(this->RemoteCacheDirectory.c_str()))
+      {
+        vtkErrorMacro("Failed to create cache directory " << this->RemoteCacheDirectory << ".");
+      }
+      else
+      {
+        if (!this->CreateSentinelFileInDirectory(this->RemoteCacheDirectory))
+        {
+          vtkErrorMacro("Failed to initialize cache sentinel file in " << this->RemoteCacheDirectory << ".");
+        }
+      }
+    }
+    else if (!vtksys::SystemTools::FileIsDirectory(this->RemoteCacheDirectory.c_str()))
+    {
+      vtkErrorMacro("Cache path is not a directory: " << this->RemoteCacheDirectory << ".");
+    }
+    else if (!this->HasSentinelFileInDirectory(this->RemoteCacheDirectory))
+    {
+      if (this->IsDirectoryEmpty(this->RemoteCacheDirectory))
+      {
+        if (!this->CreateSentinelFileInDirectory(this->RemoteCacheDirectory))
+        {
+          vtkErrorMacro("Failed to initialize cache sentinel file in empty directory " << this->RemoteCacheDirectory << ".");
+        }
+      }
+      else
+      {
+        vtkWarningMacro("Cache directory does not contain sentinel file " << this->GetSentinelFileName()
+                                                                          << ". Destructive cache operations are disabled until the sentinel is created.");
+      }
+    }
   }
-  // scan files in cache, it calls Modified
+
   this->UpdateCacheInformation();
 }
 
@@ -139,16 +420,33 @@ const char* vtkCacheManager::GetRemoteCacheDirectory()
 }
 
 //----------------------------------------------------------------------------
-int vtkCacheManager::IsRemoteReference(const char* uri)
+std::string vtkCacheManager::GetSentinelFileName() const
 {
-  int index;
+  return std::string(".slicer-cache");
+}
+
+//----------------------------------------------------------------------------
+bool vtkCacheManager::HasSentinelFile() const
+{
+  return this->HasSentinelFileInDirectory(this->RemoteCacheDirectory.c_str());
+}
+
+//----------------------------------------------------------------------------
+bool vtkCacheManager::CreateSentinelFile() const
+{
+  return this->CreateSentinelFileInDirectory(this->RemoteCacheDirectory.c_str());
+}
+
+//----------------------------------------------------------------------------
+bool vtkCacheManager::IsRemoteReference(const char* uri)
+{
   std::string uriString(uri);
-  std::string prefix;
 
   //--- get all characters up to (and not including) the '://'
+  int index;
   if ((index = (int)(uriString.find("://", 0))) != (int)(std::string::npos))
   {
-    prefix = uriString.substr(0, index);
+    std::string prefix = uriString.substr(0, index);
     //--- check to see if any leading bracketed characters are
     //--- in this part of the string.
     if ((index = (int)(prefix.find("]:", 0))) != (int)(std::string::npos))
@@ -159,23 +457,23 @@ int vtkCacheManager::IsRemoteReference(const char* uri)
     }
     if (prefix == "file")
     {
-      return (0);
+      return false;
     }
     else
     {
-      return (1);
+      return true;
     }
   }
   else
   {
     vtkDebugMacro("URI " << uri << " contains no file:// or other prefix.");
     //--- doesn't seem to be a :// in the string.
-    return (0);
+    return false;
   }
 }
 
 //----------------------------------------------------------------------------
-int vtkCacheManager::IsLocalReference(const char* uri)
+bool vtkCacheManager::IsLocalReference(const char* uri)
 {
   int index;
   std::string uriString(uri);
@@ -195,22 +493,22 @@ int vtkCacheManager::IsLocalReference(const char* uri)
     }
     if (prefix == "file")
     {
-      return (1);
+      return true;
     }
     else
     {
-      return (0);
+      return false;
     }
   }
   else
   {
     vtkWarningMacro("URI " << uri << " contains no file:// or other prefix.");
-    return (0);
+    return false;
   }
 }
 
 //----------------------------------------------------------------------------
-int vtkCacheManager::LocalFileExists(const char* uri)
+bool vtkCacheManager::LocalFileExists(const char* uri)
 {
   int index;
   std::string uriString(uri);
@@ -229,11 +527,11 @@ int vtkCacheManager::LocalFileExists(const char* uri)
 
   if (vtksys::SystemTools::FileExists(filename.c_str()))
   {
-    return (1);
+    return true;
   }
   else
   {
-    return (0);
+    return false;
   }
 }
 
@@ -244,82 +542,57 @@ void vtkCacheManager::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "RemoteCacheDirectory: " << this->GetRemoteCacheDirectory() << "\n";
   os << indent << "RemoteCacheLimit: " << this->GetRemoteCacheLimit() << "\n";
   os << indent << "CurrentCacheSize: " << this->GetCurrentCacheSize() << "\n";
-  os << indent << "RemoteCacheFreeBufferSize: " << this->GetRemoteCacheFreeBufferSize() << "\n";
-  // os << indent << "EnableRemoteCacheOverwriting: " << this->GetEnableRemoteCacheOverwriting() << "\n";
   os << indent << "EnableForceRedownload: " << this->GetEnableForceRedownload() << "\n";
-}
-
-//----------------------------------------------------------------------------
-std::vector<std::string> vtkCacheManager::GetAllCachedFiles()
-{
-  this->CachedFileList.clear();
-  this->GetCachedFileList(this->GetRemoteCacheDirectory());
-  return (this->CachedFileList);
 }
 
 //----------------------------------------------------------------------------
 std::vector<std::string> vtkCacheManager::GetCachedFiles() const
 {
-  return this->CachedFileList;
+  std::vector<std::string> paths;
+  paths.reserve(this->CacheEntries.size());
+  for (const CacheEntry& e : this->CacheEntries)
+  {
+    paths.push_back(e.Path);
+  }
+  return paths;
 }
 
 //----------------------------------------------------------------------------
-int vtkCacheManager::GetCachedFileList(const char* dirname)
+std::vector<std::string> vtkCacheManager::GetCachedFilesInDirectory(const std::string& dirname)
 {
-
-  //  std::string convdir = vtksys::SystemTools::ConvertToOutputPath ( dirname );
-  if (vtksys::SystemTools::FileIsDirectory(dirname))
+  std::vector<std::string> cachedFiles;
+  std::vector<vtkCacheManagerCachedFile> cachedFileInfo;
+  if (!this->CollectCachedFilesRecursively(dirname, dirname, cachedFileInfo))
   {
-    vtksys::Directory dir;
-    dir.Load(dirname);
-    size_t fileNum;
+    vtkDebugMacro("vtkCacheManager::GetCachedFilesInDirectory: Directory " << dirname << " doesn't look like a directory.\n");
+    return cachedFiles;
+  }
 
-    //--- get files in cache dir and add to vector of strings.
-    for (fileNum = 0; fileNum < dir.GetNumberOfFiles(); ++fileNum)
-    {
-      {
-        if (strcmp(dir.GetFile(static_cast<unsigned long>(fileNum)), ".") //
-            && strcmp(dir.GetFile(static_cast<unsigned long>(fileNum)), ".."))
-        {
-          std::string fullName = dirname;
-          //--- add backslash to end if not present.
-          if ((fullName.rfind("/", 0)) != (fullName.size() - 1))
-          {
-            fullName += "/";
-          }
-          fullName += dir.GetFile(static_cast<unsigned long>(fileNum));
-
-          //--- if the file is a directory, have to go inside and
-          //--- do some recursive thing to add those files to cached list
-          if (vtksys::SystemTools::FileIsDirectory(fullName.c_str()))
-          {
-            if (!this->GetCachedFileList(fullName.c_str()))
+  std::sort(cachedFileInfo.begin(),
+            cachedFileInfo.end(),
+            [](const vtkCacheManagerCachedFile& left, const vtkCacheManagerCachedFile& right)
             {
-              return (0);
-            }
-          }
-          else
-          {
-            this->CachedFileList.emplace_back(dir.GetFile(static_cast<unsigned long>(fileNum)));
-          }
-        }
-      }
-    }
-  }
-  else
+              if (left.ModifiedTime == right.ModifiedTime)
+              {
+                return left.Path < right.Path;
+              }
+              return left.ModifiedTime > right.ModifiedTime;
+            });
+  cachedFiles.reserve(cachedFileInfo.size());
+  for (std::vector<vtkCacheManagerCachedFile>::const_iterator it = cachedFileInfo.begin(); it != cachedFileInfo.end(); ++it)
   {
-    vtkDebugMacro("vtkCacheManager::GetCachedFileList: Cache Directory " << this->GetRemoteCacheDirectory() << " doesn't look like a directory.\n");
-    return (0);
+    cachedFiles.push_back(it->Path);
   }
-  return (1);
+
+  return cachedFiles;
 }
 
 //----------------------------------------------------------------------------
-const char* vtkCacheManager::EncodeURI(const char* uri)
+std::string vtkCacheManager::EncodeURI(const char* uri)
 {
   if (uri == nullptr)
   {
-    return "(null)";
+    return std::string();
   }
   std::string kwInString = std::string(uri);
   // encode %
@@ -335,49 +608,17 @@ const char* vtkCacheManager::EncodeURI(const char* uri)
   // encode double quote
   vtksys::SystemTools::ReplaceString(kwInString, "\"", "%22");
 
-  const char* inStr = kwInString.c_str();
-  char* returnString = nullptr;
-  size_t n = strlen(inStr) + 1;
-  char* cp1 = new char[n];
-  const char* cp2 = (inStr);
-  returnString = cp1;
-  do
-  {
-    *cp1++ = *cp2++;
-  } while (--n);
-  return (returnString);
+  return kwInString;
 }
 
 //----------------------------------------------------------------------------
-const char* vtkCacheManager::AddCachePathToFilename(const char* filename)
+std::string vtkCacheManager::GetFilenameFromURI(const std::string& uri)
 {
-  std::string cachedir(this->GetRemoteCacheDirectory());
-  if (cachedir.c_str() != nullptr)
-  {
-    std::string ret = cachedir;
-    ret += "/";
-    ret += filename;
-
-    const char* outStr = ret.c_str();
-    char* absoluteName = nullptr;
-    size_t n = strlen(outStr) + 1;
-    char* cp1 = new char[n];
-    const char* cp2 = (outStr);
-    absoluteName = cp1;
-    do
-    {
-      *cp1++ = *cp2++;
-    } while (--n);
-    return absoluteName;
-  }
-  else
-  {
-    return (nullptr);
-  }
+  return this->GetFilenameFromURI(uri.c_str());
 }
 
 //----------------------------------------------------------------------------
-const char* vtkCacheManager::GetFilenameFromURI(const char* uri)
+std::string vtkCacheManager::GetFilenameFromURI(const char* uri)
 {
   //--- this method should return the absolute path of the
   //--- file that a storage node will read from in cache
@@ -386,7 +627,7 @@ const char* vtkCacheManager::GetFilenameFromURI(const char* uri)
   if (uri == nullptr)
   {
     vtkDebugMacro("GetFilenameFromURI: input uri is null");
-    return "(null)";
+    return std::string();
   }
 
   const char* mapcheck = this->GetFileFromURIMap(uri);
@@ -468,54 +709,161 @@ const char* vtkCacheManager::GetFilenameFromURI(const char* uri)
   pathComponents.push_back(newFileName);
   fileName = vtksys::SystemTools::JoinPath(pathComponents);
 
-  const char* inStr = fileName.c_str();
-  char* returnString = nullptr;
-  size_t n = strlen(inStr) + 1;
-  char* cp1 = new char[n];
-  const char* cp2 = (inStr);
-  returnString = cp1;
-  do
-  {
-    *cp1++ = *cp2++;
-  } while (--n);
-  vtkDebugMacro("GetFilenameFromURI: returning " << returnString);
-
-  return returnString;
+  vtkDebugMacro("GetFilenameFromURI: returning " << fileName.c_str());
+  return fileName;
 }
 
 //----------------------------------------------------------------------------
 void vtkCacheManager::UpdateCacheInformation()
 {
-  //--- now recompute cache size
-  // this->CurrentCacheSize = ?;
+  if (this->UpdatingCacheInformation)
+  {
+    return;
+  }
+  this->UpdatingCacheInformation = true;
 
-  //--- recompute free buffer size
-  // this->RemoteCacheFreeBufferSize = ?;
+  // Scan the top-level cache directory entries.
+  std::vector<CacheEntry> newEntries;
+  if (!this->RemoteCacheDirectory.empty())
+  {
+    const std::string canonicalCacheDirectory = this->CanonicalizePath(this->GetRemoteCacheDirectory());
+    vtksys::Directory cacheDirectory;
+    if (cacheDirectory.Load(this->GetRemoteCacheDirectory()))
+    {
+      newEntries.reserve(cacheDirectory.GetNumberOfFiles());
+      for (size_t fileNum = 0; fileNum < cacheDirectory.GetNumberOfFiles(); ++fileNum)
+      {
+        const char* fileName = cacheDirectory.GetFile(static_cast<unsigned long>(fileNum));
+        if (IsDirectoryNavigationEntry(fileName) || this->GetSentinelFileName() == fileName)
+        {
+          continue;
+        }
 
-  //--- and refresh list of cached files.
-  this->CachedFileList.clear();
-  this->GetCachedFileList(this->GetRemoteCacheDirectory());
-  this->Modified();
+        CacheEntry entry;
+        entry.Path = this->JoinPath(this->GetRemoteCacheDirectory(), fileName);
+        entry.SizeBytes = 0;
+        entry.ModifiedTime = 0;
+        entry.IsDirectory = vtksys::SystemTools::FileIsDirectory(entry.Path.c_str());
+        entry.FileCount = 0;
+        entry.ExceedsCacheSize = false;
+
+        std::string canonicalTargetPath = this->CanonicalizePath(entry.Path.c_str());
+        if (!canonicalTargetPath.empty() && !canonicalCacheDirectory.empty() && !this->PathIsWithinDirectory(canonicalCacheDirectory, canonicalTargetPath))
+        {
+          vtkWarningMacro("Skipping cache entry outside cache root: " << entry.Path);
+          continue;
+        }
+
+        if (entry.IsDirectory)
+        {
+          std::vector<vtkCacheManagerCachedFile> cachedFilesInDirectory;
+          if (!this->CollectCachedFilesRecursively(entry.Path, entry.Path, cachedFilesInDirectory))
+          {
+            vtkWarningMacro("UpdateCacheInformation could not inspect directory: " << entry.Path);
+            continue;
+          }
+          for (const vtkCacheManagerCachedFile& cachedFile : cachedFilesInDirectory)
+          {
+            entry.SizeBytes += static_cast<unsigned long long>(vtksys::SystemTools::FileLength(cachedFile.Path.c_str()));
+            entry.ModifiedTime = std::max(entry.ModifiedTime, cachedFile.ModifiedTime);
+            entry.FileCount++;
+          }
+          if (entry.FileCount == 0)
+          {
+            entry.ModifiedTime = static_cast<long long>(vtksys::SystemTools::ModifiedTime(entry.Path));
+          }
+        }
+        else
+        {
+          entry.SizeBytes = static_cast<unsigned long long>(vtksys::SystemTools::FileLength(entry.Path.c_str()));
+          entry.ModifiedTime = static_cast<long long>(vtksys::SystemTools::ModifiedTime(entry.Path));
+        }
+
+        newEntries.push_back(entry);
+      }
+    }
+  }
+
+  // Compute total size in MB.
+  unsigned long long cacheSizeBytes = 0;
+  for (const CacheEntry& e : newEntries)
+  {
+    cacheSizeBytes += e.SizeBytes;
+  }
+  float newCacheSize = static_cast<float>(cacheSizeBytes / MB);
+
+  // Mark entries that PruneCache() would evict: oldest-first until within limit.
+  const unsigned long long cacheLimitBytes = static_cast<unsigned long long>(this->GetRemoteCacheLimit()) * static_cast<unsigned long long>(MB);
+  if (cacheSizeBytes > cacheLimitBytes)
+  {
+    std::vector<size_t> byAge(newEntries.size());
+    std::iota(byAge.begin(), byAge.end(), 0);
+    std::sort(byAge.begin(),
+              byAge.end(),
+              [&newEntries](size_t a, size_t b)
+              {
+                if (newEntries[a].ModifiedTime == newEntries[b].ModifiedTime)
+                {
+                  return newEntries[a].Path < newEntries[b].Path;
+                }
+                return newEntries[a].ModifiedTime < newEntries[b].ModifiedTime;
+              });
+    unsigned long long remaining = cacheSizeBytes;
+    for (size_t idx : byAge)
+    {
+      if (remaining <= cacheLimitBytes)
+      {
+        break;
+      }
+      newEntries[idx].ExceedsCacheSize = true;
+      remaining = (newEntries[idx].SizeBytes < remaining) ? remaining - newEntries[idx].SizeBytes : 0;
+    }
+  }
+
+  // Sort newest-first for consumers.
+  std::sort(newEntries.begin(),
+            newEntries.end(),
+            [](const CacheEntry& a, const CacheEntry& b)
+            {
+              if (a.ModifiedTime == b.ModifiedTime)
+              {
+                return a.Path < b.Path;
+              }
+              return a.ModifiedTime > b.ModifiedTime;
+            });
+
+  // Detect changes by comparing sorted entry paths and total size.
+  std::vector<std::string> oldPaths, newPaths;
+  for (const CacheEntry& e : this->CacheEntries)
+  {
+    oldPaths.push_back(e.Path);
+  }
+  for (const CacheEntry& e : newEntries)
+  {
+    newPaths.push_back(e.Path);
+  }
+  const bool changed = (oldPaths != newPaths || newCacheSize != this->CurrentCacheSize);
+
+  this->CacheEntries = std::move(newEntries);
+  this->CurrentCacheSize = newCacheSize;
+
+  if (this->CurrentCacheSize > static_cast<float>(this->RemoteCacheLimit))
+  {
+    this->InvokeEvent(vtkCacheManager::CacheLimitExceededEvent);
+  }
+
+  if (changed)
+  {
+    this->Modified();
+  }
+
+  this->UpdatingCacheInformation = false;
 }
 
 //----------------------------------------------------------------------------
-void vtkCacheManager::DeleteFromCachedFileList(const char* target)
+void vtkCacheManager::DeleteFromCache(const std::string& filename)
 {
-
-  std::string tstring = target;
-  std::vector<std::string> tmp = this->CachedFileList;
-  std::vector<std::string>::iterator it;
-  this->CachedFileList.clear();
-
-  for (it = tmp.begin(); it < tmp.end(); it++)
-  {
-    // look at each filename in the list and keep all but filename to delete
-    if (*it != tstring)
-    {
-      this->CachedFileList.push_back(*it);
-    }
-  }
-  tmp.clear();
+  this->DeleteFromCache(filename.c_str());
 }
 
 //----------------------------------------------------------------------------
@@ -529,135 +877,128 @@ void vtkCacheManager::DeleteFromCache(const char* target)
   //--- discover if target already has Remote Cache Directory prepended to path.
   //--- if not, put it there.
 
-  if (this->FindCachedFile(target, this->GetRemoteCacheDirectory()) == nullptr)
+  std::string foundPath = this->FindCachedFile(target, this->GetRemoteCacheDirectory());
+  if (foundPath.empty())
   {
     vtkDebugMacro("RemoveFromCache: can't find the target file " << target << ", so there's nothing to do, returning.");
     return;
   }
 
-  std::string str = this->FindCachedFile(target, this->GetRemoteCacheDirectory());
-  if (str.c_str() != nullptr)
+  std::string reason;
+  if (!this->CanDeletePathInCache(this->GetRemoteCacheDirectory(), foundPath.c_str(), reason))
   {
-    this->MarkNodesBeforeDeletingDataFromCache(target);
+    vtkWarningMacro("DeleteFromCache was blocked for safety (" << reason << "): " << foundPath);
+    return;
+  }
 
-    //--- remove the file or directory in str....
-    vtkDebugMacro("Removing " << str.c_str() << " from disk and from record of cached files.");
-    if (vtksys::SystemTools::FileIsDirectory(str.c_str()))
+  this->MarkNodesBeforeDeletingDataFromCache(target);
+
+  //--- remove the file or directory in str....
+  vtkDebugMacro("Removing " << foundPath << " from disk and from record of cached files.");
+  bool deleted = false;
+  if (vtksys::SystemTools::FileIsDirectory(foundPath))
+  {
+    deleted = vtksys::SystemTools::RemoveADirectory(foundPath).IsSuccess();
+    if (!deleted)
     {
-      if (!vtksys::SystemTools::RemoveADirectory(str.c_str()))
-      {
-        vtkWarningMacro("Unable to remove cached directory " << str.c_str() << "from disk.");
-      }
-      else
-      {
-        this->UpdateCacheInformation();
-        this->InvokeEvent(vtkCacheManager::CacheDeleteEvent);
-      }
+      vtkWarningMacro("Unable to remove cached directory " << foundPath << " from disk.");
     }
-    else
+  }
+  else
+  {
+    deleted = vtksys::SystemTools::RemoveFile(foundPath).IsSuccess();
+    if (!deleted)
     {
-      if (!vtksys::SystemTools::RemoveFile(str.c_str()))
-      {
-        vtkWarningMacro("Unable to remove cached file" << str.c_str() << "from disk.");
-      }
-      else
-      {
-        this->UpdateCacheInformation();
-        this->InvokeEvent(vtkCacheManager::CacheDeleteEvent);
-      }
+      vtkWarningMacro("Unable to remove cached file " << foundPath << " from disk.");
     }
-    this->DeleteFromCachedFileList(str.c_str());
+  }
+
+  if (deleted)
+  {
+    this->UpdateCacheInformation();
+    this->InvokeEvent(vtkCacheManager::CacheDeleteEvent);
   }
 }
 
 //----------------------------------------------------------------------------
-int vtkCacheManager::ClearCacheCheck()
+bool vtkCacheManager::ClearCache()
 {
-  //
-  // This method is called after ClearCache(),
-  // to see if that method actually cleaned the cache.
-  // If not, an event is invoked.
-  // Things to do: get cache dir
-  // check to see how many files are in it.
-  // if more than... 0? invoke CacheDirtyEvent.
-  //
-  std::string cachedir = this->GetRemoteCacheDirectory();
-  if (cachedir.c_str() != nullptr)
-  {
-    unsigned long numFiles = vtksys::Directory::GetNumberOfFilesInDirectory(cachedir.c_str());
-    //--- assume method will return . and ..
-    if (numFiles > 2)
-    {
-      this->InvokeEvent(vtkCacheManager::CacheDirtyEvent);
-      return 0;
-    }
-  }
-  return 1;
-}
-
-//----------------------------------------------------------------------------
-int vtkCacheManager::ClearCache()
-{
-
   //--- Careful! Before making this call, prompt user
   //--- with the RemoteCacheDirectory name and
   //--- ask for confirmation whether to delete the
   //--- directory and all of its contents...
   //--- Removes the CacheDirectory all together
   //--- and then creates the directory again.
-  if (this->RemoteCacheDirectory.c_str() != nullptr)
+  if (this->RemoteCacheDirectory.empty())
   {
-    this->MarkNodesBeforeDeletingDataFromCache(this->RemoteCacheDirectory.c_str());
-    vtksys::SystemTools::RemoveADirectory(this->RemoteCacheDirectory.c_str());
+    return true;
+  }
+
+  if (!this->HasSentinelFile())
+  {
+    vtkWarningMacro("ClearCache was blocked, as sentinel file was not found: " << this->GetSentinelFilePath(this->RemoteCacheDirectory.c_str()));
+    return false;
+  }
+
+  this->MarkNodesBeforeDeletingDataFromCache(this->RemoteCacheDirectory.c_str());
+
+  if (!vtksys::SystemTools::RemoveADirectory(this->RemoteCacheDirectory.c_str()))
+  {
+    vtkWarningMacro("Cache cleared: Error: unable to remove cache directory and its contents.");
+    return false;
   }
   if (!vtksys::SystemTools::MakeDirectory(this->RemoteCacheDirectory.c_str()))
   {
     vtkWarningMacro("Cache cleared: Error: unable to recreate cache directory after deleting its contents.");
-    return 0;
+    return false;
   }
+  if (!this->CreateSentinelFileInDirectory(this->RemoteCacheDirectory.c_str()))
+  {
+    vtkWarningMacro("Cache cleared: Error: unable to recreate cache sentinel file.");
+    return false;
+  }
+
   this->UpdateCacheInformation();
   this->InvokeEvent(vtkCacheManager::CacheClearEvent);
-  return 1;
+  return true;
 }
 
 //----------------------------------------------------------------------------
 float vtkCacheManager::GetCurrentCacheSize()
 {
-  if (this->RemoteCacheDirectory.c_str() == nullptr)
-  {
-    return (0.0);
-  }
-  float size = this->ComputeCacheSize(this->RemoteCacheDirectory.c_str(), 0);
-  this->SetCurrentCacheSize(size);
-  return (this->CurrentCacheSize);
+  return this->CurrentCacheSize;
 }
 
 //----------------------------------------------------------------------------
-void vtkCacheManager::MarkNode(std::string str)
+void vtkCacheManager::MarkNode(std::string nodeStoragePath)
 {
   //--- Find the MRML node that points to this file in cache.
   //--- If such a node exists, mark it as modified since read,
   //--- so that a user will be prompted to save the
   //--- data elsewhere (since it'll be deleted from cache.)
+  if (this->MRMLScene == nullptr)
+  {
+    return;
+  }
   int nnodes = this->MRMLScene->GetNumberOfNodesByClass("vtkMRMLStorableNode");
-  vtkMRMLStorableNode* node;
-  std::string uri;
   for (int n = 0; n < nnodes; n++)
   {
-    node = vtkMRMLStorableNode::SafeDownCast(this->MRMLScene->GetNthNodeByClass(n, "vtkMRMLStorableNode"));
-    if (node != nullptr)
+    vtkMRMLStorableNode* node = vtkMRMLStorableNode::SafeDownCast(this->MRMLScene->GetNthNodeByClass(n, "vtkMRMLStorableNode"));
+    if (!node)
     {
-      int numStorageNodes = node->GetNumberOfStorageNodes();
-      for (int i = 0; i < numStorageNodes; i++)
+      continue;
+    }
+    int numStorageNodes = node->GetNumberOfStorageNodes();
+    for (int i = 0; i < numStorageNodes; i++)
+    {
+      if (!node->GetNthStorageNode(i))
       {
-        if (node->GetNthStorageNode(i) != nullptr)
-        {
-          uri = node->GetNthStorageNode(i)->GetFullNameFromFileName();
-          if (str == uri)
-          {
-            node->GetNthStorageNode(i)->InvalidateFile();
-          }
-        }
+        continue;
+      }
+      std::string uri = node->GetNthStorageNode(i)->GetFullNameFromFileName();
+      if (nodeStoragePath == uri)
+      {
+        node->GetNthStorageNode(i)->InvalidateFile();
       }
     }
   }
@@ -674,192 +1015,190 @@ void vtkCacheManager::MarkNodesBeforeDeletingDataFromCache(const char* target)
   //--- to any of the files within as ModifiedSinceRead.
   //--- might be a slow performer....(?)
 
-  if (target != nullptr)
+  if (!target)
   {
-    std::string testFile;
-    std::string longName;
-    ;
-    std::string subdirString;
-    if (vtksys::SystemTools::FileIsDirectory(target))
-    {
-      vtkDebugMacro("MarkNodesBeforeDeletingDataFromCache: target is a directory: " << target);
-      vtksys::Directory dir;
-      dir.Load(target);
-      size_t fileNum;
-      //--- get files in cache dir and add to vector of strings.
-      for (fileNum = 0; fileNum < dir.GetNumberOfFiles(); ++fileNum)
-      {
-        if (strcmp(dir.GetFile(static_cast<unsigned long>(fileNum)), ".") //
-            && strcmp(dir.GetFile(static_cast<unsigned long>(fileNum)), ".."))
-        {
-          //--- test to see if the file is a directory;
-          //--- if so, go inside and count up file sizes, return value
-          subdirString = target;
-          subdirString += "/";
-          subdirString += dir.GetFile(static_cast<unsigned long>(fileNum));
-          if (vtksys::SystemTools::FileIsDirectory(subdirString.c_str()))
-          {
-            ///--- check in subdir too...
-            this->MarkNodesBeforeDeletingDataFromCache(subdirString.c_str());
-          }
-          else
-          {
-            //--- mark any nodes that point to this file as modified since read.
-            longName = target;
-            longName += "/";
-            testFile = dir.GetFile(static_cast<unsigned long>(fileNum));
-            longName += testFile;
-            this->MarkNode(longName);
-          }
-        }
-      }
-    }
-    else
-    {
-      if (vtksys::SystemTools::FileExists(target))
-      {
-        this->MarkNode(target);
-      }
-    }
+    return;
   }
-}
 
-//----------------------------------------------------------------------------
-float vtkCacheManager::ComputeCacheSize(const char* dirName, unsigned long sz)
-{
-
-  //--- Traverses cache directory and computes the combined size
-  //--- of all files. I guess this is a reasonable guess to the cache size,
-  //--- subdirectory size notwithstanding.
-  //--- TODO: is there a more accurate way to assess?
-
-  unsigned long cachesize = sz;
-  std::string testFile;
-  std::string longName;
-  ;
-  std::string subdirString;
-  if (vtksys::SystemTools::FileIsDirectory(dirName))
+  if (vtksys::SystemTools::FileIsDirectory(target))
   {
-    vtkDebugMacro("FindCachedFile: dirName is a directory: " << dirName);
-    vtksys::Directory dir;
-    dir.Load(dirName);
-    size_t fileNum;
-    cachesize += vtksys::SystemTools::FileLength(dirName);
-
-    //--- get files in cache dir and add to vector of strings.
-    for (fileNum = 0; fileNum < dir.GetNumberOfFiles(); ++fileNum)
+    vtkDebugMacro("MarkNodesBeforeDeletingDataFromCache: target is a directory: " << target);
+    std::vector<vtkCacheManagerCachedFile> cachedFiles;
+    if (!this->CollectCachedFilesRecursively(target, target, cachedFiles))
     {
-      if (strcmp(dir.GetFile(static_cast<unsigned long>(fileNum)), ".") //
-          && strcmp(dir.GetFile(static_cast<unsigned long>(fileNum)), ".."))
-      {
-        //--- test to see if the file is a directory;
-        //--- if so, go inside and count up file sizes, return value
-        subdirString = dirName;
-        subdirString += "/";
-        subdirString += dir.GetFile(static_cast<unsigned long>(fileNum));
-        if (vtksys::SystemTools::FileIsDirectory(subdirString.c_str()))
-        {
-          ///---compute dir and filename for recursive hunt
-          cachesize += (long unsigned int)ceil(this->ComputeCacheSize(subdirString.c_str(), 0));
-        }
-        else
-        {
-          longName = dirName;
-          longName += "/";
-          testFile = dir.GetFile(static_cast<unsigned long>(fileNum));
-          longName += testFile;
-          //--- get its size
-          cachesize += vtksys::SystemTools::FileLength(longName.c_str());
-        }
-      }
+      return;
+    }
+    for (std::vector<vtkCacheManagerCachedFile>::const_iterator it = cachedFiles.begin(); it != cachedFiles.end(); ++it)
+    {
+      this->MarkNode(it->Path);
     }
   }
   else
   {
-    vtkDebugMacro("vtkCacheManager::ComputeCacheSize: Cache Directory " << this->GetRemoteCacheDirectory() << " doesn't look like a directory. \n");
-    return (-1);
-  }
-
-  int byteSize = static_cast<int>(cachesize);
-  this->CurrentCacheSize = (float)byteSize / MB;
-  return (this->CurrentCacheSize);
-}
-
-//----------------------------------------------------------------------------
-void vtkCacheManager::CacheSizeCheck()
-{
-
-  //--- Compute size of the current cache
-  this->ComputeCacheSize(this->RemoteCacheDirectory.c_str(), 0);
-  //--- Invoke an event if cache size is exceeded.
-  if (this->CurrentCacheSize > (float)(this->RemoteCacheLimit))
-  {
-    // remove the file just downloaded?
-    this->InvokeEvent(vtkCacheManager::CacheLimitExceededEvent);
+    if (vtksys::SystemTools::FileExists(target))
+    {
+      this->MarkNode(target);
+    }
   }
 }
 
 //----------------------------------------------------------------------------
 float vtkCacheManager::GetFreeCacheSpaceRemaining()
 {
-
-  float cachesize = this->ComputeCacheSize(this->RemoteCacheDirectory.c_str(), 0);
-  // cache limit - current cache size = total space left in cache.
-  // total space in cache - free buffer size = amount that can be used.
-  float diff = (float(this->RemoteCacheLimit) - cachesize);
-  diff = diff - (float)this->RemoteCacheFreeBufferSize;
+  float diff = (float(this->RemoteCacheLimit) - this->CurrentCacheSize);
   return (diff);
 }
 
 //----------------------------------------------------------------------------
-void vtkCacheManager::FreeCacheBufferCheck()
+std::vector<vtkCacheManager::CacheEntry> vtkCacheManager::GetCacheEntries() const
 {
-
-  float buf = this->GetFreeCacheSpaceRemaining();
-  if ((buf * MB) < (float)(this->RemoteCacheFreeBufferSize) * MB)
-  {
-    this->InvokeEvent(vtkCacheManager::InsufficientFreeBufferEvent);
-  }
+  return this->CacheEntries;
 }
 
 //----------------------------------------------------------------------------
-int vtkCacheManager::CachedFileExists(const char* filename)
+bool vtkCacheManager::PruneCache()
 {
-  if (vtksys::SystemTools::FileExists(filename))
+  if (this->RemoteCacheDirectory.empty())
   {
-    return 1;
+    return false;
   }
-  else
+
+  if (!this->HasSentinelFile())
   {
-    //--- check to see if RemoteCacheDirectory/filename exists.
-    std::string testFile = this->RemoteCacheDirectory;
-    testFile += "/";
-    testFile += filename;
-    if (vtksys::SystemTools::FileExists(testFile.c_str()))
+    vtkWarningMacro("Cache pruning is disabled as no sentinel file is found in the cache directory.");
+    return false;
+  }
+
+  const unsigned long long cacheLimitBytes = static_cast<unsigned long long>(this->GetRemoteCacheLimit()) * static_cast<unsigned long long>(MB);
+  const std::string canonicalCacheDirectory = this->CanonicalizePath(this->GetRemoteCacheDirectory());
+  if (canonicalCacheDirectory.empty())
+  {
+    vtkWarningMacro("Cache pruning is disabled as cache directory could not be canonicalized: " << this->GetRemoteCacheDirectory());
+    return false;
+  }
+
+  std::vector<CacheEntry> pruneTargets = this->GetCacheEntries();
+
+  unsigned long long totalSizeBytes = 0;
+  for (const CacheEntry& entry : pruneTargets)
+  {
+    totalSizeBytes += entry.SizeBytes;
+  }
+
+  if (totalSizeBytes <= cacheLimitBytes)
+  {
+    // Cache is already within limit, no need to prune, but refresh
+    // cached bookkeeping so callers observe up-to-date cache usage.
+    this->UpdateCacheInformation();
+    return true;
+  }
+
+  // We will evict cache entries starting with the oldest modified time
+  std::sort(pruneTargets.begin(),
+            pruneTargets.end(),
+            [](const CacheEntry& left, const CacheEntry& right)
+            {
+              if (left.ModifiedTime == right.ModifiedTime)
+              {
+                return left.Path < right.Path;
+              }
+              return left.ModifiedTime < right.ModifiedTime;
+            });
+
+  bool wasModified = false;
+  for (const CacheEntry& entry : pruneTargets)
+  {
+    if (totalSizeBytes <= cacheLimitBytes)
     {
-      return 1;
+      break;
+    }
+
+    std::string reason;
+    if (!this->CanDeletePathInCache(this->GetRemoteCacheDirectory(), entry.Path.c_str(), reason))
+    {
+      vtkWarningMacro("PruneCache was blocked for safety (" << reason << "): " << entry.Path);
+      continue;
+    }
+
+    this->MarkNodesBeforeDeletingDataFromCache(entry.Path.c_str());
+
+    bool deleted = false;
+    if (entry.IsDirectory)
+    {
+      deleted = vtksys::SystemTools::RemoveADirectory(entry.Path).IsSuccess();
     }
     else
     {
-      return 0;
+      deleted = vtksys::SystemTools::RemoveFile(entry.Path).IsSuccess();
+    }
+
+    if (!deleted)
+    {
+      vtkWarningMacro("Failed to evict cached " << (entry.IsDirectory ? "directory " : "file ") << entry.Path << ".");
+      continue;
+    }
+
+    wasModified = true;
+    if (entry.SizeBytes > totalSizeBytes)
+    {
+      totalSizeBytes = 0;
+    }
+    else
+    {
+      totalSizeBytes -= entry.SizeBytes;
     }
   }
+
+  if (wasModified)
+  {
+    this->UpdateCacheInformation();
+    this->InvokeEvent(vtkCacheManager::CacheDeleteEvent);
+  }
+
+  if (totalSizeBytes > cacheLimitBytes)
+  {
+    vtkWarningMacro("PruneCache could not bring cache size within limit. Remaining bytes: " << totalSizeBytes << ", limit bytes: " << cacheLimitBytes);
+    return false;
+  }
+
+  return true;
 }
 
 //----------------------------------------------------------------------------
-const char* vtkCacheManager::FindCachedFile(const char* target, const char* dirname)
+bool vtkCacheManager::CachedFileExists(const std::string& filename)
 {
-  std::string testFile;
-  const char* result = nullptr;
-  char* returnString;
-  size_t n;
-  char* cp1;
-  const char* cp2;
+  return this->CachedFileExists(filename.c_str());
+}
 
+//----------------------------------------------------------------------------
+bool vtkCacheManager::CachedFileExists(const char* filename)
+{
+  if (IsNullOrEmpty(filename))
+  {
+    return false;
+  }
+
+  if (vtksys::SystemTools::FileExists(filename))
+  {
+    return true;
+  }
+
+  std::string testFile = this->JoinPath(this->RemoteCacheDirectory, filename);
+  if (vtksys::SystemTools::FileExists(testFile.c_str()))
+  {
+    return true;
+  }
+
+  return false;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkCacheManager::FindCachedFile(const char* target, const char* dirname)
+{
   if (target == nullptr || dirname == nullptr)
   {
     vtkErrorMacro("FindCachedFile: target or dirname null");
-    return (nullptr);
+    return "";
   }
 
   if (vtksys::SystemTools::FileIsDirectory(dirname))
@@ -872,49 +1211,22 @@ const char* vtkCacheManager::FindCachedFile(const char* target, const char* dirn
     //--- get files in cache dir and add to vector of strings.
     for (fileNum = 0; fileNum < dir.GetNumberOfFiles(); ++fileNum)
     {
-      if (strcmp(dir.GetFile(static_cast<unsigned long>(fileNum)), ".") //
-          && strcmp(dir.GetFile(static_cast<unsigned long>(fileNum)), ".."))
+      const char* fileName = dir.GetFile(static_cast<unsigned long>(fileNum));
+      if (!IsDirectoryNavigationEntry(fileName))
       {
-        testFile = dir.GetFile(static_cast<unsigned long>(fileNum));
+        std::string testFile = fileName;
         //--- Check for match to target
         //--- does the file or directory match the target?
         if (!strcmp(target, testFile.c_str()))
         {
-          //--- append the directory
-          std::string accum = dirname;
-          accum += "/";
-          testFile = accum + testFile;
-          result = testFile.c_str();
-          n = strlen(result) + 1;
-          cp1 = new char[n];
-          cp2 = (result);
-          returnString = cp1;
-          do
-          {
-            *cp1++ = *cp2++;
-          } while (--n);
-          return returnString;
+          return this->JoinPath(dirname, testFile);
         }
+
         //--- does the file or directory match the target with full path?
-        //--- add backslash if missing
-        std::string fullName = dirname;
-        if ((fullName.rfind("/", 0)) != (fullName.size() - 1))
-        {
-          fullName += "/";
-        }
-        fullName += testFile;
+        std::string fullName = this->JoinPath(dirname, testFile);
         if (!strcmp(target, fullName.c_str()))
         {
-          result = fullName.c_str();
-          n = strlen(result) + 1;
-          cp1 = new char[n];
-          cp2 = (result);
-          returnString = cp1;
-          do
-          {
-            *cp1++ = *cp2++;
-          } while (--n);
-          return returnString;
+          return fullName;
         }
 
         //--- if no match, and the file is a directory, go inside and
@@ -922,17 +1234,10 @@ const char* vtkCacheManager::FindCachedFile(const char* target, const char* dirn
         if (vtksys::SystemTools::FileIsDirectory(fullName.c_str()))
         {
           ///---compute dir and filename for recursive hunt
-          if ((result = this->FindCachedFile(target, fullName.c_str())) != nullptr)
+          std::string result = this->FindCachedFile(target, fullName.c_str());
+          if (!result.empty())
           {
-            n = strlen(result) + 1;
-            cp1 = new char[n];
-            cp2 = (result);
-            returnString = cp1;
-            do
-            {
-              *cp1++ = *cp2++;
-            } while (--n);
-            return returnString;
+            return result;
           }
         }
       }
@@ -940,24 +1245,9 @@ const char* vtkCacheManager::FindCachedFile(const char* target, const char* dirn
   }
   else
   {
-    vtkDebugMacro("vtkCacheManager::GetCachedFileList: Cache Directory " << this->GetRemoteCacheDirectory() << " doesn't look like a directory. \n");
-    return (nullptr);
+    vtkDebugMacro("FindCachedFile: Directory " << dirname << " doesn't look like a directory. \n");
+    return "";
   }
 
-  if (result != nullptr)
-  {
-    n = strlen(result) + 1;
-    cp1 = new char[n];
-    cp2 = (result);
-    returnString = cp1;
-    do
-    {
-      *cp1++ = *cp2++;
-    } while (--n);
-    return returnString;
-  }
-  else
-  {
-    return (nullptr);
-  }
+  return "";
 }

--- a/Libs/MRML/Core/vtkCacheManager.h
+++ b/Libs/MRML/Core/vtkCacheManager.h
@@ -3,11 +3,12 @@
 
 // MRML includes
 #include "vtkMRML.h"
+#include "vtkMRMLScene.h"
 class vtkCallbackCommand;
-class vtkMRMLScene;
 
 // VTK includes
 #include <vtkObject.h>
+#include <vtkWeakPointer.h>
 
 // STD includes
 #include <string>
@@ -18,6 +19,16 @@ class vtkMRMLScene;
 # define vtkObjectPointer(xx) (reinterpret_cast<vtkObject**>((xx)))
 #endif
 
+/// \brief Manages the on-disk remote cache used by MRML storage.
+///
+/// The class manages a folder that stores temporary files, mostly used for local caching of remote data.
+///
+/// The cache folder needs to be cleaned when the maximum size is reached. To prevent accidental deletion of
+/// non-cache user data, the class uses a "sentinel file" mechanism. Presence of a sentinel file (.slicer-cache)
+/// in the folder marks it as owned by the cache manager, allowing the cache manager to delete files in it.
+/// Deletion is strictly limited to files within the cache directory (symlinks are resolved and file is only
+/// deleted if the canonicalized path is inside the cache root folder).
+///
 class VTK_MRML_EXPORT vtkCacheManager : public vtkObject
 {
 public:
@@ -26,8 +37,7 @@ public:
   vtkTypeMacro(vtkCacheManager, vtkObject);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  vtkGetMacro(InsufficientFreeBufferNotificationFlag, int);
-  vtkSetMacro(InsufficientFreeBufferNotificationFlag, int);
+  void SetMRMLScene(vtkMRMLScene* scene) { this->MRMLScene = scene; }
 
   ///
   /// Sets the name of the directory to use for local file caching
@@ -35,65 +45,91 @@ public:
   /// on the local system. Makes sure there's NO "/" at the end
   /// of the string, or kwsys/SystemTools will not see as a valid dir.
   virtual void SetRemoteCacheDirectory(const char* dir);
+  virtual void SetRemoteCacheDirectory(const std::string& dir) { this->SetRemoteCacheDirectory(dir.c_str()); }
 
   ///
   /// Returns the name of the directory to use for local file caching
   const char* GetRemoteCacheDirectory();
 
+  /// Cache size limit in MB.
+  vtkGetMacro(RemoteCacheLimit, int);
+  vtkSetMacro(RemoteCacheLimit, int);
+
   ///
   /// Called when a file is loaded or removed from the cache.
   void UpdateCacheInformation();
-  ///
-  /// Removes a target from the list of locally cached files and directories
-  void DeleteFromCachedFileList(const char* target);
 
-  // Description:
-  /// Remove a target directory or file from the cache.
-  void DeleteFromCache(const char* target);
+  /// Current cache size in MB. Updated by UpdateCacheInformation().
+  float GetCurrentCacheSize();
+  /// Returns the amount of free space remaining in the cache directory, in MB. Updated by UpdateCacheInformation().
+  float GetFreeCacheSpaceRemaining();
+  /// Get list of cached files. Updated by UpdateCacheInformation().
+  /// Get files in the folder, ordered by modification time from newest to oldest.
+  /// Does not include the sentinel file.
+  std::vector<std::string> GetCachedFiles() const;
+
+  /// Describes a top-level item (file or folder) in the cache directory.
+  struct CacheEntry
+  {
+    std::string Path;
+    unsigned long long SizeBytes;
+    long long ModifiedTime;
+    bool IsDirectory;
+    int FileCount;         ///< number of files contained in the directory (0 for file entries)
+    bool ExceedsCacheSize; ///< true if PruneCache() would remove this entry to bring the cache within its size limit
+  };
+
+  /// Returns one CacheEntry per top-level item in the cache directory.
+  /// Updated by UpdateCacheInformation()
+  /// Entries are sorted newest-first (descending ModifiedTime).
+  /// Does not include the sentinel file.
+  /// CacheEntry::ExceedsCacheSize is set for entries that PruneCache() would evict.
+  std::vector<CacheEntry> GetCacheEntries() const;
+
+  /// Delete oldest files until on-disk cache usage fits within RemoteCacheLimit.
+  /// Returns true on success and false on failure.
+  bool PruneCache();
 
   ///
   /// Removes all files from the cachedir
-  /// and removes all filenames from CachedFileList
-  int ClearCache();
-  /// This method is called after ClearCache(),
-  /// to see if that method actually cleaned the cache.
-  /// If not, an event (CacheDirtyEvent) is invoked.
-  int ClearCacheCheck();
+  bool ClearCache();
 
-  ///
-  /// Before a file or directory is deleted,
-  /// Marks any nodes that hold the URI as
-  /// a reference as modified since read.
-  void MarkNodesBeforeDeletingDataFromCache(const char*);
+  /// Remove a target directory or file from the cache folder.
+  /// If the target is a directory, it will be removed recursively.
+  /// Before deletion, any MRML nodes that hold the URI as a reference will be marked as "modified since read".
+  void DeleteFromCache(const char* target);
+  void DeleteFromCache(const std::string& filename);
 
   ///
   /// Checks to see if a URI appears to point to remote location
   /// and returns true if so. Looks for a '://' and if present,
   /// checks to see if the prefix is 'file'. If not 'file' but the
   /// thing:/// pattern exists, then returns true.
-  virtual int IsRemoteReference(const char* uri);
+  virtual bool IsRemoteReference(const char* uri);
+
   ///
   /// Looks for a 'file://' in the URI and if present, returns true.
-  virtual int IsLocalReference(const char* uri);
+  virtual bool IsLocalReference(const char* uri);
 
   ///
   /// Checks to see if a URI is a file on disk and returns
   /// true if so. Strips off a file:/// prefix if present, and
   /// expects an absolute path.
-  virtual int LocalFileExists(const char* uri);
+  virtual bool LocalFileExists(const char* uri);
 
   ///
   /// Takes a filename and a dirname (usually called with the
   /// RemoteCachedDirectory) and returns the full path of
   /// the filename if it exists under the dirname.
-  const char* FindCachedFile(const char* target, const char* dirname);
+  std::string FindCachedFile(const char* target, const char* dirname);
 
   ///
   /// Checks to see if the The URI provided exists on disk.
   /// If not, it appends the Remote Cache Directory path
   /// and checks again, in case no path was provided.
-  /// If neither exists, returns 0. If one exists, returns 1.
-  virtual int CachedFileExists(const char* filename);
+  /// If neither exists, returns false. If one exists, returns true.
+  virtual bool CachedFileExists(const char* filename);
+  virtual bool CachedFileExists(const std::string& filename);
 
   ///
   /// Extracts the filename from the URI and prepends the
@@ -103,33 +139,36 @@ public:
   /// to strip them out of the extension and add them to the
   /// filenamebase. So filename.nrrd_010 would become filename.nrrd.
   /// This will cause problems for any file type with an '_' in its extension.
-  const char* GetFilenameFromURI(const char* uri);
-  const char* AddCachePathToFilename(const char* filename);
-  const char* EncodeURI(const char* uri);
+  std::string GetFilenameFromURI(const char* uri);
+  std::string GetFilenameFromURI(const std::string& uri);
+  std::string EncodeURI(const char* uri);
 
-  void CacheSizeCheck();
-  void FreeCacheBufferCheck();
-  float ComputeCacheSize(const char* dirname, unsigned long size);
-  float GetCurrentCacheSize();
-  float GetFreeCacheSpaceRemaining();
+  /// Sentinel file name used to identify cache directories where file deletion is allowed.
+  std::string GetSentinelFileName() const;
+  /// True if the sentinel file exists in the current cache directory.
+  bool HasSentinelFile() const;
+  /// Creates the sentinel file in the current cache directory.
+  bool CreateSentinelFile() const;
 
-  std::vector<std::string> GetCachedFiles() const;
+  /// Returns true if the specified directory is empty.
+  bool IsDirectoryEmpty(const std::string& directoryPath) const;
+  /// True if the sentinel file exists in the specified directory.
+  bool HasSentinelFileInDirectory(const std::string& directoryPath) const;
+  /// Creates the sentinel file in the specified directory.
+  bool CreateSentinelFileInDirectory(const std::string& directoryPath) const;
+  /// Get files in the folder, ordered by modification time from newest to oldest.
+  /// Does not include the sentinel file.
+  std::vector<std::string> GetCachedFilesInDirectory(const std::string& directoryPath);
 
-  ///
-  vtkGetMacro(RemoteCacheLimit, int);
-  vtkSetMacro(RemoteCacheLimit, int);
-  vtkSetMacro(CurrentCacheSize, float);
-  vtkGetMacro(RemoteCacheFreeBufferSize, int);
-  vtkSetMacro(RemoteCacheFreeBufferSize, int);
   vtkGetMacro(EnableForceRedownload, int);
   vtkSetMacro(EnableForceRedownload, int);
-  // vtkGetMacro ( EnableRemoteCacheOverwriting, int );
-  // vtkSetMacro ( EnableRemoteCacheOverwriting, int );
-  void SetMRMLScene(vtkMRMLScene* scene) { this->MRMLScene = scene; }
+
+  vtkGetMacro(InsufficientFreeBufferNotificationFlag, int);
+  vtkSetMacro(InsufficientFreeBufferNotificationFlag, int);
+
   void MapFileToURI(const char* uri, const char* fname);
 
-  void MarkNode(std::string);
-  /// in case we need these.
+  /// Currently these are not used.
   enum
   {
     NoCachedFile = 0,
@@ -137,7 +176,6 @@ public:
     CachedFile
   };
 
-  /// in case we need these.
   enum
   {
     InsufficientFreeBufferEvent = 21000,
@@ -147,26 +185,43 @@ public:
     CacheClearEvent
   };
 
-  std::map<std::string, std::string> uriMap;
   const char* GetFileFromURIMap(const char* uri);
 
 private:
+  struct vtkCacheManagerCachedFile
+  {
+    std::string Path;
+    long long ModifiedTime;
+  };
+
+  vtkWeakPointer<vtkMRMLScene> MRMLScene;
+  std::string RemoteCacheDirectory;
+  std::map<std::string, std::string> UriMap;
   int InsufficientFreeBufferNotificationFlag;
   int RemoteCacheLimit;
-  float CurrentCacheSize;
-  int RemoteCacheFreeBufferSize;
   int EnableForceRedownload;
-  // int EnableRemoteCacheOverwriting;
-  vtkMRMLScene* MRMLScene;
 
-  std::string RemoteCacheDirectory;
-  int GetCachedFileList(const char* dirname);
-  std::vector<std::string> GetAllCachedFiles();
-  /// This array contains a list of cached file names (without paths)
-  /// in case it's faster to search thru this list than to
-  /// snuffle thru a large cache dir. Must keep current
-  /// with every download, remove from cache, and clearcache call.
-  std::vector<std::string> CachedFileList;
+  std::vector<CacheEntry> CacheEntries;
+  float CurrentCacheSize;
+  bool UpdatingCacheInformation;
+
+  bool CollectCachedFilesRecursively(const std::string& directoryPath, const std::string& rootDirectoryPath, std::vector<vtkCacheManagerCachedFile>& cachedFiles) const;
+
+  /// Before a file or directory is deleted,
+  /// Marks any nodes that hold the URI as
+  /// a reference as modified since read.
+  void MarkNodesBeforeDeletingDataFromCache(const char*);
+
+  void MarkNode(std::string);
+
+  std::string CanonicalizePath(const char* path) const;
+  std::string JoinPath(const std::string& directoryPath, const std::string& fileName) const;
+  bool PathIsWithinDirectory(const std::string& directoryPath, const std::string& path) const;
+
+  std::string GetSentinelFilePath(const char* cacheDirectory) const;
+  std::string GetSentinelFilePath(const std::string& cacheDirectory) const;
+
+  bool CanDeletePathInCache(const char* cacheDirectory, const char* pathToDelete, std::string& reason) const;
 
 protected:
   vtkCacheManager();

--- a/Libs/MRML/Core/vtkDataIOManager.cxx
+++ b/Libs/MRML/Core/vtkDataIOManager.cxx
@@ -331,7 +331,6 @@ void vtkDataIOManager::QueueRead(vtkMRMLNode* node)
   // vtkURIHandler* handler = dnode->GetNthStorageNode(storageNodeIndex)->GetURIHandler();
   vtkDebugMacro("QueueRead: got the uri handler from the storage node");
   const char* source = dnode->GetNthStorageNode(storageNodeIndex)->GetURI();
-  const char* dest;
 
   if (source == nullptr)
   {
@@ -341,8 +340,8 @@ void vtkDataIOManager::QueueRead(vtkMRMLNode* node)
   vtkCacheManager* cm = this->GetCacheManager();
   if (cm != nullptr)
   {
-    dest = cm->GetFilenameFromURI(source);
-    if (dest == nullptr)
+    std::string dest = cm->GetFilenameFromURI(source);
+    if (dest.empty())
     {
       vtkDebugMacro("QueueRead: unable to get file name from source URI " << source);
       return;
@@ -374,8 +373,8 @@ void vtkDataIOManager::QueueRead(vtkMRMLNode* node)
     //--- a large scene that consists of multiple datasets.
     //--- ***The risk with this implementation  is that they may
     //--- forget to adjust the cache size, but aren't notified again...
-    float bufsize = (cm->GetRemoteCacheLimit() * 1000000.0) - (cm->GetRemoteCacheFreeBufferSize() * 1000000.0);
-    if ((cm->GetCurrentCacheSize() * 1000000.0) >= bufsize)
+    cm->UpdateCacheInformation();
+    if (cm->GetFreeCacheSpaceRemaining() <= 0.0)
     {
       //--- No space left in cache. Don't trigger logic to download;
       //--- by invoking a RemoteReadEvent.

--- a/Libs/MRML/Core/vtkDataTransfer.h
+++ b/Libs/MRML/Core/vtkDataTransfer.h
@@ -17,8 +17,10 @@ public:
   void PrintSelf(ostream& os, vtkIndent indent) override;
   vtkGetStringMacro(SourceURI);
   vtkSetStringMacro(SourceURI);
+  void SetSourceURI(const std::string& sourceURI) { this->SetSourceURI(sourceURI.c_str()); }
   vtkGetStringMacro(DestinationURI);
   vtkSetStringMacro(DestinationURI);
+  void SetDestinationURI(const std::string& destinationURI) { this->SetDestinationURI(destinationURI.c_str()); }
   vtkGetObjectMacro(Handler, vtkURIHandler);
   virtual void SetHandler(vtkURIHandler* uriHandler);
   vtkGetMacro(TransferType, int);

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -1003,7 +1003,7 @@ int vtkMRMLScene::LoadIntoScene(vtkCollection* nodeCollection, vtkMRMLMessageCol
   // check to see if the mrml file lives on a remote disk
   if (this->GetCacheManager())
   {
-    int remote = this->GetCacheManager()->IsRemoteReference(this->URL.c_str());
+    bool remote = this->GetCacheManager()->IsRemoteReference(this->URL.c_str());
     if (remote)
     {
       vtkDebugMacro("LoadIntoScene: mrml file lives on a remote disk: " << this->URL.c_str());
@@ -1012,8 +1012,8 @@ int vtkMRMLScene::LoadIntoScene(vtkCollection* nodeCollection, vtkMRMLMessageCol
       if (handler != nullptr)
       {
         // put it on disk somewhere
-        const char* localURL = this->GetCacheManager()->GetFilenameFromURI(this->URL.c_str());
-        handler->StageFileRead(this->URL.c_str(), localURL);
+        std::string localURL = this->GetCacheManager()->GetFilenameFromURI(this->URL);
+        handler->StageFileRead(this->URL, localURL);
         // now over ride the URL setting
         vtkDebugMacro("LoadIntoScene: downloaded the remote MRML file " << this->URL.c_str() << ", resetting URL to local file " << localURL);
         this->SetURL(localURL);

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -67,6 +67,7 @@ public:
 
   /// Set URL (file name) of the scene
   void SetURL(const char* url);
+  void SetURL(const std::string& url) { return this->SetURL(url.c_str()); };
 
   /// Get URL (file name) of the scene
   const char* GetURL();

--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -34,6 +34,7 @@ Version:   $Revision: 1.1.1.1 $
 
 // STD includes
 #include <algorithm>
+#include <cstring>
 #include <sstream>
 
 //----------------------------------------------------------------------------
@@ -441,7 +442,7 @@ void vtkMRMLStorageNode::StageReadData(vtkMRMLNode* refNode)
   }
 
   vtkCacheManager* cacheManager = this->Scene->GetCacheManager();
-  const char* fname = nullptr;
+  std::string fname;
   if (cacheManager != nullptr)
   {
     fname = cacheManager->GetFilenameFromURI(this->GetURI());
@@ -691,15 +692,15 @@ int vtkMRMLStorageNode::SupportedFileType(const char* fileName)
 {
   // check to see which file name we need to check
   std::string name;
-  if (fileName)
+  if (fileName && strlen(fileName) > 0)
   {
     name = std::string(fileName);
   }
-  else if (this->FileName != nullptr)
+  else if (this->FileName && strlen(this->FileName) > 0)
   {
     name = std::string(this->FileName);
   }
-  else if (this->URI != nullptr)
+  else if (this->URI && strlen(this->URI) > 0)
   {
     name = std::string(this->URI);
   }

--- a/Libs/MRML/Core/vtkMRMLStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.h
@@ -82,6 +82,7 @@ public:
   /// \sa ReadData(), WriteData()
   vtkSetStringMacro(FileName);
   vtkGetStringMacro(FileName);
+  void SetFileName(const std::string& fileName) { this->SetFileName(fileName.c_str()); };
 
   /// Return complete file extension for the specified filename.
   /// Longest matched extension will be returned (.seg.nrrd will be returned
@@ -182,7 +183,7 @@ public:
   /// the file content then it may return with much higher confidence values.
   /// Subclasses should implement this method.
   virtual int SupportedFileType(const char* fileName);
-
+  int SupportedFileType(const std::string& fileName) { return this->SupportedFileType(fileName.c_str()); }
   ///
   /// Get all the supported read file types
   /// Subclasses should overwrite InitializeSupportedReadFileTypes().
@@ -210,6 +211,8 @@ public:
   ///
   /// Add in another file name to the list of file names
   unsigned int AddFileName(const char* fileName);
+  unsigned int AddFileName(const std::string& fileName) { return this->AddFileName(fileName.c_str()); };
+
   ///
   /// Clear the array of file names
   void ResetFileNameList();
@@ -317,6 +320,7 @@ public:
   /// Remove supported extension from filename.
   /// If filename is not specified then the current FileName will be used.
   std::string GetFileNameWithoutExtension(const char* fileName = nullptr);
+  std::string GetFileNameWithoutExtension(const std::string& fileName) { return GetFileNameWithoutExtension(fileName.c_str()); }
 
   /// Compression parameter that is used to save the node
   vtkSetMacro(CompressionParameter, std::string);

--- a/Libs/MRML/Core/vtkURIHandler.h
+++ b/Libs/MRML/Core/vtkURIHandler.h
@@ -24,7 +24,9 @@ public:
   /// virtual methods to be defined in subclasses.
   /// (Maybe these should be defined to handle default file operations)
   virtual void StageFileRead(const char* source, const char* destination);
+  void StageFileRead(const std::string& source, const std::string& destination) { this->StageFileRead(source.c_str(), destination.c_str()); }
   virtual void StageFileWrite(const char* source, const char* destination);
+  void StageFileWrite(const std::string& source, const std::string& destination) { this->StageFileWrite(source.c_str(), destination.c_str()); }
 
   ///
   /// various Read/Write method footprints useful to redefine in specific handlers.

--- a/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
+++ b/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
@@ -306,11 +306,7 @@ vtkMRMLModelNode* vtkSlicerModelsLogic::AddModel(const char* filename,
   {
     storageNode->SetURI(filename);
     // reset filename to the local file name
-    const char* localFilePtr = this->GetMRMLScene()->GetCacheManager()->GetFilenameFromURI(filename);
-    if (localFilePtr)
-    {
-      localFile = localFilePtr;
-    }
+    localFile = this->GetMRMLScene()->GetCacheManager()->GetFilenameFromURI(filename);
   }
   else
   {

--- a/Modules/Loadable/Sequences/Logic/vtkSlicerSequencesLogic.cxx
+++ b/Modules/Loadable/Sequences/Logic/vtkSlicerSequencesLogic.cxx
@@ -165,11 +165,7 @@ vtkMRMLSequenceNode* vtkSlicerSequencesLogic::AddSequence(const char* filename, 
     volumeSequenceStorageNode->SetURI(filename);
     transformSequenceStorageNode->SetURI(filename);
     // reset filename to the local file name
-    const char* localFilePtr = ((this->GetMRMLScene())->GetCacheManager())->GetFilenameFromURI(filename);
-    if (localFilePtr)
-    {
-      localFile = localFilePtr;
-    }
+    localFile = this->GetMRMLScene()->GetCacheManager()->GetFilenameFromURI(filename);
   }
   else
   {

--- a/Modules/Loadable/Transforms/Logic/vtkSlicerTransformLogic.cxx
+++ b/Modules/Loadable/Transforms/Logic/vtkSlicerTransformLogic.cxx
@@ -116,13 +116,13 @@ vtkMRMLTransformNode* vtkSlicerTransformLogic::AddTransform(const char* filename
     useURI = scene->GetCacheManager()->IsRemoteReference(filename);
   }
 
-  const char* localFile;
+  std::string localFile;
   if (useURI)
   {
     vtkDebugMacro("AddTransforn: file name is remote: " << filename);
     storageNode->SetURI(filename);
     // reset filename to the local file name
-    localFile = ((scene)->GetCacheManager())->GetFilenameFromURI(filename);
+    localFile = scene->GetCacheManager()->GetFilenameFromURI(filename);
   }
   else
   {
@@ -130,10 +130,9 @@ vtkMRMLTransformNode* vtkSlicerTransformLogic::AddTransform(const char* filename
     localFile = filename;
   }
 
-  const std::string fname(localFile);
   // the model name is based on the file name (itksys call should work even if
   // file is not on disk yet)
-  const std::string name = itksys::SystemTools::GetFilenameName(fname);
+  const std::string name = itksys::SystemTools::GetFilenameName(localFile);
 
   if (!storageNode->SupportedFileType(name.c_str()))
   {
@@ -190,7 +189,7 @@ vtkMRMLTransformNode* vtkSlicerTransformLogic::AddTransform(const char* filename
     userMessages->AddMessages(storageNode->GetUserMessages());
   }
 
-  const std::string basename(storageNode->GetFileNameWithoutExtension(fname.c_str()));
+  const std::string basename(storageNode->GetFileNameWithoutExtension(localFile));
   const std::string uname(scene->GetUniqueNameByString(basename.c_str()));
   tnode->SetName(uname.c_str());
   scene->AddNode(storageNode.GetPointer());

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -1180,13 +1180,13 @@ vtkMRMLVolumePropertyNode* vtkSlicerVolumeRenderingLogic::AddVolumePropertyFromF
     useURI = this->GetMRMLScene()->GetCacheManager()->IsRemoteReference(filename);
   }
 
-  const char* localFile;
+  std::string localFile;
   if (useURI)
   {
     vpStorageNode->SetURI(filename);
     vpJsonStorageNode->SetURI(filename);
     // reset filename to the local file name
-    localFile = ((this->GetMRMLScene())->GetCacheManager())->GetFilenameFromURI(filename);
+    localFile = this->GetMRMLScene()->GetCacheManager()->GetFilenameFromURI(filename);
   }
   else
   {
@@ -1326,24 +1326,24 @@ vtkMRMLShaderPropertyNode* vtkSlicerVolumeRenderingLogic::AddShaderPropertyFromF
     useURI = this->GetMRMLScene()->GetCacheManager()->IsRemoteReference(filename);
   }
 
-  const char* localFile = nullptr;
+  std::string localFile;
   if (useURI)
   {
     spStorageNode->SetURI(filename);
     // reset filename to the local file name
-    localFile = ((this->GetMRMLScene())->GetCacheManager())->GetFilenameFromURI(filename);
+    localFile = this->GetMRMLScene()->GetCacheManager()->GetFilenameFromURI(filename);
   }
   else
   {
     spStorageNode->SetFileName(filename);
     localFile = filename;
   }
-  const std::string fname(localFile);
+
   // the node name is based on the file name
-  const std::string name = spStorageNode->GetFileNameWithoutExtension(fname.c_str());
+  const std::string name = spStorageNode->GetFileNameWithoutExtension(localFile);
 
   // check to see which node can read this type of file
-  if (spStorageNode->SupportedFileType(fname.c_str()))
+  if (spStorageNode->SupportedFileType(localFile))
   {
     std::string uname(this->GetMRMLScene()->GetUniqueNameByString(name.c_str()));
 


### PR DESCRIPTION
Cache folder increased without any limits, despite maximum cache size was specified in application settings. Implemented automatic trimming of cache (deleting the oldest files until the cache size is below the specified limit) and refactored the vtkCacheManager to make it safer and simpler.

- Cache is trimmed at application startup (can be disabled in application settings) by deleting oldest files (by modification time) until cache size is within the specified limit. Default cache limit increased from 200 MB to 1000 MB.
- Sentinel file mechanism: since now the class can delete files, a new safety feature was introduced. Files are only allowed to be deleted if the cache manager owns that folder. Owning is detected by presence of a sentinel file (.slicer-cache), which is only placed automatically in an empty folder or on explicit user approval. Path traversal is also guarded via CanDeletePathInCache() which resolves canonical paths and verifies the target is within the cache root.
- The old "free buffer" concept (keep N MB free) is removed. To keep some space on disk free, it is simpler - and has the same effect - if cache size is reduced by that much. GetFreeCacheSpaceRemaining() is now just RemoteCacheLimit - CurrentCacheSize, and cache-full checks in callers use <= 0.
- Simplified update of cache information. Now a single UpdateCacheInformation() call updates all information about the current state of the cache.
- Settings GUI updates: "Cache free buffer" spinbox removed (concept eliminated). "Auto-prune" checkbox added - persisted in application settings as Cache/AutoPrune setting. "Prune cache" button added to manually trims cache to size limit. "Refresh" button added to updates the used/free size display and file list. setCachePath() now validates the target folder: warns the user if the selected folder contains files but has no sentinel. If confirmed, creates the sentinel. Reverts to previous path if sentinel creation fails. clearCache() now calls updateFromCacheManager() — the old code had this commented out, so the UI was stale after clearing.
- Memory leak fixes: GetFilenameFromURI, EncodeURI, FindCachedFile, and AddCachePathToFilename previously returned new char[]-allocated strings that callers never freed. These all now return std::string. This is the most impactful correctness fix.

<img width="1424" height="1169" alt="image" src="https://github.com/user-attachments/assets/713c0ac3-2918-4edf-9ffa-9ae5cdad17f6" />
