### PR TITLE
ENH: Add 2D slice view in-plane FoV rotation and horizontal flip

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
@@ -161,10 +161,26 @@ void vtkMRMLSliceIntersectionWidget::UpdateInteractionEventMapping()
   {
     this->SetEventTranslation(WidgetStateIdle, vtkCommand::MouseMoveEvent, vtkEvent::ShiftModifier, WidgetEventSetCrosshairPositionBackground);
   }
+  if (this->GetActionEnabled(ActionRotate))
+  {
+    // Ctrl-left-click-and-drag rolls the current slice in-plane about the view center
+    // (the 2D analog of the ctrl-left-click-and-drag camera roll in 3D views).
+    this->SetEventTranslationClickAndDrag(WidgetStateIdle,
+                                          vtkCommand::LeftButtonPressEvent,
+                                          vtkEvent::ControlModifier,
+                                          WidgetStateRotateFieldOfView,
+                                          WidgetEventRotateFieldOfViewStart,
+                                          WidgetEventRotateFieldOfViewEnd);
+  }
   if (this->GetActionEnabled(ActionBlend))
   {
-    this->SetEventTranslationClickAndDrag(
-      WidgetStateIdle, vtkCommand::LeftButtonPressEvent, vtkEvent::ControlModifier, WidgetStateBlend, WidgetEventBlendStart, WidgetEventBlendEnd);
+    // Blend drag uses ctrl+shift+left because ctrl+left is reserved for slice roll (ActionRotate).
+    this->SetEventTranslationClickAndDrag(WidgetStateIdle,
+                                          vtkCommand::LeftButtonPressEvent,
+                                          vtkEvent::ControlModifier + vtkEvent::ShiftModifier,
+                                          WidgetStateBlend,
+                                          WidgetEventBlendStart,
+                                          WidgetEventBlendEnd);
     this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "g", WidgetEventToggleLabelOpacity);
     this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "t", WidgetEventToggleForegroundOpacity);
   }
