### PR TITLE
ENH: Keep markup placement preview visible when slice view moves or zooms

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceViewInteractorStyle.cxx
@@ -35,8 +35,8 @@
 #include "vtkCommand.h"
 #include "vtkNew.h"
 
-// STL includes
-#include <algorithm>
+// vtkAddon includes
+#include "vtkAddonMathUtilities.h"
 
 //----------------------------------------------------------------------------
 vtkCxxSetObjectMacro(vtkMRMLSliceViewInteractorStyle, SliceLogic, vtkMRMLSliceLogic);
@@ -140,7 +140,26 @@ bool vtkMRMLSliceViewInteractorStyle::DelegateInteractionEventToDisplayableManag
     }
   }
 
+  vtkNew<vtkMatrix4x4> xyToRasBefore;
+  xyToRasBefore->DeepCopy(xyToRasMatrix);
   bool result = this->DelegateInteractionEventDataToDisplayableManagers(ed);
+
+  // If the slice view moved or zoomed during event processing (for any reason:
+  // scroll, zoom, keyboard shortcut, linked slice, etc.), fire a synthetic mouse
+  // move so that widgets in placement mode can update their preview point to the
+  // correct position under the cursor on the new slice.
+  if (!vtkAddonMathUtilities::MatrixAreEqual(xyToRasBefore, xyToRasMatrix, 0.0))
+  {
+    // XYToRAS is a live pointer — recompute world position for the updated view
+    xyToRasMatrix->MultiplyPoint(displayPosition, worldPosition);
+    vtkNew<vtkMRMLInteractionEventData> mouseMoveEd;
+    mouseMoveEd->SetType(vtkCommand::MouseMoveEvent);
+    mouseMoveEd->SetDisplayPosition(displayPositionCorrected);
+    mouseMoveEd->SetWorldPosition(worldPosition);
+    mouseMoveEd->SetAttributesFromInteractor(this->GetInteractor());
+    this->DelegateInteractionEventDataToDisplayableManagers(mouseMoveEd);
+  }
+
   if (appLogic)
   {
     appLogic->ResumeRender();

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
@@ -637,11 +637,12 @@ bool vtkMRMLMarkupsDisplayableManager::CanProcessInteractionEvent(vtkMRMLInterac
   vtkMRMLInteractionNode* interactionNode = this->GetInteractionNode();
   // New point can be placed anywhere
   int eventid = eventData->GetType();
-  // We allow mouse move with the shift modifier to be processed while in place mode so that we can continue to update the
-  // preview position, even when using shift + mouse-move to adjust the crosshair position.
+  // We allow mouse move with the shift or control modifier to be processed while in place mode so that we can continue to update the
+  // preview position, even when using Shift or Control key is depressed (for example due to adjusting the crosshair position
+  // using Shift + mouse-move, or zooming using Control + mouse-wheel).
   if ((eventid == vtkCommand::MouseMoveEvent                                                                    //
        && (eventData->GetModifiers() == vtkEvent::NoModifier ||                                                 //
-           (eventData->GetModifiers() & vtkEvent::ShiftModifier &&                                              //
+           (eventData->GetModifiers() & (vtkEvent::ShiftModifier | vtkEvent::ControlModifier)  &&                                              //
             interactionNode && interactionNode->GetCurrentInteractionMode() == vtkMRMLInteractionNode::Place))) //
       || eventid == vtkCommand::Move3DEvent)
   {


### PR DESCRIPTION
When the user scrolled or zoomed a 2D slice view while placing a markup point, the crosshair displayable manager took focus from the markups displayable manager. This triggered Leave() on the markups widget, which removed the preview control point, making it appear as if clicks were ignored until the mouse was moved.

Fix: after each interaction event in a slice view, compare the XYToRAS matrix before and after. If it changed (slice moved or zoomed in any way then  synthesize a MouseMoveEvent at the current cursor position so displayable managers can update according to the new physical position of the mouse pointer.

Also allow ControlModifier mouse-move events to update the markup preview in placement mode, matching the existing ShiftModifier exception, so the preview stays live during Ctrl+zoom mouse movements.

fixes #8128