### PR TITLE
COMP: Force -std=gnu17 for ITK C code (GCC 15 / C23 compatibility)

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -87,6 +87,11 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
   endif()
 
 
+  # GCC 15 defaults to C23 where () means zero parameters, not unspecified.
+  # ITK's bundled MINC uses old-style () declarations with arguments.
+  # Force gnu17 for ITK's C code as a workaround.
+  set(_itk_c_flags "${ep_common_c_flags} -std=gnu17")
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${Slicer_${proj}_GIT_REPOSITORY}"
@@ -97,7 +102,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
       -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
-      -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+      -DCMAKE_C_FLAGS:STRING=${_itk_c_flags}
       -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
       -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
       -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}


### PR DESCRIPTION
Spun off from #9101 per review feedback (cc @RafaelPalomar, @pieper).

## Summary

[GCC 15](https://gcc.gnu.org/gcc-15/changes.html) changed the default C language standard from `gnu17` (C17 with GNU extensions) to `gnu23` (C23). One consequence is that empty parentheses `()` in a function declaration now mean **\"zero parameters\"** rather than **\"unspecified parameters\"**.

ITK's bundled MINC library uses old-style K&R function declarations like:

```c
int some_function ();   // old-style: \"unspecified parameters\"
// ...
some_function(arg1, arg2);   // called with arguments
```

Under GCC 15 / C23, the function declaration above means \"zero parameters\", so the call site becomes a diagnosed error, causing the ITK external project to fail to build on any system using GCC 15.

This affects:
- Fedora 42+, Ubuntu 25.10+, Arch Linux, NixOS unstable, and any other distro on GCC 15
- Anyone building Slicer with a manually-installed GCC 15+ toolchain

The proper fix lives in MINC / ITK upstream — modernizing the K&R declarations. Until that lands and propagates into the ITK fork Slicer pins, we need a build-system workaround.

## Change

Force `-std=gnu17` for ITK's C code via a dedicated `_itk_c_flags` variable that is passed to the ITK external project via `CMAKE_CACHE_ARGS`.

The variable is **quoted** before being passed, to avoid CMake splitting the value into separate semicolon-delimited tokens (which is what happens if you try to append `-std=gnu17` to `ep_common_c_flags` directly — `CMAKE_CACHE_ARGS` treats spaces inside an item as list separators).

## Scope

- **Affects:** the ITK external project's C code only
- **Does not affect:** Slicer's own C/C++ code, any other superbuild subproject, the C++ standard used by anything else
- **Pinned in the build system**, not in source: when ITK upstream resolves the MINC K&R declarations, this can be reverted

## Test plan

- [ ] GCC 15+ Linux build: ITK builds successfully (previously failed)
- [ ] GCC 14 / GCC 13 / Clang Linux build: unchanged behavior (gnu17 is still a valid request)
- [ ] macOS Clang build: unchanged behavior
- [ ] Windows MSVC build: unchanged (flag is only meaningful to GCC/Clang; MSVC ignores it harmlessly)