### PR TITLE
BUG: Rebuild model display map after batch updates

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -407,6 +407,14 @@ void vtkMRMLModelDisplayableManager::OnMRMLSceneEndClose()
 }
 
 //---------------------------------------------------------------------------
+void vtkMRMLModelDisplayableManager::OnMRMLSceneEndBatchProcess()
+{
+  this->PruneMissingNodes();
+  this->SetUpdateFromMRMLRequested(true);
+  Superclass::OnMRMLSceneEndBatchProcess();
+}
+
+//---------------------------------------------------------------------------
 void vtkMRMLModelDisplayableManager::UpdateFromMRMLScene()
 {
   // UpdateFromMRML will be executed only if there has been some actions
@@ -1231,6 +1239,29 @@ void vtkMRMLModelDisplayableManager::RemoveModelObservers(int clearCache)
   if (clearCache)
   {
     this->ClearDisplayMaps();
+  }
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLModelDisplayableManager::PruneMissingNodes()
+{
+  if (!this->GetMRMLScene())
+  {
+    return;
+  }
+
+  std::vector<vtkMRMLDisplayableNode*> removedDisplayableNodes;
+  for (auto iter = this->Internal->DisplayableNodes.begin(); iter != this->Internal->DisplayableNodes.end(); iter++)
+  {
+    vtkMRMLDisplayNode* modelDisplayNode = vtkMRMLDisplayNode::SafeDownCast(this->GetMRMLScene()->GetNodeByID(iter->first));
+    if (modelDisplayNode == nullptr)
+    {
+      removedDisplayableNodes.push_back(iter->second);
+    }
+  }
+  for (auto displayableNode : removedDisplayableNodes)
+  {
+    this->RemoveDisplayable(displayableNode);
   }
 }
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.h
@@ -121,6 +121,7 @@ protected:
   void UpdateFromMRMLScene() override;
   void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
   void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) override;
+  void OnMRMLSceneEndBatchProcess() override;
 
   void OnInteractorStyleEvent(int eventId) override;
   void ProcessMRMLNodesEvents(vtkObject* caller, unsigned long event, void* callData) override;
@@ -138,6 +139,10 @@ protected:
   void RemoveModelObservers(int clearCache);
   void RemoveDisplayable(vtkMRMLDisplayableNode* model);
   void RemoveDisplayableNodeObservers(vtkMRMLDisplayableNode* model);
+
+  /// Remove display pipelines for nodes that are not in the scene anymore
+  /// (e.g. because they were removed during batch processing).
+  void PruneMissingNodes();
 
   void UpdateModelsFromMRML();
   void UpdateModel(vtkMRMLDisplayableNode* model);


### PR DESCRIPTION
Clear existing display maps before updating from the MRML scene.

During batch processing, model nodes may be removed without removing their corresponding display pipeline. Rebuilding the map ensures stale pipelines are discarded after the batch operation completes.