### PR TITLE
BUG: Restore removed slicer.util._executePythonModule

### DIFF
--- a/Base/Python/slicer/packaging.py
+++ b/Base/Python/slicer/packaging.py
@@ -21,6 +21,7 @@ import importlib
 import importlib.metadata
 import logging
 import shlex
+import slicer.util
 import sys
 import tomllib
 from pathlib import Path
@@ -32,17 +33,12 @@ from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
 
 from slicer.i18n import tr as _
-from slicer.util import executePythonModule
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     import qt
 
-
-# Tests can monkeypatch _executePythonModule to perform mock actions instead of actually executing
-# the Python module by using slicer.packaging._executePythonModule.
-_executePythonModule = executePythonModule
 def load_requirements(path: str | Path) -> list[Requirement]:
     """Load requirements from a requirements.txt file.
 
@@ -688,11 +684,11 @@ def _pip_install_simple(
     # Handle no_deps_requirements first
     if no_deps_requirements is not None:
         args = _build_pip_args(no_deps_requirements, constraints, no_deps=True)
-        _executePythonModule("pip", args, blocking=True)
+        slicer.util.executePythonModule("pip", args, blocking=True)
 
     # Then install regular requirements
     args = _build_pip_args(requirements, constraints, no_deps=False)
-    _executePythonModule("pip", args, blocking=True)
+    slicer.util.executePythonModule("pip", args, blocking=True)
 
 
 def _pip_install_with_busy_cursor(
@@ -844,8 +840,10 @@ def _pip_install_nonblocking(
         if no_deps_requirements is None:
             # Simple case - single install
             args = _build_pip_args(requirements, constraints, no_deps=False)
-            _executePythonModule("pip", args, blocking=False,
-                                 logCallback=logCallback, completedCallback=wrappedCompletedCallback)
+            slicer.util.executePythonModule(
+                "pip", args, blocking=False,
+                logCallback=logCallback, completedCallback=wrappedCompletedCallback,
+            )
             return
 
         # Two-step installation: first no_deps, then regular
@@ -859,12 +857,16 @@ def _pip_install_nonblocking(
                 return
             # Success - proceed to regular install (flag stays set until final completion)
             args = _build_pip_args(requirements, constraints, no_deps=False)
-            _executePythonModule("pip", args, blocking=False,
-                                 logCallback=logCallback, completedCallback=wrappedCompletedCallback)
+            slicer.util.executePythonModule(
+                "pip", args, blocking=False,
+                logCallback=logCallback, completedCallback=wrappedCompletedCallback,
+            )
 
         no_deps_args = _build_pip_args(no_deps_requirements, constraints, no_deps=True)
-        _executePythonModule("pip", no_deps_args, blocking=False,
-                             logCallback=logCallback, completedCallback=onNoDepsComplete)
+        slicer.util.executePythonModule(
+            "pip", no_deps_args, blocking=False,
+            logCallback=logCallback, completedCallback=onNoDepsComplete,
+        )
     except Exception:
         _pip_install_in_progress = False
         raise
@@ -1009,7 +1011,7 @@ def _pip_install_with_skips(
         extras_str = f"[{','.join(req.extras)}]" if req.extras else ""
         install_str = f"{req.name}{extras_str}{req.specifier}"
         args = _build_pip_args(install_str, constraints, no_deps=True)
-        _executePythonModule("pip", args, blocking=True, logCallback=log_fn)
+        slicer.util.executePythonModule("pip", args, blocking=True, logCallback=log_fn)
 
         # Read sub-dependencies from installed metadata
         importlib.invalidate_caches()
@@ -1144,11 +1146,13 @@ def pip_uninstall(
 
     # In PythonSlicer, always use blocking mode
     if not _isSlicerAppAvailable():
-        _executePythonModule("pip", args, blocking=True)
+        slicer.util.executePythonModule("pip", args, blocking=True)
         return
 
-    _executePythonModule("pip", args, blocking=blocking,
-                         logCallback=logCallback, completedCallback=completedCallback)
+    slicer.util.executePythonModule(
+        "pip", args, blocking=blocking,
+        logCallback=logCallback, completedCallback=completedCallback,
+    )
 
 
 class _PipProgressDialog:

--- a/Base/Python/slicer/packaging.py
+++ b/Base/Python/slicer/packaging.py
@@ -20,9 +20,7 @@ from __future__ import annotations
 import importlib
 import importlib.metadata
 import logging
-import os
 import shlex
-import shutil
 import sys
 import tomllib
 from pathlib import Path
@@ -34,7 +32,7 @@ from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
 
 from slicer.i18n import tr as _
-from slicer.util import launchConsoleProcess, logProcessOutput
+from slicer.util import executePythonModule
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -42,57 +40,9 @@ if TYPE_CHECKING:
     import qt
 
 
-def _executePythonModule(
-    module: str,
-    args: list[str],
-    blocking: bool = True,
-    logCallback: Callable[[str], None] | None = None,
-    completedCallback: Callable[[int], None] | None = None,
-) -> None:
-    """Execute a Python module as a script in Slicer's Python environment.
-
-    Internally python -m is called with the module name and additional arguments.
-
-    :param module: Python module name to execute (e.g., "pip")
-    :param args: command-line arguments to pass to the module
-    :param blocking: If True (default), block until completion. If False, return immediately.
-    :param logCallback: When blocking=False, called with each line of output.
-    :param completedCallback: When blocking=False, called when process completes.
-    :raises RuntimeError: if PythonSlicer executable not found
-    :raises CalledProcessError: in blocking mode, if process fails
-    """
-    # Determine pythonSlicerExecutablePath
-    try:
-        from slicer import app  # noqa: F401
-
-        # If we get to this line then import from "app" is succeeded,
-        # which means that we run this function from Slicer Python interpreter.
-        # PythonSlicer is added to PATH environment variable in Slicer
-        # therefore shutil.which will be able to find it.
-        pythonSlicerExecutablePath = shutil.which("PythonSlicer")
-        if not pythonSlicerExecutablePath:
-            raise RuntimeError("PythonSlicer executable not found")
-    except ImportError:
-        # Running from console
-        pythonSlicerExecutablePath = os.path.dirname(sys.executable) + "/PythonSlicer"
-        if os.name == "nt":
-            pythonSlicerExecutablePath += ".exe"
-
-    commandLine = [pythonSlicerExecutablePath, "-m", module, *args]
-
-    if blocking:
-        proc = launchConsoleProcess(commandLine, useStartupEnvironment=False)
-        logProcessOutput(proc, logCallback=logCallback)
-    else:
-        launchConsoleProcess(
-            commandLine,
-            useStartupEnvironment=False,
-            blocking=False,
-            logCallback=logCallback,
-            completedCallback=completedCallback,
-        )
-
-
+# Tests can monkeypatch _executePythonModule to perform mock actions instead of actually executing
+# the Python module by using slicer.packaging._executePythonModule.
+_executePythonModule = executePythonModule
 def load_requirements(path: str | Path) -> list[Requirement]:
     """Load requirements from a requirements.txt file.
 

