### PR TITLE
BUG: Fix qMRMLNodeComboBox::nodeAddedByUser emitted twice

### DIFF
--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest5.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest5.cxx
@@ -28,10 +28,13 @@
 
 // qMRML includes
 #include "qMRMLNodeComboBox.h"
+#include "qMRMLSceneModel.h"
 
 // MRML includes
 #include <vtkMRMLCameraNode.h>
+#include <vtkMRMLNode.h>
 #include <vtkMRMLScene.h>
+#include <vtkMRMLScalarVolumeNode.h>
 
 // VTK includes
 #include <vtkNew.h>
@@ -83,6 +86,114 @@ int qMRMLNodeComboBoxTest5(int argc, char* argv[])
   {
     std::cerr << "qMRMLNodeComboBox::setCurrentNode() failed: " << spy.count() << std::endl;
     return EXIT_FAILURE;
+  }
+
+  // vtkMRMLNode* must be registered as a Qt metatype for QSignalSpy to
+  // capture signals with vtkMRMLNode* arguments.
+  qRegisterMetaType<vtkMRMLNode*>("vtkMRMLNode*");
+
+  // --- Test: nodeAdded / nodeAddedByUser / nodeAddedByUserAction signal counts ---
+  //
+  // A programmatic addNode() call should emit exactly one nodeAdded and one
+  // nodeAddedByUser signal, but no nodeAddedByUserAction signal.
+  //
+  // A GUI-triggered add (clicking the "Create new..." extra item) should emit
+  // one nodeAdded, one nodeAddedByUser, AND one nodeAddedByUserAction signal.
+
+  vtkNew<vtkMRMLScene> addNodeScene;
+  qMRMLNodeComboBox addNodeSelector;
+  addNodeSelector.setNodeTypes(QStringList("vtkMRMLScalarVolumeNode"));
+  addNodeSelector.setAddEnabled(true);
+  addNodeSelector.setMRMLScene(addNodeScene.GetPointer());
+
+  // Programmatic add: addNode() should emit nodeAdded x1, nodeAddedByUser x1,
+  // nodeAddedByUserAction x0.
+  {
+    QSignalSpy nodeAddedSpy(&addNodeSelector, SIGNAL(nodeAdded(vtkMRMLNode*)));
+    QSignalSpy nodeAddedByUserSpy(&addNodeSelector, SIGNAL(nodeAddedByUser(vtkMRMLNode*)));
+    QSignalSpy nodeAddedByUserActionSpy(&addNodeSelector, SIGNAL(nodeAddedByUserAction(vtkMRMLNode*)));
+
+    vtkMRMLNode* newNode = addNodeSelector.addNode();
+    if (!newNode)
+    {
+      std::cerr << __LINE__ << " - addNode() returned null." << std::endl;
+      return EXIT_FAILURE;
+    }
+    if (nodeAddedSpy.count() != 1)
+    {
+      std::cerr << __LINE__ << " - Programmatic addNode() should emit nodeAdded exactly once,"
+                << " got " << nodeAddedSpy.count() << std::endl;
+      return EXIT_FAILURE;
+    }
+    if (nodeAddedByUserSpy.count() != 1)
+    {
+      std::cerr << __LINE__ << " - Programmatic addNode() should emit nodeAddedByUser exactly once,"
+                << " got " << nodeAddedByUserSpy.count() << std::endl;
+      return EXIT_FAILURE;
+    }
+    if (nodeAddedByUserActionSpy.count() != 0)
+    {
+      std::cerr << __LINE__ << " - Programmatic addNode() should not emit nodeAddedByUserAction,"
+                << " got " << nodeAddedByUserActionSpy.count() << std::endl;
+      return EXIT_FAILURE;
+    }
+    std::cout << "Programmatic addNode() signal test passed." << std::endl;
+  }
+
+  // GUI add: activateExtraItem with a CREATE index (simulating a click on the
+  // "Create new..." dropdown item) should emit all three signals exactly once.
+  // The combobox rootModelIndex is set to model->index(0,0), the proxy-mapped
+  // mrmlSceneItem; extra items (CREATE/...) are children of that index.
+  {
+    QSignalSpy nodeAddedSpy(&addNodeSelector, SIGNAL(nodeAdded(vtkMRMLNode*)));
+    QSignalSpy nodeAddedByUserSpy(&addNodeSelector, SIGNAL(nodeAddedByUser(vtkMRMLNode*)));
+    QSignalSpy nodeAddedByUserActionSpy(&addNodeSelector, SIGNAL(nodeAddedByUserAction(vtkMRMLNode*)));
+
+    QAbstractItemModel* model = addNodeSelector.model();
+    QModelIndex sceneItemIndex = model->index(0, 0, QModelIndex());
+    QModelIndex createIndex;
+    for (int i = 0; i < model->rowCount(sceneItemIndex); ++i)
+    {
+      QModelIndex idx = model->index(i, 0, sceneItemIndex);
+      if (model->data(idx, qMRMLSceneModel::ExtraItemsRole).toString().startsWith("CREATE"))
+      {
+        createIndex = idx;
+        break;
+      }
+    }
+    if (!createIndex.isValid())
+    {
+      std::cerr << __LINE__ << " - Could not find CREATE extra item in combobox model." << std::endl;
+      return EXIT_FAILURE;
+    }
+
+    // activateExtraItem is a protected slot; QMetaObject::invokeMethod bypasses
+    // C++ access control, invoking it exactly as a user click on the item would.
+    bool invoked = QMetaObject::invokeMethod(&addNodeSelector, "activateExtraItem", Qt::DirectConnection, Q_ARG(QModelIndex, createIndex));
+    if (!invoked)
+    {
+      std::cerr << __LINE__ << " - Failed to invoke activateExtraItem." << std::endl;
+      return EXIT_FAILURE;
+    }
+    if (nodeAddedSpy.count() != 1)
+    {
+      std::cerr << __LINE__ << " - GUI addNode should emit nodeAdded exactly once,"
+                << " got " << nodeAddedSpy.count() << std::endl;
+      return EXIT_FAILURE;
+    }
+    if (nodeAddedByUserSpy.count() != 1)
+    {
+      std::cerr << __LINE__ << " - GUI addNode should emit nodeAddedByUser exactly once,"
+                << " got " << nodeAddedByUserSpy.count() << std::endl;
+      return EXIT_FAILURE;
+    }
+    if (nodeAddedByUserActionSpy.count() != 1)
+    {
+      std::cerr << __LINE__ << " - GUI addNode should emit nodeAddedByUserAction exactly once,"
+                << " got " << nodeAddedByUserActionSpy.count() << std::endl;
+      return EXIT_FAILURE;
+    }
+    std::cout << "GUI addNode (activateExtraItem) signal test passed." << std::endl;
   }
 
   nodeSelector.show();

