### PR TITLE
BUG: Fix segment metadata off-by-one when loading DICOM Labelmap SEG

### DIFF
--- a/Modules/Scripted/DICOMPlugins/DICOMSegmentationPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMSegmentationPlugin.py
@@ -152,6 +152,15 @@ class DICOMSegmentationPluginClass(DICOMPlugin):
           # metadata. ImportLabelmapToSegmentationNode does not create a VTK segment for pixel
           # value 0, so including this entry would shift all subsequent metadata assignments by one.
           if segment.get("labelID", 1) == 0:
+            typeCode, typeCodingScheme, typeCodeMeaning = \
+              self.getValuesFromCodeSequence(segment, "SegmentedPropertyTypeCodeSequence")
+            if typeCode != "125040" or typeCodingScheme != "DCM":
+              logging.warning(
+                f"Segment with labelID 0 has unexpected type code: "
+                f"{typeCodingScheme}:{typeCode} ({typeCodeMeaning}). "
+                f"Expected DCM:125040 (Background). "
+                f"This segment will not be loaded as a Slicer segment.",
+              )
             continue
 
           try:

--- a/Modules/Scripted/DICOMPlugins/DICOMSegmentationPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMSegmentationPlugin.py
@@ -147,6 +147,13 @@ class DICOMSegmentationPluginClass(DICOMPlugin):
         labelNode.labelAttributes = []
 
         for segment in segmentAttributes:
+          # Skip the background segment (labelID 0). In DICOM Labelmap Segmentation objects,
+          # pixel value 0 is reserved for background and may appear as a defined segment in the
+          # metadata. ImportLabelmapToSegmentationNode does not create a VTK segment for pixel
+          # value 0, so including this entry would shift all subsequent metadata assignments by one.
+          if segment.get("labelID", 1) == 0:
+            continue
+
           try:
             rgb255 = segment["recommendedDisplayRGBValue"]
             rgb = [float(c) / 255. for c in rgb255]


### PR DESCRIPTION
DICOM Labelmap Segmentation objects reserve pixel value 0 for background and may include it as a defined segment (SegmentNumber 0) in the segment sequence. The DICOMSegmentationPlugin was assigning metadata positionally from the JSON produced by segimage2itkimage, which lists the background entry first. Since ImportLabelmapToSegmentationNode does not create a VTK segment for pixel value 0, every subsequent segment received the metadata of its predecessor (e.g. skin appeared as costal cartilage).

dcmqi 1.5.4 labelmap conversion will generate a segment entry for the background (introduced in https://github.com/QIICR/dcmqi/pull/536, leading to shift of metadata assignment.

Fix: skip any segment entry with labelID == 0 before building the labelAttributes list.