### PR TITLE
ENH: Deprecate fcsv file format

### DIFF
--- a/Docs/developer_guide/modules/markups.md
+++ b/Docs/developer_guide/modules/markups.md
@@ -17,6 +17,16 @@ A simple example that specifies a markups point list with 3 points that can be s
 
 ## Markups fiducial point list file format (.fcsv)
 
+:::{warning}
+The fcsv file format is a legacy format that only stores control point coordinates and a limited set of display properties in a custom CSV-like file format.
+Support for this file format will be removed in future software versions.
+
+It is recommended to use [Markups JSON format](#markups-json-file-format-mrk-json) instead. Existing fcsv files can be converted using Slicer application
+(by loading from fcsv and saving as mrk.json) or - outside the 3D Slicer Python environment - using the [slicerio](https://pypi.org/project/slicerio/) Python package (see [example](https://github.com/lassoan/slicerio#convert-legacy-markup-fiducial-file-fcsv-to-current-format-mrkjson)).
+
+To save control point coordinates in standard CSV format, markups control point coordinates can be exported to a table node and save in standard CSV format.
+:::
+
 vtkMRMLMarkupsFiducialStorageNode uses a comma separated value file with a custom header to store the control points on disk. A simple example:
 
 ```

--- a/Docs/developer_guide/script_repository/markups.md
+++ b/Docs/developer_guide/script_repository/markups.md
@@ -6,7 +6,7 @@ Any markup node can be saved as a [markups json file](/developer_guide/modules/m
 
 ```python
 markupsNode = slicer.util.getNode('F')
-slicer.util.saveNode(markupsNode, "/path/to/MyMarkups.mkp.json")
+slicer.util.saveNode(markupsNode, "/path/to/MyMarkups.mrk.json")
 ```
 
 Generally the markups json file format is recommended for saving all properties of a markups node, but for exporting only control point information (name, position, and basic state) a [control points table can be exported in standard csv file format](/developer_guide/modules/markups.md#markups-control-points-table-file-format-csv-tsv):
@@ -20,7 +20,7 @@ slicer.modules.markups.logic().ExportControlPointsToCSV(markupsNode, "/path/to/M
 Any markup node can be loaded from a [markups json file](/developer_guide/modules/markups.md#markups):
 
 ```python
-markupsNode = slicer.util.loadMarkups("/path/to/MyMarkups.mkp.json")
+markupsNode = slicer.util.loadMarkups("/path/to/MyMarkups.mrk.json")
 ```
 
 Control points can be loaded from [control points table csv file](/developer_guide/modules/markups.md#markups-control-points-table-file-format-csv-tsv):

--- a/Docs/user_guide/data_loading_and_saving.md
+++ b/Docs/user_guide/data_loading_and_saving.md
@@ -186,8 +186,8 @@ Surface or volumetric meshes.
 
 ### Markups
 
-- **Markups JSON** (.mkp.json): point list, line, curve, closed curve, plane, etc. Default coordinate system: LPS. Coordinate system (LPS/RAS) can be specified in image header. JSON schema is available [here](https://github.com/Slicer/Slicer/tree/main/Modules/Loadable/Markups/Resources/Schema).
-- **Markups CSV** (.fcsv): legacy file format for storing point list. Default coordinate system: LPS. Coordinate system (LPS/RAS) can be specified in image header.
+- **Markups JSON** (.mrk.json): point list, line, curve, closed curve, plane, etc. Default coordinate system: LPS. Coordinate system (LPS/RAS) can be specified in image header. JSON schema is available [here](https://github.com/Slicer/Slicer/tree/main/Modules/Loadable/Markups/Resources/Schema).
+- **Markups CSV** (.fcsv): legacy file format for storing point list. Default coordinate system: LPS. Coordinate system (LPS/RAS) can be specified in image header. This format only stores control point coordinates and a limited set of display properties; use Markups JSON format instead. The file format is deprecated and support for it will be removed in future software versions.
 - **Annotation CSV** (.acsv): legacy file format for storing markups line, ROI.
 
 ### Scenes

--- a/Libs/MRML/Core/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -741,7 +741,13 @@ int vtkMRMLMarkupsFiducialStorageNode::WriteDataInternal(vtkMRMLNode* refNode)
     return 0;
   }
 
-  this->GetUserMessages()->AddMessage(vtkCommand::WarningEvent, "fcsv file format only stores control point coordinates and a limited set of display properties.");
+  vtkWarningToMessageCollectionMacro(this->GetUserMessages(),
+                                     "vtkMRMLMarkupsFiducialStorageNode::WriteDataInternal",
+                                     vtkMRMLTr("vtkMRMLMarkupsFiducialStorageNode",
+                                               "The fcsv format is deprecated and it will not be supported in future software versions.\n"
+                                               "Use JSON file format (.mrk.json) instead.\n"
+                                               "If using fcsv file format then only control point coordinates"
+                                               " and a limited set of display properties will be saved."));
 
   // open the file for writing
   fstream of;


### PR DESCRIPTION
Let users know that fcsv file format is deprecated, in documentation and file saving warning message.

Related to request of removing fcsv support in #7960

<img width="1400" height="643" alt="image" src="https://github.com/user-attachments/assets/0cffbf6c-ccae-4b46-9788-49654a1b4052" />
