### PR TITLE
Support installing scripted extensions from source

### DIFF
--- a/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
@@ -20,7 +20,13 @@
 
 // Qt includes
 #include <qSlicerCoreApplication.h>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QJSEngine>
+#include <QProcess>
+#include <QTemporaryFile>
+#include <QTextStream>
 
 // CTK includes
 #include <ctkTest.h>
@@ -31,6 +37,7 @@
 
 // QtCore includes
 #include "qSlicerExtensionsManagerModel.h"
+#include "vtkArchive.h"
 #include "vtkSlicerConfigure.h"
 #include "vtkSlicerVersionConfigureMinimal.h"
 
@@ -63,6 +70,24 @@ private:
   void installHelper(qSlicerExtensionsManagerModel* model, const QString& os, int extensionId, const QString& tmp);
 
   bool uninstallHelper(qSlicerExtensionsManagerModel* model, const QString& extensionName);
+
+  bool writeSourceScriptedManifest(const QString& sourcePath,
+                                   const QString& extensionName,
+                                   const QString& modulePath = "SourceModule.py",
+                                   const QStringList& pythonPaths = QStringList(),
+                                   const QString& extensionType = "source-scripted",
+                                   const QStringList& depends = QStringList());
+  bool setSourceScriptedManifestInstallSource(const QString& sourcePath, const QJsonObject& installSource);
+  QString createSourceScriptedExtension(const QString& extensionName,
+                                        const QString& modulePath = "SourceModule.py",
+                                        const QStringList& pythonPaths = QStringList(),
+                                        const QStringList& depends = QStringList());
+  bool runGit(const QString& workingDirectory, const QStringList& arguments, QString* output = nullptr);
+  bool commitGitRepository(const QString& repositoryPath, const QString& message, QString* revision = nullptr);
+  QString createSourceScriptedGitRepository(const QString& extensionName,
+                                            QString* revision = nullptr,
+                                            const QString& tagName = QString(),
+                                            const QJsonObject& installSource = QJsonObject());
 
   bool resetTmp();
   QDir Tmp;
@@ -106,7 +131,17 @@ private slots:
   void testWriteAndParseExtensionDescriptionFile();
   void testWriteAndParseExtensionDescriptionFile_data();
 
+  void testParseSourceScriptedExtensionManifest();
+  void testParseSourceScriptedExtensionInstallSource();
+
   void testInstallExtension();
+
+  void testInspectSourceScriptedExtensionArchiveFailures();
+  void testDownloadAndInspectSourceScriptedExtension();
+  void testInstallSourceScriptedExtension();
+  void testInstallSourceScriptedExtensionFromArchive();
+  void testInspectSourceScriptedExtensionFromGit();
+  void testInstallSourceScriptedExtensionFromGit();
 
   void testUninstallExtension();
 
@@ -307,6 +342,209 @@ bool qSlicerExtensionsManagerModelTester::uninstallHelper(qSlicerExtensionsManag
   bool success = model->scheduleExtensionForUninstall(extensionName);
   success = success && model->uninstallScheduledExtensions();
   return success;
+}
+
+// ----------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModelTester::writeSourceScriptedManifest(const QString& sourcePath,
+                                                                      const QString& extensionName,
+                                                                      const QString& modulePath,
+                                                                      const QStringList& pythonPaths,
+                                                                      const QString& extensionType,
+                                                                      const QStringList& depends)
+{
+  QFile manifestFile(QDir(sourcePath).filePath("slicer-extension.json"));
+  if (!manifestFile.open(QFile::WriteOnly | QFile::Truncate))
+  {
+    return false;
+  }
+
+  QTextStream stream(&manifestFile);
+  stream << "{\n";
+  stream << "  \"schema\": \"https://slicer.org/schemas/source-scripted-extension/v1\",\n";
+  stream << "  \"type\": \"" << extensionType << "\",\n";
+  stream << "  \"extensionname\": \"" << extensionName << "\",\n";
+  stream << "  \"description\": \"Source scripted test extension\",\n";
+  stream << "  \"contributors\": \"Slicer Test\",\n";
+  stream << "  \"modules\": [\n";
+  stream << "    { \"name\": \"" << QFileInfo(modulePath).completeBaseName() << "\", \"path\": \"" << modulePath << "\" }\n";
+  stream << "  ],\n";
+  stream << "  \"depends\": [";
+  for (int i = 0; i < depends.size(); ++i)
+  {
+    stream << (i == 0 ? "" : ", ") << "\"" << depends.at(i) << "\"";
+  }
+  stream << "],\n";
+  stream << "  \"pythonPaths\": [";
+  for (int i = 0; i < pythonPaths.size(); ++i)
+  {
+    stream << (i == 0 ? "" : ", ") << "\"" << pythonPaths.at(i) << "\"";
+  }
+  stream << "]\n";
+  stream << "}\n";
+  manifestFile.close();
+  return true;
+}
+
+// ----------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModelTester::setSourceScriptedManifestInstallSource(const QString& sourcePath, const QJsonObject& installSource)
+{
+  const QString manifestPath = QDir(sourcePath).filePath("slicer-extension.json");
+  QFile manifestFile(manifestPath);
+  if (!manifestFile.open(QFile::ReadOnly))
+  {
+    return false;
+  }
+  const QJsonDocument document = QJsonDocument::fromJson(manifestFile.readAll());
+  manifestFile.close();
+  if (!document.isObject())
+  {
+    return false;
+  }
+
+  QJsonObject manifest = document.object();
+  manifest.insert("installSource", installSource);
+  manifestFile.setFileName(manifestPath);
+  if (!manifestFile.open(QFile::WriteOnly | QFile::Truncate))
+  {
+    return false;
+  }
+  manifestFile.write(QJsonDocument(manifest).toJson(QJsonDocument::Indented));
+  manifestFile.close();
+  return true;
+}
+
+// ----------------------------------------------------------------------------
+QString qSlicerExtensionsManagerModelTester::createSourceScriptedExtension(const QString& extensionName,
+                                                                           const QString& modulePath,
+                                                                           const QStringList& pythonPaths,
+                                                                           const QStringList& depends)
+{
+  const QString sourcePath = this->Tmp.filePath(extensionName + "-source");
+  QDir().mkpath(sourcePath);
+
+  const QString moduleFilePath = QDir(sourcePath).filePath(modulePath);
+  QDir().mkpath(QFileInfo(moduleFilePath).absolutePath());
+  QFile moduleFile(moduleFilePath);
+  if (!moduleFile.open(QFile::WriteOnly | QFile::Truncate))
+  {
+    return QString();
+  }
+  moduleFile.write("from slicer.ScriptedLoadableModule import ScriptedLoadableModule\n\n");
+  moduleFile.write("class SourceModule(ScriptedLoadableModule):\n");
+  moduleFile.write("    pass\n");
+  moduleFile.close();
+
+  for (const QString& pythonPath : pythonPaths)
+  {
+    QDir().mkpath(QDir(sourcePath).filePath(pythonPath));
+  }
+
+  if (!this->writeSourceScriptedManifest(sourcePath, extensionName, modulePath, pythonPaths, "source-scripted", depends))
+  {
+    return QString();
+  }
+
+  return sourcePath;
+}
+
+// ----------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModelTester::runGit(const QString& workingDirectory, const QStringList& arguments, QString* output)
+{
+  QProcess process;
+  if (!workingDirectory.isEmpty())
+  {
+    process.setWorkingDirectory(workingDirectory);
+  }
+  process.start("git", arguments);
+  if (!process.waitForStarted(30000) || !process.waitForFinished(300000))
+  {
+    return false;
+  }
+  if (process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0)
+  {
+    qWarning() << "git" << arguments << "failed:" << process.readAllStandardError();
+    return false;
+  }
+  if (output)
+  {
+    *output = QString::fromLocal8Bit(process.readAllStandardOutput()).trimmed();
+  }
+  return true;
+}
+
+// ----------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModelTester::commitGitRepository(const QString& repositoryPath, const QString& message, QString* revision)
+{
+  if (!this->runGit(repositoryPath,
+                    QStringList() << "add"
+                                  << "-A"))
+  {
+    return false;
+  }
+  if (!this->runGit(repositoryPath,
+                    QStringList() << "commit"
+                                  << "-m" << message))
+  {
+    return false;
+  }
+  return this->runGit(repositoryPath,
+                      QStringList() << "rev-parse"
+                                    << "HEAD",
+                      revision);
+}
+
+// ----------------------------------------------------------------------------
+QString qSlicerExtensionsManagerModelTester::createSourceScriptedGitRepository(const QString& extensionName,
+                                                                               QString* revision,
+                                                                               const QString& tagName,
+                                                                               const QJsonObject& installSource)
+{
+  const QString repositoryPath = this->Tmp.filePath(extensionName + "-git");
+  QDir().mkpath(repositoryPath);
+
+  const QString modulePath = "Modules/" + extensionName + "/" + extensionName + ".py";
+  const QString moduleFilePath = QDir(repositoryPath).filePath(modulePath);
+  QDir().mkpath(QFileInfo(moduleFilePath).absolutePath());
+  QFile moduleFile(moduleFilePath);
+  if (!moduleFile.open(QFile::WriteOnly | QFile::Truncate))
+  {
+    return QString();
+  }
+  moduleFile.write("from slicer.ScriptedLoadableModule import ScriptedLoadableModule\n\n");
+  moduleFile.write("class SourceModule(ScriptedLoadableModule):\n");
+  moduleFile.write("    pass\n");
+  moduleFile.close();
+
+  if (!this->writeSourceScriptedManifest(repositoryPath, extensionName, modulePath))
+  {
+    return QString();
+  }
+  if (!installSource.isEmpty() && !this->setSourceScriptedManifestInstallSource(repositoryPath, installSource))
+  {
+    return QString();
+  }
+  if (!this->runGit(repositoryPath, QStringList() << "init") //
+      || !this->runGit(repositoryPath,
+                       QStringList() << "checkout"
+                                     << "-B"
+                                     << "main") //
+      || !this->runGit(repositoryPath,
+                       QStringList() << "config"
+                                     << "user.email"
+                                     << "slicer@example.invalid") //
+      || !this->runGit(repositoryPath,
+                       QStringList() << "config"
+                                     << "user.name"
+                                     << "Slicer Test") //
+      || !this->commitGitRepository(repositoryPath, "Initial source-scripted extension", revision))
+  {
+    return QString();
+  }
+  if (!tagName.isEmpty() && !this->runGit(repositoryPath, QStringList() << "tag" << tagName))
+  {
+    return QString();
+  }
+  return repositoryPath;
 }
 
 // ----------------------------------------------------------------------------
@@ -825,6 +1063,125 @@ void qSlicerExtensionsManagerModelTester::testWriteAndParseExtensionDescriptionF
 }
 
 // ----------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelTester::testParseSourceScriptedExtensionManifest()
