### PR TITLE
BUG: Prevent VTK output window from showing on startup on Windows

### DIFF
--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -68,6 +68,7 @@
 #include <vtksys/SystemTools.hxx>
 #include <vtkNew.h>
 #include <vtkLogger.h>
+#include <vtkOutputWindow.h>
 
 // PythonQt includes
 #ifdef Slicer_USE_PYTHONQT
@@ -97,6 +98,18 @@ void qSlicerApplicationHelper::preInitializeApplication(const char* argv0, ctkPr
 #endif
 
   vtkLogger::SetStderrVerbosity(vtkLogger::VERBOSITY_OFF);
+
+#ifdef _WIN32
+  // vtkWin32OutputWindow::DisplayText() unconditionally shows a GUI popup for any
+  // VTK message, ignoring DisplayMode. Replace it early with the base class which
+  // properly suppresses output in NEVER mode, until CTK's error log handler takes over.
+  {
+    vtkNew<vtkOutputWindow> suppressingWindow;
+    suppressingWindow->SetDisplayModeToNever();
+    vtkOutputWindow::SetInstance(suppressingWindow);
+  }
+#endif
+
   itk::itkFactoryRegistration();
   qMRMLWidget::preInitializeApplication();
 


### PR DESCRIPTION
After updating Slicer, I noticed that on every startup an empty vtkOutputWindow is shown. This is a workaround to prevent that. This was Claude Code's assessment of the issue:

## `vtkOutputWindow` popup appears on startup after upgrading to VTK 9.6

### Problem

Since updating Slicer to the latest revision (which uses VTK 9.6.1 as the default), an empty Win32 popup titled **"vtkOutputWindow"** appears on startup, accompanied by a system sound. No extensions are needed to reproduce this.

### Root cause

There are two compounding issues.

**1. `vtkWin32OutputWindow::DisplayText()` ignores `DisplayMode`**

`vtkWin32OutputWindow` sets `DisplayMode = NEVER` in its constructor (to suppress stdout/stderr on non-dashboard machines), but its `DisplayText()` override unconditionally calls `AddText()` regardless of the display mode:

```cpp
// vtkWin32OutputWindow::DisplayText() — both VTK 9.5 and 9.6
const auto streamtype = this->GetDisplayStream(...);  // NEVER → Null
// ...
this->AddText(someText);   // always called, regardless of streamtype
this->AddText("\r\n");     // always called
// streamtype only gates cout/cerr, NOT the Win32 GUI window
```

`AddText()` calls `Initialize()` which calls `ShowWindow()` — the popup appears for *any* VTK message that reaches the `vtkWin32OutputWindow` singleton. The base class `vtkOutputWindow::DisplayText()` correctly checks `DisplayMode` and does nothing in `NEVER` mode; the Win32 subclass does not.

**2. CTK's VTK message handler is installed too late**

`ctkVTKErrorLogMessageHandler` (which replaces `vtkWin32OutputWindow` with a silent `ctkVTKOutputWindow`) is installed in `qSlicerApplicationPrivate::init()`:

```cpp
this->ErrorLogModel->registerMsgHandler(new ctkVTKErrorLogMessageHandler);
this->ErrorLogModel->setAllMsgHandlerEnabled(true);  // ← VTK output window replaced here
```

However, a large amount of VTK/MRML initialization happens *before* this point in the same function:

| Step | Code | CTK handler? |
|------|------|-------------|
| `ctkVTKConnectionFactory::setInstance(...)` | line 318 | ✗ |
| `new qSlicerPythonManager()` | line 325 | ✗ |
| `this->Superclass::init()` → creates `vtkSlicerApplicationLogic`, `vtkMRMLScene`, initializes Python, etc. | line 334 | ✗ |
| **CTK VTK handler installed** | lines 393–394 | ✓ |

Any VTK message generated during those unguarded steps goes directly to `vtkWin32OutputWindow`.

**3. Why it is new with VTK 9.6**

VTK 9.6.1 (now the default since the March 2026 SuperBuild update) generates at least one new VTK message during the unguarded initialization phase that VTK 9.5.2 did not. A breakpoint on `vtkWin32OutputWindow::AddText()` will identify the exact trigger.

**4. Why the popup appears empty**

VTK error/warning messages start with `\n` (e.g. `"\nERROR: In file.cxx, line N\n..."`). In `DisplayText()`, the leading `\n` causes `Initialize()` to fire (showing the window) before any visible text is added. The actual message content is then queued via asynchronous `PostMessageW(EM_REPLACESEL, ...)` — since the main thread has not returned to the Win32 message loop yet, the edit control remains visually empty when the user first sees the window.

---

### Fix options

**Option A — Slicer (applied here): suppress `vtkWin32OutputWindow` early**

In `qSlicerApplicationHelper::preInitializeApplication()`, replace the default `vtkWin32OutputWindow` singleton with the base `vtkOutputWindow` before any VTK objects are created. The base class properly does nothing in `NEVER` mode.

```cpp
void qSlicerApplicationHelper::preInitializeApplication(...)
{
  vtkLogger::SetStderrVerbosity(vtkLogger::VERBOSITY_OFF);

#ifdef _WIN32
  // vtkWin32OutputWindow::DisplayText() unconditionally shows a GUI popup for any
  // VTK message, ignoring DisplayMode. Replace it early with the base class which
  // properly suppresses output in NEVER mode, until CTK's error log handler takes over.
  {
    vtkNew<vtkOutputWindow> suppressingWindow;
    suppressingWindow->SetDisplayModeToNever();
    vtkOutputWindow::SetInstance(suppressingWindow);
  }
#endif

  itk::itkFactoryRegistration();
  // ...
```

When CTK's handler is later enabled, it saves this benign base-class instance, replaces it with its own, and restores it on shutdown — all transparently.

**Option B — VTK fork: fix the underlying bug in `vtkWin32OutputWindow`**

In `Common/Core/vtkWin32OutputWindow.cxx`, make `DisplayText()` respect `DisplayMode` for the GUI window by returning early when the stream type is `Null`:

```cpp
void vtkWin32OutputWindow::DisplayText(const char* someText)
{
  std::lock_guard<std::mutex> lock(vtkWin32OutputWindowMutex);
  if (!someText) { return; }
  if (this->PromptUser) { this->PromptText(someText); return; }

  const auto streamtype = this->GetDisplayStream(this->GetCurrentMessageType());

  // Respect NEVER display mode — suppress the GUI window, not just stdout/stderr
  if (streamtype == StreamType::Null)
  {
    return;
  }

  // existing AddText / OutputDebugString / cout/cerr logic ...
```

This should be applied to the `slicer-v9.6.1-2026-03-24` branch of [Slicer/VTK](https://github.com/Slicer/VTK).