### PR TITLE
Fix CacheManager startup warning

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -657,6 +657,15 @@ void qSlicerCoreApplicationPrivate::initDataIO()
       q->setCachePath(newCacheFolder);
     }
   }
+
+  // Older Slicer versions did not add sentinel file to the cache folder, so we add it now if it was missing.
+  // But we only do that if the folder was not manually changed by the user (in that case we cannot be sure that the folder only contains temporary files, so it is safer to not add
+  // the sentinel file, because that would enable file deletion from the cache folder).
+  if (!this->MRMLRemoteIOLogic->GetCacheManager()->HasSentinelFileInDirectory(q->cachePath().toStdString()) && q->cachePath() == q->defaultCachePath())
+  {
+    this->MRMLRemoteIOLogic->GetCacheManager()->CreateSentinelFileInDirectory(q->cachePath().toStdString());
+  }
+
   this->MRMLRemoteIOLogic->GetCacheManager()->SetRemoteCacheDirectory(q->cachePath().toUtf8());
 
   this->DataIOManagerLogic = vtkSmartPointer<vtkDataIOManagerLogic>::New();

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -332,6 +332,18 @@ void qSlicerApplicationPrivate::init()
   }
 #endif
 
+  //----------------------------------------------------------------------------
+  // Instantiate ErrorLogModel
+  //----------------------------------------------------------------------------
+  this->ErrorLogModel = QSharedPointer<ctkErrorLogModel>(new ctkErrorLogModel);
+  this->ErrorLogModel->setLogEntryGrouping(true);
+  this->ErrorLogModel->setTerminalOutputs(this->CoreCommandOptions->disableTerminalOutputs() ? ctkErrorLogTerminalOutput::None : ctkErrorLogTerminalOutput::All);
+  this->ErrorLogModel->registerMsgHandler(new ctkErrorLogQtMessageHandler);
+  this->ErrorLogModel->registerMsgHandler(new ctkErrorLogStreamMessageHandler);
+  this->ErrorLogModel->registerMsgHandler(new ctkITKErrorLogMessageHandler);
+  this->ErrorLogModel->registerMsgHandler(new ctkVTKErrorLogMessageHandler);
+  this->ErrorLogModel->setAllMsgHandlerEnabled(true);
+
   this->Superclass::init();
 
 #ifdef Slicer_USE_PYTHONQT
@@ -375,24 +387,16 @@ void qSlicerApplicationPrivate::init()
   this->ToolTipTrapper->setToolTipsTrapped(false);
   this->ToolTipTrapper->setToolTipsWordWrapped(true);
 
-  //----------------------------------------------------------------------------
-  // Instantiate ErrorLogModel
-  //----------------------------------------------------------------------------
-  this->ErrorLogModel = QSharedPointer<ctkErrorLogModel>(new ctkErrorLogModel);
-  this->ErrorLogModel->setLogEntryGrouping(true);
-  this->ErrorLogModel->setTerminalOutputs(this->CoreCommandOptions->disableTerminalOutputs() ? ctkErrorLogTerminalOutput::None : ctkErrorLogTerminalOutput::All);
+  // ctkErrorLogFDMessageHandler redirects stdout and stderr to the application log.
+  // It cannot be enabled earlier, because it would make Python manager initialization hang.
 #if defined(Q_OS_WIN32) && !defined(Slicer_BUILD_WIN32_CONSOLE)
   // Must not register ctkErrorLogFDMessageHandler when building a window-based
   // (non-console) application because this handler would not
   // let the application to quit when the last window is closed.
 #else
   this->ErrorLogModel->registerMsgHandler(new ctkErrorLogFDMessageHandler);
+  this->ErrorLogModel->setMsgHandlerEnabled(ctkErrorLogFDMessageHandler::HandlerName, true);
 #endif
-  this->ErrorLogModel->registerMsgHandler(new ctkErrorLogQtMessageHandler);
-  this->ErrorLogModel->registerMsgHandler(new ctkErrorLogStreamMessageHandler);
-  this->ErrorLogModel->registerMsgHandler(new ctkITKErrorLogMessageHandler);
-  this->ErrorLogModel->registerMsgHandler(new ctkVTKErrorLogMessageHandler);
-  this->ErrorLogModel->setAllMsgHandlerEnabled(true);
 
 #ifdef Slicer_USE_PYTHONQT
   // Make ITK, VTK, Qt error messages show up in the Python console