+{
+  QVERIFY(this->resetTmp());
+
+  {
+    const QString sourcePath =
+      this->createSourceScriptedExtension("SourceScripted", "Modules/SourceScripted/SourceScripted.py", QStringList() << "Lib", QStringList() << "SampleData");
+    QVERIFY(!sourcePath.isEmpty());
+
+    QString error;
+    ExtensionMetadataType metadata = qSlicerExtensionsManagerModel::parseSourceScriptedExtensionManifest(QDir(sourcePath).filePath("slicer-extension.json"), &error);
+    QVERIFY2(!metadata.isEmpty(), qPrintable(error));
+    QCOMPARE(metadata.value("extensiontype").toString(), QString("source-scripted"));
+    QCOMPARE(metadata.value("extensionname").toString(), QString("SourceScripted"));
+    QCOMPARE(metadata.value("depends").toString(), QString("SampleData"));
+    QCOMPARE(metadata.value("pythonpaths").toStringList(), QStringList() << "Lib");
+    QCOMPARE(metadata.value("modulepaths").toStringList(), QStringList() << "Modules/SourceScripted");
+  }
+
+  {
+    QString error;
+    ExtensionMetadataType metadata = qSlicerExtensionsManagerModel::parseSourceScriptedExtensionManifest(this->Tmp.filePath("missing/slicer-extension.json"), &error);
+    QVERIFY(metadata.isEmpty());
+    QVERIFY(!error.isEmpty());
+  }
+
+  {
+    const QString sourcePath = this->Tmp.filePath("WrongType-source");
+    QDir().mkpath(sourcePath);
+    QFile moduleFile(QDir(sourcePath).filePath("WrongType.py"));
+    QVERIFY(moduleFile.open(QFile::WriteOnly | QFile::Truncate));
+    moduleFile.write("class WrongType:\n    pass\n");
+    moduleFile.close();
+    QVERIFY(this->writeSourceScriptedManifest(sourcePath, "WrongType", "WrongType.py", QStringList(), "packaged", QStringList()));
+
+    QString error;
+    ExtensionMetadataType metadata = qSlicerExtensionsManagerModel::parseSourceScriptedExtensionManifest(QDir(sourcePath).filePath("slicer-extension.json"), &error);
+    QVERIFY(metadata.isEmpty());
+    QVERIFY(error.contains("source-scripted"));
+  }
+
+  {
+    const QString sourcePath = this->Tmp.filePath("Traversal-source");
+    QDir().mkpath(sourcePath);
+    QVERIFY(this->writeSourceScriptedManifest(sourcePath, "Traversal", "../Traversal.py"));
+
+    QString error;
+    ExtensionMetadataType metadata = qSlicerExtensionsManagerModel::parseSourceScriptedExtensionManifest(QDir(sourcePath).filePath("slicer-extension.json"), &error);
+    QVERIFY(metadata.isEmpty());
+    QVERIFY(!error.isEmpty());
+  }
+
+  {
+    const QString sourcePath = this->Tmp.filePath("MissingModule-source");
+    QDir().mkpath(sourcePath);
+    QVERIFY(this->writeSourceScriptedManifest(sourcePath, "MissingModule", "MissingModule.py"));
+
+    QString error;
+    ExtensionMetadataType metadata = qSlicerExtensionsManagerModel::parseSourceScriptedExtensionManifest(QDir(sourcePath).filePath("slicer-extension.json"), &error);
+    QVERIFY(metadata.isEmpty());
+    QVERIFY(!error.isEmpty());
+  }
+
+  {
+    const QString sourcePath = this->Tmp.filePath("NotPython-source");
+    QDir().mkpath(sourcePath);
+    QFile moduleFile(QDir(sourcePath).filePath("NotPython.txt"));
+    QVERIFY(moduleFile.open(QFile::WriteOnly | QFile::Truncate));
+    moduleFile.write("not python\n");
+    moduleFile.close();
+    QVERIFY(this->writeSourceScriptedManifest(sourcePath, "NotPython", "NotPython.txt"));
+
+    QString error;
+    ExtensionMetadataType metadata = qSlicerExtensionsManagerModel::parseSourceScriptedExtensionManifest(QDir(sourcePath).filePath("slicer-extension.json"), &error);
+    QVERIFY(metadata.isEmpty());
+    QVERIFY(error.contains(".py"));
+  }
+}
+
+// ----------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelTester::testParseSourceScriptedExtensionInstallSource()
+{
+  QVERIFY(this->resetTmp());
+
+  {
+    const QString sourcePath = this->createSourceScriptedExtension("InstallSourceDescriptor", "InstallSourceDescriptor.py");
+    QVERIFY(!sourcePath.isEmpty());
+    QJsonObject installSource;
+    installSource.insert("type", "git");
+    installSource.insert("url", "https://example.invalid/InstallSourceDescriptor.git");
+    installSource.insert("ref", "main");
+    QVERIFY(this->setSourceScriptedManifestInstallSource(sourcePath, installSource));
+
+    QString error;
+    ExtensionMetadataType metadata = qSlicerExtensionsManagerModel::parseSourceScriptedExtensionManifest(QDir(sourcePath).filePath("slicer-extension.json"), &error);
+    QVERIFY2(!metadata.isEmpty(), qPrintable(error));
+    const QVariantMap parsedInstallSource = metadata.value("installSource").toMap();
+    QCOMPARE(parsedInstallSource.value("type").toString(), QString("git"));
+    QCOMPARE(parsedInstallSource.value("url").toString(), QString("https://example.invalid/InstallSourceDescriptor.git"));
+    QCOMPARE(parsedInstallSource.value("ref").toString(), QString("main"));
+    QVERIFY(!metadata.contains("origin"));
+  }
+
+  {
+    const QString sourcePath = this->createSourceScriptedExtension("BadInstallSourceDescriptor", "BadInstallSourceDescriptor.py");
+    QVERIFY(!sourcePath.isEmpty());
+    QJsonObject installSource;
+    installSource.insert("type", "directory");
+    installSource.insert("path", "/tmp/BadInstallSourceDescriptor");
+    QVERIFY(this->setSourceScriptedManifestInstallSource(sourcePath, installSource));
+
+    QString error;
+    ExtensionMetadataType metadata = qSlicerExtensionsManagerModel::parseSourceScriptedExtensionManifest(QDir(sourcePath).filePath("slicer-extension.json"), &error);
+    QVERIFY(metadata.isEmpty());
+    QVERIFY2(error.contains("installSource"), qPrintable(error));
+  }
+}
+
+// ----------------------------------------------------------------------------
 void qSlicerExtensionsManagerModelTester::testInstallExtension()
 {
   QVERIFY(this->resetTmp());
@@ -883,6 +1240,372 @@ void qSlicerExtensionsManagerModelTester::testInstallExtension()
   QCOMPARE(spyExtensionUninstalled.count(), 0);
   QCOMPARE(spySlicerRequirementsChanged.count(), 0);
   QCOMPARE(model.installedExtensionsCount(), expectedInstalledExtensionNames.count());
+}
+
+// ----------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelTester::testInspectSourceScriptedExtensionArchiveFailures()
+{
+  QVERIFY(this->resetTmp());
+
+  const QString sourcePath = this->Tmp.filePath("NoManifestSource");
+  QDir().mkpath(sourcePath);
+  QFile file(QDir(sourcePath).filePath("Module.py"));
+  QVERIFY(file.open(QFile::WriteOnly | QFile::Truncate));
+  file.write("print('no manifest')\n");
+  file.close();
+
+  const QString archivePath = this->Tmp.filePath("NoManifestSource.zip");
+  QVERIFY(vtkArchive::Zip(qPrintable(archivePath), qPrintable(sourcePath)));
+
+  qSlicerExtensionsManagerModel model;
+  QString error;
+  ExtensionMetadataType metadata = model.inspectSourceScriptedExtension(archivePath, &error);
+  QVERIFY(metadata.isEmpty());
+  QVERIFY2(error.contains("slicer-extension.json"), qPrintable(error));
+  QVERIFY2(error.contains("archive root"), qPrintable(error));
+  QVERIFY2(error.contains("one top-level directory"), qPrintable(error));
+
+  const QString htmlPath = this->Tmp.filePath("download.zip");
+  QFile htmlFile(htmlPath);
+  QVERIFY(htmlFile.open(QFile::WriteOnly | QFile::Truncate));
+  htmlFile.write("<html>not an archive</html>\n");
+  htmlFile.close();
+
+  error.clear();
+  metadata = model.inspectSourceScriptedExtension(htmlPath, &error);
+  QVERIFY(metadata.isEmpty());
+  QVERIFY2(error.contains("not a supported archive"), qPrintable(error));
+}
+
+// ----------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelTester::testDownloadAndInspectSourceScriptedExtension()
+{
+  QVERIFY(this->resetTmp());
+
+  const QString installPath = this->Tmp.filePath("Extensions");
+  QSettings().setValue("Extensions/InstallPath", installPath);
+
+  const QString sourcePath = this->createSourceScriptedExtension("DownloadedSourceScripted", "DownloadedSourceScripted.py");
+  QVERIFY(!sourcePath.isEmpty());
+  const QString archivePath = this->Tmp.filePath("DownloadedSourceScripted.zip");
+  QVERIFY(vtkArchive::Zip(qPrintable(archivePath), qPrintable(sourcePath)));
+
+  qSlicerExtensionsManagerModel model;
+  model.setExtensionsSettingsFilePath(QSettings().fileName());
+  model.setSlicerRequirements("30987", Slicer_OS_LINUX_NAME, "amd64");
+
+  QSignalSpy spyDownloadReady(&model, SIGNAL(sourceScriptedExtensionDownloadReady(QUrl, QString, QVariantMap, bool)));
+  QVERIFY(model.downloadAndInspectSourceScriptedExtension(QUrl::fromLocalFile(archivePath), /* installDependencies= */ false));
+  QCOMPARE(spyDownloadReady.count(), 1);
+
+  QCOMPARE(spyDownloadReady.at(0).at(1).toString(), archivePath);
+  QCOMPARE(spyDownloadReady.at(0).at(2).toMap().value("extensionname").toString(), QString("DownloadedSourceScripted"));
+  QVERIFY(!model.isExtensionInstalled("DownloadedSourceScripted"));
+
+  QFile archiveFile(archivePath);
+  QVERIFY(archiveFile.open(QFile::ReadOnly));
+  QTemporaryFile stagedArchive(this->Tmp.filePath("main.XXXXXX.zip"));
+  stagedArchive.setAutoRemove(false);
+  QVERIFY(stagedArchive.open());
+  stagedArchive.write(archiveFile.readAll());
+  const QString stagedArchivePath = stagedArchive.fileName();
+  stagedArchive.close();
+  QVERIFY2(stagedArchivePath.endsWith(".zip"), qPrintable(stagedArchivePath));
+  QString error;
+  ExtensionMetadataType metadata = model.inspectSourceScriptedExtension(stagedArchivePath, &error);
+  QVERIFY2(!metadata.isEmpty(), qPrintable(error));
+
+  QFile::remove(stagedArchivePath);
+}
+
+// ----------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelTester::testInstallSourceScriptedExtension()
+{
+  QVERIFY(this->resetTmp());
+
+  const QString installPath = this->Tmp.filePath("Extensions");
+  QSettings().setValue("Extensions/InstallPath", installPath);
+
+  const QString sourcePath = this->createSourceScriptedExtension("SourceScripted", "Modules/SourceScripted/SourceScripted.py", QStringList() << "Lib");
+  QVERIFY(!sourcePath.isEmpty());
+
+  qSlicerExtensionsManagerModel model;
+  model.setExtensionsSettingsFilePath(QSettings().fileName());
+  model.setSlicerRequirements("30987", Slicer_OS_LINUX_NAME, "amd64");
+
+  QSignalSpy spyExtensionInstalled(&model, SIGNAL(extensionInstalled(QString)));
+  QVERIFY(model.installSourceScriptedExtension(sourcePath, /* installDependencies= */ false));
+  QCOMPARE(spyExtensionInstalled.count(), 1);
+  QCOMPARE(spyExtensionInstalled.at(0).at(0).toString(), QString("SourceScripted"));
+
+  QVERIFY(model.isExtensionInstalled("SourceScripted"));
+  QVERIFY(model.isExtensionEnabled("SourceScripted"));
+  QCOMPARE(model.extensionMetadata("SourceScripted").value("extensiontype").toString(), QString("source-scripted"));
+  QCOMPARE(model.extensionMetadata("SourceScripted").value("description").toString(), QString("Source scripted test extension"));
+
+  QVERIFY(QFileInfo(installPath + "/SourceScripted/source/Modules/SourceScripted/SourceScripted.py").isFile());
+  QVERIFY(QFileInfo(installPath + "/SourceScripted/source-scripted-extension.json").isFile());
+  QVERIFY(QFileInfo(installPath + "/SourceScripted.s4ext").isFile());
+
+  const QStringList expectedModulePaths = QStringList() << installPath + "/SourceScripted/source/Modules/SourceScripted";
+  QCOMPARE(model.extensionModulePaths("SourceScripted"), expectedModulePaths);
+  QCOMPARE(QSettings().value("Modules/AdditionalPaths").toStringList(), expectedModulePaths);
+
+  QSettings extensionsSettings(model.extensionsSettingsFilePath(), QSettings::IniFormat);
+  QCOMPARE(qSlicerExtensionsManagerModel::readArrayValues(extensionsSettings, "LibraryPaths", "path"), QStringList());
+  QCOMPARE(qSlicerExtensionsManagerModel::readArrayValues(extensionsSettings, "Paths", "path"), QStringList());
+#ifdef Slicer_USE_PYTHONQT
+  QCOMPARE(qSlicerExtensionsManagerModel::readArrayValues(extensionsSettings, "PYTHONPATH", "path"), QStringList() << installPath + "/SourceScripted/source/Lib");
+#endif
+
+  model.setExtensionEnabled("SourceScripted", false);
+  QCOMPARE(QSettings().value("Modules/AdditionalPaths").toStringList(), QStringList());
+  QSettings disabledExtensionsSettings(model.extensionsSettingsFilePath(), QSettings::IniFormat);
+#ifdef Slicer_USE_PYTHONQT
+  QCOMPARE(qSlicerExtensionsManagerModel::readArrayValues(disabledExtensionsSettings, "PYTHONPATH", "path"), QStringList());
+#endif
+
+  model.setExtensionEnabled("SourceScripted", true);
+  QCOMPARE(QSettings().value("Modules/AdditionalPaths").toStringList(), expectedModulePaths);
+
+  {
+    qSlicerExtensionsManagerModel reloadedModel;
+    reloadedModel.setExtensionsSettingsFilePath(QSettings().fileName());
+    reloadedModel.setSlicerRequirements("30987", Slicer_OS_LINUX_NAME, "amd64");
+    reloadedModel.updateModel();
+    QVERIFY(reloadedModel.isExtensionInstalled("SourceScripted"));
+    QVERIFY(reloadedModel.isExtensionEnabled("SourceScripted"));
+    QCOMPARE(reloadedModel.extensionModulePaths("SourceScripted"), expectedModulePaths);
+    QCOMPARE(reloadedModel.extensionMetadata("SourceScripted").value("extensiontype").toString(), QString("source-scripted"));
+  }
+
+  QVERIFY(model.uninstallExtension("SourceScripted"));
+  QVERIFY(!QFileInfo(installPath + "/SourceScripted").exists());
+  QVERIFY(!QFileInfo(installPath + "/SourceScripted.s4ext").exists());
+  QCOMPARE(QSettings().value("Modules/AdditionalPaths").toStringList(), QStringList());
+}
+
+// ----------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelTester::testInstallSourceScriptedExtensionFromArchive()
+{
+  QVERIFY(this->resetTmp());
+
+  const QString installPath = this->Tmp.filePath("Extensions");
+  QSettings().setValue("Extensions/InstallPath", installPath);
+
+  const QString sourcePath = this->createSourceScriptedExtension("ArchivedSourceScripted", "ArchivedSourceScripted.py");
+  QVERIFY(!sourcePath.isEmpty());
+  QJsonObject installSource;
+  installSource.insert("type", "git");
+  installSource.insert("url", "https://example.invalid/ArchivedSourceScripted.git");
+  installSource.insert("ref", "main");
+  QVERIFY(this->setSourceScriptedManifestInstallSource(sourcePath, installSource));
+
+  const QString archivePath = this->Tmp.filePath("ArchivedSourceScripted.zip");
+  QVERIFY(vtkArchive::Zip(qPrintable(archivePath), qPrintable(sourcePath)));
+
+  qSlicerExtensionsManagerModel model;
+  model.setExtensionsSettingsFilePath(QSettings().fileName());
+  model.setSlicerRequirements("30987", Slicer_OS_LINUX_NAME, "amd64");
+
+  QVERIFY(model.installSourceScriptedExtension(archivePath, /* installDependencies= */ false));
+  QVERIFY(model.isExtensionInstalled("ArchivedSourceScripted"));
+  QVERIFY(QFileInfo(installPath + "/ArchivedSourceScripted/source/ArchivedSourceScripted.py").isFile());
+  QVERIFY(QFileInfo(installPath + "/ArchivedSourceScripted/source-scripted-extension.json").isFile());
+  QCOMPARE(model.extensionModulePaths("ArchivedSourceScripted"), QStringList() << installPath + "/ArchivedSourceScripted/source");
+
+  ExtensionMetadataType metadata = model.extensionMetadata("ArchivedSourceScripted");
+  QCOMPARE(metadata.value("extensiontype").toString(), QString("source-scripted"));
+  QCOMPARE(metadata.value("archivename").toString(), QString("ArchivedSourceScripted.zip"));
+  QCOMPARE(metadata.value("scm").toString(), QString("NA"));
+  QCOMPARE(metadata.value("revision").toString(), QString("NA"));
+
+  QFile sidecarFile(installPath + "/ArchivedSourceScripted/source-scripted-extension.json");
+  QVERIFY(sidecarFile.open(QFile::ReadOnly));
+  const QJsonObject sidecar = QJsonDocument::fromJson(sidecarFile.readAll()).object();
+  const QJsonObject installedOrigin = sidecar.value("origin").toObject();
+  QCOMPARE(installedOrigin.value("type").toString(), QString("archive"));
+  QCOMPARE(installedOrigin.value("path").toString(), archivePath);
+  QVERIFY(!sidecar.contains("installSource"));
+}
+
+// ----------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelTester::testInspectSourceScriptedExtensionFromGit()
+{
+  QVERIFY(this->resetTmp());
+
+  const QString installPath = this->Tmp.filePath("Extensions");
+  QSettings().setValue("Extensions/InstallPath", installPath);
+
+  QString branchRevision;
+  QJsonObject manifestInstallSource;
+  manifestInstallSource.insert("type", "url");
+  manifestInstallSource.insert("url", "https://example.invalid/GitPreviewSourceScripted.zip");
+  const QString repositoryPath = this->createSourceScriptedGitRepository("GitPreviewSourceScripted", &branchRevision, QString(), manifestInstallSource);
+  QVERIFY(!repositoryPath.isEmpty());
+
+  QString defaultBranchRevision;
+  const QString defaultBranchRepositoryPath = this->createSourceScriptedGitRepository("GitDefaultSourceScripted", &defaultBranchRevision);
+  QVERIFY(!defaultBranchRepositoryPath.isEmpty());
+
+  const QString noManifestRepositoryPath = this->Tmp.filePath("GitNoManifest-source");
+  QVERIFY(QDir().mkpath(noManifestRepositoryPath));
+  QVERIFY(this->runGit(noManifestRepositoryPath, QStringList() << "init"));
+  QVERIFY(this->runGit(noManifestRepositoryPath,
+                       QStringList() << "checkout"
+                                     << "-B"
+                                     << "main"));
+  QVERIFY(this->runGit(noManifestRepositoryPath,
+                       QStringList() << "config"
+                                     << "user.email"
+                                     << "slicer@example.invalid"));
+  QVERIFY(this->runGit(noManifestRepositoryPath,
+                       QStringList() << "config"
+                                     << "user.name"
+                                     << "Slicer Test"));
+  QVERIFY(this->runGit(noManifestRepositoryPath,
+                       QStringList() << "commit"
+                                     << "--allow-empty"
+                                     << "-m"
+                                     << "No source-scripted manifest"));
+
+  qSlicerExtensionsManagerModel model;
+  model.setExtensionsSettingsFilePath(QSettings().fileName());
+  model.setSlicerRequirements("30987", Slicer_OS_LINUX_NAME, "amd64");
+
+  QString defaultBranchCheckoutPath;
+  QVariantMap defaultBranchOriginMetadata;
+  QString error;
+  ExtensionMetadataType metadata =
+    model.inspectSourceScriptedExtensionFromGit(defaultBranchRepositoryPath, QString(), &defaultBranchCheckoutPath, &defaultBranchOriginMetadata, &error);
+  QVERIFY2(!metadata.isEmpty(), qPrintable(error));
+  QVERIFY(QFileInfo(defaultBranchCheckoutPath).isDir());
+  QCOMPARE(defaultBranchOriginMetadata.value("url").toString(), defaultBranchRepositoryPath);
+  QCOMPARE(defaultBranchOriginMetadata.value("ref").toString(), QString("main"));
+  QCOMPARE(defaultBranchOriginMetadata.value("refKind").toString(), QString("branch"));
+  QCOMPARE(defaultBranchOriginMetadata.value("resolvedRevision").toString(), defaultBranchRevision);
+  QVERIFY(ctk::removeDirRecursively(defaultBranchCheckoutPath));
+
+  QString noManifestCheckoutPath;
+  QVariantMap noManifestOriginMetadata;
+  error.clear();
+  metadata = model.inspectSourceScriptedExtensionFromGit(noManifestRepositoryPath, "main", &noManifestCheckoutPath, &noManifestOriginMetadata, &error);
+  QVERIFY(metadata.isEmpty());
+  QVERIFY(noManifestCheckoutPath.isEmpty());
+  QVERIFY(noManifestOriginMetadata.isEmpty());
+  QVERIFY2(error.contains("slicer-extension.json"), qPrintable(error));
+
+  QString checkoutPath;
+  QVariantMap originMetadata;
+  metadata = model.inspectSourceScriptedExtensionFromGit(repositoryPath, "main", &checkoutPath, &originMetadata, &error);
+  QVERIFY2(!metadata.isEmpty(), qPrintable(error));
+  QVERIFY(QFileInfo(checkoutPath).isDir());
+  QVERIFY(!model.isExtensionInstalled("GitPreviewSourceScripted"));
+
+  QCOMPARE(metadata.value("extensionname").toString(), QString("GitPreviewSourceScripted"));
+  const QVariantMap parsedInstallSource = metadata.value("installSource").toMap();
+  QCOMPARE(parsedInstallSource.value("type").toString(), QString("url"));
+  QCOMPARE(parsedInstallSource.value("url").toString(), QString("https://example.invalid/GitPreviewSourceScripted.zip"));
+  const QVariantMap origin = metadata.value("origin").toMap();
+  QCOMPARE(origin.value("type").toString(), QString("git"));
+  QCOMPARE(origin.value("url").toString(), repositoryPath);
+  QCOMPARE(origin.value("ref").toString(), QString("main"));
+  QCOMPARE(origin.value("refKind").toString(), QString("branch"));
+  QCOMPARE(origin.value("resolvedRevision").toString(), branchRevision);
+  QCOMPARE(originMetadata, origin);
+
+  QVERIFY(model.installInspectedSourceScriptedExtensionFromGit(checkoutPath, originMetadata, /* installDependencies= */ false));
+  QCOMPARE(model.extensionMetadata("GitPreviewSourceScripted").value("revision").toString(), branchRevision);
+  QCOMPARE(model.extensionMetadata("GitPreviewSourceScripted").value("scmurl").toString(), repositoryPath);
+  QFile sidecarFile(installPath + "/GitPreviewSourceScripted/source-scripted-extension.json");
+  QVERIFY(sidecarFile.open(QFile::ReadOnly));
+  const QJsonObject sidecar = QJsonDocument::fromJson(sidecarFile.readAll()).object();
+  const QJsonObject installedOrigin = sidecar.value("origin").toObject();
+  QCOMPARE(installedOrigin.value("url").toString(), repositoryPath);
+  QCOMPARE(installedOrigin.value("resolvedRevision").toString(), branchRevision);
+  QVERIFY(!sidecar.contains("installSource"));
+
+  QVERIFY(ctk::removeDirRecursively(checkoutPath));
+}
+
+// ----------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelTester::testInstallSourceScriptedExtensionFromGit()
+{
+  QVERIFY(this->resetTmp());
+
+  const QString installPath = this->Tmp.filePath("Extensions");
+  QSettings().setValue("Extensions/InstallPath", installPath);
+
+  QString branchRevision;
+  const QString branchRepositoryPath = this->createSourceScriptedGitRepository("GitBranchSourceScripted", &branchRevision);
+  QVERIFY(!branchRepositoryPath.isEmpty());
+
+  QString tagRevision;
+  const QString tagRepositoryPath = this->createSourceScriptedGitRepository("GitTagSourceScripted", &tagRevision, "v1.0.0");
+  QVERIFY(!tagRepositoryPath.isEmpty());
+
+  QString commitRevision;
+  const QString commitRepositoryPath = this->createSourceScriptedGitRepository("GitCommitSourceScripted", &commitRevision);
+  QVERIFY(!commitRepositoryPath.isEmpty());
+
+  qSlicerExtensionsManagerModel model;
+  model.setExtensionsSettingsFilePath(QSettings().fileName());
+  model.setSlicerRequirements("30987", Slicer_OS_LINUX_NAME, "amd64");
+
+  QVERIFY(model.installSourceScriptedExtensionFromGit(branchRepositoryPath, "main", /* installDependencies= */ false));
+  QVERIFY(model.installSourceScriptedExtensionFromGit(tagRepositoryPath, "v1.0.0", /* installDependencies= */ false));
+  QVERIFY(model.installSourceScriptedExtensionFromGit(commitRepositoryPath, commitRevision, /* installDependencies= */ false));
+
+  QCOMPARE(model.extensionMetadata("GitBranchSourceScripted").value("scm").toString(), QString("git"));
+  QCOMPARE(model.extensionMetadata("GitBranchSourceScripted").value("scmurl").toString(), branchRepositoryPath);
+  QCOMPARE(model.extensionMetadata("GitBranchSourceScripted").value("revision").toString(), branchRevision);
+
+  QFile sidecarFile(installPath + "/GitBranchSourceScripted/source-scripted-extension.json");
+  QVERIFY(sidecarFile.open(QFile::ReadOnly));
+  const QJsonObject sidecar = QJsonDocument::fromJson(sidecarFile.readAll()).object();
+  const QJsonObject origin = sidecar.value("origin").toObject();
+  QCOMPARE(origin.value("type").toString(), QString("git"));
+  QCOMPARE(origin.value("url").toString(), branchRepositoryPath);
+  QCOMPARE(origin.value("ref").toString(), QString("main"));
+  QCOMPARE(origin.value("refKind").toString(), QString("branch"));
+  QCOMPARE(origin.value("resolvedRevision").toString(), branchRevision);
+
+  QFile branchModuleFile(QDir(branchRepositoryPath).filePath("Modules/GitBranchSourceScripted/GitBranchSourceScripted.py"));
+  QVERIFY(branchModuleFile.open(QFile::WriteOnly | QFile::Append));
+  branchModuleFile.write("\nUPDATED = True\n");
+  branchModuleFile.close();
+  QString updatedBranchRevision;
+  QVERIFY(this->commitGitRepository(branchRepositoryPath, "Update branch source", &updatedBranchRevision));
+  QVERIFY(updatedBranchRevision != branchRevision);
+
+  QFile tagModuleFile(QDir(tagRepositoryPath).filePath("Modules/GitTagSourceScripted/GitTagSourceScripted.py"));
+  QVERIFY(tagModuleFile.open(QFile::WriteOnly | QFile::Append));
+  tagModuleFile.write("\nUPDATED = True\n");
+  tagModuleFile.close();
+  QString updatedTagRepositoryRevision;
+  QVERIFY(this->commitGitRepository(tagRepositoryPath, "Update tag repository source", &updatedTagRepositoryRevision));
+
+  QFile commitModuleFile(QDir(commitRepositoryPath).filePath("Modules/GitCommitSourceScripted/GitCommitSourceScripted.py"));
+  QVERIFY(commitModuleFile.open(QFile::WriteOnly | QFile::Append));
+  commitModuleFile.write("\nUPDATED = True\n");
+  commitModuleFile.close();
+  QString updatedCommitRepositoryRevision;
+  QVERIFY(this->commitGitRepository(commitRepositoryPath, "Update commit repository source", &updatedCommitRepositoryRevision));
+
+  model.checkForExtensionsUpdates();
+  QVERIFY(model.isExtensionUpdateAvailable("GitBranchSourceScripted"));
+  QVERIFY(!model.isExtensionUpdateAvailable("GitTagSourceScripted"));
+  QVERIFY(!model.isExtensionUpdateAvailable("GitCommitSourceScripted"));
+  const qSlicerExtensionsManagerModel::ExtensionMetadataType gitBranchUpdateMetadata =
+    model.extensionMetadata("GitBranchSourceScripted", qSlicerExtensionsManagerModel::MetadataServer);
+  QCOMPARE(gitBranchUpdateMetadata.value("revision").toString(), updatedBranchRevision);
+  QCOMPARE(gitBranchUpdateMetadata.value("scmurl").toString(), branchRepositoryPath);
+
+  QVERIFY(model.scheduleExtensionForUpdate("GitBranchSourceScripted"));
+  QStringList updatedExtensions;
+  QVERIFY(model.updateScheduledExtensions(updatedExtensions));
+  QVERIFY(updatedExtensions.contains("GitBranchSourceScripted"));
+  QCOMPARE(model.extensionMetadata("GitBranchSourceScripted").value("revision").toString(), updatedBranchRevision);
 }
 
 // ----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -22,15 +22,21 @@
 #include <QDebug>
 #include <QDir>
 #include <QElapsedTimer>
+#include <QFileInfo>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QJsonParseError>
 #include <QMessageBox>
 #include <QNetworkAccessManager>
 #include <QNetworkRequest>
 #include <QNetworkReply>
+#include <QProcess>
+#include <QRegularExpression>
 #include <QScopedPointer>
 #include <QSettings>
 #include <QStandardItemModel>
+#include <QTemporaryDir>
 #include <QTemporaryFile>
 #include <QTextStream>
 #include <QThread>
@@ -61,6 +67,14 @@
 namespace
 {
 
+const char SOURCE_SCRIPTED_EXTENSION_TYPE[] = "source-scripted";
+const char SOURCE_SCRIPTED_MANIFEST_FILE[] = "slicer-extension.json";
+const char SOURCE_SCRIPTED_INSTALLED_SOURCE_DIR[] = "source";
+const char SOURCE_SCRIPTED_SIDECAR_FILE[] = "source-scripted-extension.json";
+const char SOURCE_SCRIPTED_INSTALL_SOURCE_KEY[] = "installSource";
+const char SOURCE_SCRIPTED_ORIGIN_TYPE_GIT[] = "git";
+const char SOURCE_SCRIPTED_GIT_UPDATE_TYPE[] = "source-scripted-git";
+
 // --------------------------------------------------------------------------
 struct UpdateDownloadInformation
 {
@@ -73,6 +87,11 @@ struct UpdateDownloadInformation
   QString ArchiveName;
   qint64 DownloadSize{ 0 };
   qint64 DownloadProgress{ 0 };
+  QString SourceType;
+  QString SourceUrl;
+  QString SourceRef;
+  QString SourceRevision;
+  QString SourceRefKind;
 };
 
 // --------------------------------------------------------------------------
@@ -82,6 +101,321 @@ public:
   QHash<int, QByteArray> roleNames() const override { return this->CustomRoleNames; }
   QHash<int, QByteArray> CustomRoleNames;
 };
