### PR TITLE
ENH: WebServer socket-takeover hook + threeD camera controls

### DIFF
--- a/Modules/Scripted/WebServer/WebServer.py
+++ b/Modules/Scripted/WebServer/WebServer.py
@@ -16,7 +16,7 @@ from slicer.i18n import translate
 from slicer.ScriptedLoadableModule import *
 from slicer.util import settingsValue, toBool
 
-from WebServerLib.BaseRequestHandler import BaseRequestHandler, BaseRequestLoggingFunction
+from WebServerLib.BaseRequestHandler import BaseRequestHandler, BaseRequestLoggingFunction, KEEP_OPEN
 
 logger = logging.getLogger(__name__)
 
@@ -469,6 +469,54 @@ class SlicerHTTPServer(HTTPServer):
                 else:
                     contentType = b"text/plain"
                     responseBody = b""
+
+                if responseBody is KEEP_OPEN:
+                    # Handler wants ownership of the socket (Server-Sent Events,
+                    # WebSocket upgrade, long-polling, etc.). Send initial
+                    # streaming headers without a Content-Length, then transfer
+                    # the socket and notifiers to the handler and stop managing
+                    # this connection from the server side.
+                    headers = f"HTTP/1.1 {httpStatus}\r\n".encode()
+                    if self.enableCORS:
+                        headers += b"Access-Control-Allow-Origin: *\r\n"
+                    headers += b"Content-Type: %s\r\n" % contentType
+                    headers += b"Cache-Control: no-cache\r\n"
+                    headers += b"Connection: keep-alive\r\n"
+                    headers += b"\r\n"
+                    try:
+                        self.connectionSocket.sendall(headers)
+                    except OSError as e:
+                        self.logMessage("Socket error while sending takeover headers: %s" % e)
+                        try:
+                            self.connectionSocket.close()
+                        except OSError:
+                            pass
+                        return
+                    # Fresh write notifier for the handler to own. The existing
+                    # read notifier has already been disabled above (line 408-409).
+                    takeoverWriteNotifier = qt.QSocketNotifier(self.connectionSocket.fileno(), qt.QSocketNotifier.Write)
+                    takeoverWriteNotifier.setEnabled(False)
+                    takeoverSocket = self.connectionSocket
+                    # Drop our reference before invoking the handler so we can't
+                    # accidentally touch the socket from this communicator again.
+                    self.connectionSocket = None
+                    try:
+                        highestConfidenceHandler.onConnectionTakeover(
+                            socket=takeoverSocket,
+                            writeNotifier=takeoverWriteNotifier,
+                            readNotifier=self.readNotifier,
+                        )
+                    except Exception as e:
+                        etype, value, tb = sys.exc_info()
+                        import traceback
+                        for frame in traceback.format_tb(tb):
+                            self.logMessage(frame)
+                        self.logMessage("onConnectionTakeover raised: ", etype, value)
+                        try:
+                            takeoverSocket.close()
+                        except OSError:
+                            pass
+                    return
 
                 if responseBody:
                     self.response = f"HTTP/1.1 {httpStatus}\r\n".encode()

--- a/Modules/Scripted/WebServer/WebServerLib/BaseRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/BaseRequestHandler.py
@@ -9,6 +9,46 @@ BaseRequestLoggingFunction = Callable[[list[any]], None]
 """Function signature for an external handle for message logging."""
 
 
+class _KeepOpen:
+    """Sentinel type — see :data:`KEEP_OPEN`."""
+
+    __slots__ = ()
+
+    def __repr__(self):
+        return "KEEP_OPEN"
+
+    def __bool__(self):
+        # Falsy so that a handler that returns KEEP_OPEN but whose return value
+        # is accidentally treated as a normal response body falls into the 404
+        # branch rather than emitting the sentinel's repr to the client.
+        return False
+
+
+KEEP_OPEN = _KeepOpen()
+"""
+Singleton response-body sentinel used to request that SlicerHTTPServer hand
+ownership of the underlying TCP socket to the handler after sending initial
+headers, instead of writing a single ``Content-Length``-bounded response and
+closing.
+
+A handler that wants to stream data to the client over time (Server-Sent
+Events, WebSocket upgrade, long-polling, progressive media, etc.) returns::
+
+    return (b"text/event-stream", KEEP_OPEN)
+
+from :meth:`BaseRequestHandler.handleRequest`. :class:`SlicerHTTPServer` then:
+
+    1. Writes an HTTP status line + the caller-supplied ``Content-Type`` (and
+       ``Cache-Control: no-cache`` and ``Connection: keep-alive``) — but *no*
+       ``Content-Length`` — to the client socket.
+    2. Invokes :meth:`BaseRequestHandler.onConnectionTakeover` with the raw
+       socket and the existing read/write ``QSocketNotifier`` instances.
+    3. Ceases all further management of the connection. The handler is
+       responsible for writing data, reading any further client traffic, and
+       closing the socket when the stream ends.
+"""
+
+
 class BaseRequestHandler(abc.ABC):
     """
     Abstract base class (ABC) defining the `SlicerRequestHandler` virtual interface.
@@ -67,6 +107,41 @@ class BaseRequestHandler(abc.ABC):
             0. The response body MIME type.
                 For example, "application/json" or "text/plain".
                 See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
-            1. The response body content.
+            1. The response body content, or :data:`KEEP_OPEN` to take
+                ownership of the socket for streaming; see
+                :meth:`onConnectionTakeover`.
         """
         pass
