### PR TITLE
COMP: Update python packages to latest

### DIFF
--- a/SuperBuild/External_python-SimpleITK.cmake
+++ b/SuperBuild/External_python-SimpleITK.cmake
@@ -27,16 +27,16 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [simpleitk]
   # Hashes correspond to the following packages:
-  #  - simpleitk-2.5.3-cp311-abi3-macosx_10_9_x86_64.whl
-  #  - simpleitk-2.5.3-cp311-abi3-macosx_11_0_arm64.whl
-  #  - simpleitk-2.5.3-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
-  #  - simpleitk-2.5.3-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-  #  - simpleitk-2.5.3-cp311-abi3-win_amd64.whl
-  simpleitk==2.5.3 --hash=sha256:eda739126d3cdda29266b722c3bb182a534ee4b4b60a6e565c20e1ebbd7ca2da \
-                   --hash=sha256:5438fb87b7e3380b1ba02b2447bf9f474560b51a649b2ad6973195c6515a43a5 \
-                   --hash=sha256:724a8fba4a493a9da06cbba545521174092927acf99fbc0594f4f257d66061ff \
-                   --hash=sha256:b615a96826815471965899d50d089fb67381a4d59b65750eafe58a6a980ecce2 \
-                   --hash=sha256:31b187922c53c858f8604b4f90ebd7aae809e680de751674f5f95ccefcf674d5
+  #  - simpleitk-2.5.5-cp311-abi3-macosx_10_9_x86_64.whl
+  #  - simpleitk-2.5.5-cp311-abi3-macosx_11_0_arm64.whl
+  #  - simpleitk-2.5.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+  #  - simpleitk-2.5.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  #  - simpleitk-2.5.5-cp311-abi3-win_amd64.whl
+  simpleitk==2.5.5 --hash=sha256:e831d15f5ea5b0e02ed3a6ac5f2dd34ba0a0eeaa4ebacfb1d970999836b19ee0 \
+                   --hash=sha256:ee87416622cec6ed6b96747a0648c82c6e88f10b6553668ce90736f09ab5a994 \
+                   --hash=sha256:847f42057d7bf01b5721b107dd3e00d4ee8d514f6f1ff85794ffedacaf4afc53 \
+                   --hash=sha256:8ace5e392be00d5bec28c87ef1d73016f8ebe671dafffe9e9d045f20b0968033 \
+                   --hash=sha256:a5fcfcfe9242d3d509b254b3213ca0f5db2c15903f2fc375d9ac5d38e57d415d
   # [/simpleitk]
   ]===])
 

--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -42,55 +42,50 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pydicom]
-  pydicom==3.0.1 --hash=sha256:db32f78b2641bd7972096b8289111ddab01fb221610de8d7afa835eb938adb41
+  pydicom==3.0.2 --hash=sha256:abf971a5440f84dbaf42c4b6758e30e62480902584f8b270b9a5d146e278a07b
   # [/pydicom]
   # [six]
   six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
   # [/six]
   # [pillow]
   # Hashes correspond to the following packages:
-  #  - pillow-12.0.0-cp312-cp312-macosx_10_13_x86_64.whl
-  #  - pillow-12.0.0-cp312-cp312-macosx_11_0_arm64.whl
-  #  - pillow-12.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
-  #  - pillow-12.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-  #  - pillow-12.0.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
-  #  - pillow-12.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-  #  - pillow-12.0.0-cp312-cp312-musllinux_1_2_aarch64.whl
-  #  - pillow-12.0.0-cp312-cp312-musllinux_1_2_x86_64.whl
-  #  - pillow-12.0.0-cp312-cp312-win_amd64.whl
-  #  - pillow-12.0.0-cp312-cp312-win_arm64.whl
-  pillow==12.0.0 --hash=sha256:53561a4ddc36facb432fae7a9d8afbfaf94795414f5cdc5fc52f28c1dca90371 \
-                 --hash=sha256:71db6b4c1653045dacc1585c1b0d184004f0d7e694c7b34ac165ca70c0838082 \
-                 --hash=sha256:2fa5f0b6716fc88f11380b88b31fe591a06c6315e955c096c35715788b339e3f \
-                 --hash=sha256:82240051c6ca513c616f7f9da06e871f61bfd7805f566275841af15015b8f98d \
-                 --hash=sha256:55f818bd74fe2f11d4d7cbc65880a843c4075e0ac7226bc1a23261dbea531953 \
-                 --hash=sha256:b87843e225e74576437fd5b6a4c2205d422754f84a06942cfaf1dc32243e45a8 \
-                 --hash=sha256:c607c90ba67533e1b2355b821fef6764d1dd2cbe26b8c1005ae84f7aea25ff79 \
-                 --hash=sha256:21f241bdd5080a15bc86d3466a9f6074a9c2c2b314100dd896ac81ee6db2f1ba \
-                 --hash=sha256:9fe611163f6303d1619bbcb653540a4d60f9e55e622d60a3108be0d5b441017a \
-                 --hash=sha256:7dfb439562f234f7d57b1ac6bc8fe7f838a4bd49c79230e0f6a1da93e82f1fad
+  #  - pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl
+  #  - pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl
+  #  - pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+  #  - pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  #  - pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+  #  - pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  #  - pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl
+  #  - pillow-12.2.0-cp312-cp312-win_amd64.whl
+  #  - pillow-12.2.0-cp312-cp312-win_arm64.whl
+  pillow==12.2.0 --hash=sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5 \
+                 --hash=sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421 \
+                 --hash=sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987 \
+                 --hash=sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76 \
+                 --hash=sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005 \
+                 --hash=sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780 \
+                 --hash=sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5 \
+                 --hash=sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5 \
+                 --hash=sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5 \
+                 --hash=sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414
   # [/pillow]
   # [retrying]
   retrying==1.4.2 --hash=sha256:bbc004aeb542a74f3569aeddf42a2516efefcdaff90df0eb38fbfbf19f179f59
   # [/retrying]
   # [dicomweb-client]
-  dicomweb-client==0.60.1 --hash=sha256:e128866a797b7acdcd4ad280a10ebced5af77a3ce1d1bde709389ad56583955d
+  dicomweb-client==0.61.0 --hash=sha256:dc3385f5dbbeb167c521d04a70eac8bf219c4302c14574af05b5bc577a7e22c5
   # [/dicomweb-client]
   # [dcmqi]
