### PR TITLE
BUG: Resolve QtTesting install library name from imported target

### DIFF
--- a/CMake/SlicerBlockInstallQtTesting.cmake
+++ b/CMake/SlicerBlockInstallQtTesting.cmake
@@ -1,20 +1,82 @@
 # -------------------------------------------------------------------------
 # Find and install QtTesting
 # -------------------------------------------------------------------------
+#
+# QtTesting is built and installed by the CTK external project. Slicer
+# packages the resulting shared library from the CTK install tree.
+#
+# The library file name is queried from the imported QtTesting CMake
+# target rather than hard-coded, so that future upstream changes to the
+# library output name (for example the Qt5+Qt6 rename of `QtTesting` to
+# `qttesting`) do not silently break Slicer packaging.
+#
+# NOTE: This logic assumes upstream installs a single, unversioned shared
+# library file (no SONAME symlink chain such as libqttesting.so.1 ->
+# libqttesting.so). If a future QtTesting revision introduces SONAME
+# versioning, this block must also install the symlink chain — for
+# example by globbing `libqttesting.so*` or by installing both
+# TARGET_SONAME_FILE and TARGET_FILE names.
 
 set(QtTesting_INSTALL_LIB_DIR "${Slicer_INSTALL_LIB_DIR}")
 
+find_package(QtTesting CONFIG QUIET REQUIRED)
+
+# Probe known QtTesting imported-target names (current and likely-future
+# spellings) so a future namespaced rename upstream is caught loudly.
+set(_qttesting_target "")
+foreach(_candidate qttesting QtTesting QtTesting::qttesting CTK::QtTesting)
+  if(TARGET ${_candidate})
+    set(_qttesting_target ${_candidate})
+    break()
+  endif()
+endforeach()
+if(NOT _qttesting_target)
+  message(FATAL_ERROR
+    "SlicerBlockInstallQtTesting: no imported QtTesting target was "
+    "defined by find_package(QtTesting). Tried: qttesting, QtTesting, "
+    "QtTesting::qttesting, CTK::QtTesting. Upstream may have renamed "
+    "the target; extend the probe list above.")
+endif()
+
+# Resolve the shared library file name (e.g. libqttesting.so,
+# libqttesting.dylib, qttesting.dll) from the imported target.
+set(_qttesting_imported_location "")
+foreach(_cfg
+    "${CMAKE_BUILD_TYPE}"
+    ${CMAKE_CONFIGURATION_TYPES}
+    Release RelWithDebInfo MinSizeRel Debug NOCONFIG
+    )
+  if(NOT _cfg)
+    continue()
+  endif()
+  string(TOUPPER "${_cfg}" _cfg_upper)
+  get_target_property(_qttesting_imported_location
+    ${_qttesting_target} IMPORTED_LOCATION_${_cfg_upper})
+  if(_qttesting_imported_location)
+    break()
+  endif()
+endforeach()
+if(NOT _qttesting_imported_location)
+  get_target_property(_qttesting_imported_location
+    ${_qttesting_target} IMPORTED_LOCATION)
+endif()
+if(NOT _qttesting_imported_location)
+  message(FATAL_ERROR
+    "SlicerBlockInstallQtTesting: failed to read IMPORTED_LOCATION from "
+    "the '${_qttesting_target}' target.")
+endif()
+get_filename_component(_qttesting_libname "${_qttesting_imported_location}" NAME)
+
 if(WIN32)
-  install(FILES ${QtTesting_INSTALL_DIR}/bin/QtTesting.dll
+  install(FILES "${QtTesting_INSTALL_DIR}/bin/${_qttesting_libname}"
     DESTINATION bin COMPONENT Runtime)
 elseif(APPLE)
-  # needs to install symlink version named libraries as well.
-  install(FILES ${QtTesting_INSTALL_DIR}/lib/libQtTesting.dylib
+  install(FILES "${QtTesting_INSTALL_DIR}/lib/${_qttesting_libname}"
     DESTINATION ${QtTesting_INSTALL_LIB_DIR} COMPONENT Runtime)
 elseif(UNIX)
-  install(FILES ${QtTesting_INSTALL_DIR}/lib/libQtTesting.so
+  install(FILES "${QtTesting_INSTALL_DIR}/lib/${_qttesting_libname}"
     DESTINATION ${QtTesting_INSTALL_LIB_DIR} COMPONENT Runtime)
   slicerStripInstalledLibrary(
-    FILES "${QtTesting_INSTALL_LIB_DIR}/libQtTesting.so"
+    FILES "${QtTesting_INSTALL_LIB_DIR}/${_qttesting_libname}"
     COMPONENT Runtime)
 endif()


### PR DESCRIPTION
Fixes #9135. The CTK QtTesting bump (CTK pins QtTesting at [`6d153156`](https://github.com/commontk/QtTesting/commit/6d1531564ae61f702fdd0d63f573fef08853460f), which adds `OUTPUT_NAME qttesting`) renamed the shared library output from `QtTesting` to `qttesting`, causing nightly Linux packaging to fail. This change queries the actual library file name from the imported `qttesting` CMake target instead of hard-coding it, so future renames don't silently break packaging.

<details>
<summary>Root cause</summary>

`CMake/SlicerBlockInstallQtTesting.cmake` hard-coded `libQtTesting.so` / `libQtTesting.dylib` / `QtTesting.dll`. After CTK began pulling in QtTesting commit `6d153156` (which sets `OUTPUT_NAME qttesting`), CTK installs `libqttesting.so` (lowercase), so the install step errors:

```
file INSTALL cannot find
  /usr/src/Slicer-build/CTK-build/CMakeExternals/Install/lib/libQtTesting.so
```

</details>

<details>
<summary>Fix details</summary>

- `find_package(QtTesting CONFIG REQUIRED)` to load the imported target.
- Probe target names (`qttesting`, `QtTesting`, `QtTesting::qttesting`, `CTK::QtTesting`) so a future namespaced rename fails loudly instead of silently.
- Resolve the library basename from `IMPORTED_LOCATION_<CONFIG>` (with fallbacks across known config types and `IMPORTED_LOCATION`).
- Use that basename for both `install(FILES …)` and `slicerStripInstalledLibrary(…)`.
- Documents a known limitation: assumes a single unversioned shared library file (no `libqttesting.so.1` SONAME chain). If upstream introduces SONAME versioning later, the block needs to install the symlink chain too — a comment in the file flags this.

Verified locally: the generated `cmake_install.cmake` now references `libqttesting.so` from the actual CTK install tree.

</details>

## Test plan
- [x] Cross-validated by @fedorov on #9136 — that PR's CI build succeeds with this fix in place.
- [ ] Linux nightly package build (CDash) succeeds: previously failing `cmake_install.cmake:1117` step now installs `libqttesting.so`.
- [ ] macOS package contains `libqttesting.dylib`.
- [ ] Windows package contains `qttesting.dll`.

<!--
provenance: claude-code session 2026-04-30, updated 2026-05-01
related_files: CMake/SlicerBlockInstallQtTesting.cmake
issue: https://github.com/Slicer/Slicer/issues/9135
hash_correction: original body cited cf5fa41 (a stale CTK tag id); the
  actual upstream change that renamed the library is QtTesting commit
  6d153156, pulled in via CTK 549a5b7 (External_CTK.cmake:80).
-->