+
+// --------------------------------------------------------------------------
+void setErrorMessage(QString* errorMessage, const QString& message)
+{
+  if (errorMessage)
+  {
+    *errorMessage = message;
+  }
+}
+
+// --------------------------------------------------------------------------
+bool isSafeRelativePath(const QString& path, QString* errorMessage, QString* cleanPath = nullptr)
+{
+  QString normalizedPath = path.trimmed();
+  if (normalizedPath.isEmpty())
+  {
+    setErrorMessage(errorMessage, qSlicerExtensionsManagerModel::tr("Path is empty"));
+    return false;
+  }
+  if (normalizedPath.contains("\\"))
+  {
+    setErrorMessage(errorMessage, qSlicerExtensionsManagerModel::tr("Path '%1' must use forward slashes").arg(path));
+    return false;
+  }
+  if (normalizedPath.contains(":") || QDir::isAbsolutePath(normalizedPath))
+  {
+    setErrorMessage(errorMessage, qSlicerExtensionsManagerModel::tr("Path '%1' must be relative").arg(path));
+    return false;
+  }
+
+  const QString cleanedPath = QDir::cleanPath(normalizedPath);
+  if (cleanedPath == "." || cleanedPath == ".." || cleanedPath.startsWith("../") || cleanedPath.startsWith("/"))
+  {
+    setErrorMessage(errorMessage, qSlicerExtensionsManagerModel::tr("Path '%1' must stay inside the extension source").arg(path));
+    return false;
+  }
+  if (cleanPath)
+  {
+    *cleanPath = cleanedPath;
+  }
+  return true;
+}
+
+// --------------------------------------------------------------------------
+bool pathIsInsideDirectory(const QString& path, const QString& directory)
+{
+  const QString canonicalPath = QFileInfo(path).canonicalFilePath();
+  QString canonicalDirectory = QFileInfo(directory).canonicalFilePath();
+  if (canonicalPath.isEmpty() || canonicalDirectory.isEmpty())
+  {
+    return false;
+  }
+  canonicalDirectory = QDir::cleanPath(canonicalDirectory);
+  const QString cleanedPath = QDir::cleanPath(canonicalPath);
+  return cleanedPath == canonicalDirectory || cleanedPath.startsWith(canonicalDirectory + "/");
+}
+
+// --------------------------------------------------------------------------
+bool readStringValue(const QJsonObject& object, const QString& key, bool required, QString& value, QString* errorMessage)
+{
+  if (!object.contains(key))
+  {
+    if (required)
+    {
+      setErrorMessage(errorMessage, qSlicerExtensionsManagerModel::tr("Manifest is missing required key '%1'").arg(key));
+      return false;
+    }
+    value.clear();
+    return true;
+  }
+  if (!object.value(key).isString())
+  {
+    setErrorMessage(errorMessage, qSlicerExtensionsManagerModel::tr("Manifest key '%1' must be a string").arg(key));
+    return false;
+  }
+  value = object.value(key).toString().trimmed();
+  if (required && value.isEmpty())
+  {
+    setErrorMessage(errorMessage, qSlicerExtensionsManagerModel::tr("Manifest key '%1' must not be empty").arg(key));
+    return false;
+  }
+  return true;
+}
+
+// --------------------------------------------------------------------------
+bool readStringArrayValue(const QJsonObject& object, const QString& key, QStringList& values, QString* errorMessage)
+{
+  values.clear();
+  if (!object.contains(key))
+  {
+    return true;
+  }
+  if (!object.value(key).isArray())
+  {
+    setErrorMessage(errorMessage, qSlicerExtensionsManagerModel::tr("Manifest key '%1' must be an array of strings").arg(key));
+    return false;
+  }
+  const QJsonArray array = object.value(key).toArray();
+  for (const QJsonValue& value : array)
+  {
+    if (!value.isString() || value.toString().trimmed().isEmpty())
+    {
+      setErrorMessage(errorMessage, qSlicerExtensionsManagerModel::tr("Manifest key '%1' must contain only non-empty strings").arg(key));
+      return false;
+    }
+    values << value.toString().trimmed();
+  }
+  values.removeDuplicates();
+  return true;
+}
+
+// --------------------------------------------------------------------------
+QStringList splitDependencyList(const QString& depends)
+{
+  return depends.split(" ", Qt::SkipEmptyParts);
+}
+
+// --------------------------------------------------------------------------
+QJsonArray stringListToJsonArray(const QStringList& values)
+{
+  QJsonArray array;
+  for (const QString& value : values)
+  {
+    array.append(value);
+  }
+  return array;
+}
+
+// --------------------------------------------------------------------------
+QString sourceScriptedArchiveTemporaryFileTemplate(const QString& archiveName)
+{
+  QFileInfo archiveInfo(archiveName);
+  QString baseName = archiveInfo.fileName();
+  if (baseName.isEmpty())
+  {
+    baseName = "source-scripted-extension.tar.gz";
+  }
+
+  const QString completeSuffix = QFileInfo(baseName).completeSuffix();
+  if (completeSuffix.isEmpty())
+  {
+    return QDir::temp().filePath(baseName + ".XXXXXX");
+  }
+
+  const QString suffix = "." + completeSuffix;
+  if (baseName.endsWith(suffix))
+  {
+    baseName.chop(suffix.size());
+  }
+  if (baseName.isEmpty())
+  {
+    baseName = "source-scripted-extension";
+  }
+  return QDir::temp().filePath(baseName + ".XXXXXX" + suffix);
+}
+
+// --------------------------------------------------------------------------
+QString sourceScriptedArchiveNameFromUrl(const QUrl& archiveUrl)
+{
+  const QFileInfo archiveInfo(archiveUrl.path());
+  return archiveInfo.fileName().isEmpty() ? QString("source-scripted-extension.tar.gz") : archiveInfo.fileName();
+}
+
+// --------------------------------------------------------------------------
+QJsonObject sourceScriptedOriginObject(const QString& originType, const QString& originLocation)
+{
+  QJsonObject originObject;
+  if (originType.isEmpty() || originLocation.isEmpty())
+  {
+    return originObject;
+  }
+  originObject.insert("type", originType);
+  originObject.insert(originType == "url" || originType == SOURCE_SCRIPTED_ORIGIN_TYPE_GIT ? "url" : "path", originLocation);
+  return originObject;
+}
+
+// --------------------------------------------------------------------------
+bool validateSourceScriptedInstallSource(const QJsonObject& installSource, QString* errorMessage)
+{
+  QString installSourceType;
+  if (!readStringValue(installSource, "type", /* required= */ true, installSourceType, errorMessage))
+  {
+    return false;
+  }
+  if (installSourceType == SOURCE_SCRIPTED_ORIGIN_TYPE_GIT || installSourceType == "url")
+  {
+    QString installSourceUrl;
+    if (!readStringValue(installSource, "url", /* required= */ true, installSourceUrl, errorMessage))
+    {
+      return false;
+    }
+    QString installSourceRef;
+    if (!readStringValue(installSource, "ref", /* required= */ false, installSourceRef, errorMessage))
+    {
+      return false;
+    }
+    return true;
+  }
+
+  setErrorMessage(errorMessage, qSlicerExtensionsManagerModel::tr("Manifest installSource type '%1' is not supported").arg(installSourceType));
+  return false;
+}
+
+// --------------------------------------------------------------------------
+bool sourceScriptedReplyHasDownloadError(QNetworkReply* reply, const QString& sourceUrl, QString& error)
+{
+  if (reply->error() != QNetworkReply::NoError)
+  {
+    error = qSlicerExtensionsManagerModel::tr("Failed downloading source-scripted extension archive from %1: %2").arg(sourceUrl, reply->errorString());
+    return true;
+  }
+
+  const QVariant statusCodeValue = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
+  if (statusCodeValue.isValid())
+  {
+    const int statusCode = statusCodeValue.toInt();
+    if (statusCode < 200 || statusCode >= 300)
+    {
+      error = qSlicerExtensionsManagerModel::tr("Failed downloading source-scripted extension archive from %1: HTTP status %2").arg(sourceUrl).arg(statusCode);
+      return true;
+    }
+  }
+
+  const QVariant redirectTarget = reply->attribute(QNetworkRequest::RedirectionTargetAttribute);
+  if (redirectTarget.isValid() && !redirectTarget.toUrl().isEmpty())
+  {
+    error = qSlicerExtensionsManagerModel::tr("Download of source-scripted extension archive from %1 was redirected to %2")
+              .arg(sourceUrl, reply->url().resolved(redirectTarget.toUrl()).toString());
+    return true;
+  }
+
+  return false;
+}
+
+// --------------------------------------------------------------------------
+bool writeSourceScriptedReplyToTemporaryArchive(QNetworkReply* reply, const QString& archiveName, const QString& sourceUrl, QString& archivePath, QString& error)
+{
+  archivePath.clear();
+
+  if (sourceScriptedReplyHasDownloadError(reply, sourceUrl, error))
+  {
+    return false;
+  }
+
+  const QByteArray body = reply->readAll();
+  if (body.isEmpty())
+  {
+    error = qSlicerExtensionsManagerModel::tr("Downloaded source-scripted extension archive from %1 is empty").arg(sourceUrl);
+    return false;
+  }
+
+  QTemporaryFile file(sourceScriptedArchiveTemporaryFileTemplate(archiveName));
+  file.setAutoRemove(false);
+  if (!file.open())
+  {
+    error = qSlicerExtensionsManagerModel::tr("Could not create temporary file for writing: %1").arg(file.errorString());
+    return false;
+  }
+  if (file.write(body) != body.size())
+  {
+    error = qSlicerExtensionsManagerModel::tr("Could not write temporary source-scripted extension archive: %1").arg(file.errorString());
+    file.close();
+    QFile::remove(file.fileName());
+    return false;
+  }
+  archivePath = file.fileName();
+  file.close();
+  return true;
+}
+
+// --------------------------------------------------------------------------
+bool parseFirstGitLsRemoteRevision(const QString& output, QString& revision)
+{
+  revision.clear();
+  const QStringList lines = output.split(QRegularExpression("[\r\n]"), Qt::SkipEmptyParts);
+  if (lines.isEmpty())
+  {
+    return false;
+  }
+  revision = lines.first().section(QRegularExpression("\\s+"), 0, 0).trimmed();
+  return !revision.isEmpty();
+}
+
+// --------------------------------------------------------------------------
+bool isGitCommitReference(const QString& ref)
+{
+  static QRegularExpression commitReferenceExpression("^[0-9a-fA-F]{7,40}$");
+  return commitReferenceExpression.match(ref).hasMatch();
+}
+
+// --------------------------------------------------------------------------
+QString normalizedGitBranchRef(QString ref)
+{
+  if (ref.startsWith("refs/heads/"))
+  {
+    ref.remove(0, QString("refs/heads/").size());
+  }
+  return ref;
+}
+
+// --------------------------------------------------------------------------
+QString normalizedGitTagRef(QString ref)
+{
+  if (ref.startsWith("refs/tags/"))
+  {
+    ref.remove(0, QString("refs/tags/").size());
+  }
+  return ref;
+}
+
+// --------------------------------------------------------------------------
+QString compactJsonObject(const QJsonObject& object)
+{
+  return QString::fromUtf8(QJsonDocument(object).toJson(QJsonDocument::Compact));
+}
 
 } // end of anonymous namespace
 
