### PR TITLE
BUG: Force Qt WebEngine to use ANGLE/D3D11 on Windows

### DIFF
--- a/CMake/SlicerBlockCTKAppLauncherSettings.cmake
+++ b/CMake/SlicerBlockCTKAppLauncherSettings.cmake
@@ -149,6 +149,17 @@ if(UNIX AND NOT APPLE)
     "QTWEBENGINE_DISABLE_SANDBOX=1"
     )
 endif()
+if(WIN32)
+  # Route Qt WebEngine's Chromium GPU process through ANGLE/D3D11 instead of
+  # desktop OpenGL. With AA_ShareOpenGLContexts set, WebEngine on Windows can
+  # otherwise be pulled onto the desktop OpenGL backend and contend with VTK's
+  # GL context (observed on NVIDIA), causing 3D view gray-flashes during
+  # interaction and Extensions Manager rendering glitches. ANGLE/D3D11 keeps
+  # WebEngine hardware-accelerated without sharing the GL context.
+  list(APPEND SLICER_ENVVARS_BUILD
+    "QTWEBENGINE_CHROMIUM_FLAGS=--use-angle=d3d11"
+    )
+endif()
 
 # External projects - environment variables
 foreach(varname IN LISTS Slicer_EP_LABEL_ENVVARS_LAUNCHER_BUILD)
@@ -289,6 +300,17 @@ if(UNIX AND NOT APPLE)
   # (see https://github.com/Slicer/Slicer/issues/6577)
   list(APPEND SLICER_ENVVARS_INSTALLED
     "QTWEBENGINE_DISABLE_SANDBOX=1"
+    )
+endif()
+if(WIN32)
+  # Route Qt WebEngine's Chromium GPU process through ANGLE/D3D11 instead of
+  # desktop OpenGL. With AA_ShareOpenGLContexts set, WebEngine on Windows can
+  # otherwise be pulled onto the desktop OpenGL backend and contend with VTK's
+  # GL context (observed on NVIDIA), causing 3D view gray-flashes during
+  # interaction and Extensions Manager rendering glitches. ANGLE/D3D11 keeps
+  # WebEngine hardware-accelerated without sharing the GL context.
+  list(APPEND SLICER_ENVVARS_INSTALLED
+    "QTWEBENGINE_CHROMIUM_FLAGS=--use-angle=d3d11"
     )
 endif()
 


### PR DESCRIPTION
## Summary

Sets `QTWEBENGINE_CHROMIUM_FLAGS=--use-angle=d3d11` in the Slicer launcher on Windows. Resolves two long-observed Windows symptoms that share a single root cause: 3D view gray-flashing during interaction, and Extensions Manager rendering glitches.

## Symptoms (Windows 11 + NVIDIA Quadro/RTX, OpenGL2 + Qt 5.15)

- **3D view gray-flashes** during mouse interaction (rotate/pan/zoom). Window title flashes `(Not Responding)`; UI thread blocks briefly on each interaction.
- **Extensions Manager renders incorrectly** (visual glitches in the Qt WebEngine catalog view).

Reproduced on Slicer 5.11.0-2026-05-19 (rev 34550), Windows 11 Pro build 22631, NVIDIA Quadro RTX 5000, driver 595.79, Qt 5.15.2.

## Root cause

`Qt::AA_ShareOpenGLContexts` is already set in `qMRMLWidget::preInitializeApplication()` before `QApplication` construction (required for `QVTKOpenGLNativeWidget` + other Qt OpenGL widgets). A side effect on Windows is that Qt 5.15 WebEngine is pulled onto the desktop OpenGL backend rather than its usual ANGLE/D3D11 path. WebEngine's forked Chromium GPU process then competes with VTK for the same OpenGL context on the NVIDIA driver, producing the two symptoms above.

Confirmed empirically: launching with `QTWEBENGINE_CHROMIUM_FLAGS=--use-angle=d3d11` resolves both symptoms while keeping WebEngine hardware-accelerated. The more aggressive `--disable-gpu` resolves it too but at a perf cost to WebEngine UI.

## Fix

Add a Windows-only block to `CMake/SlicerBlockCTKAppLauncherSettings.cmake` (both BUILD and INSTALLED env sections) setting `QTWEBENGINE_CHROMIUM_FLAGS=--use-angle=d3d11`. Mirrors the existing Linux-only `QTWEBENGINE_DISABLE_SANDBOX=1` pattern in the same file. Setting it via the launcher (rather than in C++) is important: the variable must be present in the environment before Chromium's child process forks.

## Alternatives considered

- **`Qt::AA_ShareOpenGLContexts` adjustments** — already set correctly; not the missing piece.
- **`--disable-gpu-compositing`** — less aggressive but still degrades WebEngine perf; ANGLE/D3D11 is the cleaner choice.
- **`--disable-gpu`** — confirmed workaround in the original report but disables WebEngine GPU entirely; unnecessary trade-off.
- **`--use-angle=d3d11` was selected** because Windows ANGLE/D3D11 is the default WebEngine path absent `AA_ShareOpenGLContexts`; making it explicit just restores normal behavior.

## Test plan

- [x] Repro on Windows 11 + NVIDIA Quadro RTX 5000 + driver 595.79: both symptoms reproduced.
- [x] Apply fix: both symptoms resolved; WebEngine still GPU-accelerated.
- [ ] Linux build (NVIDIA + Mesa) — change is `if(WIN32)` guarded; no expected effect.
- [ ] macOS build — change is `if(WIN32)` guarded; no expected effect.
- [ ] Windows + AMD GPU — verify no regression.
- [ ] Windows + Intel iGPU — verify no regression.
- [ ] Windows + GeForce — verify no regression.
- [ ] WebEngine page-load and 3D-view FPS spot check — confirm no perf regression.

## Notes / known limitations

- Verified only on one Windows + NVIDIA configuration; broader hardware coverage welcome from CI / other testers before merge.
- User overrides of `QTWEBENGINE_CHROMIUM_FLAGS` set by the launcher will be overwritten by this default; if that becomes a concern, the launcher's additional-settings file can extend it.
- Qt 6 WebEngine has a different GPU process architecture; this workaround may become unnecessary after the Qt 6 migration but should remain harmless.