### PR TITLE
BUG: Fall back to find_program for Qt tools on split-prefix systems

### DIFF
--- a/CMake/SlicerBlockInstallQtTools.cmake
+++ b/CMake/SlicerBlockInstallQtTools.cmake
@@ -50,7 +50,15 @@ endif()
 foreach(tool IN LISTS Slicer_INSTALLED_QT_TOOLS)
   set(tool_executable ${qt_root_dir}/bin/${tool}${CMAKE_EXECUTABLE_SUFFIX})
   if(NOT EXISTS "${tool_executable}")
-    message(FATAL_ERROR "Qt tool ${tool} not found: ${tool_executable}")
+    # On NixOS, Qt tools may be in a different prefix than qtbase.
+    # Fall back to searching PATH (e.g. qttools provides lconvert).
+    find_program(_found_tool_executable ${tool})
+    if(_found_tool_executable)
+      set(tool_executable "${_found_tool_executable}")
+    else()
+      message(FATAL_ERROR "Qt tool ${tool} not found: ${tool_executable}")
+    endif()
+    unset(_found_tool_executable CACHE)
   endif()
   install(PROGRAMS ${tool_executable}
     DESTINATION ${Slicer_INSTALL_BIN_DIR}


### PR DESCRIPTION
Spun off from #9101 per review feedback (cc @RafaelPalomar, @pieper).

## Summary

Slicer's CMake currently locates `lconvert`/`lrelease`/`lupdate` via `${qt_root_dir}/bin/<tool>`, where `qt_root_dir` is derived from the Qt6 qtbase prefix. This assumes all Qt modules share a single install prefix.

That assumption holds on stock Ubuntu and the official [Qt online installer](https://www.qt.io/download-qt-installer-oss). It breaks on any system that installs Qt modules into separate prefixes:

- [Nix / NixOS](https://nixos.org/) — each Qt module is its own `/nix/store/<hash>-qt*` path
- [Spack](https://spack.io/) — per-package install prefixes by design
- [Conan](https://conan.io/) — each library in its own cache directory
- [vcpkg](https://github.com/microsoft/vcpkg) manifest mode — per-feature subpaths
- [Homebrew](https://brew.sh/) with per-formula `--prefix` overrides
- Multi-layer container images (Qt modules sourced from different layers)
- Distro packages with multiarch or modular layouts

In these layouts, `lconvert`/`lrelease`/`lupdate` live under qttools, not qtbase, so the existing `${qt_root_dir}/bin/` lookup fails.

## Change

Add a `find_program` fallback when the tool is not found at the expected qtbase-relative path. `find_program` consults `CMAKE_PREFIX_PATH`, which package managers populate with all module prefixes, so the tools are resolved correctly.

**Behavior on systems where the tool *is* present at the expected path is unchanged** — the fallback never triggers.

## Test plan

- [ ] Existing Ubuntu / single-prefix Qt build: tool is found at the expected path, fallback does not trigger (no regression)
- [ ] Split-prefix Qt install (verified on NixOS Qt 6.10.2): fallback resolves the tool via `CMAKE_PREFIX_PATH`
- [ ] macOS Homebrew default layout: unchanged behavior