@@ -101,6 +435,7 @@ public:
   {
     IdColumn = 0,
     NameColumn,
+    ExtensionTypeColumn,
     ScmColumn,
     ScmUrlColumn,
     DependsColumn,
@@ -129,6 +464,7 @@ public:
   {
     IdRole = Qt::UserRole + 1,
     NameRole,
+    ExtensionTypeRole,
     ScmRole,
     ScmUrlRole,
     DependsRole,
@@ -194,10 +530,22 @@ public:
   void removeExtensionFromScheduledForUninstallList(const QString& extensionName);
 
   QString extractArchive(const QDir& extensionsDir, const QString& archiveFile);
+  bool extractSourceScriptedArchive(const QString& archiveFile,
+                                    const QString& destinationPath,
+                                    QString& sourcePath,
+                                    QString& error,
+                                    const QString& sourceDescription = QString()) const;
+
+  bool installSourceScriptedExtensionFromPath(const QString& sourcePath, const QJsonObject& originObject, bool installDependencies);
+  bool runGit(const QStringList& arguments, const QString& workingDirectory, QString* standardOutput, QString& error) const;
+  bool resolveRemoteGitBranchRevision(const QString& repositoryUrl, const QString& branch, QString& revision, QString& error) const;
+  bool checkoutSourceScriptedGitExtension(const QString& repositoryUrl, const QString& ref, const QString& destinationPath, QJsonObject& originObject, QString& error) const;
+  bool updateSourceScriptedGitExtension(const QString& extensionName, const QJsonObject& updateDescriptor);
 
   qSlicerExtensionDownloadTask* downloadExtensionByName(const QString& extensionName);
 
   QStringList dependenciesToInstall(const QStringList& directDependencies, QStringList& unresolvedDependencies);
+  bool installExtensionDependencies(const QString& extensionName, const QStringList& directDependencies);
 
   /// Update (reinstall) specified extension.
   ///
@@ -219,9 +567,13 @@ public:
   QStringList extensionLibraryPaths(const QString& extensionName) const;
   QStringList extensionQtPluginPaths(const QString& extensionName) const;
   QStringList extensionPaths(const QString& extensionName) const;
+  bool isSourceScriptedExtension(const QString& extensionName) const;
+  QJsonObject sourceScriptedExtensionManifest(const QString& extensionName) const;
+  QStringList sourceScriptedExtensionModulePaths(const QString& extensionName) const;
 
 #ifdef Slicer_USE_PYTHONQT
   QStringList extensionPythonPaths(const QString& extensionName) const;
+  QStringList sourceScriptedExtensionPythonPaths(const QString& extensionName) const;
 #endif
   static bool validateExtensionMetadata(const ExtensionMetadataType& extensionMetadata, int serverAPI);
 
@@ -286,6 +638,7 @@ void qSlicerExtensionsManagerModelPrivate::init()
 
   this->initializeColumnIdToNameMap(Self::IdColumn, "extension_id");
   this->initializeColumnIdToNameMap(Self::NameColumn, "extensionname");
+  this->initializeColumnIdToNameMap(Self::ExtensionTypeColumn, "extensiontype");
   this->initializeColumnIdToNameMap(Self::ScmColumn, "scm");
   this->initializeColumnIdToNameMap(Self::ScmUrlColumn, "scmurl");
   this->initializeColumnIdToNameMap(Self::SlicerRevisionColumn, "slicer_revision");
@@ -515,6 +868,83 @@ QStringList qSlicerExtensionsManagerModelPrivate::dependenciesToInstall(const QS
     dependencies.removeDuplicates();
   }
   return toInstall;
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModelPrivate::installExtensionDependencies(const QString& extensionName, const QStringList& directDependencies)
+{
+  Q_Q(qSlicerExtensionsManagerModel);
+  bool success = true;
+
+  QStringList unresolvedDependencies;
+  QStringList dependenciesToInstall = this->dependenciesToInstall(directDependencies, unresolvedDependencies);
+
+  // Prompt to install dependencies (if any)
+  if (!dependenciesToInstall.isEmpty())
+  {
+    QMessageBox::StandardButton result = QMessageBox::Yes;
+    if (this->Interactive && !this->AutoInstallDependencies)
+    {
+      QString msg = QString("<p>%1 depends on the following extensions:</p><ul>").arg(extensionName);
+      for (const QString& dependencyName : dependenciesToInstall)
+      {
+        msg += QString("<li>%1</li>").arg(dependencyName);
+      }
+      msg += "</ul><p>Would you like to install them now?</p>";
+      result = QMessageBox::question(nullptr, "Install dependencies", msg, QMessageBox::Yes | QMessageBox::No);
+    }
+    else
+    {
+      QString msg =
+        QString("The following extensions are required by %1 extension therefore they will be installed now: %2").arg(extensionName).arg(dependenciesToInstall.join(", "));
+      qDebug() << msg;
+    }
+
+    if (result == QMessageBox::Yes)
+    {
+      // Install dependencies
+      QString msg;
+      for (const QString& dependency : dependenciesToInstall)
+      {
+        bool res = q->downloadAndInstallExtensionByName(dependency, false /*installation of dependencies already confirmed*/);
+        if (!res)
+        {
+          msg += QString("<li>%1</li>").arg(dependency);
+          success = false;
+        }
+      }
+      if (!msg.isEmpty())
+      {
+        this->critical(qSlicerExtensionsManagerModel::tr("Error while installing dependent extensions:<ul>%1<ul>").arg(msg));
+      }
+    }
+    else
+    {
+      // Skip installing dependencies
+      qWarning() << QString("%1 extension requires extensions %2 but the user chose not to install them.").arg(extensionName).arg(dependenciesToInstall.join(", "));
+      success = false;
+    }
+  }
+
+  // Warn about unresolved dependencies
+  if (!unresolvedDependencies.isEmpty())
+  {
+    success = false;
+    qWarning() << QString(/*no tr*/ "%1 extension depends on the following extensions, which could not be found: %2").arg(extensionName).arg(unresolvedDependencies.join(", "));
+    if (this->Interactive)
+    {
+      //: %1 is the extension name
+      QString msg = QString("<p>%1</p><ul>").arg(qSlicerExtensionsManagerModel::tr("%1 depends on the following extensions, which could not be found:").arg(extensionName));
+      for (const QString& dependencyName : unresolvedDependencies)
+      {
+        msg += QString("<li>%1</li>").arg(dependencyName);
+      }
+      msg += QString("</ul><p>%1</p>").arg(qSlicerExtensionsManagerModel::tr("The extension may not function properly."));
+      QMessageBox::warning(nullptr, qSlicerExtensionsManagerModel::tr("Unresolved dependencies"), msg);
+    }
+  }
+
+  return success;
 }
 
 // --------------------------------------------------------------------------
@@ -878,9 +1308,529 @@ QString qSlicerExtensionsManagerModelPrivate::extractArchive(const QDir& extensi
 }
 
 // --------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModelPrivate::extractSourceScriptedArchive(const QString& archiveFile,
+                                                                        const QString& destinationPath,
+                                                                        QString& sourcePath,
+                                                                        QString& error,
+                                                                        const QString& sourceDescription /*=QString()*/) const
+{
+  sourcePath.clear();
+  const QString displaySource = sourceDescription.isEmpty() ? archiveFile : sourceDescription;
+
+  std::vector<std::string> archiveContents;
+  if (!vtkArchive::ListArchive(qPrintable(archiveFile), archiveContents))
+  {
+    error = qSlicerExtensionsManagerModel::tr("Source-scripted extension archive '%1' is not a supported archive").arg(displaySource);
+    return false;
+  }
+  if (archiveContents.empty())
+  {
+    error = qSlicerExtensionsManagerModel::tr("Source-scripted extension archive '%1' is empty").arg(displaySource);
+    return false;
+  }
+
+  QStringList topLevelEntries;
+  bool manifestAtArchiveRoot = false;
+  for (const std::string& archiveEntry : archiveContents)
+  {
+    const QString entryPath = QString::fromLocal8Bit(archiveEntry.data(), static_cast<int>(archiveEntry.size()));
+    QString cleanEntryPath;
+    QString pathError;
+    if (!isSafeRelativePath(entryPath, &pathError, &cleanEntryPath))
+    {
+      error = qSlicerExtensionsManagerModel::tr("Unsafe archive entry '%1': %2").arg(entryPath).arg(pathError);
+      return false;
+    }
+    const QStringList components = cleanEntryPath.split("/", Qt::SkipEmptyParts);
+    if (components.isEmpty())
+    {
+      error = qSlicerExtensionsManagerModel::tr("Unsafe archive entry '%1'").arg(entryPath);
+      return false;
+    }
+    topLevelEntries << components.first();
+    if (components.size() == 1 && components.first() == SOURCE_SCRIPTED_MANIFEST_FILE)
+    {
+      manifestAtArchiveRoot = true;
+    }
+  }
+  topLevelEntries.removeDuplicates();
+
+  QDir destinationDir(destinationPath);
+  if (!destinationDir.exists())
+  {
+    error = qSlicerExtensionsManagerModel::tr("Temporary extraction directory '%1' does not exist").arg(destinationPath);
+    return false;
+  }
+
+  ctkScopedCurrentDir scopedCurrentDir(destinationDir.absolutePath());
+  std::vector<std::string> extractedFiles;
+  if (!vtkArchive::ExtractTar(qPrintable(archiveFile), /* verbose= */ false, /* extract= */ true, &extractedFiles))
+  {
+    error = qSlicerExtensionsManagerModel::tr("Failed to extract source-scripted extension archive '%1'").arg(displaySource);
+    return false;
+  }
+
+  if (manifestAtArchiveRoot && QFileInfo(destinationDir.filePath(SOURCE_SCRIPTED_MANIFEST_FILE)).isFile())
+  {
+    sourcePath = destinationDir.absolutePath();
+    return true;
+  }
+
+  if (topLevelEntries.size() == 1)
+  {
+    const QString candidateSourcePath = destinationDir.filePath(topLevelEntries.first());
+    if (QFileInfo(candidateSourcePath + "/" + SOURCE_SCRIPTED_MANIFEST_FILE).isFile())
+    {
+      sourcePath = candidateSourcePath;
+      return true;
+    }
+  }
+
+  error = qSlicerExtensionsManagerModel::tr("Source-scripted extension archive '%1' must contain '%2' at the archive root or in one top-level directory")
+            .arg(displaySource, SOURCE_SCRIPTED_MANIFEST_FILE);
+  return false;
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModelPrivate::installSourceScriptedExtensionFromPath(const QString& sourcePath, const QJsonObject& originObject, bool withDependencies)
+{
+  Q_Q(qSlicerExtensionsManagerModel);
+
+  const QString manifestFilePath = QDir(sourcePath).filePath(SOURCE_SCRIPTED_MANIFEST_FILE);
+  QString error;
+  ExtensionMetadataType extensionMetadata = qSlicerExtensionsManagerModel::parseSourceScriptedExtensionManifest(manifestFilePath, &error);
+  if (extensionMetadata.isEmpty())
+  {
+    this->critical(error);
+    return false;
+  }
+
+  const QString extensionName = extensionMetadata.value("extensionname").toString();
+  if (q->isExtensionInstalled(extensionName))
+  {
+    this->warning(qSlicerExtensionsManagerModel::tr("Skip installation of %1 extension. It is already installed.").arg(extensionName));
+    return false;
+  }
+  if (q->extensionsInstallPath().isEmpty())
+  {
+    this->critical(qSlicerExtensionsManagerModel::tr("Extensions/InstallPath setting is not set"));
+    return false;
+  }
+  if (!QDir().mkpath(q->extensionsInstallPath()))
+  {
+    this->critical(qSlicerExtensionsManagerModel::tr("Failed to create extension installation directory %1").arg(q->extensionsInstallPath()));
+    return false;
+  }
+  if (!this->checkExtensionSettingsPermissions(error))
+  {
+    this->critical(error);
+    return false;
+  }
+
+  const QString extensionInstallPath = q->extensionInstallPath(extensionName);
+  ctk::removeDirRecursively(extensionInstallPath);
+  if (!QDir().mkpath(extensionInstallPath))
+  {
+    this->critical(qSlicerExtensionsManagerModel::tr("Failed to create extension installation directory %1").arg(extensionInstallPath));
+    return false;
+  }
+
+  const QString installedSourcePath = extensionInstallPath + "/" + SOURCE_SCRIPTED_INSTALLED_SOURCE_DIR;
+  if (!ctk::copyDirRecursively(QFileInfo(sourcePath).absoluteFilePath(), installedSourcePath))
+  {
+    this->critical(qSlicerExtensionsManagerModel::tr("Failed to copy directory %1 into directory %2").arg(sourcePath, installedSourcePath));
+    return false;
+  }
+
+  QJsonObject sidecarManifest;
+  sidecarManifest.insert("schema", extensionMetadata.value("schema").toString());
+  sidecarManifest.insert("type", SOURCE_SCRIPTED_EXTENSION_TYPE);
+  sidecarManifest.insert("extensionname", extensionName);
+
+  const QStringList optionalStringKeys = QStringList() << "description"
+                                                       << "contributors"
+                                                       << "homepage"
+                                                       << "iconurl"
+                                                       << "category"
+                                                       << "screenshots"
+                                                       << "status";
+  for (const QString& key : optionalStringKeys)
+  {
+    const QString value = extensionMetadata.value(key).toString();
+    if (!value.isEmpty())
+    {
+      sidecarManifest.insert(key, value);
+    }
+  }
+
+  QJsonArray modulesArray;
+  const QVariantList modules = extensionMetadata.value("modules").toList();
+  for (const QVariant& moduleVariant : modules)
+  {
+    const QVariantMap moduleMap = moduleVariant.toMap();
+    QJsonObject moduleObject;
+    moduleObject.insert("name", moduleMap.value("name").toString());
+    moduleObject.insert("path", moduleMap.value("path").toString());
+    modulesArray.append(moduleObject);
+  }
+  sidecarManifest.insert("modules", modulesArray);
+
+  sidecarManifest.insert("depends", stringListToJsonArray(splitDependencyList(extensionMetadata.value("depends").toString())));
+  sidecarManifest.insert("pythonPaths", stringListToJsonArray(extensionMetadata.value("pythonpaths").toStringList()));
+
+  if (!originObject.isEmpty())
+  {
+    sidecarManifest.insert("origin", originObject);
+  }
+
+  QFile sidecarFile(extensionInstallPath + "/" + SOURCE_SCRIPTED_SIDECAR_FILE);
+  if (!sidecarFile.open(QFile::WriteOnly | QFile::Truncate))
+  {
+    this->critical(qSlicerExtensionsManagerModel::tr("Failed to write source-scripted extension manifest %1").arg(sidecarFile.fileName()));
+    return false;
+  }
+  sidecarFile.write(QJsonDocument(sidecarManifest).toJson(QJsonDocument::Indented));
+  sidecarFile.close();
+
+  if (!extensionMetadata.contains("enabled"))
+  {
+    extensionMetadata.insert("enabled", this->NewExtensionEnabledByDefault);
+  }
+  extensionMetadata.insert("installed", true);
+  const QString originType = originObject.value("type").toString();
+  const QString originLocation =
+    originType == "url" || originType == SOURCE_SCRIPTED_ORIGIN_TYPE_GIT ? originObject.value("url").toString() : originObject.value("path").toString();
+  extensionMetadata.insert("archivename", QFileInfo(originLocation).fileName());
+  if (originType == SOURCE_SCRIPTED_ORIGIN_TYPE_GIT)
+  {
+    extensionMetadata.insert("scm", SOURCE_SCRIPTED_ORIGIN_TYPE_GIT);
+    extensionMetadata.insert("scmurl", originObject.value("url").toString());
+    extensionMetadata.insert("revision", originObject.value("resolvedRevision").toString());
+  }
+  else
+  {
+    extensionMetadata.insert("scm", "NA");
+    extensionMetadata.insert("scmurl", "NA");
+    extensionMetadata.insert("revision", "NA");
+  }
+
+  bool success = true;
+  if (withDependencies)
+  {
+    success = this->installExtensionDependencies(extensionName, splitDependencyList(extensionMetadata.value("depends").toString()));
+  }
+
+  const bool bookmarked = QSettings().value("Extensions/Bookmarked").toStringList().contains(extensionName);
+  extensionMetadata.insert("bookmarked", bookmarked);
+  this->addExtensionModelRow(extensionMetadata);
+  this->addExtensionSettings(extensionName);
+
+  q->writeExtensionDescriptionFile(q->extensionDescriptionFile(extensionName), q->extensionMetadata(extensionName));
+
+  emit q->extensionInstalled(extensionName);
+  this->info(qSlicerExtensionsManagerModel::tr("Installed source-scripted extension %1").arg(extensionName));
+
+  return success;
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModelPrivate::runGit(const QStringList& arguments, const QString& workingDirectory, QString* standardOutput, QString& error) const
+{
+  QProcess process;
+  if (!workingDirectory.isEmpty())
+  {
+    process.setWorkingDirectory(workingDirectory);
+  }
+  process.start("git", arguments);
+  if (!process.waitForStarted(30000))
+  {
+    error = qSlicerExtensionsManagerModel::tr("Failed to start git: %1").arg(process.errorString());
+    return false;
+  }
+  if (!process.waitForFinished(300000))
+  {
+    process.kill();
+    process.waitForFinished();
+    error = qSlicerExtensionsManagerModel::tr("Git command timed out: git %1").arg(arguments.join(" "));
+    return false;
+  }
+
+  const QString output = QString::fromLocal8Bit(process.readAllStandardOutput());
+  const QString gitError = QString::fromLocal8Bit(process.readAllStandardError()).trimmed();
+  if (process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0)
+  {
+    error = qSlicerExtensionsManagerModel::tr("Git command failed: git %1").arg(arguments.join(" "));
+    if (!gitError.isEmpty())
+    {
+      error += "\n" + gitError;
+    }
+    return false;
+  }
+  if (standardOutput)
+  {
+    *standardOutput = output.trimmed();
+  }
+  return true;
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModelPrivate::resolveRemoteGitBranchRevision(const QString& repositoryUrl, const QString& branch, QString& revision, QString& error) const
+{
+  QString output;
+  const QString normalizedBranch = normalizedGitBranchRef(branch);
+  if (!this->runGit(QStringList() << "ls-remote"
+                                  << "--heads" << repositoryUrl << normalizedBranch,
+                    QString(),
+                    &output,
+                    error))
+  {
+    return false;
+  }
+  if (!parseFirstGitLsRemoteRevision(output, revision))
+  {
+    error = qSlicerExtensionsManagerModel::tr("Failed to resolve git branch '%1' from %2").arg(normalizedBranch, repositoryUrl);
+    return false;
+  }
+  return true;
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModelPrivate::checkoutSourceScriptedGitExtension(const QString& repositoryUrl,
+                                                                              const QString& requestedRef,
+                                                                              const QString& destinationPath,
+                                                                              QJsonObject& originObject,
+                                                                              QString& error) const
+{
+  originObject = QJsonObject();
+  if (repositoryUrl.trimmed().isEmpty())
+  {
+    error = qSlicerExtensionsManagerModel::tr("Git repository URL is empty");
+    return false;
+  }
+  if (!QDir().mkpath(destinationPath))
+  {
+    error = qSlicerExtensionsManagerModel::tr("Failed to create temporary git checkout directory %1").arg(destinationPath);
+    return false;
+  }
+
+  QString ref = requestedRef.trimmed();
+  QString refKind;
+  if (ref.isEmpty())
+  {
+    refKind = "branch";
+    if (!this->runGit(QStringList() << "clone"
+                                    << "--depth"
+                                    << "1"
+                                    << "--no-recurse-submodules" << repositoryUrl << destinationPath,
+                      QString(),
+                      nullptr,
+                      error))
+    {
+      return false;
+    }
+    QString currentBranch;
+    if (!this->runGit(QStringList() << "rev-parse"
+                                    << "--abbrev-ref"
+                                    << "HEAD",
+                      destinationPath,
+                      &currentBranch,
+                      error))
+    {
+      return false;
+    }
+    ref = currentBranch == "HEAD" ? QString("HEAD") : currentBranch;
+  }
+  else
+  {
+    QString output;
+    const QString branchRef = normalizedGitBranchRef(ref);
+    if (!this->runGit(QStringList() << "ls-remote"
+                                    << "--heads" << repositoryUrl << branchRef,
+                      QString(),
+                      &output,
+                      error))
+    {
+      return false;
+    }
+    if (!output.trimmed().isEmpty())
+    {
+      ref = branchRef;
+      refKind = "branch";
+      if (!this->runGit(QStringList() << "clone"
+                                      << "--depth"
+                                      << "1"
+                                      << "--branch" << ref << "--no-recurse-submodules" << repositoryUrl << destinationPath,
+                        QString(),
+                        nullptr,
+                        error))
+      {
+        return false;
+      }
+    }
+    else
+    {
+      const QString tagRef = normalizedGitTagRef(ref);
+      if (!this->runGit(QStringList() << "ls-remote"
+                                      << "--tags"
+                                      << "--refs" << repositoryUrl << tagRef,
+                        QString(),
+                        &output,
+                        error))
+      {
+        return false;
+      }
+      if (!output.trimmed().isEmpty())
+      {
+        ref = tagRef;
+        refKind = "tag";
+        if (!this->runGit(QStringList() << "clone"
+                                        << "--depth"
+                                        << "1"
+                                        << "--branch" << ref << "--no-recurse-submodules" << repositoryUrl << destinationPath,
+                          QString(),
+                          nullptr,
+                          error))
+        {
+          return false;
+        }
+      }
+      else if (isGitCommitReference(ref))
+      {
+        refKind = "commit";
+        if (!this->runGit(QStringList() << "init", destinationPath, nullptr, error) //
+            || !this->runGit(QStringList() << "remote"
+                                           << "add"
+                                           << "origin" << repositoryUrl,
+                             destinationPath,
+                             nullptr,
+                             error)
+            || !this->runGit(QStringList() << "fetch"
+                                           << "--depth"
+                                           << "1"
+                                           << "origin" << ref,
+                             destinationPath,
+                             nullptr,
+                             error)
+            || !this->runGit(QStringList() << "checkout"
+                                           << "--detach"
+                                           << "FETCH_HEAD",
+                             destinationPath,
+                             nullptr,
+                             error))
+        {
+          return false;
+        }
+      }
+      else
+      {
+        error = qSlicerExtensionsManagerModel::tr("Git ref '%1' was not found as a branch or tag in %2").arg(ref, repositoryUrl);
+        return false;
+      }
+    }
+  }
+
+  QString resolvedRevision;
+  if (!this->runGit(QStringList() << "rev-parse"
+                                  << "HEAD",
+                    destinationPath,
+                    &resolvedRevision,
+                    error))
+  {
+    return false;
+  }
+
+  originObject.insert("type", SOURCE_SCRIPTED_ORIGIN_TYPE_GIT);
+  originObject.insert("url", repositoryUrl);
+  originObject.insert("ref", ref);
+  originObject.insert("resolvedRevision", resolvedRevision);
+  originObject.insert("refKind", refKind);
+  return true;
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModelPrivate::updateSourceScriptedGitExtension(const QString& extensionName, const QJsonObject& updateDescriptor)
+{
+  Q_Q(qSlicerExtensionsManagerModel);
+
+  QString error;
+  if (!this->checkExtensionSettingsPermissions(error))
+  {
+    this->critical(error);
+    return false;
+  }
+
+  QStandardItem* item = this->extensionItem(extensionName);
+  if (!item)
+  {
+    this->critical(qSlicerExtensionsManagerModel::tr("Failed to update %1 extension").arg(extensionName));
+    return false;
+  }
+  if (!q->isExtensionScheduledForUpdate(extensionName))
+  {
+    this->critical(qSlicerExtensionsManagerModel::tr("Failed to update %1 extension: it is not scheduled for update").arg(extensionName));
+    return false;
+  }
+
+  QTemporaryDir checkoutDir;
+  if (!checkoutDir.isValid())
+  {
+    this->critical(qSlicerExtensionsManagerModel::tr("Failed to create temporary directory for source-scripted extension git checkout"));
+    return false;
+  }
+
+  QJsonObject originObject;
+  const QString repositoryUrl = updateDescriptor.value("url").toString();
+  const QString ref = updateDescriptor.value("ref").toString();
+  if (!this->checkoutSourceScriptedGitExtension(repositoryUrl, ref, checkoutDir.path(), originObject, error))
+  {
+    this->critical(error);
+    return false;
+  }
+
+  ExtensionMetadataType extensionMetadata =
+    qSlicerExtensionsManagerModel::parseSourceScriptedExtensionManifest(QDir(checkoutDir.path()).filePath(SOURCE_SCRIPTED_MANIFEST_FILE), &error);
+  if (extensionMetadata.isEmpty())
+  {
+    this->critical(error);
+    return false;
+  }
+  if (extensionMetadata.value("extensionname").toString() != extensionName)
+  {
+    this->critical(qSlicerExtensionsManagerModel::tr("Updated source-scripted extension manifest name '%1' does not match installed extension '%2'")
+                     .arg(extensionMetadata.value("extensionname").toString(), extensionName));
+    return false;
+  }
+
+  const QString& installPath = q->extensionInstallPath(extensionName);
+  const QString& descriptionFile = q->extensionDescriptionFile(extensionName);
+  bool success = true;
+  if (QFile::exists(installPath))
+  {
+    success = ctk::removeDirRecursively(installPath);
+  }
+  if (QFile::exists(descriptionFile))
+  {
+    success = success && QFile::remove(descriptionFile);
+  }
+  success = success && this->Model.removeRow(item->row());
+  success = success && this->installSourceScriptedExtensionFromPath(checkoutDir.path(), originObject, /* installDependencies= */ true);
+  if (success)
+  {
+    this->removeExtensionFromScheduledForUpdateList(extensionName);
+  }
+
+  emit q->extensionUpdated(extensionName);
+  return success;
+}
+
+// --------------------------------------------------------------------------
 QStringList qSlicerExtensionsManagerModelPrivate::extensionLibraryPaths(const QString& extensionName) const
 {
   Q_Q(const qSlicerExtensionsManagerModel);
+  if (this->isSourceScriptedExtension(extensionName))
+  {
+    return QStringList();
+  }
   if (this->SlicerVersion.isEmpty())
   {
     return QStringList();
@@ -900,6 +1850,10 @@ QStringList qSlicerExtensionsManagerModelPrivate::extensionLibraryPaths(const QS
 QStringList qSlicerExtensionsManagerModelPrivate::extensionQtPluginPaths(const QString& extensionName) const
 {
   Q_Q(const qSlicerExtensionsManagerModel);
+  if (this->isSourceScriptedExtension(extensionName))
+  {
+    return QStringList();
+  }
   if (this->SlicerVersion.isEmpty())
   {
     return QStringList();
@@ -912,6 +1866,10 @@ QStringList qSlicerExtensionsManagerModelPrivate::extensionQtPluginPaths(const Q
 QStringList qSlicerExtensionsManagerModelPrivate::extensionPaths(const QString& extensionName) const
 {
   Q_Q(const qSlicerExtensionsManagerModel);
+  if (this->isSourceScriptedExtension(extensionName))
+  {
+    return QStringList();
+  }
   if (this->SlicerVersion.isEmpty())
   {
     return QStringList();
@@ -929,6 +1887,10 @@ QStringList qSlicerExtensionsManagerModelPrivate::extensionPaths(const QString& 
 QStringList qSlicerExtensionsManagerModelPrivate::extensionPythonPaths(const QString& extensionName) const
 {
   Q_Q(const qSlicerExtensionsManagerModel);
+  if (this->isSourceScriptedExtension(extensionName))
+  {
+    return this->sourceScriptedExtensionPythonPaths(extensionName);
+  }
   if (this->SlicerVersion.isEmpty())
   {
     return QStringList();
@@ -946,6 +1908,83 @@ QStringList qSlicerExtensionsManagerModelPrivate::extensionPythonPaths(const QSt
                             << path + "/" + QString(Slicer_QTLOADABLEMODULES_LIB_DIR).replace(Slicer_VERSION, this->SlicerVersion)        //
                             << path + "/" + QString(Slicer_QTLOADABLEMODULES_PYTHON_LIB_DIR).replace(Slicer_VERSION, this->SlicerVersion) //
                             << path + "/" + QString(PYTHON_SITE_PACKAGES_SUBDIR));
+}
+#endif
+
+// --------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModelPrivate::isSourceScriptedExtension(const QString& extensionName) const
+{
+  Q_Q(const qSlicerExtensionsManagerModel);
+  const qSlicerExtensionsManagerModel::ExtensionMetadataType metadata = q->extensionMetadata(extensionName, qSlicerExtensionsManagerModel::MetadataLocal);
+  if (metadata.value("extensiontype").toString() == SOURCE_SCRIPTED_EXTENSION_TYPE)
+  {
+    return true;
+  }
+  return QFileInfo(q->extensionInstallPath(extensionName) + "/" + SOURCE_SCRIPTED_SIDECAR_FILE).exists();
+}
+
+// --------------------------------------------------------------------------
+QJsonObject qSlicerExtensionsManagerModelPrivate::sourceScriptedExtensionManifest(const QString& extensionName) const
+{
+  Q_Q(const qSlicerExtensionsManagerModel);
+  QFile manifestFile(q->extensionInstallPath(extensionName) + "/" + SOURCE_SCRIPTED_SIDECAR_FILE);
+  if (!manifestFile.open(QFile::ReadOnly))
+  {
+    return QJsonObject();
+  }
+
+  QJsonParseError parseError;
+  const QJsonDocument document = QJsonDocument::fromJson(manifestFile.readAll(), &parseError);
+  if (parseError.error != QJsonParseError::NoError || !document.isObject())
+  {
+    return QJsonObject();
+  }
+  return document.object();
+}
+
+// --------------------------------------------------------------------------
+QStringList qSlicerExtensionsManagerModelPrivate::sourceScriptedExtensionModulePaths(const QString& extensionName) const
+{
+  Q_Q(const qSlicerExtensionsManagerModel);
+  const QJsonObject manifest = this->sourceScriptedExtensionManifest(extensionName);
+  const QJsonArray modules = manifest.value("modules").toArray();
+  const QString sourcePath = q->extensionInstallPath(extensionName) + "/" + SOURCE_SCRIPTED_INSTALLED_SOURCE_DIR;
+
+  QStringList modulePaths;
+  for (const QJsonValue& moduleValue : modules)
+  {
+    const QString modulePath = moduleValue.toObject().value("path").toString();
+    if (modulePath.isEmpty())
+    {
+      continue;
+    }
+    const QString moduleDirectory = QFileInfo(modulePath).path();
+    modulePaths << (moduleDirectory == "." ? sourcePath : sourcePath + "/" + moduleDirectory);
+  }
+  modulePaths.removeDuplicates();
+  return appendToPathList(QStringList(), modulePaths);
+}
+
+#ifdef Slicer_USE_PYTHONQT
+// --------------------------------------------------------------------------
+QStringList qSlicerExtensionsManagerModelPrivate::sourceScriptedExtensionPythonPaths(const QString& extensionName) const
+{
+  Q_Q(const qSlicerExtensionsManagerModel);
+  const QJsonObject manifest = this->sourceScriptedExtensionManifest(extensionName);
+  const QJsonArray pythonPathsArray = manifest.value("pythonPaths").toArray();
+  const QString sourcePath = q->extensionInstallPath(extensionName) + "/" + SOURCE_SCRIPTED_INSTALLED_SOURCE_DIR;
+
+  QStringList pythonPaths;
+  for (const QJsonValue& pythonPathValue : pythonPathsArray)
+  {
+    const QString pythonPath = pythonPathValue.toString();
+    if (!pythonPath.isEmpty())
+    {
+      pythonPaths << sourcePath + "/" + pythonPath;
+    }
+  }
+  pythonPaths.removeDuplicates();
+  return appendToPathList(QStringList(), pythonPaths);
 }
 #endif
 
@@ -1138,6 +2177,10 @@ QString qSlicerExtensionsManagerModel::extensionInstallPath(const QString& exten
 QStringList qSlicerExtensionsManagerModel::extensionModulePaths(const QString& extensionName) const
 {
   Q_D(const qSlicerExtensionsManagerModel);
+  if (d->isSourceScriptedExtension(extensionName))
+  {
+    return d->sourceScriptedExtensionModulePaths(extensionName);
+  }
   QString path = this->extensionInstallPath(extensionName);
   return appendToPathList(QStringList(),
                           QStringList()                            //
@@ -1267,6 +2310,17 @@ qSlicerExtensionsManagerModel::ExtensionMetadataType qSlicerExtensionsManagerMod
       && d->ExtensionsMetadataFromServer.contains(extensionName))
   {
     metadata = d->ExtensionsMetadataFromServer[extensionName];
+  }
+  const UpdateDownloadInformation updateInfo = d->AvailableUpdates.value(extensionName);
+  if ((source == MetadataAll || source == MetadataServer)         //
+      && updateInfo.SourceType == SOURCE_SCRIPTED_GIT_UPDATE_TYPE //
+      && !updateInfo.SourceRevision.isEmpty())
+  {
+    metadata.insert("extensionname", extensionName);
+    metadata.insert("extensiontype", SOURCE_SCRIPTED_EXTENSION_TYPE);
+    metadata.insert("scm", SOURCE_SCRIPTED_ORIGIN_TYPE_GIT);
+    metadata.insert("scmurl", updateInfo.SourceUrl);
+    metadata.insert("revision", updateInfo.SourceRevision);
   }
   if (source == MetadataAll || source == MetadataLocal)
   {
@@ -1681,6 +2735,103 @@ bool qSlicerExtensionsManagerModel::downloadAndInstallExtensionByName(const QStr
   return true;
 }
 
+// --------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModel::downloadAndInstallSourceScriptedExtension(const QUrl& archiveUrl, bool installDependencies /*=true*/)
+{
+  Q_D(qSlicerExtensionsManagerModel);
+
+  if (!archiveUrl.isValid() || archiveUrl.isEmpty())
+  {
+    d->critical(tr("Download of source-scripted extension failed, URL is invalid."));
+    return false;
+  }
+
+  if (archiveUrl.isLocalFile())
+  {
+    return this->installSourceScriptedExtension(archiveUrl.toLocalFile(), installDependencies);
+  }
+
+  QString error;
+  if (!d->checkExtensionSettingsPermissions(error))
+  {
+    d->critical(error);
+    return false;
+  }
+
+  QNetworkRequest request(archiveUrl);
+  request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+  QNetworkReply* const reply = d->NetworkManager.get(request);
+  qSlicerExtensionDownloadTask* const task = new qSlicerExtensionDownloadTask(reply);
+  const QString archiveName = sourceScriptedArchiveNameFromUrl(archiveUrl);
+  QVariantMap taskMetadata;
+  taskMetadata.insert("sourceurl", archiveUrl.toString());
+  task->setMetadata(taskMetadata);
+  task->setArchiveName(archiveName);
+  task->setExtensionName(archiveName);
+  task->setInstallDependencies(installDependencies);
+  d->ActiveTasks[task] = tr("install source-scripted extension from %1").arg(archiveUrl.toString());
+
+  connect(task, SIGNAL(finished(qSlicerExtensionDownloadTask*)), this, SLOT(onInstallSourceScriptedDownloadFinished(qSlicerExtensionDownloadTask*)));
+  connect(task, SIGNAL(progress(qSlicerExtensionDownloadTask*, qint64, qint64)), this, SLOT(onInstallDownloadProgress(qSlicerExtensionDownloadTask*, qint64, qint64)));
+
+  emit this->downloadStarted(reply);
+  emit this->activeTasksChanged();
+  return true;
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModel::downloadAndInspectSourceScriptedExtension(const QUrl& archiveUrl, bool installDependencies /*=true*/)
+{
+  Q_D(qSlicerExtensionsManagerModel);
+
+  if (!archiveUrl.isValid() || archiveUrl.isEmpty())
+  {
+    d->critical(tr("Download of source-scripted extension failed, URL is invalid."));
+    return false;
+  }
+
+  if (archiveUrl.isLocalFile())
+  {
+    QString error;
+    ExtensionMetadataType metadata = this->inspectSourceScriptedExtension(archiveUrl.toLocalFile(), &error);
+    if (metadata.isEmpty())
+    {
+      d->critical(error);
+      return false;
+    }
+    metadata.insert("origin", sourceScriptedOriginObject("url", archiveUrl.toString()).toVariantMap());
+    emit this->sourceScriptedExtensionDownloadReady(archiveUrl, archiveUrl.toLocalFile(), metadata, installDependencies);
+    return true;
+  }
+
+  QString error;
+  if (!d->checkExtensionSettingsPermissions(error))
+  {
+    d->critical(error);
+    return false;
+  }
+
+  QNetworkRequest request(archiveUrl);
+  request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+  QNetworkReply* const reply = d->NetworkManager.get(request);
+  qSlicerExtensionDownloadTask* const task = new qSlicerExtensionDownloadTask(reply);
+  const QString archiveName = sourceScriptedArchiveNameFromUrl(archiveUrl);
+  QVariantMap taskMetadata;
+  taskMetadata.insert("sourceurl", archiveUrl.toString());
+  task->setMetadata(taskMetadata);
+  task->setArchiveName(archiveName);
+  task->setExtensionName(archiveName);
+  task->setInstallDependencies(installDependencies);
+  d->ActiveTasks[task] = tr("inspect source-scripted extension from %1").arg(archiveUrl.toString());
+
+  connect(task, SIGNAL(finished(qSlicerExtensionDownloadTask*)), this, SLOT(onInspectSourceScriptedDownloadFinished(qSlicerExtensionDownloadTask*)));
+  connect(task, SIGNAL(progress(qSlicerExtensionDownloadTask*, qint64, qint64)), this, SLOT(onInstallDownloadProgress(qSlicerExtensionDownloadTask*, qint64, qint64)));
+
+  emit this->downloadStarted(reply);
+  emit this->activeTasksChanged();
+  return true;
+}
+
 //-----------------------------------------------------------------------------
 bool qSlicerExtensionsManagerModel::installExtensionFromServer(const QString& extensionName, bool restart, bool update)
 {
@@ -1833,6 +2984,95 @@ void qSlicerExtensionsManagerModel::onInstallDownloadFinished(qSlicerExtensionDo
 }
 
 // --------------------------------------------------------------------------
+void qSlicerExtensionsManagerModel::onInstallSourceScriptedDownloadFinished(qSlicerExtensionDownloadTask* task)
+{
+  Q_D(qSlicerExtensionsManagerModel);
+
+  task->deleteLater();
+
+  QNetworkReply* const reply = task->reply();
+  QUrl downloadUrl = reply->url();
+
+  emit this->downloadFinished(reply);
+
+  const QString sourceUrl = task->metadata().value("sourceurl").toString().isEmpty() ? downloadUrl.toString() : task->metadata().value("sourceurl").toString();
+  const QString archiveName = task->archiveName().isEmpty() ? QString("source-scripted-extension.tar.gz") : task->archiveName();
+  QString archivePath;
+  QString error;
+  if (!writeSourceScriptedReplyToTemporaryArchive(reply, archiveName, sourceUrl, archivePath, error))
+  {
+    d->critical(error);
+    d->ActiveTasks.remove(task);
+    emit activeTasksChanged();
+    return;
+  }
+
+  this->installDownloadedSourceScriptedExtension(archivePath, QUrl(sourceUrl), task->installDependencies());
+  QFile::remove(archivePath);
+  d->ActiveTasks.remove(task);
+  emit activeTasksChanged();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsManagerModel::onInspectSourceScriptedDownloadFinished(qSlicerExtensionDownloadTask* task)
+{
+  Q_D(qSlicerExtensionsManagerModel);
+
+  task->deleteLater();
+
+  QNetworkReply* const reply = task->reply();
+  const QUrl downloadUrl = reply->url();
+
+  emit this->downloadFinished(reply);
+
+  const QString sourceUrl = task->metadata().value("sourceurl").toString().isEmpty() ? downloadUrl.toString() : task->metadata().value("sourceurl").toString();
+  const QString archiveName = task->archiveName().isEmpty() ? QString("source-scripted-extension.tar.gz") : task->archiveName();
+  QString archivePath;
+  QString error;
+  if (!writeSourceScriptedReplyToTemporaryArchive(reply, archiveName, sourceUrl, archivePath, error))
+  {
+    d->critical(error);
+    d->ActiveTasks.remove(task);
+    emit activeTasksChanged();
+    return;
+  }
+
+  QTemporaryDir extractionDir;
+  if (!extractionDir.isValid())
+  {
+    d->critical(tr("Failed to create temporary directory for source-scripted extension archive extraction"));
+    QFile::remove(archivePath);
+    d->ActiveTasks.remove(task);
+    emit activeTasksChanged();
+    return;
+  }
+  QString extractedSourcePath;
+  if (!d->extractSourceScriptedArchive(archivePath, extractionDir.path(), extractedSourcePath, error, sourceUrl))
+  {
+    d->critical(error);
+    QFile::remove(archivePath);
+    d->ActiveTasks.remove(task);
+    emit activeTasksChanged();
+    return;
+  }
+
+  ExtensionMetadataType metadata = Self::parseSourceScriptedExtensionManifest(QDir(extractedSourcePath).filePath(SOURCE_SCRIPTED_MANIFEST_FILE), &error);
+  if (metadata.isEmpty())
+  {
+    d->critical(error);
+    QFile::remove(archivePath);
+    d->ActiveTasks.remove(task);
+    emit activeTasksChanged();
+    return;
+  }
+  metadata.insert("origin", sourceScriptedOriginObject("url", sourceUrl).toVariantMap());
+
+  emit this->sourceScriptedExtensionDownloadReady(QUrl(sourceUrl), archivePath, metadata, task->installDependencies());
+  d->ActiveTasks.remove(task);
+  emit activeTasksChanged();
+}
+
+// --------------------------------------------------------------------------
 bool qSlicerExtensionsManagerModel::installExtension(const QString& archiveFile, bool installDependencies /*=true*/, bool waitForCompletion /*=false*/)
 {
   Q_D(qSlicerExtensionsManagerModel);
@@ -1857,6 +3097,230 @@ bool qSlicerExtensionsManagerModel::installExtension(const QString& archiveFile,
 
   d->critical(tr("No extension description found in archive '%1'").arg(archiveFile));
   return false;
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModel::installSourceScriptedExtension(const QString& sourcePath, bool installDependencies /*=true*/)
+{
+  Q_D(qSlicerExtensionsManagerModel);
+
+  if (sourcePath.isEmpty())
+  {
+    d->critical(tr("Source-scripted extension path is empty"));
+    return false;
+  }
+
+  const QFileInfo sourceInfo(sourcePath);
+  if (sourceInfo.isDir())
+  {
+    return d->installSourceScriptedExtensionFromPath(sourceInfo.absoluteFilePath(), sourceScriptedOriginObject("directory", sourceInfo.absoluteFilePath()), installDependencies);
+  }
+
+  if (!sourceInfo.isFile())
+  {
+    d->critical(tr("Source-scripted extension source does not exist: %1").arg(sourcePath));
+    return false;
+  }
+
+  QTemporaryDir extractionDir;
+  if (!extractionDir.isValid())
+  {
+    d->critical(tr("Failed to create temporary directory for source-scripted extension archive extraction"));
+    return false;
+  }
+
+  QString extractedSourcePath;
+  QString error;
+  if (!d->extractSourceScriptedArchive(sourceInfo.absoluteFilePath(), extractionDir.path(), extractedSourcePath, error))
+  {
+    d->critical(error);
+    return false;
+  }
+
+  return d->installSourceScriptedExtensionFromPath(extractedSourcePath, sourceScriptedOriginObject("archive", sourceInfo.absoluteFilePath()), installDependencies);
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModel::installDownloadedSourceScriptedExtension(const QString& archivePath, const QUrl& sourceUrl, bool installDependencies /*=true*/)
+{
+  Q_D(qSlicerExtensionsManagerModel);
+
+  if (archivePath.isEmpty() || !QFileInfo(archivePath).isFile())
+  {
+    d->critical(tr("Downloaded source-scripted extension archive does not exist: %1").arg(archivePath));
+    return false;
+  }
+
+  QTemporaryDir extractionDir;
+  if (!extractionDir.isValid())
+  {
+    d->critical(tr("Failed to create temporary directory for source-scripted extension archive extraction"));
+    return false;
+  }
+
+  QString extractedSourcePath;
+  QString error;
+  const QString sourceDescription = sourceUrl.isEmpty() ? archivePath : sourceUrl.toString();
+  if (!d->extractSourceScriptedArchive(archivePath, extractionDir.path(), extractedSourcePath, error, sourceDescription))
+  {
+    d->critical(error);
+    return false;
+  }
+
+  return d->installSourceScriptedExtensionFromPath(extractedSourcePath, sourceScriptedOriginObject("url", sourceDescription), installDependencies);
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModel::installSourceScriptedExtensionFromGit(const QString& repositoryUrl, const QString& ref /*=QString()*/, bool installDependencies /*=true*/)
+{
+  Q_D(qSlicerExtensionsManagerModel);
+
+  QString error;
+  if (!d->checkExtensionSettingsPermissions(error))
+  {
+    d->critical(error);
+    return false;
+  }
+
+  QTemporaryDir checkoutDir;
+  if (!checkoutDir.isValid())
+  {
+    d->critical(tr("Failed to create temporary directory for source-scripted extension git checkout"));
+    return false;
+  }
+
+  QJsonObject originObject;
+  if (!d->checkoutSourceScriptedGitExtension(repositoryUrl, ref, checkoutDir.path(), originObject, error))
+  {
+    d->critical(error);
+    return false;
+  }
+  return d->installSourceScriptedExtensionFromPath(checkoutDir.path(), originObject, installDependencies);
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerExtensionsManagerModel::installInspectedSourceScriptedExtensionFromGit(const QString& checkoutPath,
+                                                                                   const QVariantMap& originMetadata,
+                                                                                   bool installDependencies /*=true*/)
+{
+  Q_D(qSlicerExtensionsManagerModel);
+
+  if (checkoutPath.isEmpty() || !QFileInfo(checkoutPath).isDir())
+  {
+    d->critical(tr("Source-scripted extension git checkout does not exist: %1").arg(checkoutPath));
+    return false;
+  }
+
+  const QJsonObject originObject = QJsonObject::fromVariantMap(originMetadata);
+  if (originObject.value("type").toString() != SOURCE_SCRIPTED_ORIGIN_TYPE_GIT || originObject.value("url").toString().isEmpty()
+      || originObject.value("resolvedRevision").toString().isEmpty())
+  {
+    d->critical(tr("Source-scripted extension git origin metadata is incomplete."));
+    return false;
+  }
+
+  return d->installSourceScriptedExtensionFromPath(checkoutPath, originObject, installDependencies);
+}
+
+// --------------------------------------------------------------------------
+qSlicerExtensionsManagerModel::ExtensionMetadataType qSlicerExtensionsManagerModel::inspectSourceScriptedExtension(const QString& sourcePath, QString* errorMessage) const
+{
+  Q_D(const qSlicerExtensionsManagerModel);
+
+  const QFileInfo sourceInfo(sourcePath);
+  if (sourceInfo.isDir())
+  {
+    ExtensionMetadataType metadata = Self::parseSourceScriptedExtensionManifest(QDir(sourceInfo.absoluteFilePath()).filePath(SOURCE_SCRIPTED_MANIFEST_FILE), errorMessage);
+    if (!metadata.isEmpty())
+    {
+      metadata.insert("origin", sourceScriptedOriginObject("directory", sourceInfo.absoluteFilePath()).toVariantMap());
+    }
+    return metadata;
+  }
+
+  if (!sourceInfo.isFile())
+  {
+    setErrorMessage(errorMessage, tr("Source-scripted extension source does not exist: %1").arg(sourcePath));
+    return ExtensionMetadataType();
+  }
+
+  QTemporaryDir extractionDir;
+  if (!extractionDir.isValid())
+  {
+    setErrorMessage(errorMessage, tr("Failed to create temporary directory for source-scripted extension archive extraction"));
+    return ExtensionMetadataType();
+  }
+
+  QString extractedSourcePath;
+  QString error;
+  if (!d->extractSourceScriptedArchive(sourceInfo.absoluteFilePath(), extractionDir.path(), extractedSourcePath, error))
+  {
+    setErrorMessage(errorMessage, error);
+    return ExtensionMetadataType();
+  }
+
+  ExtensionMetadataType metadata = Self::parseSourceScriptedExtensionManifest(QDir(extractedSourcePath).filePath(SOURCE_SCRIPTED_MANIFEST_FILE), errorMessage);
+  if (!metadata.isEmpty())
+  {
+    metadata.insert("origin", sourceScriptedOriginObject("archive", sourceInfo.absoluteFilePath()).toVariantMap());
+  }
+  return metadata;
+}
+
+// --------------------------------------------------------------------------
+qSlicerExtensionsManagerModel::ExtensionMetadataType qSlicerExtensionsManagerModel::inspectSourceScriptedExtensionFromGit(const QString& repositoryUrl,
+                                                                                                                          const QString& ref,
+                                                                                                                          QString* checkoutPath,
+                                                                                                                          QVariantMap* originMetadata,
+                                                                                                                          QString* errorMessage) const
+{
+  Q_D(const qSlicerExtensionsManagerModel);
+
+  if (checkoutPath)
+  {
+    checkoutPath->clear();
+  }
+  if (originMetadata)
+  {
+    originMetadata->clear();
+  }
+
+  QTemporaryDir checkoutDir(QDir::temp().filePath("slicer-source-scripted-git.XXXXXX"));
+  if (!checkoutDir.isValid())
+  {
+    setErrorMessage(errorMessage, tr("Failed to create temporary directory for source-scripted extension git checkout"));
+    return ExtensionMetadataType();
+  }
+  checkoutDir.setAutoRemove(false);
+
+  QString error;
+  QJsonObject originObject;
+  if (!d->checkoutSourceScriptedGitExtension(repositoryUrl, ref, checkoutDir.path(), originObject, error))
+  {
+    QDir(checkoutDir.path()).removeRecursively();
+    setErrorMessage(errorMessage, error);
+    return ExtensionMetadataType();
+  }
+
+  ExtensionMetadataType metadata = Self::parseSourceScriptedExtensionManifest(QDir(checkoutDir.path()).filePath(SOURCE_SCRIPTED_MANIFEST_FILE), &error);
+  if (metadata.isEmpty())
+  {
+    QDir(checkoutDir.path()).removeRecursively();
+    setErrorMessage(errorMessage, error);
+    return ExtensionMetadataType();
+  }
+
+  const QVariantMap originMap = originObject.toVariantMap();
+  metadata.insert("origin", originMap);
+  if (checkoutPath)
+  {
+    *checkoutPath = checkoutDir.path();
+  }
+  if (originMetadata)
+  {
+    *originMetadata = originMap;
+  }
+  return metadata;
 }
 
 // --------------------------------------------------------------------------
@@ -1950,74 +3414,7 @@ bool qSlicerExtensionsManagerModel::installExtension(const QString& extensionNam
   bool success = true;
   if (withDependencies)
   {
-    QStringList unresolvedDependencies;
-    QStringList directDependencies = extensionMetadata.value("depends").toString().split(" ");
-    QStringList dependenciesToInstall = d->dependenciesToInstall(directDependencies, unresolvedDependencies);
-
-    // Prompt to install dependencies (if any)
-    if (!dependenciesToInstall.isEmpty())
-    {
-      QMessageBox::StandardButton result = QMessageBox::Yes;
-      if (d->Interactive && !d->AutoInstallDependencies)
-      {
-        QString msg = QString("<p>%1 depends on the following extensions:</p><ul>").arg(extensionName);
-        for (const QString& dependencyName : dependenciesToInstall)
-        {
-          msg += QString("<li>%1</li>").arg(dependencyName);
-        }
-        msg += "</ul><p>Would you like to install them now?</p>";
-        result = QMessageBox::question(nullptr, "Install dependencies", msg, QMessageBox::Yes | QMessageBox::No);
-      }
-      else
-      {
-        QString msg =
-          QString("The following extensions are required by %1 extension therefore they will be installed now: %2").arg(extensionName).arg(dependenciesToInstall.join(", "));
-        qDebug() << msg;
-      }
-
-      if (result == QMessageBox::Yes)
-      {
-        // Install dependencies
-        QString msg;
-        for (const QString& dependency : dependenciesToInstall)
-        {
-          bool res = this->downloadAndInstallExtensionByName(dependency, false /*installation of dependencies already confirmed*/);
-          if (!res)
-          {
-            msg += QString("<li>%1</li>").arg(dependency);
-            success = false;
-          }
-        }
-        if (!msg.isEmpty())
-        {
-          d->critical(tr("Error while installing dependent extensions:<ul>%1<ul>").arg(msg));
-        }
-      }
-      else
-      {
-        // Skip installing dependencies
-        qWarning() << QString("%1 extension requires extensions %2 but the user chose not to install them.").arg(extensionName).arg(dependenciesToInstall.join(", "));
-        success = false;
-      }
-    }
-
-    // Warn about unresolved dependencies
-    if (!unresolvedDependencies.isEmpty())
-    {
-      success = false;
-      qWarning() << QString(/*no tr*/ "%1 extension depends on the following extensions, which could not be found: %2").arg(extensionName).arg(unresolvedDependencies.join(", "));
-      if (d->Interactive)
-      {
-        //: %1 is the extension name
-        QString msg = QString("<p>%1</p><ul>").arg(tr("%1 depends on the following extensions, which could not be found:").arg(extensionName));
-        for (const QString& dependencyName : unresolvedDependencies)
-        {
-          msg += QString("<li>%1</li>").arg(dependencyName);
-        }
-        msg += QString("</ul><p>%1</p>").arg(tr("The extension may not function properly."));
-        QMessageBox::warning(nullptr, tr("Unresolved dependencies"), msg);
-      }
-    }
+    success = d->installExtensionDependencies(extensionName, splitDependencyList(extensionMetadata.value("depends").toString()));
   }
 
   // Finish installing the extension
@@ -2251,6 +3648,56 @@ void qSlicerExtensionsManagerModel::checkForExtensionsUpdates()
     }
   }
 
+  for (const QString& extensionName : this->installedExtensions())
+  {
+    if (!d->isSourceScriptedExtension(extensionName) || d->AvailableUpdates.contains(extensionName))
+    {
+      continue;
+    }
+    const QJsonObject manifest = d->sourceScriptedExtensionManifest(extensionName);
+    const QJsonObject origin = manifest.value("origin").toObject();
+    if (origin.value("type").toString() != SOURCE_SCRIPTED_ORIGIN_TYPE_GIT || origin.value("refKind").toString() != "branch")
+    {
+      continue;
+    }
+
+    const QString repositoryUrl = origin.value("url").toString();
+    const QString ref = origin.value("ref").toString();
+    const QString installedRevision = origin.value("resolvedRevision").toString();
+    if (repositoryUrl.isEmpty() || ref.isEmpty() || installedRevision.isEmpty())
+    {
+      d->warning(tr("Source-scripted git update check for %1 missed origin URL, ref, or resolved revision").arg(extensionName));
+      continue;
+    }
+
+    QString remoteRevision;
+    QString error;
+    if (!d->resolveRemoteGitBranchRevision(repositoryUrl, ref, remoteRevision, error))
+    {
+      d->warning(error);
+      continue;
+    }
+    if (remoteRevision == installedRevision)
+    {
+      continue;
+    }
+
+    d->debug(tr("Update found for %1 source-scripted extension: '%2' installed, '%3' available").arg(extensionName, installedRevision, remoteRevision));
+    UpdateDownloadInformation updateInfo;
+    updateInfo.SourceType = SOURCE_SCRIPTED_GIT_UPDATE_TYPE;
+    updateInfo.SourceUrl = repositoryUrl;
+    updateInfo.SourceRef = ref;
+    updateInfo.SourceRevision = remoteRevision;
+    updateInfo.SourceRefKind = "branch";
+    d->AvailableUpdates.insert(extensionName, updateInfo);
+    if (d->AutoUpdateInstall)
+    {
+      this->scheduleExtensionForUpdate(extensionName);
+    }
+    emit this->extensionUpdateAvailable(extensionName);
+    updatedExtensionsFound = true;
+  }
+
   if (updatedExtensionsFound)
   {
     QSettings extensionSettings(this->extensionsSettingsFilePath(), QSettings::IniFormat);
@@ -2390,6 +3837,22 @@ bool qSlicerExtensionsManagerModel::scheduleExtensionForUpdate(const QString& ex
   }
 
   const UpdateDownloadInformation& updateInfo = d->AvailableUpdates.value(extensionName);
+  if (updateInfo.SourceType == SOURCE_SCRIPTED_GIT_UPDATE_TYPE)
+  {
+    QJsonObject updateDescriptor;
+    updateDescriptor.insert("type", SOURCE_SCRIPTED_GIT_UPDATE_TYPE);
+    updateDescriptor.insert("url", updateInfo.SourceUrl);
+    updateDescriptor.insert("ref", updateInfo.SourceRef);
+    updateDescriptor.insert("refKind", updateInfo.SourceRefKind);
+    updateDescriptor.insert("resolvedRevision", updateInfo.SourceRevision);
+    scheduled[extensionName] = compactJsonObject(updateDescriptor);
+    settings.setValue("Extensions/ScheduledForUpdate", scheduled);
+
+    d->info(tr("%1 extension scheduled for update").arg(extensionName));
+    emit this->extensionScheduledForUpdate(extensionName);
+    return true;
+  }
+
   if (updateInfo.ArchiveName.isEmpty())
   {
     if (updateInfo.ExtensionId.isEmpty())
@@ -2457,6 +3920,13 @@ bool qSlicerExtensionsManagerModel::cancelExtensionScheduledForUpdate(const QStr
 bool qSlicerExtensionsManagerModelPrivate::updateExtension(const QString& extensionName, const QString& archiveFile)
 {
   Q_Q(qSlicerExtensionsManagerModel);
+
+  QJsonParseError parseError;
+  const QJsonDocument updateDocument = QJsonDocument::fromJson(archiveFile.toUtf8(), &parseError);
+  if (parseError.error == QJsonParseError::NoError && updateDocument.isObject() && updateDocument.object().value("type").toString() == SOURCE_SCRIPTED_GIT_UPDATE_TYPE)
+  {
+    return this->updateSourceScriptedGitExtension(extensionName, updateDocument.object());
+  }
 
   QString error;
   if (!this->checkExtensionSettingsPermissions(error))
@@ -2609,6 +4079,8 @@ bool qSlicerExtensionsManagerModel::uninstallExtension(const QString& extensionN
 
   bool bookmarked = this->isExtensionBookmarked(extensionName);
 
+  d->removeExtensionSettings(extensionName);
+
   bool success = true;
   if (QDir(this->extensionInstallPath(extensionName)).exists())
   {
@@ -2633,8 +4105,11 @@ bool qSlicerExtensionsManagerModel::uninstallExtension(const QString& extensionN
 
   if (success)
   {
-    d->removeExtensionSettings(extensionName);
     d->removeExtensionFromScheduledForUninstallList(extensionName);
+  }
+  else
+  {
+    d->addExtensionSettings(extensionName);
   }
 
   emit this->extensionUninstalled(extensionName);
@@ -3228,6 +4703,195 @@ qSlicerExtensionsManagerModel::ExtensionMetadataType qSlicerExtensionsManagerMod
     {
       metadata["installed"] = "true";
     }
+  }
+
+  return metadata;
+}
+
+// --------------------------------------------------------------------------
+qSlicerExtensionsManagerModel::ExtensionMetadataType qSlicerExtensionsManagerModel::parseSourceScriptedExtensionManifest(const QString& manifestFile, QString* errorMessage)
+{
+  QFile inputFile(manifestFile);
+  if (!inputFile.open(QFile::ReadOnly))
+  {
+    setErrorMessage(errorMessage, tr("Failed to open source-scripted extension manifest '%1'").arg(manifestFile));
+    return ExtensionMetadataType();
+  }
+
+  return Self::parseSourceScriptedExtensionManifestContent(inputFile.readAll(), QFileInfo(manifestFile).absolutePath(), /* validateSourceFiles= */ true, errorMessage);
+}
+
+// --------------------------------------------------------------------------
+qSlicerExtensionsManagerModel::ExtensionMetadataType qSlicerExtensionsManagerModel::parseSourceScriptedExtensionManifestContent(const QByteArray& manifestContent,
+                                                                                                                                const QString& sourceRoot,
+                                                                                                                                bool validateSourceFiles,
+                                                                                                                                QString* errorMessage)
+{
+  ExtensionMetadataType metadata;
+  const QString manifestDescription =
+    sourceRoot.isEmpty() ? tr("source-scripted extension manifest") : tr("source-scripted extension manifest '%1'").arg(QDir(sourceRoot).filePath(SOURCE_SCRIPTED_MANIFEST_FILE));
+
+  QJsonParseError parseError;
+  const QJsonDocument document = QJsonDocument::fromJson(manifestContent, &parseError);
+  if (parseError.error != QJsonParseError::NoError)
+  {
+    setErrorMessage(errorMessage, tr("Failed to parse %1: %2").arg(manifestDescription, parseError.errorString()));
+    return metadata;
+  }
+  if (!document.isObject())
+  {
+    setErrorMessage(errorMessage, tr("%1 must contain a JSON object").arg(manifestDescription));
+    return metadata;
+  }
+
+  const QJsonObject manifest = document.object();
+  QString schema;
+  QString extensionType;
+  QString extensionName;
+  if (!readStringValue(manifest, "schema", /* required= */ true, schema, errorMessage) //
+      || !readStringValue(manifest, "type", /* required= */ true, extensionType, errorMessage)
+      || !readStringValue(manifest, "extensionname", /* required= */ true, extensionName, errorMessage))
+  {
+    return metadata;
+  }
+  if (extensionType != SOURCE_SCRIPTED_EXTENSION_TYPE)
+  {
+    setErrorMessage(errorMessage, tr("Manifest type must be '%1'").arg(SOURCE_SCRIPTED_EXTENSION_TYPE));
+    return metadata;
+  }
+
+  if (!manifest.contains("modules") || !manifest.value("modules").isArray())
+  {
+    setErrorMessage(errorMessage, tr("Manifest key 'modules' must be a non-empty array"));
+    return metadata;
+  }
+  const QJsonArray modules = manifest.value("modules").toArray();
+  if (modules.isEmpty())
+  {
+    setErrorMessage(errorMessage, tr("Manifest key 'modules' must be a non-empty array"));
+    return metadata;
+  }
+
+  QVariantList parsedModules;
+  QStringList moduleNames;
+  QStringList modulePaths;
+  QStringList moduleDirectories;
+  for (const QJsonValue& moduleValue : modules)
+  {
+    if (!moduleValue.isObject())
+    {
+      setErrorMessage(errorMessage, tr("Each source-scripted module entry must be a JSON object"));
+      return ExtensionMetadataType();
+    }
+    const QJsonObject moduleObject = moduleValue.toObject();
+    QString moduleName;
+    QString modulePath;
+    if (!readStringValue(moduleObject, "name", /* required= */ true, moduleName, errorMessage) //
+        || !readStringValue(moduleObject, "path", /* required= */ true, modulePath, errorMessage))
+    {
+      return ExtensionMetadataType();
+    }
+    QString cleanModulePath;
+    if (!isSafeRelativePath(modulePath, errorMessage, &cleanModulePath))
+    {
+      return ExtensionMetadataType();
+    }
+    if (!cleanModulePath.endsWith(".py", Qt::CaseInsensitive))
+    {
+      setErrorMessage(errorMessage, tr("Module path '%1' must reference a .py file").arg(modulePath));
+      return ExtensionMetadataType();
+    }
+    const QString absoluteModulePath = QDir(sourceRoot).filePath(cleanModulePath);
+    if (validateSourceFiles && (!QFileInfo(absoluteModulePath).isFile() || !pathIsInsideDirectory(absoluteModulePath, sourceRoot)))
+    {
+      setErrorMessage(errorMessage, tr("Module file '%1' does not exist inside the extension source").arg(modulePath));
+      return ExtensionMetadataType();
+    }
+    if (moduleNames.contains(moduleName) || modulePaths.contains(cleanModulePath))
+    {
+      setErrorMessage(errorMessage, tr("Module names and paths must be unique"));
+      return ExtensionMetadataType();
+    }
+
+    QVariantMap parsedModule;
+    parsedModule.insert("name", moduleName);
+    parsedModule.insert("path", cleanModulePath);
+    parsedModules << parsedModule;
+    moduleNames << moduleName;
+    modulePaths << cleanModulePath;
+    const QString moduleDirectory = QFileInfo(cleanModulePath).path();
+    moduleDirectories << (moduleDirectory == "." ? QString() : moduleDirectory);
+  }
+
+  QStringList pythonPaths;
+  if (!readStringArrayValue(manifest, "pythonPaths", pythonPaths, errorMessage))
+  {
+    return ExtensionMetadataType();
+  }
+  for (QString& pythonPath : pythonPaths)
+  {
+    QString cleanPythonPath;
+    if (!isSafeRelativePath(pythonPath, errorMessage, &cleanPythonPath))
+    {
+      return ExtensionMetadataType();
+    }
+    const QString absolutePythonPath = QDir(sourceRoot).filePath(cleanPythonPath);
+    if (validateSourceFiles && (!QFileInfo(absolutePythonPath).isDir() || !pathIsInsideDirectory(absolutePythonPath, sourceRoot)))
+    {
+      setErrorMessage(errorMessage, tr("Python path '%1' does not exist inside the extension source").arg(pythonPath));
+      return ExtensionMetadataType();
+    }
+    pythonPath = cleanPythonPath;
+  }
+
+  QStringList dependencies;
+  if (!readStringArrayValue(manifest, "depends", dependencies, errorMessage))
+  {
+    return ExtensionMetadataType();
+  }
+
+  metadata.insert("schema", schema);
+  metadata.insert("extensiontype", SOURCE_SCRIPTED_EXTENSION_TYPE);
+  metadata.insert("extensionname", extensionName);
+  metadata.insert("modules", parsedModules);
+  moduleDirectories.removeDuplicates();
+  metadata.insert("modulepaths", moduleDirectories);
+  metadata.insert("pythonpaths", pythonPaths);
+  metadata.insert("depends", dependencies.join(" "));
+
+  QString value;
+  const QStringList optionalStringKeys = QStringList() << "description"
+                                                       << "contributors"
+                                                       << "homepage"
+                                                       << "iconurl"
+                                                       << "category"
+                                                       << "screenshots"
+                                                       << "status";
+  for (const QString& key : optionalStringKeys)
+  {
+    if (!readStringValue(manifest, key, /* required= */ false, value, errorMessage))
+    {
+      return ExtensionMetadataType();
+    }
+    if (!value.isEmpty())
+    {
+      metadata.insert(key, value);
+    }
+  }
+
+  if (manifest.contains(SOURCE_SCRIPTED_INSTALL_SOURCE_KEY))
+  {
+    if (!manifest.value(SOURCE_SCRIPTED_INSTALL_SOURCE_KEY).isObject())
+    {
+      setErrorMessage(errorMessage, tr("Manifest key 'installSource' must be a JSON object"));
+      return ExtensionMetadataType();
+    }
+    const QJsonObject installSource = manifest.value(SOURCE_SCRIPTED_INSTALL_SOURCE_KEY).toObject();
+    if (!validateSourceScriptedInstallSource(installSource, errorMessage))
+    {
+      return ExtensionMetadataType();
+    }
+    metadata.insert(SOURCE_SCRIPTED_INSTALL_SOURCE_KEY, installSource.toVariantMap());
   }
 
   return metadata;

--- a/Base/QTCore/qSlicerExtensionsManagerModel.h
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.h
@@ -22,6 +22,7 @@
 #define __qSlicerExtensionsManagerModel_h
 
 // Qt includes
+#include <QByteArray>
 #include <QHash>
 #include <QStringList>
 #include <QUrl>
@@ -296,6 +297,27 @@ public:
   /// \sa installExtension(const QString&,ExtensionMetadataType,const QString&)
   Q_INVOKABLE bool installExtension(const QString& archiveFile, bool installDependencies = true, bool waitForCompletion = false);
 
+  /// Install a source-scripted extension from a local source directory or archive.
+  ///
+  /// The source must contain a valid slicer-extension.json manifest.
+  Q_INVOKABLE bool installSourceScriptedExtension(const QString& sourcePath, bool installDependencies = true);
+
+  /// Install a source-scripted extension from a downloaded source archive.
+  ///
+  /// The source URL is recorded as the managed snapshot origin.
+  Q_INVOKABLE bool installDownloadedSourceScriptedExtension(const QString& archivePath, const QUrl& sourceUrl, bool installDependencies = true);
+
+  /// Install a source-scripted extension from a git repository.
+  ///
+  /// The optional ref may name a branch, tag, or commit. Branch refs are update-checkable.
+  Q_INVOKABLE bool installSourceScriptedExtensionFromGit(const QString& repositoryUrl, const QString& ref = QString(), bool installDependencies = true);
+
+  /// Install a source-scripted extension from a previously inspected git checkout.
+  ///
+  /// The caller owns the staged checkout directory and may remove it after this method returns.
+  /// The supplied origin metadata is recorded as the installed extension origin.
+  Q_INVOKABLE bool installInspectedSourceScriptedExtensionFromGit(const QString& checkoutPath, const QVariantMap& originMetadata, bool installDependencies = true);
+
   /// Install extension.
   ///
   /// This attempts to install an extension with the specified name and
@@ -353,6 +375,29 @@ public:
 
   static ExtensionMetadataType parseExtensionDescriptionFile(const QString& file);
 
+  static ExtensionMetadataType parseSourceScriptedExtensionManifest(const QString& manifestFile, QString* errorMessage = nullptr);
+  static ExtensionMetadataType parseSourceScriptedExtensionManifestContent(const QByteArray& manifestContent,
+                                                                           const QString& sourceRoot = QString(),
+                                                                           bool validateSourceFiles = false,
+                                                                           QString* errorMessage = nullptr);
+
+  /// Inspect a local source-scripted directory or archive without installing it.
+  ///
+  /// The returned metadata includes an origin object describing the selected
+  /// source. A manifest installSource, if present, is retained for descriptor
+  /// previews but is not used by direct installs.
+  ExtensionMetadataType inspectSourceScriptedExtension(const QString& sourcePath, QString* errorMessage = nullptr) const;
+
+  /// Inspect a git repository checkout without installing it.
+  ///
+  /// On success, checkoutPath is set to a staged checkout directory owned by the caller, and
+  /// originMetadata contains the resolved git origin that should be passed to installInspectedSourceScriptedExtensionFromGit().
+  ExtensionMetadataType inspectSourceScriptedExtensionFromGit(const QString& repositoryUrl,
+                                                              const QString& ref,
+                                                              QString* checkoutPath,
+                                                              QVariantMap* originMetadata,
+                                                              QString* errorMessage = nullptr) const;
+
 public slots:
 
   /// \brief Add/remove bookmark for an extension.
@@ -374,6 +419,16 @@ public slots:
   /// This method is used by the extensions.slicer.org extension installer.
   /// \sa installExtension, scheduleExtensionForUninstall, uninstallScheduledExtensions
   bool downloadAndInstallExtensionByName(const QString& extensionName, bool installDependencies = true, bool waitForCompletion = false);
+
+  /// \brief Download and install a source-scripted extension archive.
+  ///
+  /// The downloaded archive must contain a valid slicer-extension.json manifest.
+  bool downloadAndInstallSourceScriptedExtension(const QUrl& archiveUrl, bool installDependencies = true);
+
+  /// \brief Download and inspect a source-scripted extension archive.
+  ///
+  /// Emits sourceScriptedExtensionDownloadReady() after a valid manifest is found.
+  bool downloadAndInspectSourceScriptedExtension(const QUrl& archiveUrl, bool installDependencies = true);
 
   /// \brief Download and install an extension from the extensions server.
   ///
@@ -514,6 +569,8 @@ signals:
 
   void downloadFinished(QNetworkReply* reply);
 
+  void sourceScriptedExtensionDownloadReady(const QUrl& sourceUrl, const QString& archivePath, const QVariantMap& metadata, bool installDependencies);
+
   void updateDownloadProgress(const QString& extensionName, qint64 received, qint64 total);
 
   void modelUpdated();
@@ -579,6 +636,12 @@ protected slots:
 
   /// \sa downloadAndInstallExtension
   void onInstallDownloadFinished(qSlicerExtensionDownloadTask* task);
+
+  /// \sa downloadAndInstallSourceScriptedExtension
+  void onInstallSourceScriptedDownloadFinished(qSlicerExtensionDownloadTask* task);
+
+  /// \sa downloadAndInspectSourceScriptedExtension
+  void onInspectSourceScriptedDownloadFinished(qSlicerExtensionDownloadTask* task);
 
   /// \sa scheduleExtensionForUpdate
   void onUpdateDownloadFinished(qSlicerExtensionDownloadTask* task);

--- a/Base/QTGUI/Resources/UI/qSlicerExtensionsToolsWidget.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerExtensionsToolsWidget.ui
@@ -87,6 +87,24 @@
     </widget>
    </item>
    <item>
+    <widget class="QToolButton" name="InstallFromSourceButton">
+     <property name="toolTip">
+      <string>Install a source-scripted extension from a source directory, archive, archive URL, or Git repository</string>
+     </property>
+     <property name="text">
+      <string>Install from source...</string>
+     </property>
+     <property name="icon">
+      <iconset>
+       <normalon>:/Icons/Add.svg</normalon>
+      </iconset>
+     </property>
+     <property name="toolButtonStyle">
+      <enum>Qt::ToolButtonTextBesideIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QToolButton" name="ConfigureButton">
      <property name="icon">
       <iconset resource="../qSlicerBaseQTGUI.qrc">

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -22,15 +22,23 @@
 #include <QAction>
 #include <QDebug>
 #include <QDesktopServices>
+#include <QEventLoop>
 #include <QFile>
 #include <QLabel>
 #include <QtGlobal>
 #include <QMainWindow>
 #include <QDialog>
+#include <QMessageBox>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
 #include <QRandomGenerator>
+#include <QScopedPointer>
 #include <QSurfaceFormat>
 #include <QSysInfo>
 #include <QTextCodec>
+#include <QTimer>
+#include <QUrlQuery>
 #include <QVBoxLayout>
 
 #if defined(Q_OS_WIN32)
@@ -219,6 +227,167 @@ struct qSlicerScopedTerminalOutputSettings
   ctkErrorLogTerminalOutput::TerminalOutputs Saved;
 };
 
+#ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
+// --------------------------------------------------------------------------
+QString sourceScriptedManifestPreviewText(const qSlicerExtensionsManagerModel::ExtensionMetadataType& metadata, const QString& source)
+{
+  QStringList moduleDescriptions;
+  for (const QVariant& moduleVariant : metadata.value("modules").toList())
+  {
+    const QVariantMap module = moduleVariant.toMap();
+    moduleDescriptions << QString("%1 (%2)").arg(module.value("name").toString(), module.value("path").toString());
+  }
+
+  QStringList lines;
+  lines << qSlicerApplication::tr("Source: %1").arg(source);
+  lines << qSlicerApplication::tr("Modules: %1").arg(moduleDescriptions.join(", "));
+  const QVariantMap origin = metadata.value("origin").toMap();
+  const QString originType = origin.value("type").toString();
+  if (originType == "git")
+  {
+    lines << qSlicerApplication::tr("Git repository: %1").arg(origin.value("url").toString());
+    const QString ref = origin.value("ref").toString();
+    const QString refKind = origin.value("refKind").toString();
+    if (!ref.isEmpty())
+    {
+      lines << qSlicerApplication::tr("Git ref: %1%2").arg(ref, refKind.isEmpty() ? QString() : qSlicerApplication::tr(" (%1)").arg(refKind));
+    }
+    const QString resolvedRevision = origin.value("resolvedRevision").toString();
+    if (!resolvedRevision.isEmpty())
+    {
+      lines << qSlicerApplication::tr("Resolved commit: %1").arg(resolvedRevision);
+    }
+  }
+  else if (!origin.isEmpty())
+  {
+    lines << qSlicerApplication::tr("Origin: %1").arg(origin.value("url", origin.value("path")).toString());
+  }
+  const QVariantMap installSource = metadata.value("installSource").toMap();
+  const QString installSourceType = installSource.value("type").toString();
+  if (origin.isEmpty() && installSourceType == "git")
+  {
+    lines << qSlicerApplication::tr("Install source Git repository: %1").arg(installSource.value("url").toString());
+    const QString ref = installSource.value("ref").toString();
+    if (!ref.isEmpty())
+    {
+      lines << qSlicerApplication::tr("Install source Git ref: %1").arg(ref);
+    }
+  }
+  else if (origin.isEmpty() && !installSource.isEmpty())
+  {
+    lines << qSlicerApplication::tr("Install source: %1").arg(installSource.value("url", installSource.value("path")).toString());
+  }
+  const QStringList pythonPaths = metadata.value("pythonpaths").toStringList();
+  if (!pythonPaths.isEmpty())
+  {
+    lines << qSlicerApplication::tr("Python paths: %1").arg(pythonPaths.join(", "));
+  }
+  const QString depends = metadata.value("depends").toString();
+  if (!depends.isEmpty())
+  {
+    lines << qSlicerApplication::tr("Dependencies: %1").arg(depends);
+  }
+  return lines.join("\n");
+}
+
+// --------------------------------------------------------------------------
+bool confirmSourceScriptedUrlInstall(QWidget* parent, const qSlicerExtensionsManagerModel::ExtensionMetadataType& metadata, const QString& source)
+{
+  QMessageBox warning(parent);
+  warning.setWindowTitle(qSlicerApplication::tr("Install source-scripted extension"));
+  warning.setIcon(QMessageBox::Warning);
+  warning.setText(qSlicerApplication::tr("Install source-scripted extension '%1'?").arg(metadata.value("extensionname").toString()));
+  warning.setInformativeText(
+    qSlicerApplication::tr("Only install source-scripted extensions from sources you trust.\n\n%1").arg(sourceScriptedManifestPreviewText(metadata, source)));
+  warning.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+  warning.setDefaultButton(QMessageBox::Cancel);
+  return warning.exec() == QMessageBox::Ok;
+}
+
+// --------------------------------------------------------------------------
+void showSourceScriptedBadgeInstallFailure(qSlicerApplication* application, QObject* watchContext, const QString& extensionName)
+{
+  if (watchContext->property("completed").toBool())
+  {
+    return;
+  }
+  watchContext->setProperty("completed", true);
+
+  QString message = watchContext->property("failureMessage").toString();
+  if (message.isEmpty())
+  {
+    message = qSlicerApplication::tr("Source-scripted extension '%1' was not installed.").arg(extensionName);
+  }
+
+  QMessageBox::warning(application->mainWindow(), qSlicerApplication::tr("Install source-scripted extension"), message);
+  watchContext->deleteLater();
+}
+
+// --------------------------------------------------------------------------
+QObject* watchSourceScriptedBadgeInstall(qSlicerApplication* application,
+                                         qSlicerExtensionsManagerModel* model,
+                                         const QString& expectedExtensionName,
+                                         const QUrl& downloadUrl = QUrl())
+{
+  QObject* watchContext = new QObject(model);
+  watchContext->setProperty("completed", false);
+  QObject::connect(model,
+                   &qSlicerExtensionsManagerModel::messageLogged,
+                   watchContext,
+                   [watchContext](const QString& text, ctkErrorLogLevel::LogLevels level)
+                   {
+                     if (level == ctkErrorLogLevel::Warning || level == ctkErrorLogLevel::Critical || level == ctkErrorLogLevel::Fatal)
+                     {
+                       watchContext->setProperty("failureMessage", text);
+                     }
+                   });
+
+  QObject::connect(
+    model,
+    &qSlicerExtensionsManagerModel::extensionInstalled,
+    watchContext,
+    [application, expectedExtensionName, watchContext](const QString& extensionName)
+    {
+      if (extensionName != expectedExtensionName)
+      {
+        return;
+      }
+      watchContext->setProperty("completed", true);
+      QMessageBox::information(
+        application->mainWindow(),
+        qSlicerApplication::tr("Install source-scripted extension"),
+        qSlicerApplication::tr(
+          "Source-scripted extension '%1' has been installed.\n\nRestart Slicer to load the extension. If another Slicer instance is already running, restart it too.")
+          .arg(extensionName));
+      watchContext->deleteLater();
+    });
+
+  if (!downloadUrl.isEmpty() && !downloadUrl.isLocalFile())
+  {
+    QObject::connect(model,
+                     &qSlicerExtensionsManagerModel::downloadFinished,
+                     watchContext,
+                     [application, watchContext, expectedExtensionName, downloadUrl](QNetworkReply* reply)
+                     {
+                       if (reply->url() != downloadUrl && reply->request().url() != downloadUrl)
+                       {
+                         return;
+                       }
+                       QTimer::singleShot(0,
+                                          watchContext,
+                                          [application, watchContext, expectedExtensionName]()
+                                          {
+                                            if (!watchContext->property("completed").toBool())
+                                            {
+                                              showSourceScriptedBadgeInstallFailure(application, watchContext, expectedExtensionName);
+                                            }
+                                          });
+                     });
+  }
+  return watchContext;
+}
+#endif
+
 } // namespace
 
 //-----------------------------------------------------------------------------
@@ -333,6 +502,10 @@ void qSlicerApplicationPrivate::init()
 #endif
 
   this->Superclass::init();
+
+#ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
+  QObject::connect(q, SIGNAL(urlReceived(QString)), q, SLOT(onUrlReceived(QString)));
+#endif
 
 #ifdef Slicer_USE_PYTHONQT
   if (!qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))
@@ -971,6 +1144,122 @@ void qSlicerApplication::setHasBorderInFullScreen(bool hasBorder)
 
 // --------------------------------------------------------------------------
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
+// --------------------------------------------------------------------------
+void qSlicerApplication::onUrlReceived(const QString& urlString)
+{
+  QUrl url(urlString);
+  if (url.authority().toLower() != "extensions" || url.path() != "/install-source")
+  {
+    return;
+  }
+
+  qSlicerExtensionsManagerModel* model = this->extensionsManagerModel();
+  if (!model)
+  {
+    QMessageBox::critical(this->mainWindow(), tr("Install source-scripted extension"), tr("Extensions manager is not available."));
+    return;
+  }
+
+  const QUrlQuery query(url);
+  const QString manifestUrlString = query.queryItemValue("manifest", QUrl::FullyDecoded);
+  const QUrl manifestUrl = QUrl::fromUserInput(manifestUrlString);
+  if (!manifestUrl.isValid() || manifestUrl.isEmpty())
+  {
+    QMessageBox::critical(this->mainWindow(), tr("Install source-scripted extension"), tr("Source-scripted install URL must include a valid manifest URL."));
+    return;
+  }
+
+  QNetworkAccessManager networkManager;
+  QNetworkRequest request(manifestUrl);
+  request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+  QNetworkReply* reply = networkManager.get(request);
+  QEventLoop eventLoop;
+  QObject::connect(reply, SIGNAL(finished()), &eventLoop, SLOT(quit()));
+  eventLoop.exec();
+  QScopedPointer<QNetworkReply, QScopedPointerDeleteLater> replyGuard(reply);
+
+  if (reply->error() != QNetworkReply::NoError)
+  {
+    QMessageBox::critical(this->mainWindow(),
+                          tr("Install source-scripted extension"),
+                          tr("Failed to download source-scripted extension manifest from %1: %2").arg(manifestUrl.toString(), reply->errorString()));
+    return;
+  }
+
+  const QVariant statusCodeValue = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
+  if (statusCodeValue.isValid())
+  {
+    const int statusCode = statusCodeValue.toInt();
+    if (statusCode < 200 || statusCode >= 300)
+    {
+      QMessageBox::critical(this->mainWindow(),
+                            tr("Install source-scripted extension"),
+                            tr("Failed to download source-scripted extension manifest from %1: HTTP status %2").arg(manifestUrl.toString()).arg(statusCode));
+      return;
+    }
+  }
+
+  const QByteArray manifestContent = reply->readAll();
+  if (manifestContent.isEmpty())
+  {
+    QMessageBox::critical(
+      this->mainWindow(), tr("Install source-scripted extension"), tr("Downloaded source-scripted extension manifest from %1 is empty.").arg(manifestUrl.toString()));
+    return;
+  }
+
+  QString error;
+  qSlicerExtensionsManagerModel::ExtensionMetadataType metadata =
+    qSlicerExtensionsManagerModel::parseSourceScriptedExtensionManifestContent(manifestContent, QString(), /* validateSourceFiles= */ false, &error);
+  if (metadata.isEmpty())
+  {
+    QMessageBox::critical(this->mainWindow(), tr("Install source-scripted extension"), error);
+    return;
+  }
+
+  const QVariantMap installSource = metadata.value("installSource").toMap();
+  const QString installSourceType = installSource.value("type").toString();
+  if (installSource.isEmpty() || (installSourceType != "url" && installSourceType != "git"))
+  {
+    QMessageBox::critical(this->mainWindow(), tr("Install source-scripted extension"), tr("Remote source-scripted extension manifests must include an installSource."));
+    return;
+  }
+
+  const QString extensionName = metadata.value("extensionname").toString();
+  if (model->isExtensionInstalled(extensionName))
+  {
+    QMessageBox::information(this->mainWindow(),
+                             tr("Install source-scripted extension"),
+                             tr("Source-scripted extension '%1' is already installed.\n\n"
+                                "To reinstall it, uninstall it first. To update a Git branch install, use the Extension Manager update check.")
+                               .arg(extensionName));
+    return;
+  }
+
+  if (!confirmSourceScriptedUrlInstall(this->mainWindow(), metadata, manifestUrl.toString()))
+  {
+    return;
+  }
+
+  if (installSourceType == "git")
+  {
+    QObject* watchContext = watchSourceScriptedBadgeInstall(this, model, extensionName);
+    if (!model->installSourceScriptedExtensionFromGit(installSource.value("url").toString(), installSource.value("ref").toString()))
+    {
+      showSourceScriptedBadgeInstallFailure(this, watchContext, extensionName);
+    }
+  }
+  else
+  {
+    const QUrl sourceUrl = QUrl::fromUserInput(installSource.value("url").toString());
+    QObject* watchContext = watchSourceScriptedBadgeInstall(this, model, extensionName, sourceUrl);
+    if (!model->downloadAndInstallSourceScriptedExtension(sourceUrl))
+    {
+      showSourceScriptedBadgeInstallFailure(this, watchContext, extensionName);
+    }
+  }
+}
+
+// --------------------------------------------------------------------------
 void qSlicerApplication::openExtensionsManagerDialog()
 {
   Q_D(qSlicerApplication);

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -258,6 +258,11 @@ protected slots:
   /// Request editing of a MRML node
   void editNode(vtkObject*, void*, unsigned long) override;
 
+#ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
+  /// Handle built-in slicer:// extension install URLs.
+  void onUrlReceived(const QString& url);
+#endif
+
 #ifdef Slicer_USE_PYTHONQT
   /// Add log message to Python console
   void logToPythonConsole(const QDateTime& currentDateTime,

--- a/Base/QTGUI/qSlicerExtensionsManagerWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsManagerWidget.cxx
@@ -21,16 +21,27 @@
 #include "vtkSlicerConfigure.h" // For Slicer_BUILD_WEBENGINE_SUPPORT
 
 // Qt includes
+#include <QCheckBox>
 #include <QDesktopServices>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QDir>
+#include <QFile>
 #include <QFileDialog>
+#include <QFormLayout>
 #include <QInputDialog>
+#include <QLabel>
+#include <QLineEdit>
 #include <QMenu>
 #include <QMessageBox>
+#include <QPushButton>
 #include <QRegularExpression>
+#include <QSettings>
 #include <QTimer>
 #include <QTimerEvent>
 #include <QToolButton>
 #include <QUrlQuery>
+#include <QVBoxLayout>
 #ifdef Slicer_BUILD_WEBENGINE_SUPPORT
 # include <QWebEngineHistory>
 # include <QWebEnginePage>
@@ -96,6 +107,161 @@ void setThemeIcon(QAction* action, const QString& name)
 {
   // TODO: Can do this in the .ui once Qt 4.8 is required
   action->setIcon(QIcon::fromTheme(name, action->icon()));
+}
+
+//---------------------------------------------------------------------------
+QString sourceScriptedManifestPreview(const qSlicerExtensionsManagerModel::ExtensionMetadataType& metadata, const QString& source)
+{
+  QStringList moduleDescriptions;
+  for (const QVariant& moduleVariant : metadata.value("modules").toList())
+  {
+    const QVariantMap module = moduleVariant.toMap();
+    moduleDescriptions << QString("%1 (%2)").arg(module.value("name").toString(), module.value("path").toString());
+  }
+
+  QStringList lines;
+  lines << qSlicerExtensionsManagerWidget::tr("Source: %1").arg(source);
+  lines << qSlicerExtensionsManagerWidget::tr("Modules: %1").arg(moduleDescriptions.join(", "));
+  const QVariantMap origin = metadata.value("origin").toMap();
+  const QString originType = origin.value("type").toString();
+  if (originType == "git")
+  {
+    lines << qSlicerExtensionsManagerWidget::tr("Git repository: %1").arg(origin.value("url").toString());
+    const QString ref = origin.value("ref").toString();
+    const QString refKind = origin.value("refKind").toString();
+    if (!ref.isEmpty())
+    {
+      lines << qSlicerExtensionsManagerWidget::tr("Git ref: %1%2").arg(ref, refKind.isEmpty() ? QString() : qSlicerExtensionsManagerWidget::tr(" (%1)").arg(refKind));
+    }
+    const QString resolvedRevision = origin.value("resolvedRevision").toString();
+    if (!resolvedRevision.isEmpty())
+    {
+      lines << qSlicerExtensionsManagerWidget::tr("Resolved commit: %1").arg(resolvedRevision);
+    }
+  }
+  else if (!origin.isEmpty())
+  {
+    lines << qSlicerExtensionsManagerWidget::tr("Origin: %1").arg(origin.value("url", origin.value("path")).toString());
+  }
+  const QVariantMap installSource = metadata.value("installSource").toMap();
+  const QString installSourceType = installSource.value("type").toString();
+  if (origin.isEmpty() && installSourceType == "git")
+  {
+    lines << qSlicerExtensionsManagerWidget::tr("Install source Git repository: %1").arg(installSource.value("url").toString());
+    const QString ref = installSource.value("ref").toString();
+    if (!ref.isEmpty())
+    {
+      lines << qSlicerExtensionsManagerWidget::tr("Install source Git ref: %1").arg(ref);
+    }
+  }
+  else if (origin.isEmpty() && !installSource.isEmpty())
+  {
+    lines << qSlicerExtensionsManagerWidget::tr("Install source: %1").arg(installSource.value("url", installSource.value("path")).toString());
+  }
+  const QStringList pythonPaths = metadata.value("pythonpaths").toStringList();
+  if (!pythonPaths.isEmpty())
+  {
+    lines << qSlicerExtensionsManagerWidget::tr("Python paths: %1").arg(pythonPaths.join(", "));
+  }
+  const QString depends = metadata.value("depends").toString();
+  if (!depends.isEmpty())
+  {
+    lines << qSlicerExtensionsManagerWidget::tr("Dependencies: %1").arg(depends);
+  }
+  return lines.join("\n");
+}
+
+//---------------------------------------------------------------------------
+bool confirmSourceScriptedSecurityWarning(QWidget* parent)
+{
+  QSettings settings;
+  if (settings.value("Extensions/SourceScriptedInstall/HideSecurityWarning").toBool())
+  {
+    return true;
+  }
+
+  QMessageBox warning(parent);
+  warning.setWindowTitle(qSlicerExtensionsManagerWidget::tr("Install source-scripted extension"));
+  warning.setIcon(QMessageBox::Warning);
+  warning.setText(qSlicerExtensionsManagerWidget::tr("Only install source-scripted extensions from sources you trust."));
+  warning.setInformativeText(qSlicerExtensionsManagerWidget::tr("Source-scripted extensions are copied from source and run Python code in Slicer after restart."));
+  warning.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+  warning.setDefaultButton(QMessageBox::Cancel);
+  QCheckBox* hideWarningCheckBox = new QCheckBox(qSlicerExtensionsManagerWidget::tr("Do not show this warning again"));
+  warning.setCheckBox(hideWarningCheckBox);
+  if (warning.exec() != QMessageBox::Ok)
+  {
+    return false;
+  }
+  if (hideWarningCheckBox->isChecked())
+  {
+    settings.setValue("Extensions/SourceScriptedInstall/HideSecurityWarning", true);
+  }
+  return true;
+}
+
+//---------------------------------------------------------------------------
+bool confirmSourceScriptedManifestPreview(QWidget* parent, const qSlicerExtensionsManagerModel::ExtensionMetadataType& metadata, const QString& source)
+{
+  QMessageBox preview(parent);
+  preview.setWindowTitle(qSlicerExtensionsManagerWidget::tr("Install source-scripted extension"));
+  preview.setIcon(QMessageBox::Question);
+  preview.setText(qSlicerExtensionsManagerWidget::tr("Install source-scripted extension '%1'?").arg(metadata.value("extensionname").toString()));
+  preview.setInformativeText(sourceScriptedManifestPreview(metadata, source));
+  preview.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+  preview.setDefaultButton(QMessageBox::Cancel);
+  return preview.exec() == QMessageBox::Ok;
+}
+
+//---------------------------------------------------------------------------
+void removeSourceScriptedGitCheckout(const QString& checkoutPath)
+{
+  if (!checkoutPath.isEmpty())
+  {
+    QDir(checkoutPath).removeRecursively();
+  }
+}
+
+//---------------------------------------------------------------------------
+bool promptSourceScriptedGitSource(QWidget* parent, QString& repositoryUrl, QString& ref)
+{
+  repositoryUrl.clear();
+  ref.clear();
+
+  QDialog dialog(parent);
+  dialog.setWindowTitle(qSlicerExtensionsManagerWidget::tr("Source-scripted extension Git repository"));
+
+  QVBoxLayout* layout = new QVBoxLayout(&dialog);
+  QLabel* description = new QLabel(qSlicerExtensionsManagerWidget::tr("Enter a Git repository containing a slicer-extension.json manifest."));
+  description->setWordWrap(true);
+  layout->addWidget(description);
+
+  QFormLayout* formLayout = new QFormLayout;
+  QLineEdit* repositoryLineEdit = new QLineEdit;
+  repositoryLineEdit->setPlaceholderText(qSlicerExtensionsManagerWidget::tr("https://github.com/example/MyExtension.git"));
+  QLineEdit* refLineEdit = new QLineEdit;
+  refLineEdit->setPlaceholderText(qSlicerExtensionsManagerWidget::tr("Optional branch, tag, or commit"));
+  formLayout->addRow(qSlicerExtensionsManagerWidget::tr("Repository URL:"), repositoryLineEdit);
+  formLayout->addRow(qSlicerExtensionsManagerWidget::tr("Ref:"), refLineEdit);
+  layout->addLayout(formLayout);
+
+  QDialogButtonBox* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+  QPushButton* okButton = buttonBox->button(QDialogButtonBox::Ok);
+  okButton->setEnabled(false);
+  QObject::connect(
+    repositoryLineEdit, &QLineEdit::textChanged, okButton, [repositoryLineEdit, okButton]() { okButton->setEnabled(!repositoryLineEdit->text().trimmed().isEmpty()); });
+  QObject::connect(buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+  QObject::connect(buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+  layout->addWidget(buttonBox);
+
+  if (dialog.exec() != QDialog::Accepted)
+  {
+    return false;
+  }
+
+  repositoryUrl = repositoryLineEdit->text().trimmed();
+  ref = refLineEdit->text().trimmed();
+  return !repositoryUrl.isEmpty();
 }
 
 // --------------------------------------------------------------------------
@@ -256,6 +422,7 @@ void qSlicerExtensionsManagerWidgetPrivate::init()
   QObject::connect(this->ToolsWidget->InstallUpdatesButton, SIGNAL(clicked()), q, SLOT(onInstallUpdatesTriggered()));
   QObject::connect(this->ToolsWidget->InstallBookmarkedButton, SIGNAL(clicked()), q, SLOT(onInstallBookmarkedTriggered()));
   QObject::connect(this->ToolsWidget->InstallFromFileButton, SIGNAL(clicked()), q, SLOT(onInstallFromFileTriggered()));
+  QObject::connect(this->ToolsWidget->InstallFromSourceButton, SIGNAL(clicked()), q, SLOT(onInstallFromSourceTriggered()));
 
   this->MessageWidget = new QMessageBox(q);
   this->MessageWidget->setWindowTitle(qSlicerExtensionsManagerWidget::tr("Extensions Manager"));
@@ -321,6 +488,7 @@ void qSlicerExtensionsManagerWidget::setExtensionsManagerModel(qSlicerExtensions
 
   disconnect(this, SLOT(onModelUpdated()));
   disconnect(this, SLOT(onMessageLogged(QString, ctkErrorLogLevel::LogLevels)));
+  disconnect(this, SLOT(onSourceScriptedExtensionDownloadReady(QUrl, QString, QVariantMap, bool)));
 
   d->ExtensionsLocalWidget->setExtensionsManagerModel(model);
 #ifdef Slicer_BUILD_WEBENGINE_SUPPORT
@@ -335,6 +503,8 @@ void qSlicerExtensionsManagerWidget::setExtensionsManagerModel(qSlicerExtensions
     this->onModelUpdated();
     connect(model, SIGNAL(modelUpdated()), this, SLOT(onModelUpdated()));
     connect(model, SIGNAL(messageLogged(QString, ctkErrorLogLevel::LogLevels)), this, SLOT(onMessageLogged(QString, ctkErrorLogLevel::LogLevels)));
+    connect(
+      model, SIGNAL(sourceScriptedExtensionDownloadReady(QUrl, QString, QVariantMap, bool)), this, SLOT(onSourceScriptedExtensionDownloadReady(QUrl, QString, QVariantMap, bool)));
     connect(model, SIGNAL(extensionInstalled(QString)), this, SLOT(onModelUpdated()));
     connect(model, SIGNAL(extensionUninstalled(QString)), this, SLOT(onModelUpdated()));
     connect(model, SIGNAL(extensionScheduledForUpdate(QString)), this, SLOT(onModelUpdated()));
@@ -708,6 +878,153 @@ void qSlicerExtensionsManagerWidget::onInstallFromFileTriggered()
 }
 
 // --------------------------------------------------------------------------
+void qSlicerExtensionsManagerWidget::onInstallFromSourceTriggered()
+{
+  Q_D(qSlicerExtensionsManagerWidget);
+  qSlicerExtensionsManagerModel* const model = this->extensionsManagerModel();
+  if (!model)
+  {
+    return;
+  }
+
+  QMessageBox sourceDialog(this);
+  sourceDialog.setWindowTitle(tr("Install source-scripted extension"));
+  sourceDialog.setText(tr("Select a source-scripted extension source."));
+  QPushButton* directoryButton = sourceDialog.addButton(tr("Directory..."), QMessageBox::AcceptRole);
+  QPushButton* archiveButton = sourceDialog.addButton(tr("Archive..."), QMessageBox::AcceptRole);
+  QPushButton* urlButton = sourceDialog.addButton(tr("Archive URL..."), QMessageBox::AcceptRole);
+  QPushButton* gitButton = sourceDialog.addButton(tr("Git..."), QMessageBox::AcceptRole);
+  sourceDialog.addButton(QMessageBox::Cancel);
+  sourceDialog.exec();
+
+  QString sourcePath;
+  QUrl sourceUrl;
+  QString gitRepositoryUrl;
+  QString gitRef;
+  if (sourceDialog.clickedButton() == directoryButton)
+  {
+    sourcePath = QFileDialog::getExistingDirectory(this, tr("Select source-scripted extension directory..."));
+  }
+  else if (sourceDialog.clickedButton() == archiveButton)
+  {
+    sourcePath = QFileDialog::getOpenFileName(
+      this, tr("Select source-scripted extension archive..."), QString(), tr("Archives") + " (*.zip *.7z *.tar *.tar.gz *.tgz *.tar.bz2 *.tar.xz);;" + tr("All files") + " (*)");
+  }
+  else if (sourceDialog.clickedButton() == urlButton)
+  {
+    bool ok = false;
+    const QString urlString = QInputDialog::getText(this, tr("Source-scripted extension archive URL"), tr("Archive URL:"), QLineEdit::Normal, QString(), &ok);
+    if (!ok || urlString.trimmed().isEmpty())
+    {
+      return;
+    }
+    sourceUrl = QUrl::fromUserInput(urlString.trimmed());
+  }
+  else if (sourceDialog.clickedButton() == gitButton)
+  {
+    if (!promptSourceScriptedGitSource(this, gitRepositoryUrl, gitRef))
+    {
+      return;
+    }
+  }
+  else
+  {
+    return;
+  }
+
+  if (sourcePath.isEmpty() && sourceUrl.isEmpty() && gitRepositoryUrl.isEmpty())
+  {
+    return;
+  }
+
+  if (!confirmSourceScriptedSecurityWarning(this))
+  {
+    return;
+  }
+
+  bool wasBatchProcessing = d->setBatchProcessing(true);
+  if (!sourcePath.isEmpty())
+  {
+    QString error;
+    qSlicerExtensionsManagerModel::ExtensionMetadataType metadata = model->inspectSourceScriptedExtension(sourcePath, &error);
+    if (metadata.isEmpty())
+    {
+      QMessageBox::critical(this, tr("Install source-scripted extension"), error);
+      d->setBatchProcessing(wasBatchProcessing);
+      return;
+    }
+    if (!confirmSourceScriptedManifestPreview(this, metadata, sourcePath))
+    {
+      d->setBatchProcessing(wasBatchProcessing);
+      return;
+    }
+    model->installSourceScriptedExtension(sourcePath);
+  }
+  else if (!sourceUrl.isEmpty())
+  {
+    model->downloadAndInspectSourceScriptedExtension(sourceUrl);
+  }
+  else
+  {
+    QString error;
+    QString checkoutPath;
+    QVariantMap originMetadata;
+    qSlicerExtensionsManagerModel::ExtensionMetadataType metadata = model->inspectSourceScriptedExtensionFromGit(gitRepositoryUrl, gitRef, &checkoutPath, &originMetadata, &error);
+    if (metadata.isEmpty())
+    {
+      QMessageBox::critical(this, tr("Install source-scripted extension"), error);
+      removeSourceScriptedGitCheckout(checkoutPath);
+      d->setBatchProcessing(wasBatchProcessing);
+      return;
+    }
+    if (!confirmSourceScriptedManifestPreview(this, metadata, gitRepositoryUrl))
+    {
+      removeSourceScriptedGitCheckout(checkoutPath);
+      d->setBatchProcessing(wasBatchProcessing);
+      return;
+    }
+    model->installInspectedSourceScriptedExtensionFromGit(checkoutPath, originMetadata);
+    removeSourceScriptedGitCheckout(checkoutPath);
+  }
+  d->setBatchProcessing(wasBatchProcessing);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsManagerWidget::onSourceScriptedExtensionDownloadReady(const QUrl& sourceUrl,
+                                                                            const QString& archivePath,
+                                                                            const QVariantMap& metadata,
+                                                                            bool installDependencies)
+{
+  Q_D(qSlicerExtensionsManagerWidget);
+  qSlicerExtensionsManagerModel* const model = this->extensionsManagerModel();
+  if (!model)
+  {
+    if (!sourceUrl.isLocalFile())
+    {
+      QFile::remove(archivePath);
+    }
+    return;
+  }
+
+  if (!confirmSourceScriptedManifestPreview(this, metadata, sourceUrl.toString()))
+  {
+    if (!sourceUrl.isLocalFile())
+    {
+      QFile::remove(archivePath);
+    }
+    return;
+  }
+
+  bool wasBatchProcessing = d->setBatchProcessing(true);
+  model->installDownloadedSourceScriptedExtension(archivePath, sourceUrl, installDependencies);
+  d->setBatchProcessing(wasBatchProcessing);
+  if (!sourceUrl.isLocalFile())
+  {
+    QFile::remove(archivePath);
+  }
+}
+
+// --------------------------------------------------------------------------
 bool qSlicerExtensionsManagerWidget::confirmClose()
 {
   Q_D(qSlicerExtensionsManagerWidget);
@@ -774,9 +1091,10 @@ bool qSlicerExtensionsManagerWidget::isInBatchProcessing()
 void qSlicerExtensionsManagerWidget::onMessageLogged(const QString& text, ctkErrorLogLevel::LogLevels level)
 {
   Q_D(qSlicerExtensionsManagerWidget);
-  if (d->tabWidget->currentWidget() != d->ManageExtensionsTab)
+  if (d->tabWidget->currentWidget() != d->ManageExtensionsTab && level != ctkErrorLogLevel::Critical && level != ctkErrorLogLevel::Fatal)
   {
-    // only display messages when we are in the extensions tab (the web view uses its own style)
+    // The web view has its own message style, but critical source-install
+    // failures must still be visible when the install tab is active.
     return;
   }
 

--- a/Base/QTGUI/qSlicerExtensionsManagerWidget.h
+++ b/Base/QTGUI/qSlicerExtensionsManagerWidget.h
@@ -26,6 +26,7 @@
 
 // Qt includes
 #include <QUrl>
+#include <QVariantMap>
 #include <QWidget>
 
 // QtGUI includes
@@ -82,12 +83,14 @@ protected slots:
   void onManageUrlChanged(const QUrl& newUrl);
   void onInstallUrlChanged(const QUrl& newUrl);
   void onSearchTextChanged(const QString& newText);
+  void onSourceScriptedExtensionDownloadReady(const QUrl& sourceUrl, const QString& archivePath, const QVariantMap& metadata, bool installDependencies);
 
   void onCheckForUpdatesTriggered();
   void onEditBookmarksTriggered();
   void onInstallUpdatesTriggered();
   void onInstallBookmarkedTriggered();
   void onInstallFromFileTriggered();
+  void onInstallFromSourceTriggered();
 
   void setAutoUpdateCheck(bool toggle);
   void setAutoUpdateInstall(bool toggle);

--- a/CMake/MacOSXBundleInfo.plist.in
+++ b/CMake/MacOSXBundleInfo.plist.in
@@ -30,6 +30,17 @@
         <string>????</string>
         <key>CFBundleVersion</key>
         <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+        <key>CFBundleURLTypes</key>
+        <array>
+          <dict>
+            <key>CFBundleURLName</key>
+            <string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+              <string>${Slicer_MAIN_PROJECT_APPLICATION_NAME}</string>
+            </array>
+          </dict>
+        </array>
         <key>CSResourcesFileMapped</key>
         <true/>
         <key>LSRequiresCarbon</key>

--- a/Docs/developer_guide/extensions.md
+++ b/Docs/developer_guide/extensions.md
@@ -225,6 +225,52 @@ After installing an extension, the directories are added to revision-specific se
 - Folders containing modules bundled within an extension are added to Modules / AdditionalPaths. This ensures that libraries associated with modules are found.
 - Folders containing third-party dynamic libraries, Python libraries, etc. are added to LibraryPaths, Paths, PYTHONPATH, QT_PLUGIN_PATH. This ensures that libraries associated with modules can be successfully loaded.
 
+(source-scripted-extension-manifest)=
+## Source-scripted extension manifest
+
+Python-only scripted extensions can be installed directly from source without using the extension build system. This is intended for extensions that only need scripted modules and Python helper packages. Use the normal extension build and catalog submission workflow when the extension contains C++, CLI modules, Qt plugins, compiled Python packages, or needs automated catalog builds.
+
+The source directory or archive must contain a `slicer-extension.json` file:
+
+```json
+{
+  "schema": "https://slicer.org/schemas/source-scripted-extension/v1",
+  "type": "source-scripted",
+  "extensionname": "MyExtension",
+  "description": "One-line description.",
+  "contributors": "Firstname Lastname (Organization)",
+  "homepage": "https://example.org/MyExtension",
+  "iconurl": "https://example.org/MyExtension.png",
+  "depends": ["SampleData"],
+  "pythonPaths": ["Lib"],
+  "modules": [
+    {
+      "name": "MyModule",
+      "path": "Modules/MyModule/MyModule.py"
+    }
+  ]
+}
+```
+
+Required fields are `schema`, `type`, `extensionname`, and `modules`. The `type` value must be `source-scripted`. Each module entry must have a `name` and a relative `.py` `path`. Paths must stay inside the source tree; absolute paths and parent-directory traversal are rejected. `depends` lists Slicer extension dependencies. `pythonPaths` lists relative directories that are added to the launcher's `PYTHONPATH`.
+
+Source-scripted installs are managed snapshots. Slicer copies the source into the revision-specific extensions installation path, records normalized installed metadata in `source-scripted-extension.json`, and requires restart before the modules are loaded.
+
+When installing from a directory, archive, archive URL, or Git repository URL, Slicer records that selected source as the installed extension origin. For direct Git installs, the repository URL and ref entered by the user are authoritative. Git installs record the resolved commit SHA in the installed metadata. Branch origins are checked for updates; tag and commit origins are treated as fixed snapshots.
+
+An `installSource` object may be included in a manifest that is used as an install badge target. It is only used when Slicer is given a standalone manifest URL and needs to know where to fetch the installable source. Supported install sources are:
+
+- `{"type": "url", "url": "https://example.org/MyExtension.zip"}` for a source archive.
+- `{"type": "git", "url": "https://github.com/example/MyExtension.git", "ref": "main"}` for a git repository branch, tag, or commit.
+
+Install badges can point Slicer at a remote source-scripted manifest:
+
+```text
+slicer://extensions/install-source?manifest=https%3A%2F%2Fexample.org%2FMyExtension%2Fslicer-extension.json
+```
+
+The remote manifest must contain an `installSource` because the badge URL only identifies the manifest to fetch. Slicer downloads the manifest, shows the interpreted preview and trust warning, then installs from the declared source. A source tree manifest used for direct directory, archive, archive URL, or Git URL installs does not need an `installSource`; the selected source is recorded as the installed origin.
+
 (extension-catalog-entry-file)=
 ## Extension catalog entry file
 

--- a/Docs/user_guide/extensions.md
+++ b/Docs/user_guide/extensions.md
@@ -109,6 +109,23 @@ Extensions can be downloaded from the Extensions Catalog website and can be inst
 - Wait for the installations to complete.
 - Click "Restart" button to restart the application.
 
+#### Install source-scripted extensions
+
+Source-scripted extensions are Python-only extensions that can be installed from a source directory, a source archive, an archive URL, or a Git repository when the source contains a `slicer-extension.json` manifest.
+
+- Open Extensions manager using menu: View / Extensions manager.
+- Click the "Install from source..." button.
+- Choose a local directory, a local archive, an archive URL, or a Git repository.
+- Review the manifest preview and trust warning.
+- Wait for the installation to complete.
+- Click "Restart" button to restart the application.
+
+For Git installs, the repository URL and optional branch, tag, or commit ref entered in the dialog are recorded as the extension origin. Branch installs can be checked for updates; tag and commit installs are fixed snapshots.
+
+Some source-scripted extensions provide install badges using `slicer://extensions/install-source?manifest=...` links. The link opens Slicer, downloads the referenced manifest, shows the same preview and trust warning, and installs from the `installSource` declared by the manifest. Operating system protocol registration is automatic for Windows installers and macOS application bundles. Portable builds and some Linux desktop environments may require manual `slicer://` protocol association.
+
+Only install source-scripted extensions from sources you trust. They run Python code in Slicer after restart.
+
 ### Troubleshooting
 
 #### Extensions manager takes very long time to start


### PR DESCRIPTION
(this is quite experimental, don't look at this just yet)

<details>

<summary>ai generated pr description (WIP, will clean up)</summary>

## Summary

This adds first-class support for installing Python-only `source-scripted` extensions directly from source, without building an extension package. Source installs are driven by a required `slicer-extension.json` manifest, copied into the revision-specific extensions install path, and loaded after restart like other Extension Manager installs.

The implementation includes:

- Strict manifest parsing for `type: "source-scripted"`, module `.py` paths, extension dependencies, optional `pythonPaths`, and descriptor-only `installSource`.
- Local directory, local archive, URL archive, and git repository installs through model APIs and the Extension Manager UI.
- Extension Manager UI entry: "Install from source..." with Directory, Archive, Archive URL, and Git choices.
- Trust warning and manifest preview before install, including downloaded URL archives and inspected Git checkouts.
- Clear archive failure messages for unsupported downloads and archives without `slicer-extension.json`.
- Source-scripted path handling that only adds manifest-declared module directories to `Modules/AdditionalPaths` and manifest-declared Python paths to launcher `PYTHONPATH`.
- Git origin tracking with resolved commit SHA stored in the installed metadata and `.s4ext` metadata.
- Update checks for source-scripted git branch origins, with installed and available commit SHAs shown in the update UI; tag and commit origins are treated as fixed snapshots.
- `slicer://extensions/install-source?manifest=...` links for install badges. The remote manifest must declare an installable `installSource`, and the completion dialog reminds users to restart Slicer.
- Badge installs report already-installed extensions and other install failures in dialogs, instead of only logging to the Python console.
- User and developer documentation.

Source-scripted installs remain restart-required and intentionally do not install Python package dependencies. Manifest `depends` still means Slicer extension dependencies.

## How To Try It

Create a minimal source-scripted extension somewhere writable:

```bash
mkdir -p /tmp/SlicerScriptedExtensionExample/Modules/HelloSource
cat > /tmp/SlicerScriptedExtensionExample/Modules/HelloSource/HelloSource.py <<'PY'
from slicer.ScriptedLoadableModule import ScriptedLoadableModule


class HelloSource(ScriptedLoadableModule):
    def __init__(self, parent):
        ScriptedLoadableModule.__init__(self, parent)
        parent.title = "Hello Source"
        parent.categories = ["Examples"]
        parent.contributors = ["Slicer Developer"]
        parent.helpText = "Minimal source-scripted extension test."
PY
cat > /tmp/SlicerScriptedExtensionExample/slicer-extension.json <<'JSON'
{
  "schema": "https://slicer.org/schemas/source-scripted-extension/v1",
  "type": "source-scripted",
  "extensionname": "SlicerScriptedExtensionExample",
  "description": "Minimal source-scripted extension test.",
  "contributors": "Slicer Developer",
  "modules": [
    {
      "name": "HelloSource",
      "path": "Modules/HelloSource/HelloSource.py"
    }
  ],
  "pythonPaths": [],
  "depends": []
}
JSON
```

Then in Slicer:

1. Open Extensions Manager.
2. Click "Install from source...".
3. Choose "Directory..." and select `/tmp/SlicerScriptedExtensionExample`.
4. Review the warning and manifest preview.
5. Install, then restart Slicer.
6. Confirm the "Hello Source" module appears in the Examples category.

The same source tree can be zipped and installed with "Archive...":

```bash
cd /tmp
zip -r SlicerScriptedExtensionExample.zip SlicerScriptedExtensionExample
```

## URL Archive Flow

Serve the zip from a local or remote web server and choose "Archive URL..." from the same Extension Manager flow. Slicer should download the archive, inspect the manifest, show the interpreted preview, and only install after confirmation.

Try a bad archive too:

```bash
printf '<html>not an archive</html>\n' > /tmp/not-an-extension.zip
```

Installing that file as an archive should report that it is not a supported source-scripted extension archive. A valid archive without `slicer-extension.json` should report that the manifest must be at the archive root or in one top-level directory.

## Git Origin Flow

To test git install and update checks:

```bash
cd /tmp/SlicerScriptedExtensionExample
git init
git checkout -B main
git config user.email slicer@example.invalid
git config user.name "Slicer Test"
git add -A
git commit -m "Initial source-scripted extension"
```

In Slicer:

1. Open Extensions Manager.
2. Click "Install from source...".
3. Choose "Git...".
4. Enter `/tmp/SlicerScriptedExtensionExample` and `main`.
5. Review the preview, install, and restart.

The same flow is available from the Slicer Python console:

```python
repo = "/tmp/SlicerScriptedExtensionExample"
model = slicer.app.extensionsManagerModel()
ok = model.installSourceScriptedExtensionFromGit(repo, "main", False)
print("installed:", ok)
print("metadata:", model.extensionMetadata("SlicerScriptedExtensionExample"))
```

After restart, update the repository with another commit, then use "Check for updates" in Extension Manager. Branch installs should report an available update. Tag and commit installs should remain fixed snapshots.

## Install Badge Flow

A badge link can point to an HTTPS landing page, because GitHub README rendering does not preserve direct `slicer://` links:

Here is an example of a badge to install a minimal example extension I've put at https://github.com/ebrahimebrahim/SlicerScriptedExtensionExample:

[![Install in Slicer](https://img.shields.io/badge/Install%20in-Slicer-E6ECED?labelColor=AFB8D1)](https://ebrahimebrahim.github.io/SlicerScriptedExtensionExample/install.html)

The landing page's install button links to:

```text
slicer://extensions/install-source?manifest=https%3A%2F%2Fraw.githubusercontent.com%2Febrahimebrahim%2FSlicerScriptedExtensionExample%2Fmain%2Fslicer-extension.json
```

The remote manifest must include an installable `installSource`. For a Git-backed extension repository, the root `slicer-extension.json` can include:

```json
"installSource": {
  "type": "git",
  "url": "https://github.com/ebrahimebrahim/SlicerScriptedExtensionExample.git",
  "ref": "main"
}
```

Opening the `slicer://` link should download the manifest, show the trust warning and preview, and then install from the declared source if confirmed. Direct Directory, Archive, URL, and Git installs ignore `installSource`; they record the source selected by the user as the installed origin. Protocol registration is automatic for Windows installers and macOS application bundles; portable builds and some Linux desktop environments may need manual `slicer://` association.

A minimal example repository for this badge is `SlicerScriptedExtensionExample`, with:

- `slicer-extension.json` at the repository root.
- A scripted module at `Modules/SlicerScriptedExtensionExample/SlicerScriptedExtensionExample.py`.
- `install.html` served by GitHub Pages as the HTTPS badge target.
- The `installSource` block above so the badge can install from the Git repository.

## Python Smoke Test

From the Slicer Python console, the model API can be exercised directly:

```python
sourcePath = "/tmp/SlicerScriptedExtensionExample"
model = slicer.app.extensionsManagerModel()
ok = model.installSourceScriptedExtension(sourcePath, False)
print("installed:", ok)
print("metadata:", model.extensionMetadata("SlicerScriptedExtensionExample"))
print("module paths:", model.extensionModulePaths("SlicerScriptedExtensionExample"))
```

Restart Slicer after installation to load the module.

## Automated Testing

Locally verified with:

```bash
uvx --from pre-commit pre-commit run --all-files
env CCACHE_DIR=/tmp/slicer-ccache CCACHE_TEMPDIR=/tmp cmake --build . --target qSlicerBaseQTCoreCxxTests qSlicerBaseQTGUI
env QT_QPA_PLATFORM=offscreen XDG_CONFIG_HOME=/tmp/slicer-test-config XDG_CACHE_HOME=/tmp/slicer-test-cache CCACHE_DIR=/tmp/slicer-ccache CCACHE_TEMPDIR=/tmp ctest -R qSlicerExtensionsManagerModelTest --no-tests=error --verbose
```

The focused CTest run passed with `74 passed, 0 failed`.


</details>

## TODO

- [ ] consider adopting a python packaging based approach, rather than creating a new manifest format 
- [ ] add optional Slicer version constraints to manifest format? since installing from source does not require exact revision match.