--- a/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
@@ -450,7 +450,7 @@ void qMRMLNodeComboBox::activateExtraItem(const QModelIndex& index)
         if (newNode != nullptr)
         {
           this->setCurrentNode(newNode);
-          emit this->nodeAddedByUser(newNode);
+          emit this->nodeAddedByUserAction(newNode);
         }
       }
     }
@@ -703,7 +703,7 @@ void qMRMLNodeComboBox::createNodeAs(const QString& nodeTypeName)
     {
       newNode->SetName(nodeName.toUtf8());
       this->setCurrentNode(newNode);
-      emit this->nodeAddedByUser(newNode);
+      emit this->nodeAddedByUserAction(newNode);
     }
   }
 }

--- a/Libs/MRML/Widgets/qMRMLNodeComboBox.h
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBox.h
@@ -350,8 +350,16 @@ signals:
   /// Only nodes with valid type emit the signal
   void nodeAdded(vtkMRMLNode* node);
 
-  /// Signal emitted when \a node is added by the user
+  /// Deprecated. Use \a nodeAdded or \a nodeAddedByUserAction signal instead.
+  ///
+  /// The signal is deprecated, because the name is not accurate.
+  /// The name would suggest that it is emitted only when the user adds a new node
+  /// via GUI, but it is actually emitted whenever a node is added (even if not
+  /// triggered from the GUI).
   void nodeAddedByUser(vtkMRMLNode* node);
