### PR TITLE
Color individual control points

### DIFF
--- a/Docs/developer_guide/script_repository/markups.md
+++ b/Docs/developer_guide/script_repository/markups.md
@@ -506,6 +506,36 @@ pointListDisplayNode.SetSelectedColor(1,1,0) # Set color to yellow
 pointListDisplayNode.SetViewNodeIDs(["vtkMRMLSliceNodeRed", "vtkMRMLViewNode1"]) # Only show in red slice view and first 3D view
 ```
 
+### Set per-control-point colors
+
+Each control point can be assigned its own color. Per-point colors apply to
+the control point glyphs and override the display node's Selected/Unselected
+colors for points where a color has been set; the Active color still
+highlights the active control point. The line or curve connecting the
+control points keeps the display node's line color.
+
+```python
+m = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsFiducialNode")
+m.AddControlPoint([0, 0, 0])
+m.AddControlPoint([10, 0, 0])
+m.AddControlPoint([20, 0, 0])
+
+# Override colors on individual control points (RGBA, 0..1)
+m.SetNthControlPointColor(0, 1.0, 0.0, 0.0)        # red
+m.SetNthControlPointColor(2, 0.0, 0.7, 1.0, 0.8)   # blue, 80% opacity
+
+# Enable per-point colors on the display node
+m.GetDisplayNode().SetUseControlPointColors(True)
+
+# Inspect / clear per-point colors
+print(m.IsNthControlPointColorOverridden(0))   # True
+print(m.IsNthControlPointColorOverridden(1))   # False (uses Selected/Unselected fallback)
+rgba = [0.0, 0.0, 0.0, 0.0]
+m.GetNthControlPointColor(0, rgba); print(rgba)  # [1.0, 0.0, 0.0, 1.0]
+m.ClearNthControlPointColor(0)                # revert point 0 to fallback
+m.ClearAllControlPointColors()                # revert every point
+```
+
 ### Get a notification if a markup control point position is modified
 
 Event management of Slicer-4.11 version is still subject to change. The example below shows how control point manipulation can be observed now.

--- a/Docs/user_guide/modules/markups.md
+++ b/Docs/user_guide/modules/markups.md
@@ -86,6 +86,7 @@ The following keyboard shortcuts are active when the markups toolbar is displaye
   - Selected Color: Select the color that will be used to display the glyph and text when the markup is marked as selected.
   - Unselected Color: Select the color that will be used to display the glyph and text when the markup is not marked as selected.
   - Active Color: Select the color that will be used to display the glyph and text when the mouse hovers over the markup.
+  - Per-point colors: Enable to give each control point its own color, set via the Color column that appears in the control points table (click a swatch, or right-click for batch operations on multiple selected rows). Per-point colors apply to the control point glyphs only; the line or curve connecting them, and any control point without its own color, use the Selected/Unselected colors above.
   - Glyph Type: Select the symbol that will be used to mark each location. Default is the Sphere3D.
   - Line thickness: The thickness of lines in markups. Defined as either an absolute thickness, or as a percentage of the glyph size.
   - Outline: Visibility and opacity of the markups outline.

--- a/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.cxx
@@ -208,6 +208,7 @@ void vtkMRMLMarkupsDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLFloatMacro(occludedOpacity, OccludedOpacity);
   vtkMRMLWriteXMLStdStringMacro(textProperty, TextPropertyAsString);
   vtkMRMLWriteXMLVectorMacro(activeColor, ActiveColor, double, 3);
+  vtkMRMLWriteXMLBooleanMacro(useControlPointColors, UseControlPointColors);
 
   vtkMRMLWriteXMLVectorMacro(translationHandleAxes, TranslationHandleComponentVisibility, bool, 4);
   vtkMRMLWriteXMLVectorMacro(rotationHandleAxes, RotationHandleComponentVisibility, bool, 4);
@@ -264,6 +265,7 @@ void vtkMRMLMarkupsDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLFloatMacro(occludedOpacity, OccludedOpacity);
   vtkMRMLReadXMLStdStringMacro(textProperty, TextPropertyFromString);
   vtkMRMLReadXMLVectorMacro(activeColor, ActiveColor, double, 3);
+  vtkMRMLReadXMLBooleanMacro(useControlPointColors, UseControlPointColors);
   vtkMRMLReadXMLVectorMacro(rotationHandleAxes, RotationHandleComponentVisibility, bool, 4);
   vtkMRMLReadXMLVectorMacro(scaleHandleAxes, ScaleHandleComponentVisibility, bool, 4);
   vtkMRMLReadXMLVectorMacro(translationHandleAxes, TranslationHandleComponentVisibility, bool, 4);
@@ -353,6 +355,7 @@ void vtkMRMLMarkupsDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*
   // The name is misleading, this ShallowCopy method actually creates a deep copy
   this->TextProperty->ShallowCopy(this->SafeDownCast(copySourceNode)->GetTextProperty());
   vtkMRMLCopyVectorMacro(ActiveColor, double, 3);
+  vtkMRMLCopyBooleanMacro(UseControlPointColors);
   vtkMRMLCopyVectorMacro(RotationHandleComponentVisibility, bool, 4);
   vtkMRMLCopyVectorMacro(ScaleHandleComponentVisibility, bool, 4);
   vtkMRMLCopyVectorMacro(TranslationHandleComponentVisibility, bool, 4);
@@ -557,6 +560,7 @@ void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintFloatMacro(OccludedOpacity);
   vtkMRMLPrintStdStringMacro(TextPropertyAsString);
   vtkMRMLPrintVectorMacro(ActiveColor, double, 3);
+  vtkMRMLPrintBooleanMacro(UseControlPointColors);
   vtkMRMLPrintVectorMacro(RotationHandleComponentVisibility, bool, 4);
   vtkMRMLPrintVectorMacro(ScaleHandleComponentVisibility, bool, 4);
   vtkMRMLPrintVectorMacro(TranslationHandleComponentVisibility, bool, 4);

--- a/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.h
@@ -484,6 +484,20 @@ public:
   /// Get the active color of the markup. This color is used when the mouse pointer hovers over a markup.
   vtkGetVector3Macro(ActiveColor, double);
 
+  ///@{
+  /// When enabled, control points that have a per-control-point color override
+  /// (set via vtkMRMLMarkupsNode::SetNthControlPointColor) are rendered in
+  /// that color, overriding the display node's `Color` (unselected) and
+  /// `SelectedColor` (selected). `ActiveColor` still applies to the active
+  /// control point so interaction feedback is preserved. Folder display
+  /// overrides take precedence over per-point colors. Per-point colors apply
+  /// to the control point glyphs only; lines and curves continue to use the
+  /// display-node Color/SelectedColor. Default false.
+  vtkSetMacro(UseControlPointColors, bool);
+  vtkGetMacro(UseControlPointColors, bool);
+  vtkBooleanMacro(UseControlPointColors, bool);
+  ///@}
+
   //@{
   /// The visibility and interactability of the interaction handles
   vtkGetMacro(HandlesInteractive, bool);
@@ -602,6 +616,8 @@ protected:
   vtkTextProperty* TextProperty;
 
   double ActiveColor[3];
+
+  bool UseControlPointColors{ false };
 
   bool HandlesInteractive;
   bool TranslationHandleVisibility;

--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.cxx
@@ -37,6 +37,7 @@
 #include <vtkBoundingBox.h>
 #include <vtkCellLocator.h>
 #include <vtkCollection.h>
+#include <vtkDataArray.h>
 #include <vtkParallelTransportFrame.h>
 #include <vtkGeneralTransform.h>
 #include <vtkMatrix3x3.h>
@@ -50,6 +51,7 @@
 #include <vtkTransform.h>
 #include <vtkTransformPolyDataFilter.h>
 #include <vtkTrivialProducer.h>
+#include <vtkUnsignedCharArray.h>
 #include "vtk_eigen.h"
 #include VTK_EIGEN(Dense)
 
@@ -70,6 +72,13 @@ vtkMRMLMarkupsNode::vtkMRMLMarkupsNode()
   this->CurveInputPoly = vtkSmartPointer<vtkPolyData>::New();
   vtkNew<vtkPoints> curveInputPoints;
   this->CurveInputPoly->SetPoints(curveInputPoints);
+
+  // Control point dataset: one polydata point per control point in node-local
+  // coords. PointData arrays (Color, ColorOverridden) are created lazily by
+  // SetNthControlPointColor and synced with NumberOfControlPoints thereafter.
+  this->ControlPointDataSet = vtkSmartPointer<vtkPolyData>::New();
+  vtkNew<vtkPoints> controlPointDataSetPoints;
+  this->ControlPointDataSet->SetPoints(controlPointDataSetPoints);
 
   this->CurveGenerator = vtkSmartPointer<vtkCurveGenerator>::New();
   this->CurveGenerator->SetInputData(this->CurveInputPoly);
@@ -225,6 +234,11 @@ void vtkMRMLMarkupsNode::CopyContent(vtkMRMLNode* aSource, bool deepCopy /*=true
     this->AddControlPoint(controlPointCopy, false);
   }
   this->FixedNumberOfControlPoints = wasFixedNumberOfControlPoints;
+
+  // Deep-copy per-control-point PointData arrays (Color, ColorOverridden, ...)
+  // so per-point overrides round-trip. Dataset points are rebuilt lazily.
+  this->ControlPointDataSet->GetPointData()->DeepCopy(source->ControlPointDataSet->GetPointData());
+  this->ControlPointDataSet->Modified();
 
   // Copy measurements
   this->RemoveAllMeasurements();
@@ -454,6 +468,10 @@ void vtkMRMLMarkupsNode::RemoveAllControlPoints()
 
   this->ControlPoints.clear();
 
+  this->ControlPointDataSet->GetPoints()->Reset();
+  this->ControlPointDataSet->GetPoints()->Squeeze();
+  this->SyncControlPointDataSetArrays();
+
   if (!this->GetDisableModifiedEvent())
   {
     this->CurveInputPoly->GetPoints()->Reset();
@@ -621,6 +639,25 @@ int vtkMRMLMarkupsNode::AddControlPoint(ControlPoint* controlPoint, bool autoLab
   }
 
   this->ControlPoints.push_back(controlPoint);
+
+  // Dataset points are rebuilt lazily by GetControlPointDataSet(); only the
+  // per-point PointData arrays need eager sync because they hold user state
+  // that cannot be regenerated from ControlPoints.
+  {
+    vtkPointData* pd = this->ControlPointDataSet->GetPointData();
+    std::vector<double> zeros;
+    for (int a = 0; a < pd->GetNumberOfArrays(); ++a)
+    {
+      vtkDataArray* arr = pd->GetArray(a);
+      if (!arr || arr->GetNumberOfTuples() == 0)
+      {
+        continue;
+      }
+      zeros.assign(arr->GetNumberOfComponents(), 0.0);
+      arr->InsertNextTuple(zeros.data());
+      arr->Modified();
+    }
+  }
 
   if (!this->GetDisableModifiedEvent())
   {
@@ -837,6 +874,9 @@ void vtkMRMLMarkupsNode::RemoveNthControlPoint(int pointIndex)
   delete this->ControlPoints[static_cast<unsigned int>(pointIndex)];
   this->ControlPoints.erase(this->ControlPoints.begin() + pointIndex);
 
+  this->RemoveControlPointDataSetTupleAt(pointIndex);
+  this->ControlPointDataSet->Modified();
+
   if (!this->GetDisableModifiedEvent())
   {
     this->UpdateCurvePolyFromControlPoints();
@@ -880,6 +920,9 @@ bool vtkMRMLMarkupsNode::InsertControlPoint(ControlPoint* controlPoint, int targ
 
   std::vector<ControlPoint*>::iterator pos = this->ControlPoints.begin() + destIndex;
   this->ControlPoints.insert(pos, controlPoint);
+
+  this->InsertControlPointDataSetTupleAt(destIndex);
+  this->ControlPointDataSet->Modified();
 
   if (!this->GetDisableModifiedEvent())
   {
@@ -976,6 +1019,9 @@ void vtkMRMLMarkupsNode::SwapControlPoints(int m1, int m2)
   *controlPoint1 = *controlPoint2;
   // and copy the backup of the first one into the second
   *controlPoint2 = controlPoint1Backup;
+
+  this->SwapControlPointDataSetTuples(m1, m2);
+  this->ControlPointDataSet->Modified();
 
   if (!this->GetDisableModifiedEvent())
   {
@@ -1783,6 +1829,346 @@ void vtkMRMLMarkupsNode::SetNthControlPointDescription(int n, std::string descri
   }
   controlPoint->Description = description;
   this->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::PointModifiedEvent, static_cast<void*>(&n));
+  this->StorableModifiedTime.Modified();
+}
+
+//---------------------------------------------------------------------------
+// Per-control-point color override
+//---------------------------------------------------------------------------
+
+namespace
+{
+// Reserved PointData array names on the control point dataset.
+const char* CP_COLOR_ARRAY = "Color";
+const char* CP_COLOR_OVERRIDDEN_ARRAY = "ColorOverridden";
+
+// Read tuples via GetTuple before any resize so callers can rebuild from the
+// snapshot without relying on SetNumberOfTuples preserving the buffer
+// (vtkAOSDataArrayTemplate may reallocate on grow).
+void SnapshotArrayValues(vtkDataArray* arr, std::vector<double>& outFlat)
+{
+  int nt = static_cast<int>(arr->GetNumberOfTuples());
+  int nc = arr->GetNumberOfComponents();
+  outFlat.assign(nt * nc, 0.0);
+  for (int i = 0; i < nt; ++i)
+  {
+    arr->GetTuple(i, outFlat.data() + i * nc);
+  }
+}
+
+// Look up an array by name, creating it if it does not exist. Newly-created
+// arrays are sized to numTuples and zero-initialised.
+vtkUnsignedCharArray* EnsureUCharArray(vtkPointData* pd, const char* name, int numComponents, int numTuples)
+{
+  vtkUnsignedCharArray* arr = vtkUnsignedCharArray::SafeDownCast(pd->GetArray(name));
+  if (!arr)
+  {
+    vtkNew<vtkUnsignedCharArray> newArr;
+    newArr->SetName(name);
+    newArr->SetNumberOfComponents(numComponents);
+    newArr->SetNumberOfTuples(numTuples);
+    newArr->Fill(0);
+    pd->AddArray(newArr);
+    arr = newArr;
+  }
+  return arr;
+}
+} // namespace
+
+//---------------------------------------------------------------------------
+vtkPolyData* vtkMRMLMarkupsNode::GetControlPointDataSet()
+{
+  this->UpdateControlPointDataSetPoints();
+  return this->ControlPointDataSet;
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsNode::UpdateControlPointDataSetPoints()
+{
+  // SetNumberOfPoints/SetPoint advance the underlying data array's MTime
+  // only on real changes, so back-to-back reads on an unchanged node do
+  // not fire spurious Modified events through points->GetMTime().
+  vtkPoints* points = this->ControlPointDataSet->GetPoints();
+  int n = this->GetNumberOfControlPoints();
+  points->SetNumberOfPoints(n);
+  for (int i = 0; i < n; ++i)
+  {
+    points->SetPoint(i, this->ControlPoints[static_cast<size_t>(i)]->Position);
+  }
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsNode::SyncControlPointDataSetArrays()
+{
+  vtkPointData* pd = this->ControlPointDataSet->GetPointData();
+  int targetSize = this->GetNumberOfControlPoints();
+  for (int a = 0; a < pd->GetNumberOfArrays(); ++a)
+  {
+    vtkDataArray* arr = pd->GetArray(a);
+    if (!arr)
+    {
+      continue;
+    }
+    int currentSize = static_cast<int>(arr->GetNumberOfTuples());
+    if (currentSize == 0 || currentSize == targetSize)
+    {
+      continue;
+    }
+    int nc = arr->GetNumberOfComponents();
+    std::vector<double> snapshot;
+    SnapshotArrayValues(arr, snapshot);
+    arr->SetNumberOfTuples(targetSize);
+    int common = std::min(currentSize, targetSize);
+    for (int i = 0; i < common; ++i)
+    {
+      arr->SetTuple(i, snapshot.data() + i * nc);
+    }
+    if (currentSize < targetSize)
+    {
+      std::vector<double> zeros(nc, 0.0);
+      for (int i = currentSize; i < targetSize; ++i)
+      {
+        arr->SetTuple(i, zeros.data());
+      }
+    }
+    arr->Modified();
+  }
+  this->ControlPointDataSet->Modified();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsNode::InsertControlPointDataSetTupleAt(int insertIndex)
+{
+  // Snapshot existing values up front; do not depend on SetNumberOfTuples
+  // preserving the underlying buffer.
+  vtkPointData* pd = this->ControlPointDataSet->GetPointData();
+  for (int a = 0; a < pd->GetNumberOfArrays(); ++a)
+  {
+    vtkDataArray* arr = pd->GetArray(a);
+    if (!arr || arr->GetNumberOfTuples() == 0)
+    {
+      continue;
+    }
+    int oldSize = static_cast<int>(arr->GetNumberOfTuples());
+    int nc = arr->GetNumberOfComponents();
+    std::vector<double> snapshot;
+    SnapshotArrayValues(arr, snapshot);
+    arr->SetNumberOfTuples(oldSize + 1);
+    std::vector<double> zeros(nc, 0.0);
+    for (int i = 0; i < insertIndex; ++i)
+    {
+      arr->SetTuple(i, snapshot.data() + i * nc);
+    }
+    arr->SetTuple(insertIndex, zeros.data());
+    for (int i = insertIndex; i < oldSize; ++i)
+    {
+      arr->SetTuple(i + 1, snapshot.data() + i * nc);
+    }
+    arr->Modified();
+  }
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsNode::RemoveControlPointDataSetTupleAt(int removeIndex)
+{
+  vtkPointData* pd = this->ControlPointDataSet->GetPointData();
+  for (int a = 0; a < pd->GetNumberOfArrays(); ++a)
+  {
+    vtkDataArray* arr = pd->GetArray(a);
+    if (!arr || arr->GetNumberOfTuples() == 0)
+    {
+      continue;
+    }
+    if (removeIndex < 0 || removeIndex >= static_cast<int>(arr->GetNumberOfTuples()))
+    {
+      continue;
+    }
+    arr->RemoveTuple(removeIndex);
+    arr->Modified();
+  }
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsNode::SwapControlPointDataSetTuples(int m1, int m2)
+{
+  if (m1 == m2)
+  {
+    return;
+  }
+  vtkPointData* pd = this->ControlPointDataSet->GetPointData();
+  for (int a = 0; a < pd->GetNumberOfArrays(); ++a)
+  {
+    vtkDataArray* arr = pd->GetArray(a);
+    if (!arr || arr->GetNumberOfTuples() == 0)
+    {
+      continue;
+    }
+    int nc = arr->GetNumberOfComponents();
+    std::vector<double> t1(nc), t2(nc);
+    arr->GetTuple(m1, t1.data());
+    arr->GetTuple(m2, t2.data());
+    arr->SetTuple(m1, t2.data());
+    arr->SetTuple(m2, t1.data());
+    arr->Modified();
+  }
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsNode::SetNthControlPointColor(int n, const double rgba[4])
+{
+  this->SetNthControlPointColor(n, rgba[0], rgba[1], rgba[2], rgba[3]);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsNode::SetNthControlPointColor(int n, double r, double g, double b, double a /*=1.0*/)
+{
+  if (!this->GetNthControlPointCustomLog(n, "SetNthControlPointColor"))
+  {
+    return;
+  }
+  auto clamp01 = [](double v) { return v < 0.0 ? 0.0 : (v > 1.0 ? 1.0 : v); };
+  unsigned char rgbaBytes[4] = { static_cast<unsigned char>(clamp01(r) * 255.0 + 0.5),
+                                 static_cast<unsigned char>(clamp01(g) * 255.0 + 0.5),
+                                 static_cast<unsigned char>(clamp01(b) * 255.0 + 0.5),
+                                 static_cast<unsigned char>(clamp01(a) * 255.0 + 0.5) };
+  int targetSize = this->GetNumberOfControlPoints();
+  vtkPointData* pd = this->ControlPointDataSet->GetPointData();
+  vtkUnsignedCharArray* colorArr = EnsureUCharArray(pd, CP_COLOR_ARRAY, 4, targetSize);
+  vtkUnsignedCharArray* flagArr = EnsureUCharArray(pd, CP_COLOR_OVERRIDDEN_ARRAY, 1, targetSize);
+  this->SyncControlPointDataSetArrays();
+
+  unsigned char existing[4];
+  colorArr->GetTypedTuple(n, existing);
+  unsigned char existingFlag = flagArr->GetValue(n);
+  bool changed = (existingFlag == 0) || existing[0] != rgbaBytes[0] || existing[1] != rgbaBytes[1] //
+                 || existing[2] != rgbaBytes[2] || existing[3] != rgbaBytes[3];
+  if (!changed)
+  {
+    return;
+  }
+  colorArr->SetTypedTuple(n, rgbaBytes);
+  flagArr->SetValue(n, 1);
+  colorArr->Modified();
+  flagArr->Modified();
+  this->ControlPointDataSet->Modified();
+  this->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::PointModifiedEvent, static_cast<void*>(&n));
+  this->StorableModifiedTime.Modified();
+}
+
+//---------------------------------------------------------------------------
+vtkUnsignedCharArray* vtkMRMLMarkupsNode::GetControlPointColorArray()
+{
+  return vtkUnsignedCharArray::SafeDownCast(this->ControlPointDataSet->GetPointData()->GetArray(CP_COLOR_ARRAY));
+}
+
+//---------------------------------------------------------------------------
+vtkUnsignedCharArray* vtkMRMLMarkupsNode::GetControlPointColorOverriddenArray()
+{
+  return vtkUnsignedCharArray::SafeDownCast(this->ControlPointDataSet->GetPointData()->GetArray(CP_COLOR_OVERRIDDEN_ARRAY));
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLMarkupsNode::GetNthControlPointColor(int n, double rgba[4])
+{
+  rgba[0] = 0.0;
+  rgba[1] = 0.0;
+  rgba[2] = 0.0;
+  rgba[3] = 0.0;
+  if (!this->GetNthControlPointCustomLog(n, "GetNthControlPointColor"))
+  {
+    return false;
+  }
+  vtkUnsignedCharArray* flagArr = this->GetControlPointColorOverriddenArray();
+  vtkUnsignedCharArray* colorArr = this->GetControlPointColorArray();
+  if (!flagArr || !colorArr || flagArr->GetNumberOfTuples() <= n || colorArr->GetNumberOfTuples() <= n)
+  {
+    return false;
+  }
+  if (flagArr->GetValue(n) == 0)
+  {
+    return false;
+  }
+  unsigned char rgbaBytes[4];
+  colorArr->GetTypedTuple(n, rgbaBytes);
+  rgba[0] = rgbaBytes[0] / 255.0;
+  rgba[1] = rgbaBytes[1] / 255.0;
+  rgba[2] = rgbaBytes[2] / 255.0;
+  rgba[3] = rgbaBytes[3] / 255.0;
+  return true;
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLMarkupsNode::IsNthControlPointColorOverridden(int n)
+{
+  if (!this->GetNthControlPointCustomLog(n, "IsNthControlPointColorOverridden"))
+  {
+    return false;
+  }
+  vtkUnsignedCharArray* flagArr = this->GetControlPointColorOverriddenArray();
+  if (!flagArr || flagArr->GetNumberOfTuples() <= n)
+  {
+    return false;
+  }
+  return flagArr->GetValue(n) != 0;
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsNode::ClearNthControlPointColor(int n)
+{
+  if (!this->GetNthControlPointCustomLog(n, "ClearNthControlPointColor"))
+  {
+    return;
+  }
+  vtkUnsignedCharArray* flagArr = this->GetControlPointColorOverriddenArray();
+  vtkUnsignedCharArray* colorArr = this->GetControlPointColorArray();
+  if (!flagArr || flagArr->GetNumberOfTuples() <= n || flagArr->GetValue(n) == 0)
+  {
+    return;
+  }
+  flagArr->SetValue(n, 0);
+  if (colorArr && colorArr->GetNumberOfTuples() > n)
+  {
+    unsigned char zeros[4] = { 0, 0, 0, 0 };
+    colorArr->SetTypedTuple(n, zeros);
+    colorArr->Modified();
+  }
+  flagArr->Modified();
+  this->ControlPointDataSet->Modified();
+  this->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::PointModifiedEvent, static_cast<void*>(&n));
+  this->StorableModifiedTime.Modified();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsNode::ClearAllControlPointColors()
+{
+  vtkUnsignedCharArray* flagArr = this->GetControlPointColorOverriddenArray();
+  vtkUnsignedCharArray* colorArr = this->GetControlPointColorArray();
+  if (!flagArr || flagArr->GetNumberOfTuples() == 0)
+  {
+    return;
+  }
+  bool anyWasSet = false;
+  for (int i = 0; i < flagArr->GetNumberOfTuples(); ++i)
+  {
+    if (flagArr->GetValue(i) != 0)
+    {
+      anyWasSet = true;
+      break;
+    }
+  }
+  if (!anyWasSet)
+  {
+    return;
+  }
+  flagArr->Fill(0);
+  flagArr->Modified();
+  if (colorArr)
+  {
+    colorArr->Fill(0);
+    colorArr->Modified();
+  }
+  this->ControlPointDataSet->Modified();
+  this->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::PointModifiedEvent, nullptr);
   this->StorableModifiedTime.Modified();
 }
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsNode.h
@@ -593,6 +593,50 @@ public:
   void SetNthControlPointDescription(int n, std::string description);
   ///@}
 
+  ///@{
+  /// Per-control-point color override.
+  ///
+  /// Stored as PointData arrays on the control point dataset
+  /// (\sa GetControlPointDataSet):
+  ///  - `Color` (vtkUnsignedCharArray, 4 components, RGBA in 0-255)
+  ///  - `ColorOverridden` (vtkUnsignedCharArray, 1 component, 0 or 1)
+  /// The arrays are kept in sync with `NumberOfControlPoints` automatically
+  /// across Add/Insert/Remove/Swap/RemoveAll. The `Color` array name is
+  /// reserved for this convenience API; user-added per-point arrays should
+  /// use other names.
+  ///
+  /// \sa vtkMRMLMarkupsDisplayNode::UseControlPointColors for the toggle
+  /// that activates per-point color rendering and the precedence rules.
+  void SetNthControlPointColor(int n, double r, double g, double b, double a = 1.0);
+  void SetNthControlPointColor(int n, const double rgba[4]);
+  /// Returns true if the control point has a per-point color override; rgba is filled in.
+  /// If no override, rgba is set to (0, 0, 0, 0) and the method returns false.
+  bool GetNthControlPointColor(int n, double rgba[4]);
+  bool IsNthControlPointColorOverridden(int n);
+  /// Clear the per-point color override on the Nth control point so the
+  /// display-node fallback colors apply again.
+  void ClearNthControlPointColor(int n);
+  /// Clear all per-point color overrides on this node so all control points
+  /// fall back to the display node's Color/SelectedColor/ActiveColor.
+  void ClearAllControlPointColors();
+
+  /// Direct access to the per-control-point Color (4-component RGBA bytes)
+  /// and ColorOverridden (1-component bool flag) arrays. Returns nullptr
+  /// when the array does not yet exist on the dataset (i.e. no override has
+  /// ever been set on this node). Per-frame readers can hoist these out of
+  /// inner loops to skip repeated SafeDownCast lookups.
+  vtkUnsignedCharArray* GetControlPointColorArray();
+  vtkUnsignedCharArray* GetControlPointColorOverriddenArray();
+  ///@}
+
+  /// Get the control point dataset: a vtkPolyData mirroring control points
+  /// (one point per control point, in node-local coordinates) whose
+  /// PointData container holds per-control-point arrays such as `Color` and
+  /// `ColorOverridden`. Additional named arrays can be attached for
+  /// measurement-based per-point coloring. Points and PointData arrays are
+  /// kept in sync with `NumberOfControlPoints` by this node.
+  vtkPolyData* GetControlPointDataSet();
+
   /// Returns true since can apply non linear transforms
   /// \sa ApplyTransform
   bool CanApplyNonLinearTransforms() const override;
@@ -971,6 +1015,26 @@ protected:
 
   std::string GenerateControlPointLabel(int controlPointIndex);
 
+  /// Refresh control point dataset points to match the current control points
+  /// (positions in node-local coordinates). Does not touch PointData arrays.
+  void UpdateControlPointDataSetPoints();
+
+  /// Resize all PointData arrays on the control point dataset to match
+  /// `NumberOfControlPoints`. Newly-grown entries are zero-initialised.
+  /// Empty arrays (size 0) are left alone; they participate in resizing
+  /// only once they have any tuples written.
+  void SyncControlPointDataSetArrays();
+
+  /// Insert a default-valued tuple at \a insertIndex into every non-empty
+  /// PointData array on the control point dataset.
+  void InsertControlPointDataSetTupleAt(int insertIndex);
+
+  /// Remove the tuple at \a removeIndex from every non-empty PointData array.
+  void RemoveControlPointDataSetTupleAt(int removeIndex);
+
+  /// Swap two tuples in every non-empty PointData array on the control point dataset.
+  void SwapControlPointDataSetTuples(int m1, int m2);
+
   virtual void UpdateCurvePolyFromControlPoints();
 
   void OnTransformNodeReferenceChanged(vtkMRMLTransformNode* transformNode) override;
@@ -1016,6 +1080,13 @@ protected:
   /// Stores control point positions in a polydata (in local coordinate system).
   /// Line cells connect all points into a curve.
   vtkSmartPointer<vtkPolyData> CurveInputPoly;
+
+  /// Polydata mirror of the control points: one point per control point in
+  /// node-local coordinates, with PointData arrays holding per-control-point
+  /// attributes (e.g. `Color`, `ColorOverridden`). Kept in sync with
+  /// `NumberOfControlPoints` on every Add/Insert/Remove/Swap operation.
+  /// \sa GetControlPointDataSet
+  vtkSmartPointer<vtkPolyData> ControlPointDataSet;
 
   vtkSmartPointer<vtkTransformPolyDataFilter> CurvePolyToWorldTransformer;
   vtkSmartPointer<vtkGeneralTransform> CurvePolyToWorldTransform;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
@@ -800,7 +800,18 @@ bool vtkMRMLMarkupsJsonStorageNode::ReadControlPoints(vtkMRMLJsonElement* contro
     {
       cp->Visibility = controlPointItem->GetBoolProperty("visibility");
     }
+    // Per-control-point color override is read after AddControlPoint, since
+    // the override lives on the markups node's control point dataset, not on
+    // the ControlPoint struct. GetVectorProperty already returns false when
+    // the field is absent.
+    double colorRgba[4] = { 0.0, 0.0, 0.0, 1.0 };
+    bool hasColor = controlPointItem->GetVectorProperty("color", colorRgba, 4);
     markupsNode->AddControlPoint(cp, false);
+    if (hasColor)
+    {
+      int newIndex = markupsNode->GetNumberOfControlPoints() - 1;
+      markupsNode->SetNthControlPointColor(newIndex, colorRgba[0], colorRgba[1], colorRgba[2], colorRgba[3]);
+    }
   }
 
   markupsNode->IsUpdatingPoints = wasUpdatingPoints;
@@ -979,6 +990,9 @@ bool vtkMRMLMarkupsJsonStorageNode::WriteControlPoints(vtkMRMLJsonWriter* writer
   writer->WriteArrayPropertyStart("controlPoints");
 
   int numberOfControlPoints = markupsNode->GetNumberOfControlPoints();
+  // Arrays are nullptr on nodes that never set a per-point color.
+  vtkUnsignedCharArray* srcFlagArr = markupsNode->GetControlPointColorOverriddenArray();
+  vtkUnsignedCharArray* srcColorArr = markupsNode->GetControlPointColorArray();
   for (int controlPointIndex = 0; controlPointIndex < numberOfControlPoints; controlPointIndex++)
   {
     vtkMRMLMarkupsNode::ControlPoint* cp = markupsNode->GetNthControlPoint(controlPointIndex);
@@ -1021,6 +1035,19 @@ bool vtkMRMLMarkupsJsonStorageNode::WriteControlPoints(vtkMRMLJsonWriter* writer
     writer->WriteBoolProperty("locked", cp->Locked);
     writer->WriteBoolProperty("visibility", cp->Visibility);
     writer->WriteStringProperty("positionStatus", vtkMRMLMarkupsNode::GetPositionStatusAsString(cp->PositionStatus));
+
+    // Optional per-point color override (only emitted when set; old readers
+    // ignore the unknown field, so this stays forward-compatible).
+    if (srcFlagArr && srcColorArr                                  //
+        && controlPointIndex < srcFlagArr->GetNumberOfTuples()     //
+        && controlPointIndex < srcColorArr->GetNumberOfTuples()    //
+        && srcFlagArr->GetValue(controlPointIndex) != 0)
+    {
+      unsigned char rgbaBytes[4];
+      srcColorArr->GetTypedTuple(controlPointIndex, rgbaBytes);
+      double rgba[4] = { rgbaBytes[0] / 255.0, rgbaBytes[1] / 255.0, rgbaBytes[2] / 255.0, rgbaBytes[3] / 255.0 };
+      writer->WriteVectorProperty("color", rgba, 4);
+    }
 
     writer->WriteObjectEnd();
   }

--- a/Modules/Loadable/Markups/Testing/Python/CMakeLists.txt
+++ b/Modules/Loadable/Markups/Testing/Python/CMakeLists.txt
@@ -59,6 +59,10 @@ slicer_add_python_test(SCRIPT MarkupsMeasurementsTest.py
 slicer_add_python_test(SCRIPT MarkupsNodeNameTest.py
                        SLICER_ARGS --disable-cli-modules)
 
+# Test per-control-point color API and JSON round-trip
+slicer_add_python_test(SCRIPT MarkupsControlPointColorTest.py
+                       SLICER_ARGS --disable-cli-modules)
+
 # Test markups pluggable architecture
 slicerMacroBuildScriptedModule(
   NAME PluggableMarkupsSelfTest

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsControlPointColorTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsControlPointColorTest.py
@@ -1,0 +1,160 @@
+"""Tests for the per-control-point color API on vtkMRMLMarkupsNode.
+
+Covers the data-layer round-trip across the per-point setters, getters,
+clearers, and structural mutations (Add / Insert / Remove / Swap /
+RemoveAll), plus the JSON storage round-trip. Render-side coverage is
+in the manual test scripts under the same directory; this test is
+purely a no-GUI sanity check.
+"""
+import json
+import os
+import tempfile
+
+import slicer
+
+
+def fail(msg):
+    raise Exception("MarkupsControlPointColorTest: " + msg)
+
+
+def near(a, b, tol=2.0 / 255.0):
+    return abs(a - b) < tol
+
+
+slicer.mrmlScene.Clear()
+
+fids = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+for i in range(3):
+    fids.AddControlPoint([i * 10.0, 0.0, 0.0])
+
+# Initially no overrides
+for i in range(3):
+    if fids.IsNthControlPointColorOverridden(i):
+        fail(f"point {i} should not be overridden initially")
+
+fids.SetNthControlPointColor(0, 1.0, 0.0, 0.0, 1.0)
+fids.SetNthControlPointColor(2, 0.0, 0.5, 1.0, 0.5)
+
+# Override flags
+if not fids.IsNthControlPointColorOverridden(0):
+    fail("point 0 should be overridden")
+if fids.IsNthControlPointColorOverridden(1):
+    fail("point 1 should NOT be overridden")
+if not fids.IsNthControlPointColorOverridden(2):
+    fail("point 2 should be overridden")
+
+# Read back via GetNthControlPointColor
+rgba = [0.0, 0.0, 0.0, 0.0]
+if not fids.GetNthControlPointColor(0, rgba):
+    fail("GetNthControlPointColor(0) should return True")
+if not (near(rgba[0], 1.0) and near(rgba[3], 1.0)):
+    fail(f"point 0 color mismatch: {rgba}")
+
+# Insert in the middle: existing overrides shift right by one
+ok = fids.InsertControlPoint(1, [5.0, 5.0, 0.0], "L")
+if not ok:
+    fail("InsertControlPoint should succeed")
+if fids.GetNumberOfControlPoints() != 4:
+    fail(f"expected 4 cps after insert, got {fids.GetNumberOfControlPoints()}")
+if not fids.IsNthControlPointColorOverridden(0):
+    fail("after insert: point 0 should still be overridden")
+if fids.IsNthControlPointColorOverridden(1):
+    fail("after insert: new point 1 should NOT be overridden")
+if fids.IsNthControlPointColorOverridden(2):
+    fail("after insert: old point 1 (now 2) should NOT be overridden")
+if not fids.IsNthControlPointColorOverridden(3):
+    fail("after insert: old point 2 (now 3) should still be overridden")
+
+# Remove leading override: subsequent indices shift down
+fids.RemoveNthControlPoint(0)
+if fids.GetNumberOfControlPoints() != 3:
+    fail(f"expected 3 cps after remove, got {fids.GetNumberOfControlPoints()}")
+if fids.IsNthControlPointColorOverridden(0):
+    fail("after remove: point 0 should not be overridden")
+if not fids.IsNthControlPointColorOverridden(2):
+    fail("after remove: point 2 should still be overridden")
+
+# Swap: override flag and color follow the swapped index
+fids.SwapControlPoints(0, 2)
+if not fids.IsNthControlPointColorOverridden(0):
+    fail("after swap: point 0 should be overridden")
+if fids.IsNthControlPointColorOverridden(2):
+    fail("after swap: point 2 should NOT be overridden")
+
+# Clear single
+fids.ClearNthControlPointColor(0)
+if fids.IsNthControlPointColorOverridden(0):
+    fail("after ClearNthControlPointColor: point 0 should be cleared")
+
+# Clear all
+fids.SetNthControlPointColor(0, 0.2, 0.3, 0.4)
+fids.SetNthControlPointColor(1, 0.5, 0.6, 0.7)
+fids.ClearAllControlPointColors()
+for i in range(fids.GetNumberOfControlPoints()):
+    if fids.IsNthControlPointColorOverridden(i):
+        fail(f"after ClearAllControlPointColors: point {i} should be cleared")
+
+# JSON storage round-trip: write then read into a fresh node, verify per-point
+# colors round-trip and that "color" is omitted for non-overridden points.
+fidsRT = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+fidsRT.AddControlPoint([0.0, 0.0, 0.0])
+fidsRT.AddControlPoint([1.0, 0.0, 0.0])
+fidsRT.AddControlPoint([2.0, 0.0, 0.0])
+fidsRT.SetNthControlPointColor(0, 0.9, 0.1, 0.2, 1.0)
+fidsRT.SetNthControlPointColor(2, 0.3, 0.4, 0.5, 0.6)
+
+tmpPath = tempfile.NamedTemporaryFile(suffix=".mrk.json", delete=False).name
+try:
+    snWrite = slicer.app.coreIOManager().createAndAddDefaultStorageNode(fidsRT)
+    snWrite.SetFileName(tmpPath)
+    if not snWrite.WriteData(fidsRT):
+        fail("WriteData failed")
+
+    # Sanity check on the written file: only the two overridden points should
+    # have a "color" field. (The display node section also emits its own
+    # "color" property, so parse the JSON properly rather than text-counting.)
+    with open(tmpPath) as f:
+        parsed = json.load(f)
+    cpsWithColor = sum(1 for cp in parsed["markups"][0]["controlPoints"] if "color" in cp)
+    if cpsWithColor != 2:
+        fail(f'expected 2 controlPoints with "color" field, got {cpsWithColor}')
+
+    loaded = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+    snRead = slicer.app.coreIOManager().createAndAddDefaultStorageNode(loaded)
+    snRead.SetFileName(tmpPath)
+    if not snRead.ReadData(loaded):
+        fail("ReadData failed")
+
+    if loaded.GetNumberOfControlPoints() != 3:
+        fail(f"after JSON round-trip: expected 3 cps, got {loaded.GetNumberOfControlPoints()}")
+    if not loaded.IsNthControlPointColorOverridden(0):
+        fail("after JSON round-trip: point 0 should be overridden")
+    if loaded.IsNthControlPointColorOverridden(1):
+        fail("after JSON round-trip: point 1 should NOT be overridden")
+    if not loaded.IsNthControlPointColorOverridden(2):
+        fail("after JSON round-trip: point 2 should be overridden")
+
+    rgba = [0.0, 0.0, 0.0, 0.0]
+    loaded.GetNthControlPointColor(0, rgba)
+    if not (near(rgba[0], 0.9) and near(rgba[1], 0.1) and near(rgba[2], 0.2) and near(rgba[3], 1.0)):
+        fail(f"after JSON round-trip: point 0 RGBA mismatch: {rgba}")
+    loaded.GetNthControlPointColor(2, rgba)
+    if not (near(rgba[0], 0.3) and near(rgba[1], 0.4) and near(rgba[2], 0.5) and near(rgba[3], 0.6)):
+        fail(f"after JSON round-trip: point 2 RGBA mismatch: {rgba}")
+finally:
+    if os.path.exists(tmpPath):
+        os.unlink(tmpPath)
+
+# Display node flag setter / getter
+d = fids.GetDisplayNode()
+if d is None:
+    fids.CreateDefaultDisplayNodes()
+    d = fids.GetDisplayNode()
+d.SetUseControlPointColors(True)
+if not d.GetUseControlPointColors():
+    fail("UseControlPointColors flag setter/getter mismatch")
+d.SetUseControlPointColors(False)
+if d.GetUseControlPointColors():
+    fail("UseControlPointColors clear failed")
+
+print("MarkupsControlPointColorTest passed")

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
@@ -743,6 +743,17 @@ bool vtkSlicerMarkupsWidgetRepresentation::IsDisplayable()
 }
 
 //----------------------------------------------------------------------
+bool vtkSlicerMarkupsWidgetRepresentation::IsFolderDisplayOverrideActive()
+{
+  if (!this->MarkupsDisplayNode || !this->MarkupsDisplayNode->GetFolderDisplayOverrideAllowed())
+  {
+    return false;
+  }
+  vtkMRMLDisplayableNode* displayableNode = this->MarkupsDisplayNode->GetDisplayableNode();
+  return vtkMRMLFolderDisplayNode::GetOverridingHierarchyDisplayNode(displayableNode) != nullptr;
+}
+
+//----------------------------------------------------------------------
 void vtkSlicerMarkupsWidgetRepresentation::GetActors(vtkPropCollection* vtkNotUsed(pc)) {}
 
 //----------------------------------------------------------------------

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
@@ -147,6 +147,18 @@ public:
   bool IsDisplayable();
   //@}
 
+  /// True when an ancestor subject hierarchy folder is currently overriding
+  /// this markup's display (\sa vtkMRMLFolderDisplayNode). When true, the
+  /// folder override applies and per-display features (per-point color etc.)
+  /// should be skipped.
+  bool IsFolderDisplayOverrideActive();
+
+  /// Name of the per-point RGBA scalar array attached to a rendering
+  /// pipeline's polydata when per-control-point colors are active. Reps
+  /// populate this array on the relevant `ControlPointsPolyData` (one tuple
+  /// per visible control point).
+  static constexpr const char* PerPointColorArrayName = "ControlPointColors";
+
 protected:
   vtkSlicerMarkupsWidgetRepresentation();
   ~vtkSlicerMarkupsWidgetRepresentation() override;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
@@ -45,6 +45,7 @@
 #include "vtkTextActor.h"
 #include "vtkTextProperty.h"
 #include "vtkTransform.h"
+#include "vtkUnsignedCharArray.h"
 
 // MRML includes
 #include <vtkMRMLFolderDisplayNode.h>
@@ -59,6 +60,10 @@ vtkSlicerMarkupsWidgetRepresentation2D::ControlPointsPipeline2D::ControlPointsPi
   this->Glypher = vtkSmartPointer<vtkGlyph2D>::New();
   this->Glypher->SetInputData(this->ControlPointsPolyData);
   this->Glypher->SetScaleFactor(1.0);
+  // Avoid scaling glyphs by an input scalar -- without this, the per-point
+  // RGBA color array would be interpreted as a scale factor and produce
+  // huge glyphs.
+  this->Glypher->SetScaleModeToDataScalingOff();
 
   // By default the Points are rendered as spheres
   this->Glypher->SetSourceConnection(this->GlyphSourceSphere->GetOutputPort());
@@ -307,6 +312,11 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateAllPointsAndLabelsFromMRML(do
   }
 
   int numPoints = markupsNode->GetNumberOfControlPoints();
+  const bool folderOverrideActive = this->IsFolderDisplayOverrideActive();
+  // Source per-point color arrays are invariant across the pipeline loop.
+  const bool perPointColorsEnabled = this->MarkupsDisplayNode->GetUseControlPointColors() && !folderOverrideActive;
+  vtkUnsignedCharArray* srcColorArr = perPointColorsEnabled ? markupsNode->GetControlPointColorArray() : nullptr;
+  vtkUnsignedCharArray* srcFlagArr = perPointColorsEnabled ? markupsNode->GetControlPointColorOverriddenArray() : nullptr;
 
   for (int controlPointType = 0; controlPointType < NumberOfControlPointTypes; ++controlPointType)
   {
@@ -319,6 +329,37 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateAllPointsAndLabelsFromMRML(do
     controlPoints->LabelControlPointsPolyData->GetPointData()->GetNormals()->Reset();
     controlPoints->Labels->Reset();
     controlPoints->LabelsPriority->Reset();
+
+    // Per-point color array populated for Unselected and Selected pipelines
+    // (Active stays flat ActiveColor).
+    const bool applyPerPointColors = perPointColorsEnabled //
+                                     && (controlPointType == Unselected || controlPointType == Selected);
+    vtkUnsignedCharArray* perPointColorsArray = nullptr;
+    if (applyPerPointColors)
+    {
+      perPointColorsArray = vtkUnsignedCharArray::SafeDownCast(controlPoints->ControlPointsPolyData->GetPointData()->GetArray(PerPointColorArrayName));
+      if (!perPointColorsArray)
+      {
+        vtkNew<vtkUnsignedCharArray> newArr;
+        newArr->SetName(PerPointColorArrayName);
+        newArr->SetNumberOfComponents(4);
+        controlPoints->ControlPointsPolyData->GetPointData()->AddArray(newArr);
+        perPointColorsArray = newArr;
+      }
+      perPointColorsArray->SetNumberOfTuples(0);
+    }
+    else
+    {
+      controlPoints->ControlPointsPolyData->GetPointData()->RemoveArray(PerPointColorArrayName);
+    }
+    unsigned char fallbackBytes[4] = { 255, 255, 255, 255 };
+    if (applyPerPointColors)
+    {
+      double* widgetColor = this->GetWidgetColor(controlPointType);
+      fallbackBytes[0] = static_cast<unsigned char>(widgetColor[0] * 255.0 + 0.5);
+      fallbackBytes[1] = static_cast<unsigned char>(widgetColor[1] * 255.0 + 0.5);
+      fallbackBytes[2] = static_cast<unsigned char>(widgetColor[2] * 255.0 + 0.5);
+    }
 
     int startIndex = 0;
     int stopIndex = numPoints - 1;
@@ -416,11 +457,73 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateAllPointsAndLabelsFromMRML(do
 
       controlPoints->Labels->InsertNextValue(markupsNode->GetNthControlPointLabel(pointIndex));
       controlPoints->LabelsPriority->InsertNextValue(std::to_string(pointIndex));
+
+      if (perPointColorsArray)
+      {
+        unsigned char rgba[4];
+        if (srcFlagArr && srcColorArr                            //
+            && pointIndex < srcFlagArr->GetNumberOfTuples()      //
+            && pointIndex < srcColorArr->GetNumberOfTuples()     //
+            && srcFlagArr->GetValue(pointIndex) != 0)
+        {
+          srcColorArr->GetTypedTuple(pointIndex, rgba);
+        }
+        else
+        {
+          rgba[0] = fallbackBytes[0];
+          rgba[1] = fallbackBytes[1];
+          rgba[2] = fallbackBytes[2];
+          rgba[3] = 255;
+        }
+        perPointColorsArray->InsertNextTypedTuple(rgba);
+      }
+    }
+
+    if (perPointColorsArray)
+    {
+      perPointColorsArray->Modified();
+      controlPoints->ControlPointsPolyData->GetPointData()->SetActiveScalars(PerPointColorArrayName);
+    }
+    else
+    {
+      controlPoints->ControlPointsPolyData->GetPointData()->SetActiveScalars(nullptr);
     }
 
     controlPoints->ControlPoints->Modified();
     controlPoints->ControlPointsPolyData->GetPointData()->GetNormals()->Modified();
     controlPoints->ControlPointsPolyData->Modified();
+
+    // vtkGlyph2D does not propagate input point scalars to its output. Run
+    // the filter explicitly and replicate input scalars per output vertex.
+    if (perPointColorsArray && controlPoints->ControlPoints->GetNumberOfPoints() > 0)
+    {
+      controlPoints->Glypher->Update();
+      vtkPolyData* gout = controlPoints->Glypher->GetOutput();
+      vtkIdType numInput = controlPoints->ControlPoints->GetNumberOfPoints();
+      vtkIdType numOutput = gout->GetNumberOfPoints();
+      if (numInput > 0 && numOutput > 0 && numOutput % numInput == 0)
+      {
+        int verticesPerGlyph = static_cast<int>(numOutput / numInput);
+        vtkNew<vtkUnsignedCharArray> outRgba;
+        outRgba->SetName(PerPointColorArrayName);
+        outRgba->SetNumberOfComponents(4);
+        outRgba->SetNumberOfTuples(numOutput);
+        unsigned char tuple[4];
+        for (vtkIdType oi = 0; oi < numOutput; ++oi)
+        {
+          vtkIdType inputIdx = oi / verticesPerGlyph;
+          if (inputIdx >= numInput)
+          {
+            inputIdx = numInput - 1;
+          }
+          perPointColorsArray->GetTypedTuple(inputIdx, tuple);
+          outRgba->SetTypedTuple(oi, tuple);
+        }
+        gout->GetPointData()->RemoveArray(PerPointColorArrayName);
+        gout->GetPointData()->AddArray(outRgba);
+        gout->GetPointData()->SetActiveScalars(PerPointColorArrayName);
+      }
+    }
 
     controlPoints->LabelControlPoints->Modified();
     controlPoints->LabelControlPointsPolyData->GetPointData()->GetNormals()->Modified();
@@ -533,6 +636,8 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateFromMRMLInternal(vtkMRMLNode*
     return;
   }
 
+  const bool useControlPointColors = this->MarkupsDisplayNode->GetUseControlPointColors() && !this->IsFolderDisplayOverrideActive();
+
   for (int controlPointType = 0; controlPointType < NumberOfControlPointTypes; ++controlPointType)
   {
     double* color = this->GetWidgetColor(controlPointType);
@@ -541,6 +646,19 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateFromMRMLInternal(vtkMRMLNode*
     ControlPointsPipeline2D* controlPoints = this->GetControlPointsPipeline(controlPointType);
     controlPoints->Property->SetColor(color);
     controlPoints->Property->SetOpacity(opacity);
+
+    const bool perPointForThisPipeline = useControlPointColors //
+                                         && (controlPointType == Unselected || controlPointType == Selected);
+    if (perPointForThisPipeline)
+    {
+      controlPoints->Mapper->SetScalarVisibility(true);
+      controlPoints->Mapper->SetScalarModeToUsePointData();
+      controlPoints->Mapper->SetColorModeToDirectScalars();
+    }
+    else
+    {
+      controlPoints->Mapper->SetScalarVisibility(false);
+    }
 
     controlPoints->TextProperty->ShallowCopy(this->MarkupsDisplayNode->GetTextProperty());
     if (this->GetApplicationLogic())

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -43,6 +43,7 @@
 #include "vtkStringArray.h"
 #include "vtkTextActor.h"
 #include "vtkTextProperty.h"
+#include "vtkUnsignedCharArray.h"
 
 // MRML includes
 #include <vtkMRMLAbstractThreeDViewDisplayableManager.h>
@@ -289,6 +290,10 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateAllPointsAndLabelsFromMRML()
   int numPoints = markupsNode->GetNumberOfControlPoints();
   std::vector<int> activeControlPointIndices;
   this->MarkupsDisplayNode->GetActiveControlPoints(activeControlPointIndices);
+  const bool perPointColorsEnabled = this->MarkupsDisplayNode->GetUseControlPointColors() //
+                                     && !this->IsFolderDisplayOverrideActive();
+  vtkUnsignedCharArray* srcColorArr = perPointColorsEnabled ? markupsNode->GetControlPointColorArray() : nullptr;
+  vtkUnsignedCharArray* srcFlagArr = perPointColorsEnabled ? markupsNode->GetControlPointColorOverriddenArray() : nullptr;
   for (int controlPointType = 0; controlPointType < NumberOfControlPointTypes; ++controlPointType)
   {
     ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[controlPointType]);
@@ -317,6 +322,36 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateAllPointsAndLabelsFromMRML()
     controlPoints->Labels->SetNumberOfValues(0);
     controlPoints->LabelsPriority->SetNumberOfValues(0);
     controlPoints->ControlPointIndices->SetNumberOfValues(0);
+
+    // Active pipeline always uses the flat ActiveColor (interaction feedback).
+    const bool applyPerPointColors = perPointColorsEnabled //
+                                     && (controlPointType == Unselected || controlPointType == Selected);
+    vtkUnsignedCharArray* perPointColorsArray = nullptr;
+    if (applyPerPointColors)
+    {
+      perPointColorsArray = vtkUnsignedCharArray::SafeDownCast(controlPoints->ControlPointsPolyData->GetPointData()->GetArray(PerPointColorArrayName));
+      if (!perPointColorsArray)
+      {
+        vtkNew<vtkUnsignedCharArray> newArr;
+        newArr->SetName(PerPointColorArrayName);
+        newArr->SetNumberOfComponents(4);
+        controlPoints->ControlPointsPolyData->GetPointData()->AddArray(newArr);
+        perPointColorsArray = newArr;
+      }
+      perPointColorsArray->SetNumberOfTuples(0);
+    }
+    else
+    {
+      controlPoints->ControlPointsPolyData->GetPointData()->RemoveArray(PerPointColorArrayName);
+    }
+    unsigned char fallbackBytes[4] = { 255, 255, 255, 255 };
+    if (applyPerPointColors)
+    {
+      double* widgetColor = this->GetWidgetColor(controlPointType);
+      fallbackBytes[0] = static_cast<unsigned char>(widgetColor[0] * 255.0 + 0.5);
+      fallbackBytes[1] = static_cast<unsigned char>(widgetColor[1] * 255.0 + 0.5);
+      fallbackBytes[2] = static_cast<unsigned char>(widgetColor[2] * 255.0 + 0.5);
+    }
 
     for (int pointIndex = 0; pointIndex < numPoints; ++pointIndex)
     {
@@ -367,6 +402,35 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateAllPointsAndLabelsFromMRML()
       controlPoints->Labels->InsertNextValue(markupsNode->GetNthControlPointLabel(pointIndex));
       controlPoints->LabelsPriority->InsertNextValue(std::to_string(pointIndex));
       controlPoints->ControlPointIndices->InsertNextValue(pointIndex);
+
+      if (perPointColorsArray)
+      {
+        unsigned char rgba[4];
+        if (srcFlagArr && srcColorArr                                //
+            && pointIndex < srcFlagArr->GetNumberOfTuples()          //
+            && pointIndex < srcColorArr->GetNumberOfTuples()         //
+            && srcFlagArr->GetValue(pointIndex) != 0)
+        {
+          srcColorArr->GetTypedTuple(pointIndex, rgba);
+        }
+        else
+        {
+          rgba[0] = fallbackBytes[0];
+          rgba[1] = fallbackBytes[1];
+          rgba[2] = fallbackBytes[2];
+          rgba[3] = 255;
+        }
+        perPointColorsArray->InsertNextTypedTuple(rgba);
+      }
+    }
+    if (perPointColorsArray)
+    {
+      perPointColorsArray->Modified();
+      controlPoints->ControlPointsPolyData->GetPointData()->SetActiveScalars(PerPointColorArrayName);
+    }
+    else
+    {
+      controlPoints->ControlPointsPolyData->GetPointData()->SetActiveScalars(nullptr);
     }
 
     if (controlPoints->ControlPointIndices->GetNumberOfValues() > 0)
@@ -619,6 +683,8 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateFromMRMLInternal(vtkMRMLNode*
     hierarchyOpacity = vtkMRMLFolderDisplayNode::GetHierarchyOpacity(displayableNode);
   }
 
+  const bool useControlPointColors = this->MarkupsDisplayNode->GetUseControlPointColors() && !this->IsFolderDisplayOverrideActive();
+
   for (int controlPointType = 0; controlPointType < NumberOfControlPointTypes; ++controlPointType)
   {
     double* color = this->GetWidgetColor(controlPointType);
@@ -627,6 +693,27 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateFromMRMLInternal(vtkMRMLNode*
     ControlPointsPipeline3D* controlPoints = this->GetControlPointsPipeline(controlPointType);
     controlPoints->Property->SetColor(color);
     controlPoints->Property->SetOpacity(opacity);
+
+    // Unselected/Selected: direct-RGB scalars from PerPointColorArrayName.
+    // Active: flat ActiveColor (interaction feedback).
+    const bool perPointForThisPipeline = useControlPointColors //
+                                         && (controlPointType == Unselected || controlPointType == Selected);
+    if (perPointForThisPipeline)
+    {
+      controlPoints->GlyphMapper->SetScalarVisibility(true);
+      controlPoints->GlyphMapper->SetScalarModeToUsePointFieldData();
+      controlPoints->GlyphMapper->SelectColorArray(PerPointColorArrayName);
+      controlPoints->GlyphMapper->SetColorModeToDirectScalars();
+      controlPoints->OccludedGlyphMapper->SetScalarVisibility(true);
+      controlPoints->OccludedGlyphMapper->SetScalarModeToUsePointFieldData();
+      controlPoints->OccludedGlyphMapper->SelectColorArray(PerPointColorArrayName);
+      controlPoints->OccludedGlyphMapper->SetColorModeToDirectScalars();
+    }
+    else
+    {
+      controlPoints->GlyphMapper->SetScalarVisibility(false);
+      controlPoints->OccludedGlyphMapper->SetScalarVisibility(false);
+    }
 
     controlPoints->TextProperty->ShallowCopy(this->MarkupsDisplayNode->GetTextProperty());
     if (this->GetApplicationLogic())

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
@@ -131,7 +131,7 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item row="12" column="0" colspan="2">
+      <item row="13" column="0" colspan="2">
        <widget class="ctkCollapsibleGroupBox" name="TextDisplayGroupBox">
         <property name="title">
          <string>Text Display</string>
@@ -236,7 +236,7 @@
         </property>
        </widget>
       </item>
-      <item row="14" column="0" colspan="2">
+      <item row="15" column="0" colspan="2">
        <widget class="ctkCollapsibleGroupBox" name="TwoDDisplayGroupBox">
         <property name="title">
          <string>2D Display</string>
@@ -454,7 +454,7 @@
         </property>
        </widget>
       </item>
-      <item row="13" column="0" colspan="2">
+      <item row="14" column="0" colspan="2">
        <widget class="ctkCollapsibleGroupBox" name="ThreeDDisplayGroupBox">
         <property name="title">
          <string>3D Display</string>
@@ -534,6 +534,26 @@
         </property>
        </widget>
       </item>
+      <item row="12" column="0">
+       <widget class="QLabel" name="useControlPointColorsLabel">
+        <property name="text">
+         <string>Per-point colors:</string>
+        </property>
+        <property name="toolTip">
+         <string>Show each control point in its own color. Points without a color use the Selected/Unselected colors above.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="1">
+       <widget class="QCheckBox" name="useControlPointColorsCheckBox">
+        <property name="toolTip">
+         <string>Show each control point in its own color. Points without a color use the Selected/Unselected colors above.</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
       <item row="8" column="1">
        <widget class="QCheckBox" name="PropertiesLabelVisibilityCheckBox">
         <property name="toolTip">
@@ -544,7 +564,7 @@
         </property>
        </widget>
       </item>
-      <item row="15" column="0" colspan="2">
+      <item row="16" column="0" colspan="2">
        <widget class="ctkCollapsibleGroupBox" name="LineDirectionMarkersCollapsibleGroupBox">
         <property name="title">
          <string>Direction Markers</string>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
@@ -91,6 +91,7 @@ void qMRMLMarkupsDisplayNodeWidgetPrivate::init()
   QObject::connect(this->curveLineThicknessSliderWidget, SIGNAL(valueChanged(double)), q, SLOT(onCurveLineThicknessSliderWidgetChanged(double)));
   QObject::connect(this->curveLineDiameterSliderWidget, SIGNAL(valueChanged(double)), q, SLOT(onCurveLineDiameterSliderWidgetChanged(double)));
   QObject::connect(this->PropertiesLabelVisibilityCheckBox, SIGNAL(toggled(bool)), q, SLOT(setPropertiesLabelVisibility(bool)));
+  QObject::connect(this->useControlPointColorsCheckBox, SIGNAL(toggled(bool)), q, SLOT(setUseControlPointColors(bool)));
   QObject::connect(this->PointLabelsVisibilityCheckBox, SIGNAL(toggled(bool)), q, SLOT(setPointLabelsVisibility(bool)));
   QObject::connect(this->textScaleSliderWidget, SIGNAL(valueChanged(double)), q, SLOT(onTextScaleSliderWidgetChanged(double)));
 
@@ -330,6 +331,8 @@ void qMRMLMarkupsDisplayNodeWidget::updateWidgetFromMRML()
 
   d->PointLabelsVisibilityCheckBox->setChecked(markupsDisplayNode->GetPointLabelsVisibility());
 
+  d->useControlPointColorsCheckBox->setChecked(markupsDisplayNode->GetUseControlPointColors());
+
   // text scale
   double textScale = markupsDisplayNode->GetTextScale();
   // make sure that the slider can accommodate this scale
@@ -475,6 +478,17 @@ void qMRMLMarkupsDisplayNodeWidget::setPropertiesLabelVisibility(bool visible)
     return;
   }
   d->MarkupsDisplayNode->SetPropertiesLabelVisibility(visible);
+}
+
+//------------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::setUseControlPointColors(bool enabled)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode.GetPointer())
+  {
+    return;
+  }
+  d->MarkupsDisplayNode->SetUseControlPointColors(enabled);
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
@@ -91,6 +91,8 @@ public slots:
   void setOccludedVisibility(bool visibility);
   void setOccludedOpacity(double OccludedOpacity);
 
+  void setUseControlPointColors(bool enabled);
+
   void setLineDirectionVisibility(bool visible);
   void onLineDirectionMarkerScaleChanged(double value);
   void onLineDirectionMarkerSpacingScaleChanged(double value);

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -26,6 +26,7 @@
 #include <QMessageBox>
 #include <QModelIndex>
 #include <QMouseEvent>
+#include <QPainter>
 #include <QSettings>
 #include <QShortcut>
 #include <QSignalMapper>
@@ -40,6 +41,7 @@
 #include <qSlicerAbstractCoreModule.h>
 
 // CTK includes
+#include "ctkColorDialog.h"
 #include "ctkMessageBox.h"
 
 // Slicer includes
@@ -139,6 +141,7 @@ public:
     SelectedColumn = 0,
     LockedColumn,
     VisibleColumn,
+    ColorColumn,
     NameColumn,
     DescriptionColumn,
     RColumn,
@@ -197,9 +200,10 @@ qSlicerMarkupsModuleWidgetPrivate::qSlicerMarkupsModuleWidgetPrivate(qSlicerMark
   Q_Q(qSlicerMarkupsModuleWidget);
 
   this->columnLabels << qSlicerMarkupsModuleWidget::tr("Selected") << qSlicerMarkupsModuleWidget::tr("Locked") << qSlicerMarkupsModuleWidget::tr("Visible")
-                     << qSlicerMarkupsModuleWidget::tr("Name") << qSlicerMarkupsModuleWidget::tr("Description") << qSlicerMarkupsModuleWidget::tr("R") //: right
-                     << qSlicerMarkupsModuleWidget::tr("A")                                                                                            //: anterior
-                     << qSlicerMarkupsModuleWidget::tr("S")                                                                                            //: superior
+                     << qSlicerMarkupsModuleWidget::tr("Color") << qSlicerMarkupsModuleWidget::tr("Name") << qSlicerMarkupsModuleWidget::tr("Description")
+                     << qSlicerMarkupsModuleWidget::tr("R") //: right
+                     << qSlicerMarkupsModuleWidget::tr("A") //: anterior
+                     << qSlicerMarkupsModuleWidget::tr("S") //: superior
                      << qSlicerMarkupsModuleWidget::tr("Position");
 
   this->newMarkupWithCurrentDisplayPropertiesAction = nullptr;
@@ -452,6 +456,12 @@ void qSlicerMarkupsModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
   visibleHeader->setIcon(QIcon(":/Icons/Small/SlicerVisibleInvisible.png"));
   visibleHeader->setToolTip((qSlicerMarkupsModuleWidget::tr("Click in this column to show/hide control points in 2D and 3D")));
   this->activeMarkupTableWidget->setColumnWidth(qSlicerMarkupsModuleWidgetPrivate::VisibleColumn, 30);
+  QTableWidgetItem* colorHeader = this->activeMarkupTableWidget->horizontalHeaderItem(qSlicerMarkupsModuleWidgetPrivate::ColorColumn);
+  colorHeader->setText(qSlicerMarkupsModuleWidget::tr("Color"));
+  colorHeader->setToolTip(qSlicerMarkupsModuleWidget::tr("Click in this column to set the per-control-point color. Right-click for batch operations. "
+                                                         "Visible only when 'Use control point colors' is enabled in the Display panel."));
+  this->activeMarkupTableWidget->setColumnWidth(qSlicerMarkupsModuleWidgetPrivate::ColorColumn, 40);
+  this->activeMarkupTableWidget->setColumnHidden(qSlicerMarkupsModuleWidgetPrivate::ColorColumn, true);
   // position is a location bubble
   QTableWidgetItem* positionHeader = this->activeMarkupTableWidget->horizontalHeaderItem(qSlicerMarkupsModuleWidgetPrivate::PositionColumn);
   positionHeader->setText("");
@@ -911,6 +921,12 @@ void qSlicerMarkupsModuleWidget::updateWidgetFromMRML()
   d->activeMarkupTreeView->blockSignals(wasBlocked);
   d->markupsDisplayWidget->setMRMLMarkupsNode(d->MarkupsNode);
 
+  // Show the Color column only when UseControlPointColors is enabled on
+  // the display node.
+  vtkMRMLMarkupsDisplayNode* dispNodeForColorColumn = d->markupsDisplayNode();
+  bool showColorColumn = (dispNodeForColorColumn != nullptr && dispNodeForColorColumn->GetUseControlPointColors());
+  d->activeMarkupTableWidget->setColumnHidden(qSlicerMarkupsModuleWidgetPrivate::ColorColumn, !showColorColumn);
+
   // Color legend
   vtkMRMLColorLegendDisplayNode* colorLegendNode = nullptr;
   vtkMRMLDisplayNode* displayNode = d->markupsDisplayWidget->mrmlMarkupsDisplayNode();
@@ -1128,6 +1144,49 @@ void qSlicerMarkupsModuleWidget::updateRow(int controlPointIndex)
   {
     item->setData(Qt::UserRole, QVariant(visible));
     item->setData(Qt::DecorationRole, visible ? d->SlicerVisibleIcon : d->SlicerInvisibleIcon);
+  }
+  if (isNewItem)
+  {
+    d->activeMarkupTableWidget->setItem(controlPointIndex, column, item);
+  }
+
+  column = qSlicerMarkupsModuleWidgetPrivate::ColorColumn;
+  item = d->activeMarkupTableWidget->item(controlPointIndex, column);
+  isNewItem = false;
+  if (!item)
+  {
+    item = new QTableWidgetItem();
+    item->setFlags(item->flags() & ~Qt::ItemIsEditable & ~Qt::ItemIsUserCheckable);
+    isNewItem = true;
+  }
+  double rgba[4] = { 0.0, 0.0, 0.0, 0.0 };
+  bool colorOverridden = markupsNode->GetNthControlPointColor(controlPointIndex, rgba);
+  // Invalid QColor is the "no override" sentinel; a valid QColor is the cached swatch state.
+  QColor stateKey = colorOverridden ? QColor::fromRgbF(rgba[0], rgba[1], rgba[2], rgba[3]) : QColor();
+  if (isNewItem || item->data(Qt::UserRole).value<QColor>() != stateKey)
+  {
+    item->setData(Qt::UserRole, stateKey);
+    if (colorOverridden)
+    {
+      QPixmap swatch(16, 16);
+      swatch.fill(stateKey);
+      item->setData(Qt::DecorationRole, swatch);
+      item->setToolTip(qSlicerMarkupsModuleWidget::tr("Per-point color set. Click to change; right-click for batch operations."));
+    }
+    else
+    {
+      // Hollow X swatch indicates "no per-point color set; falls back to Selected/Unselected color above".
+      QPixmap swatch(16, 16);
+      swatch.fill(Qt::transparent);
+      QPainter painter(&swatch);
+      painter.setPen(QColor(150, 150, 150));
+      painter.drawRect(0, 0, 15, 15);
+      painter.drawLine(0, 0, 15, 15);
+      painter.drawLine(15, 0, 0, 15);
+      painter.end();
+      item->setData(Qt::DecorationRole, swatch);
+      item->setToolTip(qSlicerMarkupsModuleWidget::tr("No per-point color set. Click to set; right-click for batch operations."));
+    }
   }
   if (isNewItem)
   {
@@ -2176,6 +2235,11 @@ void qSlicerMarkupsModuleWidget::onActiveMarkupTableCellClicked(QTableWidgetItem
       item->setData(Qt::UserRole, QVariant(vtkMRMLMarkupsNode::PositionDefined));
     }
   }
+  else if (column == qSlicerMarkupsModuleWidgetPrivate::ColorColumn)
+  {
+    this->pickAndApplyPerPointColor({ row });
+    return;
+  }
   d->MarkupsNode->SetControlPointPlacementStartIndex(row);
 }
 
@@ -2253,10 +2317,89 @@ void qSlicerMarkupsModuleWidget::onRightClickActiveMarkupTableWidget(QPoint pos)
   menu.addAction(unsetPointAction);
   QObject::connect(unsetPointAction, SIGNAL(triggered()), this, SLOT(onUnsetControlPointPushButtonClicked()));
 
+  // Per-point color actions are always offered; the visual effect only
+  // applies when UseControlPointColors is enabled.
+  if (d->MarkupsNode)
+  {
+    menu.addSeparator();
+    QAction* setColorAction = new QAction(tr("Set color of highlighted control point(s)..."), &menu);
+    menu.addAction(setColorAction);
+    QObject::connect(setColorAction, SIGNAL(triggered()), this, SLOT(onSetColorOfHighlightedControlPointsTriggered()));
+    QAction* clearColorAction = new QAction(tr("Clear color of highlighted control point(s)"), &menu);
+    menu.addAction(clearColorAction);
+    QObject::connect(clearColorAction, SIGNAL(triggered()), this, SLOT(onClearColorOfHighlightedControlPointsTriggered()));
+  }
+
   menu.addSeparator();
   this->addSelectedCoordinatesToMenu(&menu);
 
   menu.exec(QCursor::pos());
+}
+
+//-----------------------------------------------------------------------------
+QList<int> qSlicerMarkupsModuleWidget::highlightedControlPointRowIndices() const
+{
+  Q_D(const qSlicerMarkupsModuleWidget);
+  QList<int> rows;
+  for (const QModelIndex& idx : d->activeMarkupTableWidget->selectionModel()->selectedRows())
+  {
+    rows << idx.row();
+  }
+  std::sort(rows.begin(), rows.end());
+  return rows;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerMarkupsModuleWidget::pickAndApplyPerPointColor(const QList<int>& rows)
+{
+  Q_D(qSlicerMarkupsModuleWidget);
+  if (!d->MarkupsNode || rows.isEmpty())
+  {
+    return;
+  }
+  // Pre-fill the dialog with the first row's per-point color, falling back
+  // to the display node's Unselected color when the row has no override.
+  QColor initial(255, 255, 255);
+  double rgba[4] = { 1.0, 1.0, 1.0, 1.0 };
+  if (d->MarkupsNode->GetNthControlPointColor(rows.first(), rgba))
+  {
+    initial = QColor::fromRgbF(rgba[0], rgba[1], rgba[2], rgba[3]);
+  }
+  else if (vtkMRMLMarkupsDisplayNode* dispNode = d->markupsDisplayNode())
+  {
+    double fallback[3] = { 1.0, 1.0, 1.0 };
+    dispNode->GetColor(fallback);
+    initial = QColor::fromRgbF(fallback[0], fallback[1], fallback[2], 1.0);
+  }
+  QColor chosen = ctkColorDialog::getColor(initial, this, tr("Select per-point color"), ctkColorDialog::ShowAlphaChannel);
+  if (!chosen.isValid())
+  {
+    return;
+  }
+  for (int row : rows)
+  {
+    d->MarkupsNode->SetNthControlPointColor(row, chosen.redF(), chosen.greenF(), chosen.blueF(), chosen.alphaF());
+  }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerMarkupsModuleWidget::onSetColorOfHighlightedControlPointsTriggered()
+{
+  this->pickAndApplyPerPointColor(this->highlightedControlPointRowIndices());
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerMarkupsModuleWidget::onClearColorOfHighlightedControlPointsTriggered()
+{
+  Q_D(qSlicerMarkupsModuleWidget);
+  if (!d->MarkupsNode)
+  {
+    return;
+  }
+  for (int row : this->highlightedControlPointRowIndices())
+  {
+    d->MarkupsNode->ClearNthControlPointColor(row);
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
@@ -191,6 +191,18 @@ public slots:
   void onRightClickActiveMarkupTableWidget(QPoint pos);
   /// Add the coordinates of the currently selected markups as strings to the given menu, then add a separator
   void addSelectedCoordinatesToMenu(QMenu* menu);
+  /// Open a color picker and apply the chosen color to all currently selected control points.
+  void onSetColorOfHighlightedControlPointsTriggered();
+  /// Clear the per-point color override on all currently selected control points.
+  void onClearColorOfHighlightedControlPointsTriggered();
+  /// Open a color picker pre-filled from the first row, then apply the chosen color to every row in \a rows.
+  void pickAndApplyPerPointColor(const QList<int>& rows);
+
+protected:
+  /// Return the unique sorted control-point row indices currently selected in the table.
+  QList<int> highlightedControlPointRowIndices() const;
+
+public slots:
   /// Jump slices action slot
   void onJumpSlicesActionTriggered();
   /// Refocus cameras action slot


### PR DESCRIPTION
Adds per-point color support to `vtkMRMLMarkupsNode`. It is off by default.

When enabled, per-point colors override the Selected/Unselected colors when they are set.
They all start out in an "unset" state.

The challenge with this was that the control points in a vtkMRMLMarkupsNode are not a vtkPolyData but rather a std::vector of ControlPoint structs called `ControlPoints`. 
The way it's done is by adding to vtkMRMLMarkupsNode a new member that is actually a vtkPolyData, called `ControlPointDataSet`, to which we can add color data any other data one might to add in the future. We still have `ControlPoints` as the source of truth, but now we also have `ControlPointDataSet` as a mirror of it. It's duplication, but it doesn't actually duplicate anything unless you go and try to `SetNthControlPointColor`, which is when it's needed.

Adds an optional `"color"` field per `controlPoints[]` entry in the markups JSON.

<img width="768" height="432" alt="vid-loop-768x432-15fps" src="https://github.com/user-attachments/assets/5d9b5076-4b97-494f-a64f-c8b8f48c8fde" />


### Try

```python
m = slicer.modules.markups.logic().AddNewMarkupsNode("vtkMRMLMarkupsFiducialNode")
m.AddControlPoint([0, 0, 0])
m.AddControlPoint([40, 0, 0])
m.AddControlPoint([60, 0, 0])

# Override colors on individual control points (RGBA, 0..1)
m.SetNthControlPointColor(0, 1.0, 0.0, 0.0)
m.SetNthControlPointColor(2, 0.0, 0.7, 1.0, 0.5)

# Enable per-point colors on the display node
m.GetDisplayNode().SetUseControlPointColors(True)

# Inspect / clear per-point colors
print(m.IsNthControlPointColorOverridden(0))   # True
print(m.IsNthControlPointColorOverridden(1))   # False (uses Selected/Unselected fallback)
rgba = [0.0, 0.0, 0.0, 0.0]
m.GetNthControlPointColor(0, rgba); print(rgba)  # [1.0, 0.0, 0.0, 1.0]
m.ClearNthControlPointColor(0)                # revert point 0 to fallback
m.ClearAllControlPointColors()                # revert every point
```