-  # Binary distribution of the DCMQI tools (segimage2itkimage, itkimage2segimage,
-  # paramap2itkimage, tid1500reader, tid1500writer, etc.) used by DICOM plugins.
-  # Note: macOS wheels require macOS 13+; Linux wheel is manylinux_2_28 x86_64 only.
   # Hashes correspond to the following packages:
-  #  - dcmqi-0.3.3-py3-none-macosx_13_0_arm64.whl
-  #  - dcmqi-0.3.3-py3-none-macosx_13_0_x86_64.whl
-  #  - dcmqi-0.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-  #  - dcmqi-0.3.3-py3-none-win32.whl
-  #  - dcmqi-0.3.3-py3-none-win_amd64.whl
-  dcmqi==0.3.3 --hash=sha256:92f5f942d0349357e511c6a5d3a3703884c3f2127e822e2a204dec8021aa83c4 \
-               --hash=sha256:cb007a8991928ff09c864d4c468255f460f6457629a449ad3d52390bf11489f3 \
-               --hash=sha256:5a689b17c1163094a73468d8a624611d460ad86969d24ffd22aeccfee7cb4dc1 \
-               --hash=sha256:daf19ba9326574eb5df6bed91598e6ee55852637c277e37ff29231936526d5ab \
-               --hash=sha256:ca684f09857323389355196cba3c58fce30f4581f1d5220725e2ab08596f6e0f
+  #  - dcmqi-0.4.0-py3-none-macosx_13_0_arm64.whl
+  #  - dcmqi-0.4.0-py3-none-macosx_13_0_x86_64.whl
+  #  - dcmqi-0.4.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  #  - dcmqi-0.4.0-py3-none-win_amd64.whl
+  dcmqi==0.4.0 --hash=sha256:2138fc78e79c28449348572eb7ff0483f98f6a71c821814ca3cf28e3357ad848 \
+               --hash=sha256:60f6a9e4d4828c5399e932f44b500e4619becbe27dd4e4574cc94a802cbdcd00 \
+               --hash=sha256:1721bf1308fa416b00d3f9895c99b2376524a9982a408f15cf281ceef159df5b \
+               --hash=sha256:c3cc2c32f196e96017e08b27550c4b05ac84fde411ef743f882eb8e00ab5709a
   # [/dcmqi]
   # [highdicom]
   # Pure-Python package for creating/reading complex DICOM objects (SR, SEG, PM, etc.)

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -34,7 +34,21 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [chardet]
-  chardet==5.2.0 --hash=sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970
+  # Hashes correspond to the following packages:
+  #  - chardet-7.4.3-cp312-cp312-macosx_10_13_x86_64.whl
+  #  - chardet-7.4.3-cp312-cp312-macosx_11_0_arm64.whl
+  #  - chardet-7.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  #  - chardet-7.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  #  - chardet-7.4.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl
+  #  - chardet-7.4.3-cp312-cp312-win_amd64.whl
+  #  - chardet-7.4.3-py3-none-any.whl
+  chardet==7.4.3 --hash=sha256:75d3c65cc16bddf40b8da1fd25ba84fca5f8070f2b14e86083653c1c85aee971 \
+                 --hash=sha256:29af5999f654e8729d251f1724a62b538b1262d9292cccaefddf8a02aae1ef6a \
+                 --hash=sha256:626f00299ad62dfe937058a09572beed442ccc7b58f87aa667949b20fd3db235 \
+                 --hash=sha256:9a4904dd5f071b7a7d7f50b4a67a86db3c902d243bf31708f1d5cde2f68239cb \
+                 --hash=sha256:5d2879598bc220689e8ce509fe9c3f37ad2fca53a36be9c9bd91abdd91dd364f \
+                 --hash=sha256:4b2799bd58e7245cfa8d4ab2e8ad1d76a5c3a5b1f32318eb6acca4c69a3e7101 \
+                 --hash=sha256:1173b74051570cf08099d7429d92e4882d375ad4217f92a6e5240ccfb26f231e
   # [/chardet]
   # [CouchDB]
   couchdb==1.2 --hash=sha256:13a28a1159c49f8346732e8724b9a4d65cba54bec017c4a7eeb1499fe88151d1
@@ -43,10 +57,10 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   gitdb==4.0.12 --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
   # [/gitdb]
   # [smmap]
-  smmap==5.0.2 --hash=sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e
+  smmap==5.0.3 --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
   # [/smmap]
   # [GitPython]
-  GitPython==3.1.45 --hash=sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77
+  GitPython==3.1.50 --hash=sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9
   # [/GitPython]
   # [six]
   six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -34,88 +34,82 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [cryptography]
   # Hashes correspond to the following packages:
