### PR TITLE
BUG: Fix SampleData module

### DIFF
--- a/Applications/SlicerApp/Testing/Python/UtilTest.py
+++ b/Applications/SlicerApp/Testing/Python/UtilTest.py
@@ -72,6 +72,7 @@ class UtilTestTest(ScriptedLoadableModuleTest):
         self.test_setSliceViewerLayers()
         self.test_loadUI()
         self.test_findChild()
+        self.test_findChild_properties()
         self.test_arrayFromVolume()
         self.test_updateVolumeFromArray()
         self.test_updateTableFromArray()
@@ -191,6 +192,44 @@ class UtilTestTest(ScriptedLoadableModuleTest):
 
         # Parent window is created automatically, delete it now to prevent memory leaks
         utilWidget.parent.deleteLater()
+
+    def test_findChild_properties(self):
+        # Create a parent widget with two labeled children
+        parent = qt.QWidget()
+        child1 = qt.QLabel("first", parent)
+        child1.setProperty("myCategory", "alpha")
+        child2 = qt.QLabel("second", parent)
+        child2.setProperty("myCategory", "beta")
+
+        # Find by property alone
+        found = slicer.util.findChild(parent, None, properties={"myCategory": "alpha"})
+        self.assertEqual(found, child1)
+
+        found = slicer.util.findChild(parent, None, properties={"myCategory": "beta"})
+        self.assertEqual(found, child2)
+
+        # Find by name and property together
+        child1.setObjectName("child_one")
+        found = slicer.util.findChild(parent, "child_one", properties={"myCategory": "alpha"})
+        self.assertEqual(found, child1)
+
+        # Name matches but property does not — should raise
+        caughtException = False
+        try:
+            slicer.util.findChild(parent, "child_one", properties={"myCategory": "beta"})
+        except RuntimeError:
+            caughtException = True
+        self.assertTrue(caughtException)
+
+        # Property does not exist — should raise
+        caughtException = False
+        try:
+            slicer.util.findChild(parent, None, properties={"myCategory": "gamma"})
+        except RuntimeError:
+            caughtException = True
+        self.assertTrue(caughtException)
+
+        parent.deleteLater()
 
     def test_arrayFromVolume(self):
         # Test if retrieving voxels as a numpy array works

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -332,20 +332,29 @@ def findChildren(widget=None, name="", text="", title="", className=""):
     return children
 
 
-def findChild(widget, name):
-    """Convenience method to access a widget by its ``name``.
+def findChild(widget, name, properties=None):
+    """Convenience method to access a widget by its ``name`` and/or Qt dynamic properties.
 
-    :raises RuntimeError: if the widget with the given ``name`` does not exist.
+    :param widget: parent widget to search within.
+    :param name: name of the child widget, or ``None`` to skip name filtering.
+    :param properties: optional dict of Qt dynamic property names and expected values.
+        When provided, only children whose properties match all entries are considered.
+    :raises RuntimeError: if a matching widget does not exist.
     """
-    errorMessage = "Widget named " + str(name) + " does not exist."
-    child = None
-    try:
-        child = findChildren(widget, name=name)[0]
-        if not child:
-            raise RuntimeError(errorMessage)
-    except IndexError:
-        raise RuntimeError(errorMessage)
-    return child
+    candidates = findChildren(widget, name=name) if name else findChildren(widget)
+    if properties is not None:
+        candidates = [c for c in candidates if all(c.property(k) == v for k, v in properties.items())]
+    if not candidates:
+        descriptionParts = []
+        if name:
+            descriptionParts.append(f"name={name!r}")
+        if properties:
+            descriptionParts.append(f"properties={properties}")
+        if descriptionParts:
+            raise RuntimeError(f"Widget with {', '.join(descriptionParts)} does not exist.")
+        else:
+            raise RuntimeError("No child widget was found.")
+    return candidates[0]
 
 
 def loadUI(path):

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -480,7 +480,7 @@ class SampleDataWidget(ScriptedLoadableModuleWidget):
     @staticmethod
     def findCategoryWidget(parent, category):
         """Find the category widget (frame) by its custom property 'sampleDataCategory'."""
-        return slicer.util.findChild(parent, None, options={"sampleDataCategory": category})
+        return slicer.util.findChild(parent, None, properties={"sampleDataCategory": category})
 
     def isCategoryVisible(self, category):
         """Check the visibility of a SampleData category given its name.
@@ -490,8 +490,9 @@ class SampleDataWidget(ScriptedLoadableModuleWidget):
         """
         if not SampleDataLogic.sampleDataSourcesByCategory(category):
             return False
-        frame = slicer.util.findChild(self.parent, None, options={"sampleDataCategory": category})
-        if frame is None:
+        try:
+            frame = SampleDataWidget.findCategoryWidget(self.parent, category)
+        except RuntimeError:
             return False
         return frame.isVisible()
 
@@ -502,9 +503,11 @@ class SampleDataWidget(ScriptedLoadableModuleWidget):
         """
         if not SampleDataLogic.sampleDataSourcesByCategory(category):
             return
-        frame = slicer.util.findChild(self.parent, None, options={"sampleDataCategory": category})
-        if frame is not None:
-            frame.setVisible(visible)
+        try:
+            frame = SampleDataWidget.findCategoryWidget(self.parent, category)
+        except RuntimeError:
+            return
+        frame.setVisible(visible)
 
 
 #


### PR DESCRIPTION
Add missed property-based filtering option to slicer.util.findChild.

Fixes issue reported at https://discourse.slicer.org/t/volume-rendering-broken-in-latest-linux-previews/46974/3