### PR TITLE
BUG: Fix GetFileNameWithoutExtension() failing when called with no arguments

### DIFF
--- a/Libs/MRML/Core/vtkMRMLStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.h
@@ -320,7 +320,11 @@ public:
   /// Remove supported extension from filename.
   /// If filename is not specified then the current FileName will be used.
   std::string GetFileNameWithoutExtension(const char* fileName = nullptr);
+// Make sure that the Python wrapper uses the char* version
+// (because the std::string& version does not have a default argument)
+#ifndef __VTK_WRAP__
   std::string GetFileNameWithoutExtension(const std::string& fileName) { return GetFileNameWithoutExtension(fileName.c_str()); }
+#endif
 
   /// Compression parameter that is used to save the node
   vtkSetMacro(CompressionParameter, std::string);


### PR DESCRIPTION
The std::string overload added in https://github.com/Slicer/Slicer/commit/74d1fa0b9479c304d6dc18050ed94252e833aedb caused the VTK Python wrapper to see two overloads of GetFileNameWithoutExtension, breaking the default argument on the const char* version. As a result, calling the method with no arguments from Python raised:

  TypeError: GetFileNameWithoutExtension() takes exactly 1 argument (0 given)

Guard the std::string overload with #ifndef __VTK_WRAP__ so it is hidden from the VTK wrapper while remaining available to C++ callers.