-  #  - cryptography-46.0.3-cp311-abi3-macosx_10_9_universal2.whl
-  #  - cryptography-46.0.3-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
-  #  - cryptography-46.0.3-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-  #  - cryptography-46.0.3-cp311-abi3-manylinux_2_28_aarch64.whl
-  #  - cryptography-46.0.3-cp311-abi3-manylinux_2_28_x86_64.whl
-  #  - cryptography-46.0.3-cp311-abi3-manylinux_2_34_aarch64.whl
-  #  - cryptography-46.0.3-cp311-abi3-manylinux_2_34_x86_64.whl
-  #  - cryptography-46.0.3-cp311-abi3-musllinux_1_2_aarch64.whl
-  #  - cryptography-46.0.3-cp311-abi3-musllinux_1_2_x86_64.whl
-  #  - cryptography-46.0.3-cp311-abi3-win_amd64.whl
-  #  - cryptography-46.0.3-cp311-abi3-win_arm64.whl
-  #  - cryptography-46.0.3-cp38-abi3-macosx_10_9_universal2.whl
-  #  - cryptography-46.0.3-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
-  #  - cryptography-46.0.3-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-  #  - cryptography-46.0.3-cp38-abi3-manylinux_2_28_aarch64.whl
-  #  - cryptography-46.0.3-cp38-abi3-manylinux_2_28_x86_64.whl
-  #  - cryptography-46.0.3-cp38-abi3-manylinux_2_34_aarch64.whl
-  #  - cryptography-46.0.3-cp38-abi3-manylinux_2_34_x86_64.whl
-  #  - cryptography-46.0.3-cp38-abi3-musllinux_1_2_aarch64.whl
-  #  - cryptography-46.0.3-cp38-abi3-musllinux_1_2_x86_64.whl
-  #  - cryptography-46.0.3-cp38-abi3-win_amd64.whl
-  #  - cryptography-46.0.3-cp38-abi3-win_arm64.whl
-  cryptography==46.0.3 --hash=sha256:109d4ddfadf17e8e7779c39f9b18111a09efb969a301a31e987416a0191ed93a \
-                       --hash=sha256:09859af8466b69bc3c27bdf4f5d84a665e0f7ab5088412e9e2ec49758eca5cbc \
-                       --hash=sha256:01ca9ff2885f3acc98c29f1860552e37f6d7c7d013d7334ff2a9de43a449315d \
-                       --hash=sha256:6eae65d4c3d33da080cff9c4ab1f711b15c1d9760809dad6ea763f3812d254cb \
-                       --hash=sha256:a2c0cd47381a3229c403062f764160d57d4d175e022c1df84e168c6251a22eec \
-                       --hash=sha256:549e234ff32571b1f4076ac269fcce7a808d3bf98b76c8dd560e42dbc66d7d91 \
-                       --hash=sha256:10b01676fc208c3e6feeb25a8b83d81767e8059e1fe86e1dc62d10a3018fa926 \
-                       --hash=sha256:0abf1ffd6e57c67e92af68330d05760b7b7efb243aab8377e583284dbab72c71 \
-                       --hash=sha256:a04bee9ab6a4da801eb9b51f1b708a1b5b5c9eb48c03f74198464c66f0d344ac \
-                       --hash=sha256:a9a3008438615669153eb86b26b61e09993921ebdd75385ddd748702c5adfddb \
-                       --hash=sha256:5d7f93296ee28f68447397bf5198428c9aeeab45705a55d53a6343455dcb2c3c \
-                       --hash=sha256:cb3d760a6117f621261d662bccc8ef5bc32ca673e037c83fbe565324f5c46936 \
-                       --hash=sha256:4b7387121ac7d15e550f5cb4a43aef2559ed759c35df7336c402bb8275ac9683 \
-                       --hash=sha256:15ab9b093e8f09daab0f2159bb7e47532596075139dd74365da52ecc9cb46c5d \
-                       --hash=sha256:46acf53b40ea38f9c6c229599a4a13f0d46a6c3fa9ef19fc1a124d62e338dfa0 \
-                       --hash=sha256:1000713389b75c449a6e979ffc7dcc8ac90b437048766cef052d4d30b8220971 \
-                       --hash=sha256:b02cf04496f6576afffef5ddd04a0cb7d49cf6be16a9059d793a30b035f6b6ac \
-                       --hash=sha256:402b58fc32614f00980b66d6e56a5b4118e6cb362ae8f3fda141ba4689bd4506 \
-                       --hash=sha256:ef639cb3372f69ec44915fafcd6698b6cc78fbe0c2ea41be867f6ed612811963 \
-                       --hash=sha256:3b51b8ca4f1c6453d8829e1eb7299499ca7f313900dd4d89a24b8b87c0a780d4 \
-                       --hash=sha256:416260257577718c05135c55958b674000baef9a1c7d9e8f306ec60d71db850f \
-                       --hash=sha256:d89c3468de4cdc4f08a57e214384d0471911a3830fcdaf7a8cc587e42a866372
+  #  - cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl
+  #  - cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+  #  - cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  #  - cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl
+  #  - cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl
+  #  - cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl
+  #  - cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl
+  #  - cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl
+  #  - cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl
+  #  - cryptography-48.0.0-cp311-abi3-win_amd64.whl
+  #  - cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl
+  #  - cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+  #  - cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  #  - cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl
+  #  - cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl
+  #  - cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl
+  #  - cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl
+  #  - cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl
+  #  - cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl
+  #  - cryptography-48.0.0-cp39-abi3-win_amd64.whl
+  cryptography==48.0.0 --hash=sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6 \
+                       --hash=sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c \
+                       --hash=sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3 \
+                       --hash=sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5 \
+                       --hash=sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f \
+                       --hash=sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602 \
+                       --hash=sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5 \
+                       --hash=sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321 \
+                       --hash=sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74 \
+                       --hash=sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7 \
+                       --hash=sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86 \
+                       --hash=sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e \
+                       --hash=sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f \
+                       --hash=sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7 \
+                       --hash=sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c \
+                       --hash=sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a \
+                       --hash=sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239 \
+                       --hash=sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c \
+                       --hash=sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4 \
+                       --hash=sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8
   # [/cryptography]
   # Specifying "[crypto]" is required since PyGithub 1.58.1
   # See https://github.com/Slicer/Slicer/issues/7112
   # [PyJWT]
-  PyJWT==2.10.1 --hash=sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb
+  PyJWT==2.13.0 --hash=sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728
   # [/PyJWT]
   # [wrapt]
   # Hashes correspond to the following packages:
-  #  - wrapt-2.0.1-cp312-cp312-macosx_10_13_universal2.whl
-  #  - wrapt-2.0.1-cp312-cp312-macosx_10_13_x86_64.whl
-  #  - wrapt-2.0.1-cp312-cp312-macosx_11_0_arm64.whl
-  #  - wrapt-2.0.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-  #  - wrapt-2.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-  #  - wrapt-2.0.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl
-  #  - wrapt-2.0.1-cp312-cp312-musllinux_1_2_aarch64.whl
-  #  - wrapt-2.0.1-cp312-cp312-musllinux_1_2_riscv64.whl
-  #  - wrapt-2.0.1-cp312-cp312-musllinux_1_2_x86_64.whl
-  #  - wrapt-2.0.1-cp312-cp312-win_amd64.whl
-  #  - wrapt-2.0.1-cp312-cp312-win_arm64.whl
-  #  - wrapt-2.0.1-py3-none-any.whl
-  wrapt==2.0.1 --hash=sha256:1fdbb34da15450f2b1d735a0e969c24bdb8d8924892380126e2a293d9902078c \
-               --hash=sha256:3d32794fe940b7000f0519904e247f902f0149edbe6316c710a8562fb6738841 \
-               --hash=sha256:386fb54d9cd903ee0012c09291336469eb7b244f7183d40dc3e86a16a4bace62 \
-               --hash=sha256:7b219cb2182f230676308cdcacd428fa837987b89e4b7c5c9025088b8a6c9faf \
-               --hash=sha256:641e94e789b5f6b4822bb8d8ebbdfc10f4e4eae7756d648b717d980f657a9eb9 \
-               --hash=sha256:fe21b118b9f58859b5ebaa4b130dee18669df4bd111daad082b7beb8799ad16b \
-               --hash=sha256:17fb85fa4abc26a5184d93b3efd2dcc14deb4b09edcdb3535a536ad34f0b4dba \
-               --hash=sha256:b89ef9223d665ab255ae42cc282d27d69704d94be0deffc8b9d919179a609684 \
-               --hash=sha256:a453257f19c31b31ba593c30d997d6e5be39e3b5ad9148c2af5a7314061c63eb \
-               --hash=sha256:2da620b31a90cdefa9cd0c2b661882329e2e19d1d7b9b920189956b76c564d75 \
-               --hash=sha256:aea9c7224c302bc8bfc892b908537f56c430802560e827b75ecbde81b604598b \
-               --hash=sha256:4d2ce1bf1a48c5277d7969259232b57645aae5686dba1eaeade39442277afbca
+  #  - wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl
+  #  - wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl
+  #  - wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  #  - wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  #  - wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl
+  #  - wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl
+  #  - wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl
+  #  - wrapt-2.2.1-cp312-cp312-win_amd64.whl
+  #  - wrapt-2.2.1-cp312-cp312-win_arm64.whl
+  #  - wrapt-2.2.1-py3-none-any.whl
+  wrapt==2.2.1 --hash=sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0 \
+               --hash=sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8 \
+               --hash=sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e \
+               --hash=sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926 \
+               --hash=sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624 \
+               --hash=sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710 \
+               --hash=sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f \
+               --hash=sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797 \
+               --hash=sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5 \
+               --hash=sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579 \
+               --hash=sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f
   # [/wrapt]
   # [Deprecated]
   Deprecated==1.3.1 --hash=sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f
   # [/Deprecated]
   # [pycparser]
-  pycparser==2.23 --hash=sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934
+  pycparser==3.0 --hash=sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
   # [/pycparser]
   # [cffi]
   # Hashes correspond to the following packages:
@@ -138,32 +132,28 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [/cffi]
   # [PyNaCl]
   # Hashes correspond to the following packages:
-  #  - pynacl-1.6.1-cp38-abi3-macosx_10_10_universal2.whl
-  #  - pynacl-1.6.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
-  #  - pynacl-1.6.1-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-  #  - pynacl-1.6.1-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
-  #  - pynacl-1.6.1-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
-  #  - pynacl-1.6.1-cp38-abi3-manylinux_2_34_aarch64.whl
-  #  - pynacl-1.6.1-cp38-abi3-manylinux_2_34_x86_64.whl
-  #  - pynacl-1.6.1-cp38-abi3-musllinux_1_1_aarch64.whl
-  #  - pynacl-1.6.1-cp38-abi3-musllinux_1_1_x86_64.whl
-  #  - pynacl-1.6.1-cp38-abi3-musllinux_1_2_aarch64.whl
-  #  - pynacl-1.6.1-cp38-abi3-musllinux_1_2_x86_64.whl
-  #  - pynacl-1.6.1-cp38-abi3-win_amd64.whl
-  #  - pynacl-1.6.1-cp38-abi3-win_arm64.whl
-  PyNaCl==1.6.1 --hash=sha256:a6f9fd6d6639b1e81115c7f8ff16b8dedba1e8098d2756275d63d208b0e32021 \
-                --hash=sha256:e49a3f3d0da9f79c1bec2aa013261ab9fa651c7da045d376bd306cf7c1792993 \
-                --hash=sha256:7713f8977b5d25f54a811ec9efa2738ac592e846dd6e8a4d3f7578346a841078 \
-                --hash=sha256:5a3becafc1ee2e5ea7f9abc642f56b82dcf5be69b961e782a96ea52b55d8a9fc \
-                --hash=sha256:4ce50d19f1566c391fedc8dc2f2f5be265ae214112ebe55315e41d1f36a7f0a9 \
-                --hash=sha256:543f869140f67d42b9b8d47f922552d7a967e6c116aad028c9bfc5f3f3b3a7b7 \
-                --hash=sha256:a2bb472458c7ca959aeeff8401b8efef329b0fc44a89d3775cffe8fad3398ad8 \
-                --hash=sha256:3206fa98737fdc66d59b8782cecc3d37d30aeec4593d1c8c145825a345bba0f0 \
-                --hash=sha256:53543b4f3d8acb344f75fd4d49f75e6572fce139f4bfb4815a9282296ff9f4c0 \
-                --hash=sha256:319de653ef84c4f04e045eb250e6101d23132372b0a61a7acf91bac0fda8e58c \
-                --hash=sha256:262a8de6bba4aee8a66f5edf62c214b06647461c9b6b641f8cd0cb1e3b3196fe \
-                --hash=sha256:a569a4069a7855f963940040f35e87d8bc084cb2d6347428d5ad20550a0a1a21 \
-                --hash=sha256:5953e8b8cfadb10889a6e7bd0f53041a745d1b3d30111386a1bb37af171e6daf
+  #  - pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl
+  #  - pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+  #  - pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  #  - pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
+  #  - pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
+  #  - pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl
+  #  - pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl
+  #  - pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl
+  #  - pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl
+  #  - pynacl-1.6.2-cp38-abi3-win_amd64.whl
+  #  - pynacl-1.6.2-cp38-abi3-win_arm64.whl
+  PyNaCl==1.6.2 --hash=sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465 \
+                --hash=sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0 \
+                --hash=sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4 \
+                --hash=sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87 \
+                --hash=sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c \
+                --hash=sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130 \
+                --hash=sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6 \
+                --hash=sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e \
+                --hash=sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577 \
+                --hash=sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0 \
+                --hash=sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c
   # [/PyNaCl]
   # [python-dateutil]
   python-dateutil==2.9.0.post0 --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
@@ -175,7 +165,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   typing_extensions==4.15.0 --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
   # [/typing_extensions]
   # [PyGithub]
-  PyGithub==2.8.1 --hash=sha256:23a0a5bca93baef082e03411bf0ce27204c32be8bfa7abc92fe4a3e132936df0
+  PyGithub==2.9.1 --hash=sha256:2ec78fca30092d51a42d76f4ddb02131b6f0c666a35dfdf364cf302cdda115b9
   # [/PyGithub]
   ]===])
 

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -31,26 +31,26 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [numpy]
   # Hashes correspond to the following packages:
-  #  - numpy-2.3.4-cp312-cp312-macosx_10_13_x86_64.whl
-  #  - numpy-2.3.4-cp312-cp312-macosx_11_0_arm64.whl
-  #  - numpy-2.3.4-cp312-cp312-macosx_14_0_arm64.whl
-  #  - numpy-2.3.4-cp312-cp312-macosx_14_0_x86_64.whl
-  #  - numpy-2.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
-  #  - numpy-2.3.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-  #  - numpy-2.3.4-cp312-cp312-musllinux_1_2_aarch64.whl
-  #  - numpy-2.3.4-cp312-cp312-musllinux_1_2_x86_64.whl
-  #  - numpy-2.3.4-cp312-cp312-win_amd64.whl
-  #  - numpy-2.3.4-cp312-cp312-win_arm64.whl
-  numpy==2.3.4 --hash=sha256:ef1b5a3e808bc40827b5fa2c8196151a4c5abe110e1726949d7abddfe5c7ae11 \
-               --hash=sha256:c2f91f496a87235c6aaf6d3f3d89b17dba64996abadccb289f48456cff931ca9 \
-               --hash=sha256:f77e5b3d3da652b474cc80a14084927a5e86a5eccf54ca8ca5cbd697bf7f2667 \
-               --hash=sha256:8ab1c5f5ee40d6e01cbe96de5863e39b215a4d24e7d007cad56c7184fdf4aeef \
-               --hash=sha256:77b84453f3adcb994ddbd0d1c5d11db2d6bda1a2b7fd5ac5bd4649d6f5dc682e \
-               --hash=sha256:4121c5beb58a7f9e6dfdee612cb24f4df5cd4db6e8261d7f4d7450a997a65d6a \
-               --hash=sha256:65611ecbb00ac9846efe04db15cbe6186f562f6bb7e5e05f077e53a599225d16 \
-               --hash=sha256:dabc42f9c6577bcc13001b8810d300fe814b4cfbe8a92c873f269484594f9786 \
-               --hash=sha256:985f1e46358f06c2a09921e8921e2c98168ed4ae12ccd6e5e87a4f1857923f32 \
-               --hash=sha256:4635239814149e06e2cb9db3dd584b2fa64316c96f10656983b8026a82e6e4db
+  #  - numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl
+  #  - numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl
+  #  - numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl
+  #  - numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl
+  #  - numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+  #  - numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  #  - numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl
+  #  - numpy-2.4.6-cp312-cp312-win_amd64.whl
+  #  - numpy-2.4.6-cp312-cp312-win_arm64.whl
+  numpy==2.4.6 --hash=sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1 \
+               --hash=sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb \
+               --hash=sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41 \
+               --hash=sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698 \
+               --hash=sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f \
+               --hash=sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853 \
+               --hash=sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a \
+               --hash=sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2 \
+               --hash=sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751 \
+               --hash=sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8
   # [/numpy]
   ]===])
 

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pip]
-  pip==25.3 --hash=sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd
+  pip==26.1.1 --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb
   # [/pip]
   ]===])
 

--- a/SuperBuild/External_python-pythonqt-requirements.cmake
+++ b/SuperBuild/External_python-pythonqt-requirements.cmake
@@ -32,10 +32,10 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [packaging]
-  packaging==25.0 --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484
+  packaging==26.2 --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e
   # [/packaging]
   # [pyparsing]
-  pyparsing==3.2.5 --hash=sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e
+  pyparsing==3.3.2 --hash=sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d
   # [/pyparsing]
   # [six]
   six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -27,39 +27,39 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [certifi]
-  certifi==2025.11.12 --hash=sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b
+  certifi==2026.5.20 --hash=sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897
   # [/certifi]
   # [idna]
-  idna==3.11 --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea
+  idna==3.16 --hash=sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5
   # [/idna]
   # [charset-normalizer]
   # Hashes correspond to the following packages:
-  #  - charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl
-  #  - charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-  #  - charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-  #  - charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl
-  #  - charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl
-  #  - charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl
-  #  - charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl
-  #  - charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl
-  #  - charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl
-  #  - charset_normalizer-3.4.4-py3-none-any.whl
-  charset-normalizer==3.4.4 --hash=sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394 \
-                            --hash=sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25 \
-                            --hash=sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86 \
-                            --hash=sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a \
-                            --hash=sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f \
-                            --hash=sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15 \
-                            --hash=sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0 \
-                            --hash=sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525 \
-                            --hash=sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3 \
-                            --hash=sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f
+  #  - charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
+  #  - charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  #  - charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  #  - charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl
+  #  - charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl
+  #  - charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl
+  #  - charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl
+  #  - charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl
+  #  - charset_normalizer-3.4.7-py3-none-any.whl
+  charset-normalizer==3.4.7 --hash=sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46 \
+                            --hash=sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2 \
+                            --hash=sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116 \
+                            --hash=sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1 \
+                            --hash=sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15 \
+                            --hash=sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7 \
+                            --hash=sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49 \
+                            --hash=sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6 \
+                            --hash=sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d \
+                            --hash=sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d
   # [/charset-normalizer]
   # [urllib3]
-  urllib3==2.6.3 --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+  urllib3==2.7.0 --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
   # [/urllib3]
   # [requests]
-  requests==2.32.5 --hash=sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6
+  requests==2.34.2 --hash=sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
   # [/requests]
   ]===])
 

--- a/SuperBuild/External_python-scipy.cmake
+++ b/SuperBuild/External_python-scipy.cmake
@@ -31,26 +31,26 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [scipy]
   # Hashes correspond to the following packages:
-  #  - scipy-1.16.3-cp312-cp312-macosx_10_14_x86_64.whl
-  #  - scipy-1.16.3-cp312-cp312-macosx_12_0_arm64.whl
-  #  - scipy-1.16.3-cp312-cp312-macosx_14_0_arm64.whl
-  #  - scipy-1.16.3-cp312-cp312-macosx_14_0_x86_64.whl
-  #  - scipy-1.16.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
-  #  - scipy-1.16.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-  #  - scipy-1.16.3-cp312-cp312-musllinux_1_2_aarch64.whl
-  #  - scipy-1.16.3-cp312-cp312-musllinux_1_2_x86_64.whl
-  #  - scipy-1.16.3-cp312-cp312-win_amd64.whl
-  #  - scipy-1.16.3-cp312-cp312-win_arm64.whl
-  scipy==1.16.3 --hash=sha256:81fc5827606858cf71446a5e98715ba0e11f0dbc83d71c7409d05486592a45d6 \
-                --hash=sha256:c97176013d404c7346bf57874eaac5187d969293bf40497140b0a2b2b7482e07 \
-                --hash=sha256:2b71d93c8a9936046866acebc915e2af2e292b883ed6e2cbe5c34beb094b82d9 \
-                --hash=sha256:3d4a07a8e785d80289dfe66b7c27d8634a773020742ec7187b85ccc4b0e7b686 \
-                --hash=sha256:0553371015692a898e1aa858fed67a3576c34edefa6b7ebdb4e9dde49ce5c203 \
-                --hash=sha256:72d1717fd3b5e6ec747327ce9bda32d5463f472c9dce9f54499e81fbd50245a1 \
-                --hash=sha256:1fb2472e72e24d1530debe6ae078db70fb1605350c88a3d14bc401d6306dbffe \
-                --hash=sha256:c5192722cffe15f9329a3948c4b1db789fbb1f05c97899187dcf009b283aea70 \
-                --hash=sha256:56edc65510d1331dae01ef9b658d428e33ed48b4f77b1d51caf479a0253f96dc \
-                --hash=sha256:a8a26c78ef223d3e30920ef759e25625a0ecdd0d60e5a8818b7513c3e5384cf2
+  #  - scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl
+  #  - scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl
+  #  - scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl
+  #  - scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl
+  #  - scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+  #  - scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  #  - scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl
+  #  - scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl
+  #  - scipy-1.17.1-cp312-cp312-win_amd64.whl
+  #  - scipy-1.17.1-cp312-cp312-win_arm64.whl
+  scipy==1.17.1 --hash=sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8 \
+                --hash=sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76 \
+                --hash=sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086 \
+                --hash=sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b \
+                --hash=sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21 \
+                --hash=sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458 \
+                --hash=sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb \
+                --hash=sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea \
+                --hash=sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87 \
+                --hash=sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3
   # [/scipy]
   ]===])
 

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -26,7 +26,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [setuptools]
-  setuptools==80.9.0 --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922
+  setuptools==82.0.1 --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
   # [/setuptools]
   ]===])
 

--- a/SuperBuild/External_python-wheel.cmake
+++ b/SuperBuild/External_python-wheel.cmake
@@ -15,7 +15,7 @@ endif()
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
 
 if(Slicer_USE_SYSTEM_${proj})
-  foreach(module_name IN ITEMS wheel)
+  foreach(module_name IN ITEMS packaging wheel)
     ExternalProject_FindPythonPackage(
       MODULE_NAME "${module_name}"
       REQUIRED
@@ -26,8 +26,11 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
+  # [packaging]
+  packaging==26.2 --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e
+  # [/packaging]
   # [wheel]
-  wheel==0.45.1 --hash=sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248
+  wheel==0.47.0 --hash=sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced
   # [/wheel]
   ]===])
 


