### PR TITLE
ENH: Allow Slicer_USE_QtTesting=ON with Qt 6 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,13 +213,10 @@ mark_as_superbuild(Slicer_REQUIRED_QT_VERSION)
 #-----------------------------------------------------------------------------
 # QtTesting compatibility check
 #-----------------------------------------------------------------------------
-if(Slicer_REQUIRED_QT_VERSION VERSION_GREATER_EQUAL "6")
-  if(Slicer_USE_QtTesting)
-    message(WARNING "QtTesting is not yet compatible with Qt 6. Forcing Slicer_USE_QtTesting to OFF. "
-                    "Please review the state of https://github.com/Slicer/Slicer/issues/8839")
-  endif()
-  set(Slicer_USE_QtTesting OFF CACHE BOOL "Integrate QtTesting framework into Slicer." FORCE)
-endif()
+# QtTesting is now supported under both Qt 5 and Qt 6 by the upstream
+# commontk/QtTesting and CTK projects. The previous Qt 6 force-disable
+# has been removed; Slicer_USE_QtTesting follows its user-facing default
+# regardless of Qt major version. See https://github.com/Slicer/Slicer/issues/8839
 
 #-----------------------------------------------------------------------------
 # Python requirements
@@ -663,7 +660,9 @@ endif()
     Svg Sql
     )
 
-  if(Slicer_USE_QtTesting)
+  if(Slicer_USE_QtTesting AND Slicer_REQUIRED_QT_VERSION VERSION_LESS "6")
+    # XmlPatterns was removed in Qt 6; CTK's QtTesting wrapper already guards
+    # its usage. Only require the module for Qt 5 builds.
     list(APPEND Slicer_REQUIRED_QT_MODULES
       XmlPatterns
       )


### PR DESCRIPTION
Closes #8839. Removes the Qt 6 force-disable of `Slicer_USE_QtTesting` and guards the legacy `XmlPatterns` Qt module requirement so it only applies to Qt 5. The upstream `commontk/QtTesting` project and CTK's QtTesting wrapper both already support Qt 6, so the blanket disable is no longer needed.

> **Note for reviewers:** this branch is built on top of #9137 (the QtTesting library-name resolution fix). #9137 should land first; until it does, this PR will display two commits. After #9137 merges, only the Qt 6 enablement commit will remain.

<details>
<summary>Why the disable was originally needed, and why it isn't anymore</summary>

`Slicer_USE_QtTesting` was force-disabled under Qt 6 because:

1. Upstream `commontk/QtTesting` had no Qt 6 build path. **Fixed** in revision `cf5fa41…` ("Qt5+Qt6 support"), which Slicer's CTK now pins.
2. CTK's QtTesting wrapper used `Qt5::XmlPatterns` and `ctkXMLEventSource`. **Fixed** in the CTK update at Slicer commit `d2735cf6` ("COMP: Guard ctkXMLEventSource XmlPatterns usage for Qt 6", "COMP: Guard Qt5::XmlPatterns link dependency for Qt 6 builds", "ENH: Allow CTK_USE_QTTESTING=ON with Qt 6 builds").
3. Slicer's top-level CMake added `XmlPatterns` to `Slicer_REQUIRED_QT_MODULES` whenever `Slicer_USE_QtTesting` was on. **Fixed in this PR** by guarding the addition with `Slicer_REQUIRED_QT_VERSION VERSION_LESS "6"`.

</details>

<details>
<summary>Local validation</summary>

Full Release SuperBuild + package on Linux:

- OS: Ubuntu 24.04.4 LTS, GCC 13.3.0, CMake 4.2.1 (Ninja)
- Hardware: Xeon w7-3545 (24c/48t), 251 GB RAM
- Qt: 6.8.2 (aqtinstall, modules: `qtshadertools qtmultimedia qtwebchannel qtwebengine qtwebsockets qtwebview qtimageformats qt5compat qtcharts qtdatavis3d qtnetworkauth qtserialport qtspeech qt3d qtscxml qtpositioning`)
- `Slicer_USE_QtTesting=ON`, `Slicer_REQUIRED_QT_VERSION=6.8`
- Branch: built on top of #9137

**Result:** 528 MB tarball, with under `lib/Slicer-5.11/`:

```
libqttesting.so
libCTKQtTesting.so
libCTKQtTesting.so.0.1
libCTKQtTesting.so.0.1.0
CTKQtTestingPythonQt.so
```

CDash filter (build name `Qt6-USE_QtTesting-ON`):
https://slicer.cdash.org/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=Qt6-USE_QtTesting-ON

Some Python tests failed at runtime (display/environment-related, not related to QtTesting integration); these match the failure profile already seen on the equivalent Qt 5 dashboard run and are not regressions introduced by this change.

</details>

## Test plan
- [x] CI Qt 6 build (verifies the configure / compile path on the official runners)
- [x] CI Qt 5 build (verifies the `XmlPatterns` requirement still works under Qt 5)
- [ ] Smoke test of QtTesting macro recording / playback under Qt 6 (manual; not yet exercised)

<!--
provenance: claude-code session 2026-04-30
related_files: CMakeLists.txt
issue: https://github.com/Slicer/Slicer/issues/8839
depends_on_pr: #9137
local_branch: qt6-enable-qttesting @ 4a2d0f4d47 (built on fix-qttesting-install-name)
verified_qt_version: 6.8.2 via aqtinstall
-->