### PR TITLE
COMP: Update VTK to 9.6.2

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -148,8 +148,8 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "08210fbecda09bea2544dbb80777d634e1bfea25") # slicer-v9.5.2-2025-09-16-7c0494a68
     set(vtk_dist_info_version "9.5.2")
   elseif("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.6")
-    set(_git_tag "a0bea7a6f58008e3599142594d9f9c8845618645") # slicer-v9.6.1-2026-03-24-d3ad22cd8
-    set(vtk_dist_info_version "9.6.1")
+    set(_git_tag "ddd10cf957df01f54eca6546e975e502ea248645") # slicer-v9.6.2-2026-05-15-f49a1dbaf
+    set(vtk_dist_info_version "9.6.2")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR.Slicer_VTK_VERSION_MINOR: ${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}")
   endif()


### PR DESCRIPTION
Announcement: http://discourse.vtk.org/t/vtk-9-6-2-release/16427
Release notes: https://github.com/Kitware/VTK/blob/v9.6.2/Documentation/release/9.6.md#v962

This includes https://github.com/Kitware/VTK/commit/c15bbf80fc113e361424b3e4792f5afd81cbac8d addressing https://discourse.vtk.org/t/cpu-usage-is-high-since-v9-5-0/16367/4 (FYI @pieper)

```
Slicer/VTK:
$ git shortlog a0bea7a..ddd10cf --no-merges
Cory Quammen (10):
      ci: add --verbose flag to twine upload commands
      vtkIOSSReaderInternal: remove redundant pointer addition
      TestIOSSExodusMergeEntityBlocks: add test with different topologies
      TestMapperLUT: test mapping of data values to below/above range texture values
      vtkMapper: special handling of data values near range
      Add release note
      vtkCellGridReader.cxx: handle arrays with more than one component
      EnSightReader: fix parsing of model line in EnSight Gold case files
      Add test for fix of parsing paths starting with a number
      EnSightReader: fix reading of "measured:" line

David Gobbi (2):
      Fix vtkDICOMImageReader for scientific notation
      Add release note for vtkDICOMImageReader fix

Jaswant Panchumarti (4):
      Exit early if MTime of data array < MTime in state
      Disambiguate variable names in vtkSSAAPass
      Fix vtkSSAAPass bug with multiple viewports
      Do not busy wait in win32 event loop

Jean-Christophe Fillion-Robin (3):
      [Slicer] COMP: Remove custom FindOpenGL to ensure OpenGL_GL_PREFERENCE is considered
      [Slicer] BUG: Update vtkPythonUtil to disable relative import causing crash for Slicer modules
      [Slicer] COMP: Remove FindTBB and expect VTK to be configured with TBB_DIR

Kenneth Moreland (2):
      Properly handle special Viskores arrays
      Fix crash when vtkConvertToPointCloud has null points in input

Louis Gombert (5):
      vtkHTGEvaluateCoarse: fix race condition & bad performance
      vtkHyperTreeGridEvaluateCoarse: add release note
      vtkHyperTreeGridRedistribute: fix crash on null input
      Add HTG Redistribute test with null HTG on all ranks
      HTG redistribute crash: add release note

Michael Migliore (4):
      Fix PBR unlit with texture
      Add a test checking sRGB conversion
      fix warnings and use const ref
      Fix GLTF flat actor indexing

Sankhesh Jhaveri (4):
      Update the TestSkybox baseline with multiscatterig changes
      Update baseline for PBR Edge Tint test with multiscattering
      MomentInvariants: Bring in the latest compile error fix
      Implement multiscatter IBL for vtkGLSLModLight

Sean McBride (1):
      Fixed build of SimpleCocoaVTK example project

Spiros Tsalikis (9):
      vtkPExodusIIReader: Fix setting of FilePattern
      vtkIOSSReaderInternal: Support Int32/64 entity processor
      vtkDataArrayRange: assert given tuple size
      vtkDataArrayRange: Fix assert given tuple size
      Clipping: Fix clipping to be inclusive when InsideOut is off
      vtkTableBasedClipDataSet: Fix edge interpolation
      vtkIOSSReaderInternal: Warn if update is needed when fields are not the same
      vtkDataArraySelection: Call modified when editing the array selection
      vtkIOSSReader: Ensure that reading is cache friendly for each file

Vicente Adolfo Bolea Sanchez (4):
      Revert "docs: final edits to the 9.6.md release notes."
      docs: moved dev release notes to 9.6
      release: 9.6.2 release notes
      Update version number to 9.6.2
```

## Testing Results:
Windows
- Build ✔️      
- Packaging ✔️      
- Tests ✔️ 