### PR TITLE
COMP: Update ITK to 5.4.6

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -33,7 +33,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "ac65b49c34fcfa3c3422a66026c7fe2bbaa88902" # slicer-v5.4.5-2025-11-19-f51594a
+    "5bfed9195aa26be10b0c4df533b9685bcc10cefe" # slicer-v5.4.6-2026-04-20-f7ff6ad
     QUIET
     )
 


### PR DESCRIPTION
This updates ITK to v5.4.6. The new Slicer branch being used is https://github.com/Slicer/ITK/commits/slicer-v5.4.6-2026-04-20-f7ff6ad/.

I've tested the build/package/test on the Windows platform with success (no new test failures).

```
List of ITK changes:
$ git shortlog ac65b49..5bfed91 --no-merges
Andras Lasso (2):
      [backport] BUG: Fix image file reader crash when axis direction vector is short
      COMP: Fix itkFileTools build error when testing enabled

Bradley Lowekamp (1):
      BUG: Fix GDCM posix_memalign undefined with mingw

Csaba Pinter (1):
      [backport] ENH: Support 5D files in NRRD IO

Dženan Zukić (2):
      ENH: Update CI images from Windows-2019 to Windows-2022
      COMP: Fix doc-string of TreeIteratorBase::RemoveChild from Deprecated

GDCM Upstream (1):
      GDCM 2026-03-10 (dacccb6c)

Hans J. Johnson (7):
      PERF: Enable FFTW SIMD codelets with per-CPU introspection at configure time
      COMP: Move inline = default destructors to .cxx for 30 exported classes
      COMP: Update retired windows-2019 CI runner to windows-2022
      DOC: Sync spell-check dictionary with main branch
      BUG: Add null checks after ReadHeader in IPLCommonImageIO
      BUG: Value-initialize singleton instances to avoid indeterminate values
      BUG: Add zero-check guard in CumulativeGaussianCostFunction

Hans Johnson (5):
      COMP: Fix FFTW SIMD detection for Windows ARM64 and MSVC
      PERF: Backport ABI-guaranteed SIMD baselines for FFTW builds
      ENH: Add PEP 688 buffer protocol and fix np.asarray() lifetime safety
      ENH: Add comprehensive tests for itk.Image buffer protocol and lifetime
      BUG: Fix infinite loop in VoronoiDiagram2DGenerator::ConstructDiagram

James Butler (1):
      [backport] COMP: Update DCMTK targets based on new DCMTK namespace

Jean-Christophe Fillion-Robin (1):
      COMP: Add support for customizing ITK namespace (draft)

Matt McCormick (7):
      DOC: ITK 5.4.5 release notes
      COMP: Update tool.pixi.project to tool.pixi.workspace
      COMP: Update Azure Pipelines Windows image to windows-2022
      COMP: Update CI ExternalDataVersion from 5.4.3 to 5.4.5
      BUG: Remove 'Utilities/gdcmutfcpp' from GDCM UpdateFromUpstream.sh
      BUG: Backport GDCM CVE-2026-3650 fix
      ENH: Bump ITK version to 5.4.6

Matthew McCormick (2):
      DOC: Do not upgrade CMake in emulated Linux ARM build
      DOC: Update Python Xcode version to 16.2 for macos-15 runners

Niels Dekker (2):
      BUG: Add ImageAdaptor::ComputeOffset, to fix ImageRegionIterator support
      ENH: Add `ComputeIndex()` member function to ImageConstIterator

Simon Rit (1):
      BUG: Allow auto registering more than two factories in Python modules

Viacheslav Ustymenko (2):
      BUG: Implement integer-only Bresenham for BuildLine(Index, Index)
      BUG: BresenhamLine - use double precision floats for ending index computation

Vladimir S. FONOV (1):
      MINC 2025-02-24 (3b8d9c7e)

copilot-swe-agent[bot] (1):
      ENH: Add ITK_PYTHON_RELEASE_GIL option and SWIG -threads flag
```