### PR TITLE
BUG: Guard vtkWin32OutputWindow.h include behind _WIN32 in test driver template

### DIFF
--- a/CMake/SlicerMacroConfigureModuleCxxTestDriver.cmake
+++ b/CMake/SlicerMacroConfigureModuleCxxTestDriver.cmake
@@ -55,7 +55,7 @@ macro(SlicerMacroConfigureModuleCxxTestDriver)
     set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN "")
     set(CMAKE_TESTDRIVER_AFTER_TESTMAIN "")
 
-    set(EXTRA_INCLUDE "vtkWin32OutputWindow.h\"\n\#include <iostream>\n\#include \"vtkVersionMacros.h")
+    set(EXTRA_INCLUDE "vtkOutputWindow.h\"\n\#ifdef _WIN32\n\#include \"vtkWin32OutputWindow.h\"\n\#endif\n\#include <iostream>\n\#include \"vtkVersionMacros.h")
 
     if(SLICER_TEST_DRIVER_WITH_VTK_ERROR_OUTPUT_CHECK)
       set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN


### PR DESCRIPTION
Spun off from #9101 per review feedback (cc @RafaelPalomar, @pieper).

## Summary

The CMake test driver template unconditionally `#include`s `vtkWin32OutputWindow.h`. This header only exists when VTK is configured with Windows support — i.e., on Windows builds of VTK. On Linux/macOS builds, or on builds of VTK that explicitly disable the Win32 output window module, the header is absent and the test driver fails to compile.

The intended use here is just to suppress a popup output window on Windows. The Linux/macOS equivalent of \"send messages to stderr instead of a popup\" lives in `vtkOutputWindow.h`, which is always available.

## Change

Make `vtkOutputWindow.h` the unconditional include (it is always available) and guard the `vtkWin32OutputWindow.h` include behind `_WIN32`.

## Why this matters

- Surfaces on minimal VTK builds (headless container images, Spack/Nix builds with non-default VTK module sets)
- Surfaces when building Slicer against a system VTK that does not include the Win32 output window module (most non-Windows distro packages of VTK do not)
- Behavior on Windows is unchanged: the `_WIN32`-guarded include path is identical to before

## Test plan

- [ ] Existing Windows build: include path unchanged, no regression
- [ ] Linux build against system VTK without Win32 output window module: previously failed, now succeeds
- [ ] Linux build against bundled superbuild VTK: unchanged