### PR TITLE
ENH: Add pip --target fallback for read-only site-packages

### DIFF
--- a/Base/Python/slicer/__init__.py
+++ b/Base/Python/slicer/__init__.py
@@ -220,6 +220,20 @@ if not standalone_python:
         print(detail)
 
 # -----------------------------------------------------------------------------
+# Add Slicer user site-packages to sys.path so that packages installed via
+# pip --target are importable.
+from pathlib import Path as _Path
+
+_user_site = str(
+    _Path.home() / ".local" / "lib" / "Slicer"
+    / f"python{sys.version_info.major}.{sys.version_info.minor}"
+    / "site-packages"
+)
+if os.path.isdir(_user_site) and _user_site not in sys.path:
+    sys.path.append(_user_site)
+del _user_site, _Path
+
+# -----------------------------------------------------------------------------
 # Cleanup: Removing things the user shouldn't have to see.
 
 del _createModule

--- a/Base/Python/slicer/packaging.py
+++ b/Base/Python/slicer/packaging.py
@@ -20,9 +20,11 @@ from __future__ import annotations
 import importlib
 import importlib.metadata
 import logging
+import os
 import shlex
 import slicer.util
 import sys
+import sysconfig
 import tomllib
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -911,6 +913,20 @@ def _pip_install_with_skips_busy_cursor(
         qt.QApplication.restoreOverrideCursor()
 
 
+def _get_user_site_packages_dir() -> Path:
+    """Return Slicer user site-packages directory path.
+
+    Used as pip ``--target`` when the default site-packages is not writable
+    (e.g. system-wide installation).
+    Path format: ``~/.local/lib/Slicer/python{X.Y}/site-packages/``
+    """
+    return (
+        Path.home() / ".local" / "lib" / "Slicer"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+    )
+
+
 def _build_pip_args(
     requirements: str | list[str],
     constraints: str | Path | None = None,
@@ -935,6 +951,13 @@ def _build_pip_args(
 
     if constraints is not None:
         args.extend(["-c", str(constraints)])
+
+    default_site = sysconfig.get_path("purelib")
+    if not os.access(default_site, os.W_OK):
+        user_site = str(_get_user_site_packages_dir())
+        args.extend(["--target", user_site])
+        if user_site not in sys.path:
+            sys.path.append(user_site)
 
     return args
 


### PR DESCRIPTION
On Linux distributions that package Slicer into system directories (e.g. /opt or /usr), the default Python site-packages is owned by root and not writable by regular users. This causes pip_install to fail when extensions try to install additional Python packages.

This change adds a fallback: when the default site-packages is not writable, _build_pip_args automatically appends --target pointing to ~/.local/lib/Slicer/python{X.Y}/site-packages/. The directory is also appended to sys.path at startup so that packages installed there are importable.

This does not affect Windows, macOS, or any scenario where Slicer is installed into a user-writable location.