### PR TITLE
BUG: When reparenting a selected node maintain selection

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
@@ -1028,9 +1028,22 @@ void qMRMLSubjectHierarchyModel::updateItemFromSubjectHierarchyItem(QStandardIte
       int newIndex = this->subjectHierarchyItemIndex(shItemID);
       if ((newParentItem != nullptr) && (parentItem != newParentItem || newIndex != item->row()))
       {
+        // Save selection before reparenting: takeRow/insertRow is a remove+insert at the Qt
+        // model level, which causes QItemSelectionModel to clear selection for the moved row.
+        // Each connected view independently saves and restores its own selection.
+        // Drag-and-drop operations restore selection separately in dropMimeData, so skip here.
+        if (d->DraggedSubjectHierarchyItems.isEmpty())
+        {
+          emit requestSaveSelection();
+        }
         // Reparent items
         QList<QStandardItem*> children = parentItem->takeRow(item->row());
         newParentItem->insertRow(newIndex, children);
+        // Restore selection (each connected view restores its own previously saved selection)
+        if (d->DraggedSubjectHierarchyItems.isEmpty())
+        {
+          emit requestRestoreSelection();
+        }
       }
     }
   }
@@ -1656,6 +1669,11 @@ void qMRMLSubjectHierarchyModel::onSubjectHierarchyItemChildrenReordered(vtkIdTy
 
   std::vector<vtkIdType> childrenItemIDs;
   d->SubjectHierarchyNode->GetItemChildren(parentItemID, childrenItemIDs);
+
+  // Save selection before reordering: takeRow/insertRow clears selection for moved items.
+  // Each connected view independently saves and restores its own selection.
+  emit requestSaveSelection();
+
   for (int positionInShNode = 0; positionInShNode < childrenItemIDs.size(); ++positionInShNode)
   {
     vtkIdType childItemID = childrenItemIDs[positionInShNode];
@@ -1681,6 +1699,9 @@ void qMRMLSubjectHierarchyModel::onSubjectHierarchyItemChildrenReordered(vtkIdTy
       newParentItem->insertRow(positionInShNode, children);
     }
   }
+
+  // Restore selection (each connected view restores its own previously saved selection)
+  emit requestRestoreSelection();
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.h
@@ -180,6 +180,11 @@ signals:
   void requestCollapseItem(vtkIdType itemID);
   /// Signal requesting selecting items in the tree
   void requestSelectItems(QList<vtkIdType> itemIDs);
+  /// Signal requesting each connected view to save its current selection before a model
+  /// operation (reparenting/reordering) that will clear selection for moved rows
+  void requestSaveSelection();
+  /// Signal requesting each connected view to restore the selection saved by requestSaveSelection
+  void requestRestoreSelection();
   /// Triggers invalidating the sort filter proxy model
   void invalidateFilter();
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -150,6 +150,9 @@ public:
   /// List of selected items to restore at the end of batch processing (the whole tree is rebuilt and selection is lost)
   QList<vtkIdType> SelectedItemsToRestore;
 
+  /// List of selected items saved before a model operation (reparenting/reordering) to restore after
+  QList<vtkIdType> SelectedItemsSavedByModel;
+
   /// Cached list of highlighted items to speed up clearing highlight after new selection
   QList<vtkIdType> HighlightedItems;
 
@@ -188,6 +191,8 @@ void qMRMLSubjectHierarchyTreeViewPrivate::init()
   QObject::connect(this->Model, SIGNAL(requestExpandItem(vtkIdType)), q, SLOT(expandItem(vtkIdType)));
   QObject::connect(this->Model, SIGNAL(requestCollapseItem(vtkIdType)), q, SLOT(collapseItem(vtkIdType)));
   QObject::connect(this->Model, SIGNAL(requestSelectItems(QList<vtkIdType>)), q, SLOT(setCurrentItems(QList<vtkIdType>)));
+  QObject::connect(this->Model, SIGNAL(requestSaveSelection()), q, SLOT(saveSelectionBeforeModelUpdate()));
+  QObject::connect(this->Model, SIGNAL(requestRestoreSelection()), q, SLOT(restoreSelectionAfterModelUpdate()));
   QObject::connect(this->Model, SIGNAL(subjectHierarchyUpdated()), q, SLOT(updateRootItem()));
 
   this->SortFilterModel = new qMRMLSortFilterSubjectHierarchyProxyModel(q);
@@ -2247,6 +2252,24 @@ void qMRMLSubjectHierarchyTreeView::onMRMLSceneEndBatchProcess(vtkObject* sceneO
   {
     this->setCurrentItems(d->SelectedItemsToRestore);
     d->SelectedItemsToRestore.clear();
+  }
+}
+
+//------------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::saveSelectionBeforeModelUpdate()
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+  d->SelectedItemsSavedByModel = d->SelectedItems;
+}
+
+//------------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::restoreSelectionAfterModelUpdate()
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+  if (!d->SelectedItemsSavedByModel.isEmpty())
+  {
+    this->setCurrentItems(d->SelectedItemsSavedByModel);
+    d->SelectedItemsSavedByModel.clear();
   }
 }
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
@@ -407,6 +407,13 @@ protected slots:
   /// Called when batch processing ends. Restores selection, which is lost when the hierarchy is rebuilt
   virtual void onMRMLSceneEndBatchProcess(vtkObject* sceneObject);
 