--- a/Libs/MRML/Core/vtkCacheManager.cxx
+++ b/Libs/MRML/Core/vtkCacheManager.cxx
@@ -404,8 +404,8 @@ void vtkCacheManager::SetRemoteCacheDirectory(const char* dir)
       }
       else
       {
-        vtkWarningMacro("Cache directory does not contain sentinel file " << this->GetSentinelFileName()
-                                                                          << ". Destructive cache operations are disabled until the sentinel is created.");
+        vtkWarningMacro("Cache directory '" << this->RemoteCacheDirectory << "' does not contain sentinel file " << this->GetSentinelFileName()
+                                            << ". Destructive cache operations are disabled until the sentinel is created.");
       }
     }
   }

--- a/Modules/Loadable/SceneViews/Testing/Cxx/vtkSceneViewImportSceneTest.cxx
+++ b/Modules/Loadable/SceneViews/Testing/Cxx/vtkSceneViewImportSceneTest.cxx
@@ -27,6 +27,7 @@
 #include <vtkMRMLScene.h>
 
 // VTK includes
+#include <vtksys/SystemTools.hxx>
 
 #include <vtkImageData.h>
 #include <vtkNew.h>
@@ -87,9 +88,17 @@ int vtkSceneViewImportSceneTest(int argc, char* argv[])
 
   // Save a scene containing a viewnode and a sceneview node.
   vtkNew<vtkMRMLScene> scene;
+
+  std::string cacheDir = std::string(tempDir) + "/" + scene->GetTemporaryBundleDirectory();
+  if (!vtksys::SystemTools::MakeDirectory(cacheDir.c_str()))
+  {
+    std::cerr << "Failed to create cache directory: " << cacheDir << std::endl;
+    return EXIT_FAILURE;
+  }
+
   scene->SetDataIOManager(vtkNew<vtkDataIOManager>());
   scene->GetDataIOManager()->SetCacheManager(vtkNew<vtkCacheManager>());
-  scene->GetDataIOManager()->GetCacheManager()->SetRemoteCacheDirectory(tempDir);
+  scene->GetDataIOManager()->GetCacheManager()->SetRemoteCacheDirectory(cacheDir.c_str());
 
   vtkNew<vtkMRMLApplicationLogic> appLogic;
 
@@ -126,5 +135,6 @@ int vtkSceneViewImportSceneTest(int argc, char* argv[])
 
   CHECK_INT(sceneViewLogic->GetNumberOfSceneViews(), 1);
 
+  vtksys::SystemTools::RemoveADirectory(cacheDir);
   return EXIT_SUCCESS;
 }

--- a/Modules/Loadable/Sequences/Testing/Cxx/vtkMRMLSequenceStorageNodeTest1.cxx
+++ b/Modules/Loadable/Sequences/Testing/Cxx/vtkMRMLSequenceStorageNodeTest1.cxx
@@ -32,6 +32,8 @@
 #include <vtkMRMLVolumeSequenceStorageNode.h>
 
 // VTK includes
+#include <vtksys/SystemTools.hxx>
+
 #include <vtkImageData.h>
 #include <vtkMatrix4x4.h>
 #include <vtkNew.h>
@@ -87,9 +89,17 @@ int vtkMRMLSequenceStorageNodeTest1(int argc, char* argv[])
   }
 
   vtkNew<vtkMRMLScene> scene;
+
+  std::string cacheDir = tempDir + "/" + scene->GetTemporaryBundleDirectory();
+  if (!vtksys::SystemTools::MakeDirectory(cacheDir.c_str()))
+  {
+    std::cerr << "Failed to create cache directory: " << cacheDir << std::endl;
+    return EXIT_FAILURE;
+  }
+
   scene->SetDataIOManager(vtkNew<vtkDataIOManager>());
   scene->GetDataIOManager()->SetCacheManager(vtkNew<vtkCacheManager>());
-  scene->GetDataIOManager()->GetCacheManager()->SetRemoteCacheDirectory(tempDir.c_str());
+  scene->GetDataIOManager()->GetCacheManager()->SetRemoteCacheDirectory(cacheDir.c_str());
 
   // Add generic node sequence
   {
@@ -158,5 +168,6 @@ int vtkMRMLSequenceStorageNodeTest1(int argc, char* argv[])
     CHECK_NOT_NULL(createdTransformStorageNode);
   }
 
+  vtksys::SystemTools::RemoveADirectory(cacheDir);
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Initialize application logger earlier to capture more messages during startup.
Only log warning about missing cache folder sentinel file if the cache folder location is non-default.

see #9155
