### PR TITLE
BUG: Disable default VTK render window keyboard shortcuts

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
@@ -87,9 +87,11 @@ void vtkMRMLViewInteractorStyle::OnKeyRelease()
 //----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::OnChar()
 {
-  // Do not call this->GetInteractorStyle->OnChar(), because char OnChar events perform various
-  // low-level operations on the actors (change their rendering style to wireframe, pick them,
-  // change rendering mode to stereo, etc.), which would interfere with displayable managers.
+  // Abort CharEvent so VTK's vtkInteractorStyle::OnChar() does not get invoked
+  // after this callback, because that would perform various low-level operations
+  // on the actors (such as "3" change to stereo rendering, "w" change rendering
+  // style to wireframe, etc.), which would interfere with displayable managers.
+  this->EventCallbackCommand->AbortFlagOn();
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
VTK render window interactor base class registers default low-level keyboard shortcuts for toggling stereo mode, wireframe rendering, etc., which would interfere with rendering set up by displayable managers.

There was an attempt to disable these shortcuts but it was not effective, as if the custom interactor style does not abort the event then the default one gets to process it.

fixes #8368