+
+    def onConnectionTakeover(self, socket, writeNotifier, readNotifier):
+        """
+        Called by :class:`SlicerHTTPServer` after :meth:`handleRequest`
+        returned a ``(contentType, KEEP_OPEN)`` tuple.
+
+        The server has already written the HTTP status line, ``Content-Type``,
+        ``Cache-Control: no-cache``, ``Connection: keep-alive``, and the
+        blank-line header terminator to ``socket``. No ``Content-Length`` is
+        sent. From this point forward the handler owns the socket and both
+        notifiers; the server will not touch them.
+
+        The default implementation disables the notifiers and closes the
+        socket — a handler that returns ``KEEP_OPEN`` without overriding
+        this method is buggy, and the default prevents it from leaking a
+        half-open connection.
+
+        :param socket: The underlying :class:`socket.socket` for the
+            connection. Still connected, TCP_NODELAY not set.
+        :param writeNotifier: A ``qt.QSocketNotifier(fileno, Write)`` ready
+            for the handler to connect to its own write slot. Not yet
+            enabled.
+        :param readNotifier: The ``qt.QSocketNotifier(fileno, Read)`` the
+            server used to read the request. Already disabled. The handler
+            may re-enable it if it expects more client→server traffic
+            (WebSocket frames, SSE client abort detection, etc.).
+        """
+        writeNotifier.setEnabled(False)
+        readNotifier.setEnabled(False)
+        try:
+            socket.close()
+        except OSError:
+            pass

--- a/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
@@ -1049,10 +1049,17 @@ space origin: %%origin%%
             orbitY = float(q["orbitY"][0].strip())
         except (KeyError, ValueError):
             orbitY = None
+        try:
+            dolly = float(q["dolly"][0].strip())
+        except (KeyError, ValueError):
+            dolly = None
 
         layoutManager = slicer.app.layoutManager()
         view = layoutManager.threeDWidget(0).threeDView()
         view.renderEnabled = False
+        # qMRMLThreeDView has no .renderer() accessor — go via the render
+        # window.  The 3D view always has a single renderer.
+        renderer = view.renderWindow().GetRenderers().GetFirstRenderer()
 
         if lookFromAxis:
             axes = ["None", "r", "l", "s", "i", "a", "p"]
@@ -1061,6 +1068,60 @@ space origin: %%origin%%
                 view.lookFromAxis(axis)
             except ValueError:
                 pass