@@ -369,6 +385,7 @@ bool vtkMRMLSliceIntersectionWidget::CanProcessInteractionEvent(vtkMRMLInteracti
   if (this->WidgetState == WidgetStateMoveCrosshair                             //
       || this->WidgetState == WidgetStateTranslate                              //
       || this->WidgetState == WidgetStateRotateIntersectingSlices               //
+      || this->WidgetState == WidgetStateRotateFieldOfView                      //
       || this->WidgetState == WidgetStateBlend                                  //
       || this->WidgetState == WidgetStateTranslateSlice                         //
       || this->WidgetState == WidgetStateZoomSlice                              //
@@ -475,6 +492,15 @@ bool vtkMRMLSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionE
       processedEvent = this->ProcessRotateIntersectingSlicesStart(eventData);
       break;
     case WidgetEventRotateIntersectingSlicesEnd:
+      processedEvent = this->ProcessEndMouseDrag(eventData);
+      this->SliceLogic->EndSliceNodeInteraction();
+      break;
+    case WidgetEventRotateFieldOfViewStart:
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
+      this->SliceLogic->StartSliceNodeInteraction(vtkMRMLSliceNode::SliceToRASFlag);
+      processedEvent = this->ProcessRotateFieldOfViewStart(eventData);
+      break;
+    case WidgetEventRotateFieldOfViewEnd:
       processedEvent = this->ProcessEndMouseDrag(eventData);
       this->SliceLogic->EndSliceNodeInteraction();
       break;
@@ -630,6 +656,7 @@ void vtkMRMLSliceIntersectionWidget::Leave(vtkMRMLInteractionEventData* eventDat
       || this->WidgetState == WidgetStateZoomSlice                              //
       || this->WidgetState == WidgetStateBlend                                  //
       || this->WidgetState == WidgetStateRotateIntersectingSlices               //
+      || this->WidgetState == WidgetStateRotateFieldOfView                      //
       || this->WidgetState == WidgetStateTranslateIntersectingSlicesHandle      //
       || this->WidgetState == WidgetStateTranslateSingleIntersectingSliceHandle //
       || this->WidgetState == WidgetStateRotateIntersectingSlicesHandle         //
@@ -663,6 +690,7 @@ bool vtkMRMLSliceIntersectionWidget::ProcessMouseMove(vtkMRMLInteractionEventDat
   switch (this->WidgetState)
   {
     case WidgetStateRotateIntersectingSlices: this->ProcessRotateIntersectingSlices(eventData); break;
+    case WidgetStateRotateFieldOfView: this->ProcessRotateFieldOfView(eventData); break;
     case WidgetStateTranslate:
     {
       const double* worldPos = eventData->GetWorldPosition();
@@ -1160,6 +1188,76 @@ bool vtkMRMLSliceIntersectionWidget::Rotate(double sliceRotationAngleRad)
   this->PreviousRotationAngleRad = sliceRotationAngleRad;
 
   rep->TransformIntersectingSlices(rotatedSliceToSliceTransform->GetMatrix());
+  return true;
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::ProcessRotateFieldOfViewStart(vtkMRMLInteractionEventData* eventData)
+{
+  if (!this->GetRenderer() || !this->GetSliceNode())
+  {
+    return false;
+  }
+
+  this->SetWidgetState(WidgetStateRotateFieldOfView);
+
+  // Roll the slice in-plane about the center of the view (the 2D analog of the camera roll
+  // performed with ctrl+left-click-and-drag in 3D views).
+  double* viewCenter = this->GetRenderer()->GetCenter();
+  this->StartRotationCenter[0] = viewCenter[0];
+  this->StartRotationCenter[1] = viewCenter[1];
+  double startRotationCenterXY[4] = { viewCenter[0], viewCenter[1], 0.0, 1.0 };
+  this->GetSliceNode()->GetXYToRAS()->MultiplyPoint(startRotationCenterXY, this->StartRotationCenter_RAS);
+
+  // Save initial rotation angle
+  const int* displayPos = eventData->GetDisplayPosition();
+  double displayPosDouble[2] = { static_cast<double>(displayPos[0]), static_cast<double>(displayPos[1]) };
+  this->PreviousRotationAngleRad = this->GetSliceRotationAngleRad(displayPosDouble);
+
+  return this->ProcessStartMouseDrag(eventData);
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::ProcessRotateFieldOfView(vtkMRMLInteractionEventData* eventData)
+{
+  vtkMRMLSliceNode* sliceNode = this->GetSliceNode();
+  if (!sliceNode)
+  {
+    return false;
+  }
+
+  const int* displayPos = eventData->GetDisplayPosition();
+  double displayPosDouble[2] = { static_cast<double>(displayPos[0]), static_cast<double>(displayPos[1]) };
+  double sliceRotationAngleRad = this->GetSliceRotationAngleRad(displayPosDouble);
+
+  vtkMatrix4x4* sliceToRAS = sliceNode->GetSliceToRAS();
+  vtkNew<vtkTransform> rotatedSliceToSliceTransform;
+
+  // Rotate about the slice normal (3rd column of SliceToRAS) through the view-center pivot,
+  // so the displayed image rolls in-plane while the pivot stays fixed on screen.
+  // Note: here we rotate the current slice's own SliceToRAS (the view frame), so the
+  // displayed image appears to rotate opposite to the frame. Negate the angle so the image
+  // follows the cursor direction.
+  rotatedSliceToSliceTransform->Translate(this->StartRotationCenter_RAS[0], this->StartRotationCenter_RAS[1], this->StartRotationCenter_RAS[2]);
+  double rotationDirection = vtkMath::Determinant3x3(sliceToRAS->Element[0], sliceToRAS->Element[1], sliceToRAS->Element[2]) >= 0 ? 1.0 : -1.0;
+  rotatedSliceToSliceTransform->RotateWXYZ(-rotationDirection * vtkMath::DegreesFromRadians(sliceRotationAngleRad - this->PreviousRotationAngleRad),
+                                           sliceToRAS->GetElement(0, 2),
+                                           sliceToRAS->GetElement(1, 2),
+                                           sliceToRAS->GetElement(2, 2));
+  rotatedSliceToSliceTransform->Translate(-this->StartRotationCenter_RAS[0], -this->StartRotationCenter_RAS[1], -this->StartRotationCenter_RAS[2]);
+
+  this->PreviousRotationAngleRad = sliceRotationAngleRad;
+  this->PreviousEventPosition[0] = displayPos[0];
+  this->PreviousEventPosition[1] = displayPos[1];
+
+  // Apply the roll to the current slice only (not all intersecting slices).
+  int wasModified = sliceNode->StartModify();
+  vtkNew<vtkMatrix4x4> rotatedSliceToRAS;
+  vtkMatrix4x4::Multiply4x4(rotatedSliceToSliceTransform->GetMatrix(), sliceToRAS, rotatedSliceToRAS);
+  sliceNode->GetSliceToRAS()->DeepCopy(rotatedSliceToRAS);
+  sliceNode->UpdateMatrices();
+  sliceNode->EndModify(wasModified);
+
   return true;
 }
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
@@ -175,12 +175,8 @@ void vtkMRMLSliceIntersectionWidget::UpdateInteractionEventMapping()
   if (this->GetActionEnabled(ActionBlend))
   {
     // Blend drag uses ctrl+shift+left because ctrl+left is reserved for slice roll (ActionRotate).
-    this->SetEventTranslationClickAndDrag(WidgetStateIdle,
-                                          vtkCommand::LeftButtonPressEvent,
-                                          vtkEvent::ControlModifier + vtkEvent::ShiftModifier,
-                                          WidgetStateBlend,
-                                          WidgetEventBlendStart,
-                                          WidgetEventBlendEnd);
+    this->SetEventTranslationClickAndDrag(
+      WidgetStateIdle, vtkCommand::LeftButtonPressEvent, vtkEvent::ControlModifier + vtkEvent::ShiftModifier, WidgetStateBlend, WidgetEventBlendStart, WidgetEventBlendEnd);
     this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "g", WidgetEventToggleLabelOpacity);
     this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "t", WidgetEventToggleForegroundOpacity);
   }

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.h
@@ -84,6 +84,7 @@ public:
     WidgetStateMoveCrosshair = WidgetStateUser, ///< Move crosshair position, can be used for moving the crosshair with click-and-drag.
     WidgetStateBlend,                           ///< Fade between foreground/background volumes
     WidgetStateTranslateSlice,                  ///< Pan (translate in-plane) the current slice (using shift+left-click-and-drag or middle-click-and-drag)
+    WidgetStateRotateFieldOfView,               ///< Roll the current slice in-plane about the view center (ctrl+left-click-and-drag)
     WidgetStateRotateIntersectingSlices,        ///< Rotate all intersecting slices (ctrl+alt+left-click-and-drag)
     WidgetStateZoomSlice,                       ///< Zoom slice (using right-button or mouse wheel)
     WidgetStateTouchGesture,                    ///< Pinch/zoom/pan using touch gestures
@@ -131,6 +132,8 @@ public:
     WidgetEventShowPreviousForegroundVolume,
     WidgetEventRotateIntersectingSlicesStart, // rotate all intersecting slices (ctrl-alt-left-click-and-drag)
     WidgetEventRotateIntersectingSlicesEnd,
+    WidgetEventRotateFieldOfViewStart, // roll the current slice in-plane about the view center (ctrl-left-click-and-drag)
+    WidgetEventRotateFieldOfViewEnd,
     WidgetEventTranslateSliceStart,
     WidgetEventTranslateSliceEnd,
     WidgetEventZoomSliceStart,
@@ -207,6 +210,11 @@ protected:
 
   bool ProcessRotateIntersectingSlicesStart(vtkMRMLInteractionEventData* eventData);
   bool ProcessRotateIntersectingSlices(vtkMRMLInteractionEventData* eventData);
+
+  // Roll the current slice in-plane about the view center by click-and-drag
+  bool ProcessRotateFieldOfViewStart(vtkMRMLInteractionEventData* eventData);
+  bool ProcessRotateFieldOfView(vtkMRMLInteractionEventData* eventData);
+
   bool ProcessSetCrosshair(vtkMRMLInteractionEventData* eventData);
   bool ProcessSetCrosshairBackground(vtkMRMLInteractionEventData* eventData);
   double GetSliceRotationAngleRad(double eventPos[2]);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
@@ -567,9 +567,19 @@ void qSlicerSubjectHierarchyViewContextMenuPlugin::flipSliceViewHorizontal()
   // This negates the in-plane horizontal axis and the slice normal (column 0 and column 2 of
   // SliceToRAS), mirroring the displayed image left-right while keeping the matrix right-handed
   // (i.e. viewing the slice from the opposite side). Triggering it again restores the orientation.
+  //
+  // Pivot the mirror about the current field of view center rather than the slice origin, so the
+  // point the user is looking at stays put even when zoomed in and panned off the slice origin.
+  // The slice X coordinate at the view center equals XYZOrigin[0] (see vtkMRMLSliceNode::UpdateMatrices,
+  // where the -FieldOfView/2 and spacing terms cancel at the window center).
+  double xyzOrigin[3] = { 0.0, 0.0, 0.0 };
+  sliceNode->GetXYZOrigin(xyzOrigin);
+
   vtkNew<vtkTransform> sliceToRASTransform;
   sliceToRASTransform->SetMatrix(sliceNode->GetSliceToRAS());
+  sliceToRASTransform->Translate(xyzOrigin[0], 0.0, 0.0);
   sliceToRASTransform->RotateY(180.0);
+  sliceToRASTransform->Translate(-xyzOrigin[0], 0.0, 0.0);
 
   int wasModifying = sliceNode->StartModify();
   sliceNode->GetSliceToRAS()->DeepCopy(sliceToRASTransform->GetMatrix());

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
@@ -55,6 +55,9 @@
 #include <vtkSmartPointer.h>
 #include <vtkMRMLCameraDisplayableManager.h>
 #include <vtkMRMLCameraWidget.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+#include <vtkTransform.h>
 
 // CTK includes
 #include "ctkSignalMapper.h"
@@ -81,6 +84,7 @@ public:
 
   QAction* MaximizeViewAction = nullptr;
   QAction* FitSliceViewAction = nullptr;
+  QAction* FlipSliceViewHorizontalAction = nullptr;
   QAction* RefocusAllCamerasAction = nullptr;
   QAction* CenterThreeDViewAction = nullptr;
   QAction* RefocusCameraAction = nullptr;
@@ -167,6 +171,13 @@ void qSlicerSubjectHierarchyViewContextMenuPluginPrivate::init()
   this->FitSliceViewAction->setToolTip(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Center the slice view on the currently displayed volume."));
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->FitSliceViewAction, qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 1);
   QObject::connect(this->FitSliceViewAction, SIGNAL(triggered()), q, SLOT(fitSliceView()));
+
+  this->FlipSliceViewHorizontalAction = new QAction(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Flip horizontal"), q);
+  this->FlipSliceViewHorizontalAction->setObjectName("FlipSliceViewHorizontalAction");
+  this->FlipSliceViewHorizontalAction->setToolTip(
+    qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Mirror the slice view horizontally (view the slice from the opposite side)."));
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->FlipSliceViewHorizontalAction, qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 6);
+  QObject::connect(this->FlipSliceViewHorizontalAction, SIGNAL(triggered()), q, SLOT(flipSliceViewHorizontal()));
 
   this->RefocusAllCamerasAction = new QAction(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Refocus cameras on this point"), q);
   this->RefocusAllCamerasAction->setObjectName("RefocusAllCamerasAction");
@@ -271,7 +282,7 @@ QList<QAction*> qSlicerSubjectHierarchyViewContextMenuPlugin::viewContextMenuAct
   Q_D(const qSlicerSubjectHierarchyViewContextMenuPlugin);
   QList<QAction*> actions;
   actions << d->InteractionModeViewTransformAction << d->InteractionModeAdjustWindowLevelAction << d->InteractionModePlaceAction << d->MaximizeViewAction << d->FitSliceViewAction
-          << d->RefocusAllCamerasAction << d->CenterThreeDViewAction << d->RefocusCameraAction << d->CopyImageAction << d->ToggleTiltLockAction
+          << d->FlipSliceViewHorizontalAction << d->RefocusAllCamerasAction << d->CenterThreeDViewAction << d->RefocusCameraAction << d->CopyImageAction << d->ToggleTiltLockAction
           << d->ConfigureSliceViewAnnotationsAction << d->IntersectingSlicesVisibilityAction << d->IntersectingSlicesInteractiveAction << d->EnableSlabReconstructionAction
           << d->SlabReconstructionInteractiveAction;
   return actions;
@@ -362,6 +373,7 @@ void qSlicerSubjectHierarchyViewContextMenuPlugin::showViewContextMenuActionsFor
   bool isSliceViewNode = (sliceViewNode != nullptr);
   d->ConfigureSliceViewAnnotationsAction->setVisible(isSliceViewNode);
   d->FitSliceViewAction->setVisible(isSliceViewNode);
+  d->FlipSliceViewHorizontalAction->setVisible(isSliceViewNode);
   d->RefocusAllCamerasAction->setVisible(isSliceViewNode);
   d->CenterThreeDViewAction->setVisible(!isSliceViewNode);
   d->RefocusCameraAction->setVisible(!isSliceViewNode);
@@ -537,6 +549,32 @@ void qSlicerSubjectHierarchyViewContextMenuPlugin::fitSliceView()
     qWarning() << Q_FUNC_INFO << " failed: sliceWidget not found";
     return;
   }
+}
+
+//---------------------------------------------------------------------------
+void qSlicerSubjectHierarchyViewContextMenuPlugin::flipSliceViewHorizontal()
+{
+  Q_D(qSlicerSubjectHierarchyViewContextMenuPlugin);
+
+  vtkMRMLSliceNode* sliceNode = vtkMRMLSliceNode::SafeDownCast(d->ViewNode);
+  if (!sliceNode)
+  {
+    qWarning() << Q_FUNC_INFO << " failed: not a slice view";
+    return;
+  }
+
+  // Flip the view horizontally with a 180 degree rotation about the in-plane vertical (Y) axis.
+  // This negates the in-plane horizontal axis and the slice normal (column 0 and column 2 of
+  // SliceToRAS), mirroring the displayed image left-right while keeping the matrix right-handed
+  // (i.e. viewing the slice from the opposite side). Triggering it again restores the orientation.
+  vtkNew<vtkTransform> sliceToRASTransform;
+  sliceToRASTransform->SetMatrix(sliceNode->GetSliceToRAS());
+  sliceToRASTransform->RotateY(180.0);
+
+  int wasModifying = sliceNode->StartModify();
+  sliceNode->GetSliceToRAS()->DeepCopy(sliceToRASTransform->GetMatrix());
+  sliceNode->UpdateMatrices();
+  sliceNode->EndModify(wasModifying);
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
@@ -174,8 +174,7 @@ void qSlicerSubjectHierarchyViewContextMenuPluginPrivate::init()
 
   this->FlipSliceViewHorizontalAction = new QAction(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Flip horizontal"), q);
   this->FlipSliceViewHorizontalAction->setObjectName("FlipSliceViewHorizontalAction");
-  this->FlipSliceViewHorizontalAction->setToolTip(
-    qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Mirror the slice view horizontally (view the slice from the opposite side)."));
+  this->FlipSliceViewHorizontalAction->setToolTip(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Mirror the slice view horizontally (view the slice from the opposite side)."));
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->FlipSliceViewHorizontalAction, qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 6);
   QObject::connect(this->FlipSliceViewHorizontalAction, SIGNAL(triggered()), q, SLOT(flipSliceViewHorizontal()));
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.h
@@ -63,6 +63,7 @@ protected slots:
   void configureSliceViewAnnotationsAction();
   void maximizeView();
   void fitSliceView();
+  void flipSliceViewHorizontal();
   void centerThreeDView();
   void refocusCamera();
   void refocusAllCameras();


### PR DESCRIPTION
## Summary

Adds two interactions for adjusting the in-plane orientation of a 2D slice view: an in-plane "roll" via **Ctrl+Left-click-and-drag** (the 2D analog of the existing 3D camera-roll gesture in `vtkMRMLCameraWidget`), and a **Flip horizontal** action in the slice view's right-click context menu. Both operate on the slice node's `SliceToRAS` and pivot about the current field-of-view center so that what the user is looking at stays put under pan/zoom.

Three commits, all `ENH:`:

1. `2051d08a` — `ENH: Add in-plane field of view rotation to 2D slice views`
2. `cb27aee5` — `ENH: Add horizontal flip action to slice view context menu`
3. `7faa5572` — `ENH: Flip slice view about field of view center instead of slice origin`

## Motivation

3D views already support a roll/spin gesture (Ctrl+Left-drag in `vtkMRMLCameraWidget::ProcessSpin`). 2D slice views had no equivalent: in-plane orientation could only be changed via the slice-controller orientation dropdown, `RotateToVolumePlane`, the reformat widget, or the multi-slice "rotate intersecting slices" gesture (Ctrl+Alt+Left). None of these gives a quick "tilt this view a few degrees" without committing to an orientation preset or reorienting *other* slices. Similarly, there was no built-in way to flip a slice view to view it from the opposite side (radiological/neurological convention swap), short of constructing a transform.

These two interactions fill those gaps with a UX that mirrors the established 3D roll gesture and a discoverable context-menu entry consistent with `Reset field of view`.

## What this adds

**FoV roll — Ctrl+Left-drag in 2D slice views.** Rolls the current slice in-plane about the renderer center. Implemented as a new `WidgetStateRotateFieldOfView` in `vtkMRMLSliceIntersectionWidget`, gated by the previously-unused `ActionRotate = 4 /* not used */` flag (already included in `ActionAll`, so the gesture is on by default with no extra flag wiring). The handler rotates only the *current* slice node's `SliceToRAS` about its normal through the renderer-center pivot — `ProcessRotateIntersectingSlices` is left untouched, so other slices' orientations are unaffected. The angle-vs-pivot helper `GetSliceRotationAngleRad` and the `rotationDirection` determinant convention are reused from `ProcessRotateIntersectingSlices`. The rotation sign is negated relative to that helper because we are rotating the view's own frame (rather than the *other* slices' frames as `TransformIntersectingSlices` does), so the displayed image follows the cursor.

**Flip horizontal — right-click → Flip horizontal in slice views.** Adds a new `QAction` to `qSlicerSubjectHierarchyViewContextMenuPlugin`, shown only for slice view nodes and positioned alongside `Reset field of view`. The slot mirrors the displayed image left-right by post-multiplying `SliceToRAS` by a 180-degree rotation about the in-plane vertical axis (`vtkTransform::RotateY(180)`), pivoted at the current FoV-center slice coordinate (`XYZOrigin[0]`, which `vtkMRMLSliceNode::UpdateMatrices` shows equals the slice X at the window center because the `-FieldOfView/2` and `spacing * (Dim/2)` terms cancel). This is the same `vtkTransform`-180-degree idiom SlicerIGT's `VolumeResliceDriver` uses for its `Flip` checkbox; the in-plane horizontal axis and the slice normal are negated together so the matrix stays right-handed. The action is a momentary toggle: triggering it again restores the original orientation. Pivoting at the FoV center means content at the window center stays put even when the user has zoomed in and panned off the slice origin; when not panned, this reduces exactly to the simpler `RotateY(180)` form.

## Behavior change — Blend drag relocation

Because Ctrl+Left was previously bound to **Blend** (foreground/label opacity click-and-drag) in `vtkMRMLSliceIntersectionWidget`, the Blend *drag* has been moved to **Ctrl+Shift+Left**. The `t` (foreground) and `g` (label) opacity-toggle keys are unchanged. Users who depend on the previous Blend gesture can disable the new rotate by clearing `ActionRotate` via `SetActionEnabled` — the same per-action bitmask mechanism Slicer already exposes for `Translate`, `Zoom`, `Blend`, etc.

**Why not keep Blend on Ctrl+Left and mode-gate it?** The natural pattern is the one `vtkMRMLWindowLevelWidget` already follows — self-gate on `vtkMRMLInteractionNode::AdjustWindowLevel` mode and win by returning a smaller `distance2` than the intersection widget's `1e10`. The blocker is that Ctrl+Left is *already* claimed in `AdjustWindowLevel` mode by `WidgetEventAdjustWindowLevelAlternativeStart` (the region-based W/L gesture) at `distance2 = 1e9`, so a mode-gated Blend at `1e10` would still be shadowed by region-grow and unreachable. Making it reachable would require also relocating region-grow off Ctrl+Left or introducing Blend as a peer sub-mode of the `AdjustWindowLevelMenu` — both larger surgeries that did not seem worth bundling with this change. Happy to revisit if reviewers prefer a different resolution; see "Open questions" below.

## Files changed

- `Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.h` — new `WidgetStateRotateFieldOfView`, `WidgetEventRotateFieldOfViewStart`/`End`, and `ProcessRotateFieldOfViewStart` / `ProcessRotateFieldOfView` method declarations.
- `Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx` — event mapping (Ctrl+Left → rotate; Blend relocated to Ctrl+Shift+Left), dispatch in `ProcessInteractionEvent` / `ProcessMouseMove`, drag-state lists in `CanProcessInteractionEvent` / `Leave`, and the two new handlers.
- `Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.{h,cxx}` — new `FlipSliceViewHorizontalAction`, `flipSliceViewHorizontal()` slot, and the FoV-center-pivoted `RotateY(180)` flip.

No public MRML API changes; no new MRML node types; no new settings or scene attributes.

## Backward compatibility

- `ActionRotate` (the flag gating the new gesture) was already declared `/* not used */` in `ActionsEnabled` and was already included in `ActionAll`. Existing applications/extensions are unaffected unless they explicitly call `SetActionsEnabled` with a custom mask omitting the rotate bit, in which case the new gesture stays off — matching their explicit configuration.
- Existing 2D pan/zoom/intersecting-slice gestures and the `t`/`g` opacity-toggle keys are unchanged.
- The flip action is purely additive; nothing was renamed or removed in the context-menu plugin.
- Default flip behavior with no pan (`XYZOrigin == 0`) is identical to a plain `RotateY(180)`; the FoV-center pivot only changes behavior when the user has actually panned off the slice origin.

## Test plan

Manual verification I performed locally on Linux (GCC 15, Qt 6.10):

- [x] Ctrl+Left-drag in a slice view rolls the image in-plane about the renderer center; release ends the drag. Confirmed on Axial, Sagittal, and Coronal views (the `rotationDirection` determinant handles both handedness conventions).
- [x] Ctrl+Shift+Left-drag adjusts foreground/label opacity (vertical = foreground, horizontal = label) as Blend did before; `t`/`g` toggles still work.
- [x] Right-click → Flip horizontal mirrors the image left-right. After zooming in and panning off the slice origin, the content at the window center stays put across a flip. Two flips return to the original orientation.
- [x] Linked slices, intersecting-slice lines, and segmentation/volume overlays continue to render correctly after rotate or flip.

No automated tests added. If reviewers prefer, we can add a unit test under `Libs/MRML/DisplayableManager/Testing/` that drives `ProcessRotateFieldOfViewStart` / the flip slot on a synthetic slice node and asserts the resulting `SliceToRAS`.

## i18n

The two new user-facing strings (`"Flip horizontal"` and its tooltip) go through `tr()`, consistent with the rest of the context-menu plugin. The rotate path adds no user-visible strings (it is a gesture only).

## Open questions for reviewers

1. **Blend migration to Ctrl+Shift+Left.** The main behavior change. Alternatives I weighed: (a) mode-gate Blend on `AdjustWindowLevel` (blocked by region-grow at higher priority on Ctrl+Left in that mode); (b) move *Rotate* to a different gesture (e.g. Alt+Left, currently free) so Blend stays on Ctrl+Left — breaks parity with the 3D Ctrl+Left roll; (c) keep migration as-is. Maintainer preference here decides the final binding.
2. **Flip pivot.** Currently FoV center, matching the rotate pivot and the intuition that "what I'm looking at stays put." Alternatives: pivot at the volume center, or at the cursor position at trigger time.
3. **Slice controller button for flip?** The flip lives only in the right-click context menu today. A toolbar button alongside `Rotate to volume plane` in the slice controller would improve discoverability — easy to add as a follow-up commit if desired.

## Screenshots

[Screencast_20260528_153138.webm](https://github.com/user-attachments/assets/31598cb5-481e-4981-8b07-13cad9c70118)

<img width="1920" height="1080" alt="Screenshot_20260528_152949" src="https://github.com/user-attachments/assets/39cbb8bf-87cc-4354-9fcf-af1fec79aca8" />
