### PR TITLE
BUG: Prevent loss of volume rendering opacity transfer function points

### DIFF
--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyJsonStorageNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyJsonStorageNode.cxx
@@ -36,7 +36,9 @@
 #include <vtkVolumeProperty.h>
 
 // std includes
+#include <algorithm>
 #include <sstream>
+#include <vector>
 
 namespace
 {
@@ -298,7 +300,28 @@ bool vtkMRMLVolumePropertyJsonStorageNode::ReadTransferFunction(vtkObject* trans
     colorTransferFunction->RemoveAllPoints();
   }
 
+  // Collect all points first, then sort by x before inserting.
+  // Sorting before applying HigherAndUnique ensures that out-of-order points in the file
+  // (the schema does not require ordering) do not result in points being shifted rightward
+  // by HigherAndUnique's std::max.
+  struct PiecewisePoint
+  {
+    double x, y, midpoint, sharpness;
+  };
+  struct ColorPoint
+  {
+    double x, r, g, b, midpoint, sharpness;
+  };
+  std::vector<PiecewisePoint> pwPoints;
+  std::vector<ColorPoint> colorPoints;
+
   vtkSmartPointer<vtkMRMLJsonElement> pointsElement = vtkSmartPointer<vtkMRMLJsonElement>::Take(transferFunctionElement->GetArrayProperty("points"));
+  if (!pointsElement)
+  {
+    vtkErrorToMessageCollectionMacro(
+      this->GetUserMessages(), "vtkMRMLVolumePropertyJsonStorageNode::ReadTransferFunction", "Reading transfer function failed: 'points' array is missing.");
+    return false;
+  }
   for (int i = 0; i < pointsElement->GetArraySize(); ++i)
   {
     vtkSmartPointer<vtkMRMLJsonElement> pointElement = vtkSmartPointer<vtkMRMLJsonElement>::Take(pointsElement->GetArrayItem(i));
@@ -319,14 +342,39 @@ bool vtkMRMLVolumePropertyJsonStorageNode::ReadTransferFunction(vtkObject* trans
     {
       double y = 0.0;
       pointElement->GetDoubleProperty("y", y);
-      piecewiseFunction->AddPoint(x, y, midpoint, sharpness);
+      pwPoints.push_back({ x, y, midpoint, sharpness });
     }
     else if (colorTransferFunction)
     {
       double color[3] = { 0.0, 0.0, 0.0 };
       pointElement->GetVectorProperty("color", color, 3);
-      colorTransferFunction->AddRGBPoint(x, color[0], color[1], color[2], midpoint, sharpness);
+      colorPoints.push_back({ x, color[0], color[1], color[2], midpoint, sharpness });
     }
+  }
+
+  // Using stable_sort preserves file order for points with equal x, which matters for equal or near-equal x values
+  // because they may be intentionally placed in a specific order in the file.
+  // For example, y=0.0 then y=1.0 at the same x to create a sharp opacity step.
+  std::stable_sort(pwPoints.begin(), pwPoints.end(), [](const PiecewisePoint& a, const PiecewisePoint& b) { return a.x < b.x; });
+  std::stable_sort(colorPoints.begin(), colorPoints.end(), [](const ColorPoint& a, const ColorPoint& b) { return a.x < b.x; });
+
+  // Ensure x is greater than the previous point's x.
+  // This is critical because vtkPiecewiseFunction::AddPoint() silently removes any existing point at the same x
+  // before inserting the new one, so duplicate or near-duplicate x values in the file would cause points to be lost.
+  // Near-duplicate x values may be introduced for example by temporary conversions of coordinates through float32, collapsing
+  // values that were distinct as double into the same float32.
+
+  double previousX = VTK_DOUBLE_MIN;
+  for (auto& p : pwPoints)
+  {
+    p.x = vtkMRMLVolumePropertyNode::HigherAndUnique(p.x, previousX);
+    piecewiseFunction->AddPoint(p.x, p.y, p.midpoint, p.sharpness);
+  }
+  previousX = VTK_DOUBLE_MIN;
+  for (auto& p : colorPoints)
+  {
+    p.x = vtkMRMLVolumePropertyNode::HigherAndUnique(p.x, previousX);
+    colorTransferFunction->AddRGBPoint(p.x, p.r, p.g, p.b, p.midpoint, p.sharpness);
   }
 
   return true;

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.cxx
@@ -16,6 +16,7 @@
 // STD includes
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <limits>
 #include <sstream>
 
@@ -243,7 +244,9 @@ int vtkMRMLVolumePropertyNode::NodesFromString(const std::string& dataString, do
     vtkGenericWarningMacro("vtkMRMLVolumePropertyNode::NodesFromString: Error parsing data string");
     return 0;
   }
-  // Ensure uniqueness
+  // Ensure uniqueness with a float32-safe minimum spacing. This may shift x
+  // coordinates upward even when they are already strictly increasing but too
+  // close to survive float32 round-tripping.
   double previous = VTK_DOUBLE_MIN;
   for (int i = 0; i < size; i += nodeSize)
   {
@@ -291,34 +294,39 @@ void vtkMRMLVolumePropertyNode::GetColorTransferFunctionFromString(const std::st
 //----------------------------------------------------------------------------
 double vtkMRMLVolumePropertyNode::NextHigher(double value)
 {
-  if (value == 0.)
+  // Advance by 10 float32 ULPs so the result remains distinguishable from
+  // value even when coordinates pass through float32 arithmetic (e.g., in
+  // VTK widget MovePoints which stores positions in vtkVector2f). 10 ULPs
+  // provides a comfortable margin against accumulated numerical inaccuracies.
+  float fNext = static_cast<float>(value);
+  // Start from the smallest normal float when f is zero so that the ULP steps
+  // advance through normal (non-subnormal) values only, as subnormal floats
+  // could be flushed back to 0.0f on some systems.
+  if (fNext == 0.0f)
   {
-    // special case to avoid denormalized numbers
-    return std::numeric_limits<double>::min();
+    fNext = std::numeric_limits<float>::min();
   }
-  // Increment the value by the smallest offset possible
-  // The challenge here is to find the offset, if the value is 100000000., an
-  // offset of epsilon won't work.
-  typedef union
+  for (int i = 0; i < 10; ++i)
   {
-    long long i64;
-    double d64;
-  } dbl_64;
-  dbl_64 d;
-  d.d64 = value;
-  d.i64 += (value < 0.) ? -1 : 1;
-  return d.d64;
+    fNext = std::nextafter(fNext, std::numeric_limits<float>::infinity());
+  }
+  // fNext in theory can be infinity if value is very large, but in practice it
+  // should not be an issue because volume rendering transfer function points with
+  // such large x values would not make sense.
+  return static_cast<double>(fNext);
 }
 
 //----------------------------------------------------------------------------
 double vtkMRMLVolumePropertyNode::HigherAndUnique(double value, double& previousValue)
 {
   value = std::max(value, previousValue);
-  if (value == previousValue)
+  // Ensure a very small but safe gap to ensure adjacent point remain distinct,
+  // even if point coordinates are temporarily converted to float32.
+  double minAcceptable = vtkMRMLVolumePropertyNode::NextHigher(previousValue);
+  if (value < minAcceptable)
   {
-    value = vtkMRMLVolumePropertyNode::NextHigher(value);
+    value = minAcceptable;
   }
-  assert(value != previousValue);
   previousValue = value;
   return value;
 }

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.h
@@ -112,12 +112,22 @@ public:
   static inline void GetColorTransferFunctionFromString(const char* str, vtkColorTransferFunction* result);
 
   /// Utility function:
-  /// Return the nearest higher value.
+  /// Return a slightly higher value that is guaranteed to remain distinct
+  /// from the input after float32 round-tripping.
+  ///
+  /// This intentionally uses a larger-than-minimal increment (multiple
+  /// float32 ULPs) so that values that are distinct in double precision do not
+  /// collapse to the same coordinate after operations that temporarily use
+  /// float32.
   /// \sa HigherAndUnique()
   static double NextHigher(double value);
   /// Utility function:
-  /// Return the value or the nearest higher value if the value is equal
-  /// to previousValue. Update previousValue with the new higher value.
+  /// Return a value that is strictly greater than previousValue and robust to
+  /// float32 round-tripping. Update previousValue with the returned value.
+  ///
+  /// Note: the returned value may be shifted upward even when input values are
+  /// already strictly increasing, if adjacent points are too close to remain
+  /// distinct after float32 conversion.
   /// \sa NextHigher()
   static double HigherAndUnique(double value, double& previousValue);
 

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumePropertyJsonStorageNodeTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumePropertyJsonStorageNodeTest1.cxx
@@ -29,6 +29,8 @@
 #include <vtkVolumeProperty.h>
 
 // STD includes
+#include <cmath>
+#include <fstream>
 #include <iostream>
 
 //---------------------------------------------------------------------------
@@ -116,6 +118,184 @@ int CompareVolumeProperty(vtkVolumeProperty* actualVolumeProperty, vtkVolumeProp
 }
 
 //---------------------------------------------------------------------------
+// Verify that loading a JSON file with duplicate x coordinates in scalarOpacity,
+// gradientOpacity, and rgbTransferFunction preserves all points, separates them
+// so x values are strictly increasing, and retains file order for duplicate pairs.
+//
+// Duplicate x values arise when VTK widget arithmetic passes coordinates through
+// float32 (vtkVector2f), collapsing two near-duplicate doubles into the same
+// float32 value after a shift operation.
+int TestTransferFunctionDuplicateXValuesOnLoad(const char* tempDir)
+{
+  // Write the JSON directly to control exact x values including duplicates,
+  // bypassing VTK's piecewise/color function insert which would deduplicate.
+  //
+  // scalarOpacity / gradientOpacity: duplicate in the middle with y=1 then y=0
+  //   (a sharp opacity spike — rises then immediately falls).
+  // rgbTransferFunction: duplicate in the middle with distinct colors
+  //   (red then green) so file order is unambiguous.
+  std::string fileName = std::string(tempDir) + "/TransferFunctionWithDuplicateX.vp.json";
+  {
+    std::ofstream f(fileName);
+    f << R"({
+    "@schema": "https://raw.githubusercontent.com/slicer/slicer/main/Modules/Loadable/VolumeRendering/Resources/Schema/volume-property-schema-v1.0.0.json#",
+    "volumeProperties": [{ "components": [{
+        "scalarOpacity": { "type": "piecewiseLinearFunction", "points": [
+            { "x": -300.0, "y": 0.0 },
+            { "x": -150.0, "y": 1.0 },
+            { "x": -150.0, "y": 0.0 },
+            { "x": 2000.0, "y": 0.0 }
+        ]},
+        "gradientOpacity": { "type": "piecewiseLinearFunction", "points": [
+            { "x":    0.0, "y": 0.0 },
+            { "x":  500.0, "y": 1.0 },
+            { "x":  500.0, "y": 0.0 },
+            { "x": 1000.0, "y": 0.0 }
+        ]},
+        "rgbTransferFunction": { "type": "colorTransferFunction", "points": [
+            { "x":  10000.0, "color": [0.0, 0.0, 0.0] },
+            { "x":  15000.0, "color": [1.0, 0.0, 0.0] },
+            { "x":  15000.0, "color": [0.0, 1.0, 0.0] },
+            { "x": 100000.0, "color": [1.0, 1.0, 1.0] }
+        ]}
+    }]}]
+    })";
+  }
+
+  vtkNew<vtkMRMLVolumePropertyJsonStorageNode> storageNode;
+  storageNode->SetFileName(fileName.c_str());
+  vtkNew<vtkMRMLVolumePropertyNode> vpNode;
+  CHECK_INT(storageNode->ReadData(vpNode), 1);
+
+  // --- scalarOpacity ---
+  {
+    vtkPiecewiseFunction* opacity = vpNode->GetVolumeProperty()->GetScalarOpacity(0);
+    // All 4 points must survive — without the HigherAndUnique fix, AddPoint's
+    // deduplication (AllowDuplicateScalars=false) silently drops the first point.
+    CHECK_INT(opacity->GetSize(), 4);
+    double p[4][4];
+    for (int i = 0; i < 4; ++i)
+    {
+      opacity->GetNodeValue(i, p[i]);
+    }
+    CHECK_BOOL(p[0][0] < p[1][0], true);
+    CHECK_BOOL(p[1][0] < p[2][0], true);
+    CHECK_BOOL(p[2][0] < p[3][0], true);
+    CHECK_DOUBLE_TOLERANCE(p[0][0], -300.0, DOUBLE_TOLERANCE);
+    CHECK_DOUBLE_TOLERANCE(p[3][0], 2000.0, DOUBLE_TOLERANCE);
+    CHECK_BOOL(std::abs(p[1][0] - -150.0) < 1.0, true);
+    CHECK_BOOL(std::abs(p[2][0] - -150.0) < 1.0, true);
+    // File order preserved: spike up (y=1) before spike down (y=0).
+    CHECK_DOUBLE_TOLERANCE(p[0][1], 0.0, DOUBLE_TOLERANCE);
+    CHECK_DOUBLE_TOLERANCE(p[1][1], 1.0, DOUBLE_TOLERANCE);
+    CHECK_DOUBLE_TOLERANCE(p[2][1], 0.0, DOUBLE_TOLERANCE);
+    CHECK_DOUBLE_TOLERANCE(p[3][1], 0.0, DOUBLE_TOLERANCE);
+  }
+
+  // --- gradientOpacity ---
+  {
+    vtkPiecewiseFunction* gradient = vpNode->GetVolumeProperty()->GetGradientOpacity(0);
+    CHECK_INT(gradient->GetSize(), 4);
+    double p[4][4];
+    for (int i = 0; i < 4; ++i)
+    {
+      gradient->GetNodeValue(i, p[i]);
+    }
+    CHECK_BOOL(p[0][0] < p[1][0], true);
+    CHECK_BOOL(p[1][0] < p[2][0], true);
+    CHECK_BOOL(p[2][0] < p[3][0], true);
+    CHECK_DOUBLE_TOLERANCE(p[0][0], 0.0, DOUBLE_TOLERANCE);
+    CHECK_DOUBLE_TOLERANCE(p[3][0], 1000.0, DOUBLE_TOLERANCE);
+    CHECK_BOOL(std::abs(p[1][0] - 500.0) < 1.0, true);
+    CHECK_BOOL(std::abs(p[2][0] - 500.0) < 1.0, true);
+    CHECK_DOUBLE_TOLERANCE(p[0][1], 0.0, DOUBLE_TOLERANCE);
+    CHECK_DOUBLE_TOLERANCE(p[1][1], 1.0, DOUBLE_TOLERANCE);
+    CHECK_DOUBLE_TOLERANCE(p[2][1], 0.0, DOUBLE_TOLERANCE);
+    CHECK_DOUBLE_TOLERANCE(p[3][1], 0.0, DOUBLE_TOLERANCE);
+  }
+
+  // --- rgbTransferFunction ---
+  // GetNodeValue returns [x, r, g, b, midpoint, sharpness].
+  {
+    vtkColorTransferFunction* color = vpNode->GetVolumeProperty()->GetRGBTransferFunction(0);
+    CHECK_INT(color->GetSize(), 4);
+    double p[4][6];
+    for (int i = 0; i < 4; ++i)
+    {
+      color->GetNodeValue(i, p[i]);
+    }
+    CHECK_BOOL(p[0][0] < p[1][0], true);
+    CHECK_BOOL(p[1][0] < p[2][0], true);
+    CHECK_BOOL(p[2][0] < p[3][0], true);
+    CHECK_DOUBLE_TOLERANCE(p[0][0], 10000.0, DOUBLE_TOLERANCE);
+    CHECK_DOUBLE_TOLERANCE(p[3][0], 100000.0, DOUBLE_TOLERANCE);
+    CHECK_BOOL(std::abs(p[1][0] - 15000.0) < 1.0, true);
+    CHECK_BOOL(std::abs(p[2][0] - 15000.0) < 1.0, true);
+    // File order preserved: red before green.
+    CHECK_DOUBLE_TOLERANCE(p[0][1], 0.0, DOUBLE_TOLERANCE); // black r
+    CHECK_DOUBLE_TOLERANCE(p[1][1], 1.0, DOUBLE_TOLERANCE); // red   r
+    CHECK_DOUBLE_TOLERANCE(p[1][2], 0.0, DOUBLE_TOLERANCE); // red   g
+    CHECK_DOUBLE_TOLERANCE(p[2][1], 0.0, DOUBLE_TOLERANCE); // green r
+    CHECK_DOUBLE_TOLERANCE(p[2][2], 1.0, DOUBLE_TOLERANCE); // green g
+    CHECK_DOUBLE_TOLERANCE(p[3][1], 1.0, DOUBLE_TOLERANCE); // white r
+    CHECK_DOUBLE_TOLERANCE(p[3][2], 1.0, DOUBLE_TOLERANCE); // white g
+    CHECK_DOUBLE_TOLERANCE(p[3][3], 1.0, DOUBLE_TOLERANCE); // white b
+  }
+
+  return EXIT_SUCCESS;
+}
+
+//---------------------------------------------------------------------------
+// Verify that gradient opacity points stored out of x order in the JSON are
+// sorted correctly on load.
+int TestTransferFunctionUnsortedXValuesOnLoad(const char* tempDir)
+{
+  std::string fileName = std::string(tempDir) + "/GradientOpacityUnsorted.vp.json";
+  {
+    std::ofstream f(fileName);
+    f << R"({
+    "@schema": "https://raw.githubusercontent.com/slicer/slicer/main/Modules/Loadable/VolumeRendering/Resources/Schema/volume-property-schema-v1.0.0.json#",
+    "volumeProperties": [{ "components": [{ "gradientOpacity": {
+        "type": "piecewiseLinearFunction",
+        "points": [
+            { "x": 1000.0, "y": 0.0 },
+            { "x":    0.0, "y": 0.0 },
+            { "x":  500.0, "y": 0.5 },
+            { "x":  750.0, "y": 1.0 }
+    ]}}]}]
+    })";
+  }
+
+  vtkNew<vtkMRMLVolumePropertyJsonStorageNode> storageNode;
+  storageNode->SetFileName(fileName.c_str());
+  vtkNew<vtkMRMLVolumePropertyNode> vpNode;
+  CHECK_INT(storageNode->ReadData(vpNode), 1);
+
+  vtkPiecewiseFunction* gradient = vpNode->GetVolumeProperty()->GetGradientOpacity(0);
+  CHECK_INT(gradient->GetSize(), 4);
+
+  double p[4][4];
+  for (int i = 0; i < 4; ++i)
+  {
+    gradient->GetNodeValue(i, p[i]);
+  }
+
+  // Points must be sorted by x regardless of file order.
+  CHECK_DOUBLE_TOLERANCE(p[0][0], 0.0, DOUBLE_TOLERANCE);
+  CHECK_DOUBLE_TOLERANCE(p[1][0], 500.0, DOUBLE_TOLERANCE);
+  CHECK_DOUBLE_TOLERANCE(p[2][0], 750.0, DOUBLE_TOLERANCE);
+  CHECK_DOUBLE_TOLERANCE(p[3][0], 1000.0, DOUBLE_TOLERANCE);
+
+  // y values must follow the sorted x values, not the original file order.
+  CHECK_DOUBLE_TOLERANCE(p[0][1], 0.0, DOUBLE_TOLERANCE);
+  CHECK_DOUBLE_TOLERANCE(p[1][1], 0.5, DOUBLE_TOLERANCE);
+  CHECK_DOUBLE_TOLERANCE(p[2][1], 1.0, DOUBLE_TOLERANCE);
+  CHECK_DOUBLE_TOLERANCE(p[3][1], 0.0, DOUBLE_TOLERANCE);
+
+  return EXIT_SUCCESS;
+}
+
+//---------------------------------------------------------------------------
 int vtkMRMLVolumePropertyJsonStorageNodeTest1(int argc, char* argv[])
 {
   if (argc != 2)
@@ -194,6 +374,9 @@ int vtkMRMLVolumePropertyJsonStorageNodeTest1(int argc, char* argv[])
   CHECK_DOUBLE_TOLERANCE(actualVolumePropertyNode->GetEffectiveRange()[1], expectedVolumePropertyNode->GetEffectiveRange()[1], DOUBLE_TOLERANCE);
 
   CHECK_EXIT_SUCCESS(CompareVolumeProperty(actualVolumePropertyNode->GetVolumeProperty(), expectedVolumePropertyNode->GetVolumeProperty()));
+
+  CHECK_EXIT_SUCCESS(TestTransferFunctionDuplicateXValuesOnLoad(tempDir));
+  CHECK_EXIT_SUCCESS(TestTransferFunctionUnsortedXValuesOnLoad(tempDir));
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
When volume rendering opacity transfer function is shifted using MovePoints, the point x coordinates are temporarily converted to 32-bit float. The small difference that vtkMRMLVolumePropertyNode::NextHigher and vtkMRMLVolumePropertyNode::HigherAndUnique functions introduced was not sufficient to survive this conversion and the x coordinates could end up having the same value. When the points were saved and reloaded, the vtkMRMLVolumePropertyJsonStorageNode did not use vtkMRMLVolumePropertyNode::HigherAndUnique, which resulted in piecewiseFunction->AddPoint overwriting an existing point.

Fix the problem by making vtkMRMLVolumePropertyNode::NextHigher large enough difference that comfortably survives 32-bit float conversion.

In addition to this, vtkMRMLVolumePropertyJsonStorageNode is improved to use vtkMRMLVolumePropertyNode::HigherAndUnique function, which ensures that every point has a unique coordinate regardless of how close the point coordinates are in the file. This is necessary because volume rendering property files may be created by external software, which may not know that x values have to be unique.

fixes #9129