+
+  /// Signal emitted when \a node is added by the user
+  void nodeAddedByUserAction(vtkMRMLNode* node);
 
   /// Signal emitted when \a node is about to be removed from
   /// the comboBox. Only nodes with valid type emit the signal


### PR DESCRIPTION
## Summary

Fixes #9143.

`qMRMLNodeComboBox::nodeAddedByUser` is emitted twice for every user-initiated node creation through the combo box. The duplicate fire comes from `addNode(QString)` itself emitting the signal on every successful return at `Libs/MRML/Widgets/qMRMLNodeComboBox.cxx:610`, on top of the explicit emit at the two user-action call sites:

- `onComboBoxIndexChanged` slot at line 449 calls `addNode(nodeTypeName)` then emits at line 453.
- `createNodeAs` slot (after the rename dialog) at line 701 calls `addNode(nodeTypeName)` then emits at line 706.

This PR removes the emit inside `addNode(QString)`. Both user-initiated call sites still emit exactly once. The Python reproducer in the issue (`combo.nodeAddedByUser.connect(...)` then add a node from the dropdown) now fires the slot once instead of twice.

## Why remove the inner emit, not one of the outer ones

`addNode(QString)` is a public `Q_INVOKABLE` method (declared in `qMRMLNodeComboBox.h:300`). It can be called from Python, from scripted modules, and from C++ that wants to create a node without going through any user gesture. Emitting `nodeAddedByUser` from inside that method means a programmatic add silently fires a signal whose name explicitly says "by user." The two user-action call sites are the right and only place for the signal.

Behavior change scope:

- User combo dropdown "Create new node" path: ONE emit (line 453). Was TWO.
- User combo dropdown "Create new node as..." path: ONE emit (line 706). Was TWO.
- Programmatic `addNode(QString)` callers (Python, C++, scripted modules): ZERO emits. Was ONE.

Net: every user-driven flow keeps emitting exactly once; programmatic flows stop falsely emitting "by user."

## Test plan

- [x] Read `Libs/MRML/Widgets/qMRMLNodeComboBox.cxx` lines 440-470, 595-625, and 685-710 to confirm the call graph above.
- [x] Read `Libs/MRML/Widgets/qMRMLNodeComboBox.h` to confirm `addNode(QString)` is `Q_INVOKABLE` and `nodeAddedByUser` is the documented signal at line 354.
- [x] Confirm via grep there is no other caller of `addNode(QString)` that would lose a needed emit (only the two user-action paths and the no-arg `addNode()` overload at line 615 which itself delegates to the QString overload).
- [ ] **Could not validate locally**: I do not have a working Slicer build environment (full build is hours). I am relying on the existing CI to confirm the change compiles and passes the existing widget test suite (`Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest{1..5}.cxx` plus `qMRMLNodeComboBoxLazyUpdateTest1.cxx` and `qMRMLNodeComboBoxEventTranslatorPlayerTest1.cxx`). None of those existing tests assert emission count on `nodeAddedByUser`, so they will not catch a regression here either way; adding a counting test would require either a full Slicer build or a more focused QSignalSpy-based unit. Happy to add one in a follow-up if a maintainer prefers.
- [ ] @che85, if you can run your Python reproducer from the issue against this branch, the connected slot should print exactly once now.

cc: @che85

## AI Assistance Disclosure

Analysis and the patch were drafted with Claude assistance. I traced the call graph by hand against the repo's source, verified the public Q_INVOKABLE surface of `addNode`, and reviewed every changed line. I am the human contributor accountable for this PR.