+  /// Save current selection before a model operation (reparenting/reordering) that will clear
+  /// selection for moved rows. Connected to qMRMLSubjectHierarchyModel::requestSaveSelection.
+  virtual void saveSelectionBeforeModelUpdate();
+  /// Restore selection saved by saveSelectionBeforeModelUpdate.
+  /// Connected to qMRMLSubjectHierarchyModel::requestRestoreSelection.
+  virtual void restoreSelectionAfterModelUpdate();
+
   void onCustomContextMenu(const QPoint& point);
 
   virtual void addNode();


### PR DESCRIPTION
When a subject hierarchy item is reparented programmatically (e.g. via "Move item here" in the context menu, or through scene loading that triggers a parent change) or when children of a node are reordered, the current selection in the Subject Hierarchy tree view is silently lost.

The root cause is in how Qt handles `QStandardItemModel::takeRow()` followed by `insertRow()`. This remove-then-reinsert sequence causes `QItemSelectionModel` to invalidate and clear the selection for the affected rows, since from the selection model's perspective the original item index no longer exists.

This regression affects any workflow that triggers subject hierarchy reparenting: drag-and-drop already had a workaround via `dropMimeData`, but programmatic reparenting and children reordering did not.

This solution adds two new signals to `qMRMLSubjectHierarchyModel`:

`requestSaveSelection()` emitted immediately before `takeRow()` is called during reparenting or reordering.
`requestRestoreSelection()` emitted immediately after `insertRow()` completes.

Each connected `qMRMLSubjectHierarchyTreeView` responds to these signals independently via two new slots:

`saveSelectionBeforeModelUpdate()` snapshots the current `SelectedItems` list into a separate `SelectedItemsSavedByModel` buffer.
`restoreSelectionAfterModelUpdate()` calls `setCurrentItems()` with the saved list and then clears the buffer.

This design keeps the model free of any view-specific logic. Multiple views connected to the same model each manage their own saved selection independently, so no cross-view coupling is introduced. The save/restore buffer (`SelectedItemsSavedByModel`) is separate from the existing `SelectedItemsToRestore` mechanism (which handles full tree rebuilds during batch scene processing) to avoid interference between the two paths.

Re [Project Week 44, Subject hierarchy combobox selection bug](https://projectweek.na-mic.org/PW44_2026_GranCanaria/Projects/DebugParemeterNodeAndQtmrmlcomboboxSetToNoneAfterAddingToASubjectHierarchy/)