+
+        # Apply camera transforms if requested.  Angles in degrees, pan in
+        # window pixels (scaled to world units via the camera's parallel
+        # scale and the 3D view size), dolly is a multiplicative factor.
+        if any(v is not None for v in (orbitX, orbitY, roll, panX, panY, dolly)):
+            camera = renderer.GetActiveCamera()
+            # Sign conventions chosen to match Slicer's native 3D drag
+            # behaviour (vtkMRMLThreeDViewInteractorStyle): left-drag
+            # rotates the scene the same way you drag, shift+left-drag
+            # pans the scene with the cursor, right-drag dollies toward
+            # the cursor direction.
+            if orbitX is not None:
+                camera.Azimuth(-orbitX)
+            if orbitY is not None:
+                camera.Elevation(orbitY)
+            if orbitX is not None or orbitY is not None:
+                camera.OrthogonalizeViewUp()
+            if roll is not None:
+                camera.Roll(roll)
+            if dolly is not None and dolly > 0.0:
+                camera.Dolly(dolly)
+            if panX is not None or panY is not None:
+                import math
+                vup = list(camera.GetViewUp())
+                dop = list(camera.GetDirectionOfProjection())
+                right = [
+                    vup[1] * dop[2] - vup[2] * dop[1],
+                    vup[2] * dop[0] - vup[0] * dop[2],
+                    vup[0] * dop[1] - vup[1] * dop[0],
+                ]
+                n = math.sqrt(sum(c * c for c in right)) or 1.0
+                right = [c / n for c in right]
+                winSize = view.renderWindow().GetSize()
+                winH = max(1, winSize[1])
+                if camera.GetParallelProjection():
+                    world_per_pixel = (2.0 * camera.GetParallelScale()) / winH
+                else:
+                    fp = camera.GetFocalPoint()
+                    pos = camera.GetPosition()
+                    dist = math.sqrt(sum((fp[i] - pos[i]) ** 2 for i in range(3)))
+                    world_per_pixel = (2.0 * dist * math.tan(math.radians(camera.GetViewAngle()) / 2)) / winH
+                dx = (panX or 0.0) * world_per_pixel
+                dy = (panY or 0.0) * world_per_pixel
+                fp = list(camera.GetFocalPoint())
+                pos = list(camera.GetPosition())
+                for i in range(3):
+                    # Camera moves with the drag so the scene appears
+                    # to follow the cursor.
+                    delta = right[i] * dx + vup[i] * dy
+                    fp[i] += delta
+                    pos[i] += delta
+                camera.SetFocalPoint(*fp)
+                camera.SetPosition(*pos)
+            renderer.ResetCameraClippingRange()
 
         view.renderWindow().Render()
         view.renderEnabled = True

--- a/Modules/Scripted/WebServer/WebServerLib/StaticPagesRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/StaticPagesRequestHandler.py
@@ -28,13 +28,15 @@ class StaticPagesRequestHandler(BaseRequestHandler):
     def __init__(self, docroot, logMessage: BaseRequestLoggingFunction | None = None):
         """
         Initialize a new request handler instance.
-        :param docroot: directory path of static pages content
+        :param docroot: directory path of static pages content; accepted as
+            ``str`` or ``bytes`` and stored as ``bytes`` so it composes with
+            the ``bytes`` URIs used elsewhere in the handler.
         :param logMessage: An optional external handle for message logging.
         """
         self.uriRewriteRules = []
-        self.docroot = docroot
+        self.docroot = docroot.encode() if isinstance(docroot, str) else docroot
         self.logMessage = logMessage or self.defaultLogMessage
-        self.logMessage("docroot: %s" % self.docroot)
+        self.logMessage("docroot: %s" % self.docroot.decode(errors="replace"))
 
     def canHandleRequest(self, **_kwargs) -> float:
         """
@@ -73,7 +75,7 @@ class StaticPagesRequestHandler(BaseRequestHandler):
         if uri.startswith(b"/"):
             uri = uri[1:]
         path = os.path.join(self.docroot, uri)
-        self.logMessage("docroot: %s" % self.docroot)
+        self.logMessage("docroot: %s" % self.docroot.decode(errors="replace"))
         if os.path.isdir(path):
             for index in b"index.html", b"index.htm":
                 index = os.path.join(path, index)


### PR DESCRIPTION
Adds a small, backward-compatible hook that lets a request handler take ownership of the underlying TCP socket after sending initial headers, enabling Server-Sent Events and (later) WebSocket support without touching the per-request write/close lifecycle.  Also fills in a few small gaps in the existing handlers.

BaseRequestHandler
  * New KEEP_OPEN sentinel: a handler returns (contentType, KEEP_OPEN) from handleRequest to signal that it wants to stream to the client rather than emit a single Content-Length-bounded response.
  * New onConnectionTakeover(socket, writeNotifier, readNotifier) default method.  Called after KEEP_OPEN; the handler then owns the socket.  Default implementation disables the notifiers and closes the socket so a buggy handler does not leak a half-open connection.

SlicerHTTPServer.SlicerRequestCommunicator
  * When handleRequest returns KEEP_OPEN, write an HTTP status line plus the caller-supplied Content-Type (no Content-Length), hand the socket and notifiers to the handler, and stop managing the connection.

SlicerRequestHandler.threeD
  * orbitX, orbitY, panX, panY, roll, and a new dolly query parameter now actually apply to the 3D camera instead of being parsed and ignored.  Sign conventions chosen to match Slicer's native 3D drag behaviour.
  * Fixed an AttributeError path: qMRMLThreeDView has no .renderer() accessor -- go through renderWindow().GetRenderers().GetFirstRenderer().
  * ResetCameraClippingRange after camera moves so clipping follows.

StaticPagesRequestHandler
  * Coerce docroot to bytes in __init__ so callers that pass a str no longer trip "TypeError: Can't mix strings and bytes in path components" when composing with bytes URIs elsewhere in the handler.