### PR DESCRIPTION
Python packages were last updated on November 14th 2025 (https://github.com/Slicer/Slicer/commit/226e8001668eaec5efb89874c4bf7f6df2f574ed) through https://github.com/Slicer/Slicer/pull/8844.

Included in this update is a newer version of `dicomweb-client` which no longer uses deprecated versions of pydicom and therefore no longer throws the following warning on startup as was seen in the python console:
`[Python] get_frame_offsets is deprecated and will be removed in v4.0`
<img width="672" height="74" alt="image" src="https://github.com/user-attachments/assets/523f7ee0-d15a-42c7-a47b-af5a03f35c7d" />


```
PS C:\Users\ButleJ30383\AppData\Local\slicer.org\3D Slicer 5.11.0-2026-05-11\bin> ./PythonSlicer.exe "C:\Slicer\Utilities\Scripts\python_package_updater.py"
Searching external projects in C:\Slicer\SuperBuild
Validate external projects
Package            Version    Latest    Type
------------------ ---------- --------- -----
certifi            2025.11.12 2026.5.20 wheel
chardet            5.2.0      7.4.3     wheel
charset-normalizer 3.4.4      3.4.7     wheel
cryptography       46.0.3     48.0.0    wheel
dcmqi              0.3.3      0.4.0     wheel
dicomweb-client    0.60.1     0.61.0    wheel
GitPython          3.1.45     3.1.50    wheel
idna               3.11       3.16      wheel
numpy              2.3.4      2.4.6     wheel
packaging          25.0       26.2      wheel
pillow             12.0.0     12.2.0    wheel
pip                25.3       26.1.1    wheel
pycparser          2.23       3.0       wheel
pydicom            3.0.1      3.0.2     wheel
PyGithub           2.8.1      2.9.1     wheel
PyJWT              2.10.1     2.13.0    wheel
PyNaCl             1.6.1      1.6.2     wheel
pyparsing          3.2.5      3.3.2     wheel
requests           2.32.5     2.34.2    wheel
scipy              1.16.3     1.17.1    wheel
setuptools         80.9.0     82.0.1    wheel
simpleitk          2.5.3      2.5.5     wheel
smmap              5.0.2      5.0.3     wheel
urllib3            2.6.3      2.7.0     wheel
vtk                9.6.1      9.6.2     wheel
wheel              0.45.1     0.47.0    wheel
wrapt              2.0.1      2.2.1     wheel

  certifi==2026.5.20 --hash=sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897
  # Hashes correspond to the following packages:
  #  - chardet-7.4.3-cp312-cp312-macosx_10_13_x86_64.whl
  #  - chardet-7.4.3-cp312-cp312-macosx_11_0_arm64.whl
  #  - chardet-7.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
  #  - chardet-7.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
  #  - chardet-7.4.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl
  #  - chardet-7.4.3-cp312-cp312-win_amd64.whl
  #  - chardet-7.4.3-py3-none-any.whl
  chardet==7.4.3 --hash=sha256:75d3c65cc16bddf40b8da1fd25ba84fca5f8070f2b14e86083653c1c85aee971 \
                 --hash=sha256:29af5999f654e8729d251f1724a62b538b1262d9292cccaefddf8a02aae1ef6a \
                 --hash=sha256:626f00299ad62dfe937058a09572beed442ccc7b58f87aa667949b20fd3db235 \
                 --hash=sha256:9a4904dd5f071b7a7d7f50b4a67a86db3c902d243bf31708f1d5cde2f68239cb \
                 --hash=sha256:5d2879598bc220689e8ce509fe9c3f37ad2fca53a36be9c9bd91abdd91dd364f \
                 --hash=sha256:4b2799bd58e7245cfa8d4ab2e8ad1d76a5c3a5b1f32318eb6acca4c69a3e7101 \
                 --hash=sha256:1173b74051570cf08099d7429d92e4882d375ad4217f92a6e5240ccfb26f231e
  # Hashes correspond to the following packages:
  #  - charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
  #  - charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
  #  - charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
  #  - charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl
  #  - charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl
  #  - charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl
  #  - charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl
  #  - charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl
  #  - charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl
  #  - charset_normalizer-3.4.7-py3-none-any.whl
  charset-normalizer==3.4.7 --hash=sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46 \
                            --hash=sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2 \
                            --hash=sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116 \
                            --hash=sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1 \
                            --hash=sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15 \
                            --hash=sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7 \
                            --hash=sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49 \
                            --hash=sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6 \
                            --hash=sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d \
                            --hash=sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d
  # Hashes correspond to the following packages:
  #  - cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl
  #  - cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
  #  - cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
  #  - cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl
  #  - cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl
  #  - cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl
  #  - cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl
  #  - cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl
  #  - cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl
  #  - cryptography-48.0.0-cp311-abi3-win_amd64.whl
  #  - cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl
  #  - cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
  #  - cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
  #  - cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl
  #  - cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl
  #  - cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl
  #  - cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl
  #  - cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl
  #  - cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl
  #  - cryptography-48.0.0-cp39-abi3-win_amd64.whl
  cryptography==48.0.0 --hash=sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6 \
                       --hash=sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c \
                       --hash=sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3 \
                       --hash=sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5 \
                       --hash=sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f \
                       --hash=sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602 \
                       --hash=sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5 \
                       --hash=sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321 \
                       --hash=sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74 \
                       --hash=sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7 \
                       --hash=sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86 \
                       --hash=sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e \
                       --hash=sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f \
                       --hash=sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7 \
                       --hash=sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c \
                       --hash=sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a \
                       --hash=sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239 \
                       --hash=sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c \
                       --hash=sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4 \
                       --hash=sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8
  # Hashes correspond to the following packages:
  #  - dcmqi-0.4.0-py3-none-macosx_13_0_arm64.whl
  #  - dcmqi-0.4.0-py3-none-macosx_13_0_x86_64.whl
  #  - dcmqi-0.4.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
  #  - dcmqi-0.4.0-py3-none-win_amd64.whl
  dcmqi==0.4.0 --hash=sha256:2138fc78e79c28449348572eb7ff0483f98f6a71c821814ca3cf28e3357ad848 \
               --hash=sha256:60f6a9e4d4828c5399e932f44b500e4619becbe27dd4e4574cc94a802cbdcd00 \
               --hash=sha256:1721bf1308fa416b00d3f9895c99b2376524a9982a408f15cf281ceef159df5b \
               --hash=sha256:c3cc2c32f196e96017e08b27550c4b05ac84fde411ef743f882eb8e00ab5709a
  dicomweb-client==0.61.0 --hash=sha256:dc3385f5dbbeb167c521d04a70eac8bf219c4302c14574af05b5bc577a7e22c5
  GitPython==3.1.50 --hash=sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9
  idna==3.16 --hash=sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5
  # Hashes correspond to the following packages:
  #  - numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl
  #  - numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl
  #  - numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl
  #  - numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl
  #  - numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
  #  - numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
  #  - numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl
  #  - numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl
  #  - numpy-2.4.6-cp312-cp312-win_amd64.whl
  #  - numpy-2.4.6-cp312-cp312-win_arm64.whl
  numpy==2.4.6 --hash=sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1 \
               --hash=sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb \
               --hash=sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41 \
               --hash=sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698 \
               --hash=sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f \
               --hash=sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853 \
               --hash=sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a \
               --hash=sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2 \
               --hash=sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751 \
               --hash=sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8
  packaging==26.2 --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e
  # Hashes correspond to the following packages:
  #  - pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl
  #  - pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl
  #  - pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
  #  - pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
  #  - pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
  #  - pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
  #  - pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl
  #  - pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl
  #  - pillow-12.2.0-cp312-cp312-win_amd64.whl
  #  - pillow-12.2.0-cp312-cp312-win_arm64.whl
  pillow==12.2.0 --hash=sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5 \
                 --hash=sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421 \
                 --hash=sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987 \
                 --hash=sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76 \
                 --hash=sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005 \
                 --hash=sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780 \
                 --hash=sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5 \
                 --hash=sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5 \
                 --hash=sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5 \
                 --hash=sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414
  pip==26.1.1 --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb
  pycparser==3.0 --hash=sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
  pydicom==3.0.2 --hash=sha256:abf971a5440f84dbaf42c4b6758e30e62480902584f8b270b9a5d146e278a07b
  PyGithub==2.9.1 --hash=sha256:2ec78fca30092d51a42d76f4ddb02131b6f0c666a35dfdf364cf302cdda115b9
  PyJWT==2.13.0 --hash=sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728
  # Hashes correspond to the following packages:
  #  - pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl
  #  - pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
  #  - pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
  #  - pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
  #  - pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
  #  - pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl
  #  - pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl
  #  - pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl
  #  - pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl
  #  - pynacl-1.6.2-cp38-abi3-win_amd64.whl
  #  - pynacl-1.6.2-cp38-abi3-win_arm64.whl
  PyNaCl==1.6.2 --hash=sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465 \
                --hash=sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0 \
                --hash=sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4 \
                --hash=sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87 \
                --hash=sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c \
                --hash=sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130 \
                --hash=sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6 \
                --hash=sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e \
                --hash=sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577 \
                --hash=sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0 \
                --hash=sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c
  pyparsing==3.3.2 --hash=sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d
  requests==2.34.2 --hash=sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
  # Hashes correspond to the following packages:
  #  - scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl
  #  - scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl
  #  - scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl
  #  - scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl
  #  - scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
  #  - scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
  #  - scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl
  #  - scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl
  #  - scipy-1.17.1-cp312-cp312-win_amd64.whl
  #  - scipy-1.17.1-cp312-cp312-win_arm64.whl
  scipy==1.17.1 --hash=sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8 \
                --hash=sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76 \
                --hash=sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086 \
                --hash=sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b \
                --hash=sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21 \
                --hash=sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458 \
                --hash=sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb \
                --hash=sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea \
                --hash=sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87 \
                --hash=sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3
  setuptools==82.0.1 --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
  # Hashes correspond to the following packages:
  #  - simpleitk-2.5.5-cp311-abi3-macosx_10_9_x86_64.whl
  #  - simpleitk-2.5.5-cp311-abi3-macosx_11_0_arm64.whl
  #  - simpleitk-2.5.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
  #  - simpleitk-2.5.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
  #  - simpleitk-2.5.5-cp311-abi3-win_amd64.whl
  simpleitk==2.5.5 --hash=sha256:e831d15f5ea5b0e02ed3a6ac5f2dd34ba0a0eeaa4ebacfb1d970999836b19ee0 \
                   --hash=sha256:ee87416622cec6ed6b96747a0648c82c6e88f10b6553668ce90736f09ab5a994 \
                   --hash=sha256:847f42057d7bf01b5721b107dd3e00d4ee8d514f6f1ff85794ffedacaf4afc53 \
                   --hash=sha256:8ace5e392be00d5bec28c87ef1d73016f8ebe671dafffe9e9d045f20b0968033 \
                   --hash=sha256:a5fcfcfe9242d3d509b254b3213ca0f5db2c15903f2fc375d9ac5d38e57d415d
  smmap==5.0.3 --hash=sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
  urllib3==2.7.0 --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
  wheel==0.47.0 --hash=sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced
  # Hashes correspond to the following packages:
  #  - wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl
  #  - wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl
  #  - wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
  #  - wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
  #  - wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl
  #  - wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl
  #  - wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl
  #  - wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl
  #  - wrapt-2.2.1-cp312-cp312-win_amd64.whl
  #  - wrapt-2.2.1-cp312-cp312-win_arm64.whl
  #  - wrapt-2.2.1-py3-none-any.whl
  wrapt==2.2.1 --hash=sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0 \
               --hash=sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8 \
               --hash=sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e \
               --hash=sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926 \
               --hash=sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624 \
               --hash=sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710 \
               --hash=sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f \
               --hash=sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797 \
               --hash=sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5 \
               --hash=sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579 \
               --hash=sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f
```
Changes to note with the numpy version update from 2.3 to 2.4 are the following:
https://numpy.org/doc/stable/release/2.4.0-notes.html#deprecations
https://numpy.org/doc/stable/release/2.4.0-notes.html#expired-deprecations

Changes to note with the scipy version update from 1.16 to 1.17 are the following:
https://scipy.github.io/devdocs/release/1.17.0-notes.html#deprecated-features
https://scipy.github.io/devdocs/release/1.17.0-notes.html#expired-deprecations

Since scipy is not directly used in Slicer core, we may have to update extensions to account for changes.

Additionally re https://github.com/Slicer/Slicer/pull/6590#issuecomment-1282762511, on macOS, the dependent libraries shipped with scipy remain the same
```
Directory: C:\Users\butlej30383\Downloads\scipy-1.16.3-cp312-cp312-macosx_10_14_x86_64\scipy\.dylibs

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         5/18/2026   9:54 AM         138704 libgcc_s.1.1.dylib
-a----         5/18/2026   9:54 AM        6786304 libgfortran.5.dylib
-a----         5/18/2026   9:54 AM         352704 libquadmath.0.dylib
-a----         5/18/2026   9:54 AM       68560032 libscipy_openblas.dylib

Directory: C:\Users\ButleJ30383\Downloads\scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64\scipy\.dylibs

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         5/17/2026   9:14 PM         138704 libgcc_s.1.1.dylib
-a----         5/17/2026   9:14 PM        6786304 libgfortran.5.dylib
-a----         5/17/2026   9:14 PM         352704 libquadmath.0.dylib
-a----         5/17/2026   9:14 PM       24917648 libscipy_openblas.dylib

Directory: C:\Users\butlej30383\Downloads\scipy-1.16.3-cp312-cp312-macosx_14_0_x86_64\scipy\.dylibs

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         5/18/2026   9:54 AM         244384 libgcc_s.1.1.dylib
-a----         5/18/2026   9:54 AM        3497360 libgfortran.5.dylib
-a----         5/18/2026   9:54 AM         381088 libquadmath.0.dylib

Directory: C:\Users\ButleJ30383\Downloads\scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64\scipy\.dylibs

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         5/17/2026   9:14 PM         207056 libgcc_s.1.1.dylib
-a----         5/17/2026   9:14 PM        3459472 libgfortran.5.dylib
-a----         5/17/2026   9:14 PM         364432 libquadmath.0.dylib

```

Python packages with more than just a patch release update (newest release date to oldest):
```
Package            Version    Latest    Release Date
------------------ ---------- --------- -----
PyJWT              2.10.1     2.13.0    2026-05-21
wrapt              2.0.1      2.2.1     2026-05-21 (date for 2.2.0)
idna               3.11       3.16      2026-05-21
certifi            2025.11.12 2026.5.20 2026-05-20
dcmqi              0.3.3      0.4.0     2026-05-18
requests           2.32.5     2.34.2    2025-05-11 (date for 2.34.0)
urllib3            2.6.3      2.7.0     2026-05-07
cryptography       46.0.3     48.0.0    2026-05-04
pip                25.3       26.1.1    2026-04-26 (date for 26.1)
packaging          25.0       26.2      2026-04-24
wheel              0.45.1     0.47.0    2026-04-22
dicomweb-client    0.60.1     0.61.0    2026-04-21
pillow             12.0.0     12.2.0    2026-04-01
chardet            5.2.0      7.4.3     2026-03-26 (date for 7.4.0)
PyGithub           2.8.1      2.9.1     2026-03-22 (date for 2.9.0)
setuptools         80.9.0     82.0.1    2026-02-08 (date for 82.0.0)
pycparser          2.23       3.0       2026-01-21
scipy              1.16.3     1.17.1    2026-01-10 (date for 1.17.0)
pyparsing          3.2.5      3.3.2     2025-12-22 (date for 3.3.0)
numpy              2.3.4      2.4.6     2025-12-20 (date for 2.4.0)
```

## Testing Results:
Windows
- Build      ✔️ 
- Packaging ✔️       
- Tests ✔️    (no new tests failing compared to latest factory Windows build)