### PR TITLE
BUG: Fix Extension Wizard module creation

### DIFF
--- a/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/CreateComponentDialog.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/CreateComponentDialog.py
@@ -22,8 +22,8 @@ class _ui_CreateComponentDialog:
         self.componentName = qt.QLineEdit()
         self.formLayout.addRow(_("Name:"), self.componentName)
 
-        self.componentNameValidator = qt.QRegExpValidator(
-            qt.QRegExp(r"^[a-zA-Z_][a-zA-Z0-9_]*$"))
+        self.componentNameValidator = qt.QRegularExpressionValidator(
+            qt.QRegularExpression(r"^[a-zA-Z_][a-zA-Z0-9_]*$"))
         self.componentName.setValidator(self.componentNameValidator)
 
         self.componentType = qt.QComboBox()


### PR DESCRIPTION
Classes deprecated in Qt6 have been replaced with their new variants. They are available in Qt 5.15.2 as well, so no condition is needed.