--- a/Base/Python/slicer/tests/test_slicer_packaging.py
+++ b/Base/Python/slicer/tests/test_slicer_packaging.py
@@ -408,7 +408,7 @@ class PipInstallNonBlockingTest(unittest.TestCase):
             completed.set()
 
         # Use --version which is quick
-        slicer.packaging._executePythonModule(
+        slicer.util.executePythonModule(
             "pip", ["--version"],
             blocking=False,
             logCallback=on_log,
@@ -430,7 +430,7 @@ class PipInstallNonBlockingTest(unittest.TestCase):
         """Test that blocking mode still works (backward compatibility)."""
         # pip --version should succeed without callbacks
         try:
-            slicer.packaging._executePythonModule("pip", ["--version"])
+            slicer.util.executePythonModule("pip", ["--version"])
         except Exception as e:
             self.fail(f"Blocking mode failed: {e}")
 
@@ -564,7 +564,7 @@ class ConstraintsTest(unittest.TestCase):
             constraints_path = f.name
 
         try:
-            with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
                 slicer.packaging.pip_install("scipy", constraints=constraints_path)
 
                 mock_exec.assert_called_once()
@@ -582,7 +582,7 @@ class ConstraintsTest(unittest.TestCase):
 
     def test_pip_install_without_constraints_no_c_flag(self):
         """Test that pip_install does not pass -c flag when constraints is None."""
-        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+        with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
             slicer.packaging.pip_install("scipy")
 
             mock_exec.assert_called_once()
@@ -644,7 +644,7 @@ class ConstraintsTest(unittest.TestCase):
             constraints_path = Path(f.name)
 
         try:
-            with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+            with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
                 slicer.packaging.pip_install("scipy", constraints=constraints_path)
 
                 mock_exec.assert_called_once()
@@ -1031,7 +1031,7 @@ class PipInstallWithSkipsTest(unittest.TestCase):
         tree = {"top-pkg": ["torch>=2.0", "numpy>=1.0"]}
         patches = self._mock_dep_tree(tree)
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+        with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
             for p in patches:
                 p.start()
             try:
@@ -1070,7 +1070,7 @@ class PipInstallWithSkipsTest(unittest.TestCase):
         }
         patches = self._mock_dep_tree(tree)
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+        with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
             for p in patches:
                 p.start()
             try:
@@ -1092,7 +1092,7 @@ class PipInstallWithSkipsTest(unittest.TestCase):
         tree = {"pkg": ["torch>=2.0.1", "SimpleITK>=2.0.2"]}
         patches = self._mock_dep_tree(tree)
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule"):
+        with unittest.mock.patch("slicer.util.executePythonModule"):
             for p in patches:
                 p.start()
             try:
@@ -1117,7 +1117,7 @@ class PipInstallWithSkipsTest(unittest.TestCase):
         }
         patches = self._mock_dep_tree(tree)
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule"):
+        with unittest.mock.patch("slicer.util.executePythonModule"):
             for p in patches:
                 p.start()
             try:
@@ -1132,7 +1132,7 @@ class PipInstallWithSkipsTest(unittest.TestCase):
         tree = {"pkg": ['ruff>=0.1; extra == "dev"', "numpy>=1.0"]}
         patches = self._mock_dep_tree(tree)
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+        with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
             for p in patches:
                 p.start()
             try:
@@ -1157,7 +1157,7 @@ class PipInstallWithSkipsTest(unittest.TestCase):
         tree = {"pkg": ['win-only>=1.0; sys_platform == "nonexistent"', "numpy>=1.0"]}
         patches = self._mock_dep_tree(tree)
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+        with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
             for p in patches:
                 p.start()
             try:
@@ -1190,7 +1190,7 @@ class PipInstallWithSkipsTest(unittest.TestCase):
         tree = {"pkg": [f'scipy>=1.0; sys_platform == "{current_platform}"']}
         patches = self._mock_dep_tree(tree)
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+        with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
             for p in patches:
                 p.start()
             try:
@@ -1221,7 +1221,7 @@ class PipInstallWithSkipsTest(unittest.TestCase):
         tree = {"pkg[extra1]>=1.0": []}
         patches = self._mock_dep_tree(tree)
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+        with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
             for p in patches:
                 p.start()
             try:
@@ -1242,7 +1242,7 @@ class PipInstallWithSkipsTest(unittest.TestCase):
         # numpy is marked as already installed
         patches = self._mock_dep_tree(tree, installed={"numpy"})
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+        with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
             for p in patches:
                 p.start()
             try:
@@ -1259,7 +1259,7 @@ class PipInstallWithSkipsTest(unittest.TestCase):
         tree = {"pkg": ["numpy>=1.0"]}
         patches = self._mock_dep_tree(tree)
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+        with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
             for p in patches:
                 p.start()
             try:
@@ -1289,7 +1289,7 @@ class PipInstallWithSkipsTest(unittest.TestCase):
         tree = {"pkg": []}
         patches = self._mock_dep_tree(tree)
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+        with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
             mock_exec.side_effect = CalledProcessError(1, "pip")
             for p in patches:
                 p.start()
@@ -1319,7 +1319,7 @@ class PipInstallWithSkipsTest(unittest.TestCase):
                 raise CalledProcessError(1, "pip")
             # pkg and dep-b succeed
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+        with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
             mock_exec.side_effect = selective_fail
             for p in patches:
                 p.start()
@@ -1406,7 +1406,7 @@ class NoDepsRequirementsTwoStepTest(unittest.TestCase):
         First call should have --no-deps for the no_deps_requirements,
         second call should install regular requirements without --no-deps.
         """
-        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+        with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
             slicer.packaging._pip_install_simple(
                 requirements="numpy scipy",
                 no_deps_requirements="problematic-pkg==1.0",
@@ -1427,7 +1427,7 @@ class NoDepsRequirementsTwoStepTest(unittest.TestCase):
 
     def test_two_step_passes_constraints_to_both(self):
         """Test that constraints file is passed to both steps."""
-        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+        with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
             slicer.packaging._pip_install_simple(
                 requirements="numpy",
                 constraints="/path/to/constraints.txt",
@@ -1442,7 +1442,7 @@ class NoDepsRequirementsTwoStepTest(unittest.TestCase):
 
     def test_without_no_deps_requirements_single_call(self):
         """Test that omitting no_deps_requirements makes only one pip call."""
-        with unittest.mock.patch("slicer.packaging._executePythonModule") as mock_exec:
+        with unittest.mock.patch("slicer.util.executePythonModule") as mock_exec:
             slicer.packaging._pip_install_simple(requirements="numpy scipy")
 
             mock_exec.assert_called_once()
@@ -1470,7 +1470,7 @@ class IsPipInstallInProgressTest(unittest.TestCase):
             if completedCallback:
                 completedCallback(0)
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule", side_effect=fake_exec):
+        with unittest.mock.patch("slicer.util.executePythonModule", side_effect=fake_exec):
             slicer.packaging._pip_install_nonblocking("numpy")
 
         # Flag should have been True during execution
@@ -1480,9 +1480,9 @@ class IsPipInstallInProgressTest(unittest.TestCase):
         self.assertFalse(slicer.packaging.isPipInstallInProgress())
 
     def test_flag_cleared_on_exception(self):
-        """Test that the flag is cleared if _executePythonModule raises."""
+        """Test that the flag is cleared if executePythonModule raises."""
         with unittest.mock.patch(
-            "slicer.packaging._executePythonModule",
+            "slicer.util.executePythonModule",
             side_effect=RuntimeError("test error"),
         ):
             with self.assertRaises(RuntimeError):
@@ -1510,7 +1510,7 @@ class NonBlockingPipInstallCallbackTest(unittest.TestCase):
             if completedCallback:
                 completedCallback(42)
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule", side_effect=fake_exec):
+        with unittest.mock.patch("slicer.util.executePythonModule", side_effect=fake_exec):
             slicer.packaging._pip_install_nonblocking(
                 "numpy", completedCallback=on_complete,
             )
@@ -1527,7 +1527,7 @@ class NonBlockingPipInstallCallbackTest(unittest.TestCase):
             if completedCallback:
                 completedCallback(0)
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule", side_effect=fake_exec):
+        with unittest.mock.patch("slicer.util.executePythonModule", side_effect=fake_exec):
             slicer.packaging._pip_install_nonblocking(
                 "numpy", no_deps_requirements="problematic-pkg",
             )
@@ -1552,7 +1552,7 @@ class NonBlockingPipInstallCallbackTest(unittest.TestCase):
         def on_complete(return_code):
             result["return_code"] = return_code
 
-        with unittest.mock.patch("slicer.packaging._executePythonModule", side_effect=fake_exec):
+        with unittest.mock.patch("slicer.util.executePythonModule", side_effect=fake_exec):
             slicer.packaging._pip_install_nonblocking(
                 "numpy",
                 no_deps_requirements="problematic-pkg",

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -4082,6 +4082,75 @@ def logProcessOutput(proc, logCallback=None):
     if retcode != 0:
         raise CalledProcessError(retcode, proc.args, output=proc.stdout, stderr=proc.stderr)
 
+def _executePythonModule(
+    module: str,
+    args: list[str],
+    blocking: bool = True,
+    logCallback: Callable[[str], None] | None = None,
+    completedCallback: Callable[[int], None] | None = None,
+) -> None:
+    """Execute a Python module as a script in Slicer's Python environment.
+    .. deprecated:: 5.11.0
+       Use :func:`executePythonModule` function instead.
+    """
+    import warnings
+    warnings.warn("_executePythonModule is deprecated, use executePythonModule instead", DeprecationWarning, stacklevel=2)
+    return executePythonModule(module, args, blocking, logCallback, completedCallback)
+
+
+def executePythonModule(
+    module: str,
+    args: list[str],
+    blocking: bool = True,
+    logCallback: Callable[[str], None] | None = None,
+    completedCallback: Callable[[int], None] | None = None,
+) -> None:
+    """Execute a Python module as a script in Slicer's Python environment.
+
+    Internally python -m is called with the module name and additional arguments.
+
+    :param module: Python module name to execute (e.g., "pip")
+    :param args: command-line arguments to pass to the module
+    :param blocking: If True (default), block until completion. If False, return immediately.
+    :param logCallback: When blocking=False, called with each line of output.
+    :param completedCallback: When blocking=False, called when process completes.
+    :raises RuntimeError: if PythonSlicer executable not found
+    :raises CalledProcessError: in blocking mode, if process fails
+    """
+    import os, sys
+    import shutil
+
+    # Determine pythonSlicerExecutablePath
+    try:
+        from slicer import app  # noqa: F401
+
+        # If we get to this line then import from "app" is succeeded,
+        # which means that we run this function from Slicer Python interpreter.
+        # PythonSlicer is added to PATH environment variable in Slicer
+        # therefore shutil.which will be able to find it.
+        pythonSlicerExecutablePath = shutil.which("PythonSlicer")
+        if not pythonSlicerExecutablePath:
+            raise RuntimeError("PythonSlicer executable not found")
+    except ImportError:
+        # Running from console
+        pythonSlicerExecutablePath = os.path.dirname(sys.executable) + "/PythonSlicer"
+        if os.name == "nt":
+            pythonSlicerExecutablePath += ".exe"
+
+    commandLine = [pythonSlicerExecutablePath, "-m", module, *args]
+
+    if blocking:
+        proc = launchConsoleProcess(commandLine, useStartupEnvironment=False)
+        logProcessOutput(proc, logCallback=logCallback)
+    else:
+        launchConsoleProcess(
+            commandLine,
+            useStartupEnvironment=False,
+            blocking=False,
+            logCallback=logCallback,
+            completedCallback=completedCallback,
+        )
+
 
 def pip_install(requirements, **kwargs):
     """Install python packages.


### PR DESCRIPTION
`slicer.util._executePythonModule` function has been widely used in many extensions. Recently this function was moved to packaging, and since then these extensions no longer work. The name started with an underscore because it was originally intended to be an internal function, but then it turned out to be essential, and we started using it in extensions. It should be actually a public utility function.

This commit restores `slicer.util._executePythonModule` to make extensions work again, but makes it deprecated. From now on, `slicer.util.executePythonModule` function should be used instead.