### PR TITLE
ENH: Gray out visibility icon of SH item under hidden parent

### DIFF
--- a/Libs/MRML/Core/vtkMRMLFolderDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLFolderDisplayNode.cxx
@@ -116,8 +116,11 @@ void vtkMRMLFolderDisplayNode::ProcessMRMLEvents(vtkObject* caller, unsigned lon
   if (event == vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemReparentedEvent //
       && vtkMRMLSubjectHierarchyNode::SafeDownCast(caller))
   {
-    // No-op if this folder node does not apply display properties on its branch
-    if (!this->ApplyDisplayPropertiesOnBranch)
+    // Skip if this folder neither applies display properties nor is hidden.
+    // A visible folder with no property override has no effect on a reparented item.
+    // A hidden folder must always notify the reparented node so the display manager
+    // re-evaluates GetHierarchyVisibility(), which checks parent visibility unconditionally.
+    if (!this->ApplyDisplayPropertiesOnBranch && this->GetVisibility() != 0)
     {
       return;
     }
@@ -132,19 +135,30 @@ void vtkMRMLFolderDisplayNode::ProcessMRMLEvents(vtkObject* caller, unsigned lon
       }
     }
     vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::SafeDownCast(caller);
-    vtkMRMLDisplayableNode* displayableReparentedNode = vtkMRMLDisplayableNode::SafeDownCast(shNode->GetItemDataNode(reparentedItemID));
-    if (displayableReparentedNode)
+
+    // Collect the reparented item's entire subtree, then prepend the item itself.
+    // GetItemChildren clears the vector before filling it, so reparentedItemID
+    // must be inserted after the call, not before.
+    std::vector<vtkIdType> itemsToNotify;
+    shNode->GetItemChildren(reparentedItemID, itemsToNotify, /*recursive=*/true);
+    itemsToNotify.insert(itemsToNotify.begin(), reparentedItemID);
+
+    for (vtkIdType notifyItemID : itemsToNotify)
     {
-      // Trigger display update for reparented displayable node if it is in a folder that applies
-      // display properties on its branch (only display nodes that allow overriding)
-      for (int i = 0; i < displayableReparentedNode->GetNumberOfDisplayNodes(); ++i)
+      vtkMRMLDisplayableNode* displayableNode = vtkMRMLDisplayableNode::SafeDownCast(shNode->GetItemDataNode(notifyItemID));
+      if (!displayableNode)
       {
-        vtkMRMLDisplayNode* currentDisplayNode = displayableReparentedNode->GetNthDisplayNode(i);
+        continue;
+      }
+      // Trigger display update so the displayable manager re-evaluates hierarchy visibility.
+      for (int i = 0; i < displayableNode->GetNumberOfDisplayNodes(); ++i)
+      {
+        vtkMRMLDisplayNode* currentDisplayNode = displayableNode->GetNthDisplayNode(i);
         if (currentDisplayNode && currentDisplayNode->GetFolderDisplayOverrideAllowed())
         {
           currentDisplayNode->Modified();
         }
-      } // For all display nodes
+      }
     }
   } // SubjectHierarchyItemReparentedEvent
 }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
@@ -956,7 +956,7 @@ QFlags<Qt::ItemFlag> qMRMLSubjectHierarchyModel::subjectHierarchyItemFlags(vtkId
     return flags;
   }
 
-  if (column == this->nameColumn() || column == this->colorColumn() || column == this->descriptionColumn())
+  if (column == this->nameColumn() || column == this->descriptionColumn())
   {
     flags |= Qt::ItemIsEditable;
   }
@@ -1157,15 +1157,44 @@ void qMRMLSubjectHierarchyModel::updateItemDataFromSubjectHierarchyItem(QStandar
     int visible = ownerPlugin->getDisplayVisibility(shItemID);
     QIcon visibilityIcon = ownerPlugin->visibilityIcon(visible);
 
+    // Check if any ancestor item has visibility turned off; if so the item's own
+    // visibility setting has no effect and the icon should be grayed out.
+    bool parentVisible = true;
+    {
+      vtkIdType parentID = d->SubjectHierarchyNode->GetItemParent(shItemID);
+      vtkIdType sceneItemID = d->SubjectHierarchyNode->GetSceneItemID();
+      while (parentID != vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID && parentID != sceneItemID)
+      {
+        qSlicerSubjectHierarchyAbstractPlugin* parentPlugin = qSlicerSubjectHierarchyPluginHandler::instance()->getOwnerPluginForSubjectHierarchyItem(parentID);
+        if (parentPlugin && parentPlugin->getDisplayVisibility(parentID) == 0)
+        {
+          parentVisible = false;
+          break;
+        }
+        parentID = d->SubjectHierarchyNode->GetItemParent(parentID);
+      }
+    }
+
     // It should be fine to set the icon even if it is the same, but due
     // to a bug in Qt (http://bugreports.qt.nokia.com/browse/QTBUG-20248),
     // it would fire a superfluous itemChanged() signal.
-    if (item->data(VisibilityRole).isNull() || item->data(VisibilityRole).toInt() != visible)
+    if (item->data(VisibilityRole).isNull() || item->data(VisibilityRole).toInt() != visible || item->data(ParentVisibilityRole).isNull()
+        || item->data(ParentVisibilityRole).toBool() != parentVisible)
     {
       item->setData(visible, VisibilityRole);
+      item->setData(parentVisible, ParentVisibilityRole);
       if (!visibilityIcon.isNull())
       {
-        item->setData(visibilityIcon, VisibilityIconRole);
+        if (!parentVisible)
+        {
+          // The default plugin caches these icons; other plugins fall back to the plain icon.
+          QIcon parentHiddenIcon = ownerPlugin->visibilityIconWithParentHidden(visible);
+          item->setData(!parentHiddenIcon.isNull() ? parentHiddenIcon : visibilityIcon, VisibilityIconRole);
+        }
+        else
+        {
+          item->setData(visibilityIcon, VisibilityIconRole);
+        }
       }
     }
   }
@@ -1559,8 +1588,8 @@ void qMRMLSubjectHierarchyModel::onEvent(vtkObject* caller, unsigned long event,
     case vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemRemovedEvent: sceneModel->onSubjectHierarchyItemRemoved(itemID); break;
     case vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemModifiedEvent:
     case vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemTransformModifiedEvent:
-    case vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemDisplayModifiedEvent:
     case vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemReparentedEvent: sceneModel->onSubjectHierarchyItemModified(itemID); break;
+    case vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemDisplayModifiedEvent: sceneModel->onSubjectHierarchyItemDisplayModified(itemID); break;
     case vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemChildrenReorderedEvent: sceneModel->onSubjectHierarchyItemChildrenReordered(itemID); break;
     case vtkMRMLScene::EndImportEvent: sceneModel->onMRMLSceneImported(scene); break;
     case vtkMRMLScene::EndCloseEvent: sceneModel->onMRMLSceneClosed(scene); break;
@@ -1647,7 +1676,69 @@ void qMRMLSubjectHierarchyModel::onSubjectHierarchyItemRemoved(vtkIdType removed
 //------------------------------------------------------------------------------
 void qMRMLSubjectHierarchyModel::onSubjectHierarchyItemModified(vtkIdType itemID)
 {
+  Q_D(qMRMLSubjectHierarchyModel);
+
+  // Snapshot both the item's own visibility and its parent-hidden state before
+  // the update so we can detect either kind of change afterwards.
+  // - VisibilityRole changes when the item's own display node is toggled
+  //   (folder items fire SubjectHierarchyItemModifiedEvent for this, not DisplayModifiedEvent).
+  // - ParentVisibilityRole changes when the item is reparented into/out of a
+  //   hidden subtree via drag-and-drop (SubjectHierarchyItemReparentedEvent).
+  // In both cases we need to cascade the update to all descendants.
+  int previousVisible = -1;
+  bool previousParentVisible = true;
+  if (this->visibilityColumn() >= 0)
+  {
+    QStandardItem* visItem = this->itemFromSubjectHierarchyItem(itemID, this->visibilityColumn());
+    if (visItem)
+    {
+      if (!visItem->data(VisibilityRole).isNull())
+      {
+        previousVisible = visItem->data(VisibilityRole).toInt();
+      }
+      if (!visItem->data(ParentVisibilityRole).isNull())
+      {
+        previousParentVisible = visItem->data(ParentVisibilityRole).toBool();
+      }
+    }
+  }
+
   this->updateModelItems(itemID);
+
+  // Cascade to descendants whenever own visibility or effective parent visibility changed.
+  if (this->visibilityColumn() >= 0 && d->SubjectHierarchyNode)
+  {
+    QStandardItem* visItem = this->itemFromSubjectHierarchyItem(itemID, this->visibilityColumn());
+    int currentVisible = visItem ? visItem->data(VisibilityRole).toInt() : -1;
+    bool currentParentVisible = visItem ? visItem->data(ParentVisibilityRole).toBool() : true;
+    if (currentVisible != previousVisible || currentParentVisible != previousParentVisible)
+    {
+      std::vector<vtkIdType> childrenIDs;
+      d->SubjectHierarchyNode->GetItemChildren(itemID, childrenIDs, /*recursive=*/true);
+      for (vtkIdType childID : childrenIDs)
+      {
+        this->updateModelItems(childID);
+      }
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+void qMRMLSubjectHierarchyModel::onSubjectHierarchyItemDisplayModified(vtkIdType itemID)
+{
+  Q_D(qMRMLSubjectHierarchyModel);
+  this->updateModelItems(itemID);
+  // Also update all descendants: their visibility icons may need to be grayed out or restored
+  // depending on whether this item's visibility was turned on or off.
+  if (d->SubjectHierarchyNode)
+  {
+    std::vector<vtkIdType> childrenIDs;
+    d->SubjectHierarchyNode->GetItemChildren(itemID, childrenIDs, /*recursive=*/true);
+    for (vtkIdType childID : childrenIDs)
+    {
+      this->updateModelItems(childID);
+    }
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.h
@@ -96,6 +96,9 @@ public:
     /// Integer that contains the visibility property of an item.
     /// It is closely related to the item icon.
     VisibilityRole,
+    /// Boolean indicating whether all ancestor items have visibility turned on.
+    /// When false, the item's own visibility icon is grayed out.
+    ParentVisibilityRole,
     /// MRML node ID of the parent transform
     TransformIDRole,
     /// QIcon for the visibility button; stored here instead of DecorationRole so the delegate does not paint it
@@ -211,6 +214,7 @@ protected slots:
   virtual void onSubjectHierarchyItemAboutToBeRemoved(vtkIdType itemID);
   virtual void onSubjectHierarchyItemRemoved(vtkIdType itemID);
   virtual void onSubjectHierarchyItemModified(vtkIdType itemID);
+  virtual void onSubjectHierarchyItemDisplayModified(vtkIdType itemID);
   virtual void onSubjectHierarchyItemChildrenReordered(vtkIdType itemID);
 
   virtual void onMRMLSceneImported(vtkMRMLScene* scene);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -178,6 +178,11 @@ public:
 
   void setupVisibilityButton(const QModelIndex& proxyIndex);
   void setupColorButton(const QModelIndex& proxyIndex);
+  void setupAllButtons();
+  void setupRowsRecursively(const QModelIndex& parent);
+  void setupInsertedRows(QPersistentModelIndex parent, int first, int last);
+  void onDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight);
+  void onColorButtonClicked(vtkIdType itemID, QPersistentModelIndex persistentIndex);
 };
 
 //------------------------------------------------------------------------------
@@ -267,73 +272,26 @@ void qMRMLSubjectHierarchyTreeViewPrivate::init()
   QObject::connect(q, SIGNAL(expanded(const QModelIndex&)), q, SLOT(onItemExpanded(const QModelIndex&)));
   QObject::connect(q, SIGNAL(collapsed(const QModelIndex&)), q, SLOT(onItemCollapsed(const QModelIndex&)));
 
-  // Visibility buttons: create on row insert, update icon on data change, recreate on reset.
+  // Visibility buttons: create on row insert, update icon on data change, recreate on reset/layout change.
   QObject::connect(this->SortFilterModel,
                    &QAbstractItemModel::rowsInserted,
                    q,
                    [this, q](const QModelIndex& parent, int first, int last)
                    {
-                     QTimer::singleShot(0,
-                                        q,
-                                        [this, q, parent, first, last]()
-                                        {
-                                          for (int row = first; row <= last; ++row)
-                                          {
-                                            this->setupVisibilityButton(this->SortFilterModel->index(row, this->Model->visibilityColumn(), parent));
-                                            this->setupColorButton(this->SortFilterModel->index(row, this->Model->colorColumn(), parent));
-                                          }
-                                        });
+                     // Capture parent as QPersistentModelIndex so it remains valid after
+                     // further model changes (e.g. reparenting during drag-and-drop) that
+                     // would otherwise invalidate a plain QModelIndex before the timer fires.
+                     QPersistentModelIndex persistentParent(parent);
+                     QTimer::singleShot(0, q, [this, persistentParent, first, last]() { this->setupInsertedRows(persistentParent, first, last); });
                    });
-  QObject::connect(this->SortFilterModel,
-                   &QAbstractItemModel::dataChanged,
-                   q,
-                   [this, q](const QModelIndex& topLeft, const QModelIndex& bottomRight, const QVector<int>&)
-                   {
-                     QModelIndex parent = topLeft.parent();
-                     int visCol = this->Model->visibilityColumn();
-                     int colorCol = this->Model->colorColumn();
-                     for (int row = topLeft.row(); row <= bottomRight.row(); ++row)
-                     {
-                       if (topLeft.column() <= visCol && visCol <= bottomRight.column())
-                       {
-                         QModelIndex index = this->SortFilterModel->index(row, visCol, parent);
-                         auto* button = qobject_cast<QToolButton*>(q->indexWidget(index));
-                         if (button)
-                         {
-                           button->setIcon(index.data(qMRMLSubjectHierarchyModel::VisibilityIconRole).value<QIcon>());
-                         }
-                       }
-                       if (topLeft.column() <= colorCol && colorCol <= bottomRight.column())
-                       {
-                         QModelIndex index = this->SortFilterModel->index(row, colorCol, parent);
-                         auto* button = qobject_cast<QToolButton*>(q->indexWidget(index));
-                         if (button)
-                         {
-                           button->setIcon(QIcon(qMRMLUtils::createColorPixmap(qApp->style(), //
-                                                                               index.data(qMRMLSubjectHierarchyModel::ColorRole).value<QColor>())));
-                         }
-                       }
-                     }
-                   });
-  QObject::connect(this->SortFilterModel,
-                   &QAbstractItemModel::modelReset,
-                   q,
-                   [this, q]()
-                   {
-                     // Recreate buttons for all currently visible rows after a reset.
-                     std::function<void(const QModelIndex&)> setupRows = [&](const QModelIndex& parent)
-                     {
-                       int visCol = this->Model->visibilityColumn();
-                       int colorCol = this->Model->colorColumn();
-                       for (int row = 0; row < this->SortFilterModel->rowCount(parent); ++row)
-                       {
-                         this->setupVisibilityButton(this->SortFilterModel->index(row, visCol, parent));
-                         this->setupColorButton(this->SortFilterModel->index(row, colorCol, parent));
-                         setupRows(this->SortFilterModel->index(row, 0, parent));
-                       }
-                     };
-                     setupRows(QModelIndex());
-                   });
+  QObject::connect(this->SortFilterModel, &QAbstractItemModel::dataChanged, q, &qMRMLSubjectHierarchyTreeView::onSortFilterDataChanged);
+
+  // Recreate all buttons after a model reset or filter invalidation.
+  // Both operations rebuild the proxy model's internal mapping, which changes the
+  // internalPointer() of every proxy index and orphans any QWidget stored via
+  // setIndexWidget() (Qt stores them by QPersistentModelIndex keyed on that pointer).
+  QObject::connect(this->SortFilterModel, &QAbstractItemModel::modelReset, q, &qMRMLSubjectHierarchyTreeView::onSortFilterModelChanged);
+  QObject::connect(this->SortFilterModel, &QAbstractItemModel::layoutChanged, q, &qMRMLSubjectHierarchyTreeView::onSortFilterModelChanged);
 
   // Set up scene and node actions for the tree view
   this->updateMenuActions();
@@ -360,11 +318,12 @@ void qMRMLSubjectHierarchyTreeViewPrivate::setupVisibilityButton(const QModelInd
   button->setIconSize(QSize(iconSize, iconSize));
   button->setStyleSheet("QToolButton { padding: 0px; }");
   button->setIcon(proxyIndex.data(qMRMLSubjectHierarchyModel::VisibilityIconRole).value<QIcon>());
+  button->setProperty("itemID", QVariant::fromValue(itemID));
 
-  QObject::connect(button, &QToolButton::clicked, q, [this, itemID]() { this->setSubjectHierarchyItemVisibility(itemID, ToggleVisibility); });
+  QObject::connect(button, &QToolButton::clicked, q, &qMRMLSubjectHierarchyTreeView::onVisibilityButtonClicked);
 
   button->setContextMenuPolicy(Qt::CustomContextMenu);
-  QObject::connect(button, &QWidget::customContextMenuRequested, q, [q, button](const QPoint& pos) { q->onCustomContextMenu(button->mapToParent(pos)); });
+  QObject::connect(button, &QWidget::customContextMenuRequested, q, &qMRMLSubjectHierarchyTreeView::onButtonContextMenuRequested);
 
   q->setIndexWidget(proxyIndex, button);
 }
@@ -394,134 +353,197 @@ void qMRMLSubjectHierarchyTreeViewPrivate::setupColorButton(const QModelIndex& p
   button->setStyleSheet("QToolButton { padding: 0px; }");
   button->setIcon(QIcon(qMRMLUtils::createColorPixmap(qApp->style(), color)));
 
-  QPersistentModelIndex persistentIndex(proxyIndex);
-  QObject::connect(button,
-                   &QToolButton::clicked,
-                   q,
-                   [this, q, persistentIndex, itemID]()
-                   {
-                     if (!q->useTerminologySelector())
-                     {
-                       QModelIndex currentProxyIndex = persistentIndex;
-                       if (!currentProxyIndex.isValid())
-                       {
-                         currentProxyIndex = this->SortFilterModel->indexFromSubjectHierarchyItem(itemID, this->Model->colorColumn());
-                       }
-                       if (!currentProxyIndex.isValid())
-                       {
-                         return;
-                       }
+  button->setProperty("itemID", QVariant::fromValue(itemID));
+  button->setProperty("persistentIndex", QVariant::fromValue(QPersistentModelIndex(proxyIndex)));
 
-                       QColor currentColor = currentProxyIndex.data(qMRMLSubjectHierarchyModel::ColorRole).value<QColor>();
-
-                       ctkColorPickerButton* colorPicker = new ctkColorPickerButton(q);
-                       colorPicker->setProperty("changeColorOnSet", true);
-                       colorPicker->setDisplayColorName(false);
-                       ctkColorPickerButton::ColorDialogOptions options = ctkColorPickerButton::ShowAlphaChannel | ctkColorPickerButton::UseCTKColorDialog;
-                       colorPicker->setDialogOptions(options);
-                       colorPicker->setColor(currentColor);
-
-                       QObject::connect(colorPicker,
-                                        &ctkColorPickerButton::colorChanged,
-                                        q,
-                                        [this, persistentIndex, itemID](const QColor& newColor)
-                                        {
-                                          QModelIndex sourceIndex = this->Model->indexFromSubjectHierarchyItem(itemID, this->Model->colorColumn());
-                                          if (!sourceIndex.isValid())
-                                          {
-                                            sourceIndex = this->SortFilterModel->mapToSource(persistentIndex);
-                                          }
-                                          if (!sourceIndex.isValid())
-                                          {
-                                            return;
-                                          }
-                                          this->Model->setData(sourceIndex, newColor, qMRMLSubjectHierarchyModel::ColorRole);
-                                          this->Model->setData(sourceIndex, false, qMRMLSubjectHierarchyModel::ColorAutoGeneratedRole);
-                                        });
-
-                       colorPicker->changeColor();
-                       colorPicker->deleteLater();
-                       return;
-                     }
-
-                     QModelIndex currentProxyIndex = persistentIndex;
-                     if (!currentProxyIndex.isValid())
-                     {
-                       currentProxyIndex = this->SortFilterModel->indexFromSubjectHierarchyItem(itemID, this->Model->colorColumn());
-                     }
-                     if (!currentProxyIndex.isValid())
-                     {
-                       return;
-                     }
-
-                     vtkSlicerTerminologiesModuleLogic* terminologiesLogic = nullptr;
-                     qSlicerCoreApplication* app = qSlicerCoreApplication::application();
-                     if (app)
-                     {
-                       terminologiesLogic = vtkSlicerTerminologiesModuleLogic::SafeDownCast(app->moduleLogic("Terminologies"));
-                     }
-
-                     // Build current terminology info from model roles
-                     vtkNew<vtkSlicerTerminologyEntry> terminologyEntry;
-                     QString terminologyString = currentProxyIndex.data(qMRMLSubjectHierarchyModel::TerminologyRole).toString();
-                     if (terminologiesLogic && !terminologyString.isEmpty())
-                     {
-                       terminologiesLogic->DeserializeTerminologyEntry(terminologyString.toUtf8().constData(), terminologyEntry);
-                     }
-                     QString name = currentProxyIndex.data(qMRMLSubjectHierarchyModel::NameRole).toString();
-                     QColor color = currentProxyIndex.data(qMRMLSubjectHierarchyModel::ColorRole).value<QColor>();
-                     bool nameAutoGenerated = currentProxyIndex.data(qMRMLSubjectHierarchyModel::NameAutoGeneratedRole).toBool();
-                     QVariant colorAutoGeneratedData = currentProxyIndex.data(qMRMLSubjectHierarchyModel::ColorAutoGeneratedRole);
-                     bool colorAutoGenerated = colorAutoGeneratedData.isValid() ? colorAutoGeneratedData.toBool() : true;
-                     QColor generatedColor = currentProxyIndex.data(qMRMLSubjectHierarchyModel::GeneratedColorRole).value<QColor>();
-                     if (!generatedColor.isValid())
-                     {
-                       // Fallback to current color when no generated color is stored yet.
-                       generatedColor = color;
-                     }
-
-                     qSlicerTerminologyNavigatorWidget::TerminologyInfoBundle terminologyInfo( //
-                       terminologyEntry,
-                       name,
-                       nameAutoGenerated,
-                       color,
-                       colorAutoGenerated,
-                       generatedColor);
-
-                     if (!qSlicerTerminologySelectorDialog::getTerminology(terminologyInfo, q))
-                     {
-                       return;
-                     }
-
-                     // Resolve source index by item ID (robust against proxy model refreshes during the dialog)
-                     QModelIndex sourceIndex = this->Model->indexFromSubjectHierarchyItem(itemID, this->Model->colorColumn());
-                     if (!sourceIndex.isValid())
-                     {
-                       sourceIndex = this->SortFilterModel->mapToSource(persistentIndex);
-                     }
-                     if (!sourceIndex.isValid())
-                     {
-                       return;
-                     }
-
-                     this->Model->setData(sourceIndex, terminologyInfo.Color, qMRMLSubjectHierarchyModel::ColorRole);
-                     this->Model->setData(sourceIndex, terminologyInfo.ColorAutoGenerated, qMRMLSubjectHierarchyModel::ColorAutoGeneratedRole);
-                     this->Model->setData(sourceIndex,                                                                                       //
-                                          terminologyInfo.GeneratedColor.isValid() ? terminologyInfo.GeneratedColor : terminologyInfo.Color, //
-                                          qMRMLSubjectHierarchyModel::GeneratedColorRole);
-                     this->Model->setData(sourceIndex, terminologyInfo.Name, qMRMLSubjectHierarchyModel::NameRole);
-                     this->Model->setData(sourceIndex, terminologyInfo.NameAutoGenerated, qMRMLSubjectHierarchyModel::NameAutoGeneratedRole);
-                     if (terminologiesLogic)
-                     {
-                       std::string terminologyStr = terminologiesLogic->SerializeTerminologyEntry(terminologyInfo.GetTerminologyEntry());
-                       this->Model->setData(sourceIndex, QString::fromStdString(terminologyStr), qMRMLSubjectHierarchyModel::TerminologyRole);
-                     }
-                   });
+  QObject::connect(button, &QToolButton::clicked, q, &qMRMLSubjectHierarchyTreeView::onColorButtonClicked);
 
   button->setContextMenuPolicy(Qt::CustomContextMenu);
-  QObject::connect(button, &QWidget::customContextMenuRequested, q, [q, button](const QPoint& pos) { q->onCustomContextMenu(button->mapToParent(pos)); });
+  QObject::connect(button, &QWidget::customContextMenuRequested, q, &qMRMLSubjectHierarchyTreeView::onButtonContextMenuRequested);
 
   q->setIndexWidget(proxyIndex, button);
+}
+
+//--------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeViewPrivate::setupAllButtons()
+{
+  this->setupRowsRecursively(QModelIndex());
+}
+
+//--------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeViewPrivate::setupRowsRecursively(const QModelIndex& parent)
+{
+  int visCol = this->Model->visibilityColumn();
+  int colorCol = this->Model->colorColumn();
+  for (int row = 0; row < this->SortFilterModel->rowCount(parent); ++row)
+  {
+    this->setupVisibilityButton(this->SortFilterModel->index(row, visCol, parent));
+    this->setupColorButton(this->SortFilterModel->index(row, colorCol, parent));
+    this->setupRowsRecursively(this->SortFilterModel->index(row, 0, parent));
+  }
+}
+
+//--------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeViewPrivate::setupInsertedRows(QPersistentModelIndex parent, int first, int last)
+{
+  int visCol = this->Model->visibilityColumn();
+  int colorCol = this->Model->colorColumn();
+  for (int row = first; row <= last; ++row)
+  {
+    this->setupVisibilityButton(this->SortFilterModel->index(row, visCol, parent));
+    this->setupColorButton(this->SortFilterModel->index(row, colorCol, parent));
+    QModelIndex childParent = this->SortFilterModel->index(row, 0, parent);
+    int childCount = this->SortFilterModel->rowCount(childParent);
+    if (childCount > 0)
+    {
+      this->setupInsertedRows(childParent, 0, childCount - 1);
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeViewPrivate::onDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight)
+{
+  Q_Q(qMRMLSubjectHierarchyTreeView);
+  QModelIndex parent = topLeft.parent();
+  int visCol = this->Model->visibilityColumn();
+  int colorCol = this->Model->colorColumn();
+  for (int row = topLeft.row(); row <= bottomRight.row(); ++row)
+  {
+    if (topLeft.column() <= visCol && visCol <= bottomRight.column())
+    {
+      QModelIndex index = this->SortFilterModel->index(row, visCol, parent);
+      auto* button = qobject_cast<QToolButton*>(q->indexWidget(index));
+      if (button)
+      {
+        button->setIcon(index.data(qMRMLSubjectHierarchyModel::VisibilityIconRole).value<QIcon>());
+      }
+    }
+    if (topLeft.column() <= colorCol && colorCol <= bottomRight.column())
+    {
+      QModelIndex index = this->SortFilterModel->index(row, colorCol, parent);
+      QColor color = index.data(qMRMLSubjectHierarchyModel::ColorRole).value<QColor>();
+      auto* button = qobject_cast<QToolButton*>(q->indexWidget(index));
+      if (button && color.isValid() && color.alpha() != 0)
+      {
+        // Button already exists and color is still valid: just update the icon.
+        button->setIcon(QIcon(qMRMLUtils::createColorPixmap(qApp->style(), color)));
+      }
+      else if (button || (color.isValid() && color.alpha() != 0))
+      {
+        // Button needs to be created (color became valid) or removed (color became transparent).
+        this->setupColorButton(index);
+      }
+      // No button and no valid color: nothing to do.
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeViewPrivate::onColorButtonClicked(vtkIdType itemID, QPersistentModelIndex persistentIndex)
+{
+  Q_Q(qMRMLSubjectHierarchyTreeView);
+  if (!q->useTerminologySelector())
+  {
+    QModelIndex currentProxyIndex = persistentIndex;
+    if (!currentProxyIndex.isValid())
+    {
+      currentProxyIndex = this->SortFilterModel->indexFromSubjectHierarchyItem(itemID, this->Model->colorColumn());
+    }
+    if (!currentProxyIndex.isValid())
+    {
+      return;
+    }
+
+    QColor currentColor = currentProxyIndex.data(qMRMLSubjectHierarchyModel::ColorRole).value<QColor>();
+
+    ctkColorPickerButton* colorPicker = new ctkColorPickerButton(q);
+    colorPicker->setProperty("changeColorOnSet", true);
+    colorPicker->setDisplayColorName(false);
+    ctkColorPickerButton::ColorDialogOptions options = ctkColorPickerButton::ShowAlphaChannel | ctkColorPickerButton::UseCTKColorDialog;
+    colorPicker->setDialogOptions(options);
+    colorPicker->setColor(currentColor);
+
+    colorPicker->setProperty("itemID", QVariant::fromValue(itemID));
+    colorPicker->setProperty("persistentIndex", QVariant::fromValue(persistentIndex));
+    QObject::connect(colorPicker, &ctkColorPickerButton::colorChanged, q, &qMRMLSubjectHierarchyTreeView::onColorPickerColorChanged);
+
+    colorPicker->changeColor();
+    colorPicker->deleteLater();
+    return;
+  }
+
+  QModelIndex currentProxyIndex = persistentIndex;
+  if (!currentProxyIndex.isValid())
+  {
+    currentProxyIndex = this->SortFilterModel->indexFromSubjectHierarchyItem(itemID, this->Model->colorColumn());
+  }
+  if (!currentProxyIndex.isValid())
+  {
+    return;
+  }
+
+  vtkSlicerTerminologiesModuleLogic* terminologiesLogic = nullptr;
+  qSlicerCoreApplication* app = qSlicerCoreApplication::application();
+  if (app)
+  {
+    terminologiesLogic = vtkSlicerTerminologiesModuleLogic::SafeDownCast(app->moduleLogic("Terminologies"));
+  }
+
+  // Build current terminology info from model roles
+  vtkNew<vtkSlicerTerminologyEntry> terminologyEntry;
+  QString terminologyString = currentProxyIndex.data(qMRMLSubjectHierarchyModel::TerminologyRole).toString();
+  if (terminologiesLogic && !terminologyString.isEmpty())
+  {
+    terminologiesLogic->DeserializeTerminologyEntry(terminologyString.toUtf8().constData(), terminologyEntry);
+  }
+  QString name = currentProxyIndex.data(qMRMLSubjectHierarchyModel::NameRole).toString();
+  QColor color = currentProxyIndex.data(qMRMLSubjectHierarchyModel::ColorRole).value<QColor>();
+  bool nameAutoGenerated = currentProxyIndex.data(qMRMLSubjectHierarchyModel::NameAutoGeneratedRole).toBool();
+  QVariant colorAutoGeneratedData = currentProxyIndex.data(qMRMLSubjectHierarchyModel::ColorAutoGeneratedRole);
+  bool colorAutoGenerated = colorAutoGeneratedData.isValid() ? colorAutoGeneratedData.toBool() : true;
+  QColor generatedColor = currentProxyIndex.data(qMRMLSubjectHierarchyModel::GeneratedColorRole).value<QColor>();
+  if (!generatedColor.isValid())
+  {
+    generatedColor = color;
+  }
+
+  qSlicerTerminologyNavigatorWidget::TerminologyInfoBundle terminologyInfo( //
+    terminologyEntry,
+    name,
+    nameAutoGenerated,
+    color,
+    colorAutoGenerated,
+    generatedColor);
+
+  if (!qSlicerTerminologySelectorDialog::getTerminology(terminologyInfo, q))
+  {
+    return;
+  }
+
+  // Resolve source index by item ID (robust against proxy model refreshes during the dialog)
+  QModelIndex sourceIndex = this->Model->indexFromSubjectHierarchyItem(itemID, this->Model->colorColumn());
+  if (!sourceIndex.isValid())
+  {
+    sourceIndex = this->SortFilterModel->mapToSource(persistentIndex);
+  }
+  if (!sourceIndex.isValid())
+  {
+    return;
+  }
+
+  this->Model->setData(sourceIndex, terminologyInfo.Color, qMRMLSubjectHierarchyModel::ColorRole);
+  this->Model->setData(sourceIndex, terminologyInfo.ColorAutoGenerated, qMRMLSubjectHierarchyModel::ColorAutoGeneratedRole);
+  this->Model->setData(sourceIndex,                                                                                       //
+                       terminologyInfo.GeneratedColor.isValid() ? terminologyInfo.GeneratedColor : terminologyInfo.Color, //
+                       qMRMLSubjectHierarchyModel::GeneratedColorRole);
+  this->Model->setData(sourceIndex, terminologyInfo.Name, qMRMLSubjectHierarchyModel::NameRole);
+  this->Model->setData(sourceIndex, terminologyInfo.NameAutoGenerated, qMRMLSubjectHierarchyModel::NameAutoGeneratedRole);
+  if (terminologiesLogic)
+  {
+    std::string terminologyStr = terminologiesLogic->SerializeTerminologyEntry(terminologyInfo.GetTerminologyEntry());
+    this->Model->setData(sourceIndex, QString::fromStdString(terminologyStr), qMRMLSubjectHierarchyModel::TerminologyRole);
+  }
 }
 
 //--------------------------------------------------------------------------
@@ -2575,6 +2597,94 @@ bool qMRMLSubjectHierarchyTreeView::showContextMenuHint(bool visibility /*=false
   }
 
   return true;
+}
+
+//------------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::onVisibilityButtonClicked()
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+  auto* button = qobject_cast<QToolButton*>(sender());
+  if (!button)
+  {
+    return;
+  }
+  vtkIdType itemID = button->property("itemID").value<vtkIdType>();
+  if (!itemID)
+  {
+    return;
+  }
+  d->setSubjectHierarchyItemVisibility(itemID, qMRMLSubjectHierarchyTreeViewPrivate::ToggleVisibility);
+}
+
+//------------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::onColorPickerColorChanged(const QColor& newColor)
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+  auto* colorPicker = qobject_cast<ctkColorPickerButton*>(sender());
+  if (!colorPicker)
+  {
+    return;
+  }
+  vtkIdType itemID = colorPicker->property("itemID").value<vtkIdType>();
+  if (!itemID)
+  {
+    return;
+  }
+  QPersistentModelIndex persistentIndex = colorPicker->property("persistentIndex").value<QPersistentModelIndex>();
+  QModelIndex sourceIndex = d->Model->indexFromSubjectHierarchyItem(itemID, d->Model->colorColumn());
+  if (!sourceIndex.isValid())
+  {
+    sourceIndex = d->SortFilterModel->mapToSource(persistentIndex);
+  }
+  if (!sourceIndex.isValid())
+  {
+    return;
+  }
+  d->Model->setData(sourceIndex, newColor, qMRMLSubjectHierarchyModel::ColorRole);
+  d->Model->setData(sourceIndex, false, qMRMLSubjectHierarchyModel::ColorAutoGeneratedRole);
+}
+
+//------------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::onColorButtonClicked()
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+  auto* button = qobject_cast<QToolButton*>(sender());
+  if (!button)
+  {
+    return;
+  }
+  vtkIdType itemID = button->property("itemID").value<vtkIdType>();
+  if (!itemID)
+  {
+    return;
+  }
+  QPersistentModelIndex persistentIndex = button->property("persistentIndex").value<QPersistentModelIndex>();
+  d->onColorButtonClicked(itemID, persistentIndex);
+}
+
+//------------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::onButtonContextMenuRequested(const QPoint& pos)
+{
+  auto* button = qobject_cast<QWidget*>(sender());
+  if (!button)
+  {
+    return;
+  }
+  this->onCustomContextMenu(button->mapToParent(pos));
+}
+
+//------------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::onSortFilterDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight)
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+  d->onDataChanged(topLeft, bottomRight);
+}
+
+//------------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::onSortFilterModelChanged()
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+  d->setupAllButtons();
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
@@ -411,6 +411,14 @@ protected slots:
 
   virtual void addNode();
 
+private slots:
+  void onSortFilterModelChanged();
+  void onSortFilterDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight);
+  void onVisibilityButtonClicked();
+  void onColorButtonClicked();
+  void onColorPickerColorChanged(const QColor& newColor);
+  void onButtonContextMenuRequested(const QPoint& pos);
+
 protected:
   /// Set the subject hierarchy node found in the given scene. Called only internally.
   virtual void setSubjectHierarchyNode(vtkMRMLSubjectHierarchyNode* shNode);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.cxx
@@ -32,6 +32,7 @@
 
 // Qt includes
 #include <QDebug>
+#include <QPainter>
 #include <QStandardItem>
 #include <QAction>
 #include <QColor>
@@ -123,6 +124,75 @@ QIcon qSlicerSubjectHierarchyAbstractPlugin::visibilityIcon(int visible)
   // Default implementation applies to plugins that do not define roles, only functions and/or levels
   // If there is no role, then there is no visibility icon to set
   return QIcon();
+}
+
+//---------------------------------------------------------------------------
+// static
+QIcon qSlicerSubjectHierarchyAbstractPlugin::applyParentHiddenEffect(const QIcon& icon)
+{
+  if (icon.isNull())
+  {
+    return icon;
+  }
+  QSize iconLogicalSize = icon.availableSizes().value(0, QSize(16, 16));
+  // Render at higher physical resolution so the arrow is sharp on HiDPI displays.
+  const qreal renderScale = qMax(2.0, qApp->devicePixelRatio());
+  QSize physicalSize(qRound(iconLogicalSize.width() * renderScale), qRound(iconLogicalSize.height() * renderScale));
+  QPixmap srcPixmap = icon.pixmap(physicalSize);
+  QPixmap result(physicalSize);
+  result.fill(Qt::transparent);
+  QPainter painter(&result);
+  painter.setRenderHint(QPainter::Antialiasing);
+
+  // Draw the main icon faded to indicate the item is not effectively visible.
+  painter.setOpacity(0.35);
+  painter.drawPixmap(QRect(QPoint(0, 0), physicalSize), srcPixmap, srcPixmap.rect());
+  painter.setOpacity(1.0);
+
+  // Overlay an upward-pointing arrow in the bottom-right corner.
+  // The arrow signals that visibility is controlled by a parent item.
+  const qreal pw = physicalSize.width();
+  const qreal ph = physicalSize.height();
+  const qreal badgeSize = pw * 0.42;
+  const qreal margin = renderScale; // 1 logical-pixel margin from icon edge
+
+  const qreal bx = pw - badgeSize - margin;
+  const qreal by = ph - badgeSize - margin;
+
+  // Up-arrow (arrowhead + stem polygon)
+  const qreal pad = badgeSize * 0.05;
+  const qreal aw = badgeSize - 2.0 * pad;      // arrow bounding width
+  const qreal ah = badgeSize - 2.0 * pad;      // arrow bounding height
+  const qreal ax = bx + pad;                   // arrow bounding-box origin x
+  const qreal ay = by + pad;                   // arrow bounding-box origin y
+  const qreal headH = ah * 0.55;               // height of the triangular head
+  const qreal stemW = aw * 0.35;               // width of the stem
+  const qreal stemX = ax + (aw - stemW) * 0.5; // left edge of stem
+
+  QPolygonF arrow;
+  arrow << QPointF(ax + aw * 0.5, ay)         // tip
+        << QPointF(ax + aw, ay + headH)       // right shoulder
+        << QPointF(stemX + stemW, ay + headH) // right stem-top
+        << QPointF(stemX + stemW, ay + ah)    // right stem-bottom
+        << QPointF(stemX, ay + ah)            // left stem-bottom
+        << QPointF(stemX, ay + headH)         // left stem-top
+        << QPointF(ax, ay + headH);           // left shoulder
+
+  painter.setPen(Qt::NoPen);
+  painter.setBrush(QColor(60, 60, 60));
+  painter.drawPolygon(arrow);
+
+  painter.end();
+  result.setDevicePixelRatio(renderScale);
+  return QIcon(result);
+}
+
+//---------------------------------------------------------------------------
+QIcon qSlicerSubjectHierarchyAbstractPlugin::visibilityIconWithParentHidden(int visible)
+{
+  // Apply the grayed-out effect to whatever icon this plugin returns for the given
+  // visibility state. Plugins that return no visibility icon get no grayed icon either.
+  return applyParentHiddenEffect(this->visibilityIcon(visible));
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
@@ -189,6 +189,13 @@ public:
   /// Get visibility icon for a visibility state
   Q_INVOKABLE virtual QIcon visibilityIcon(int visible);
 
+  /// Get the visibility icon for an item that is nominally visible or hidden
+  /// but whose effective visibility is overridden because a parent item is hidden.
+  /// The default implementation calls applyParentHiddenEffect() on the result of
+  /// visibilityIcon(), which renders the icon at reduced opacity and overlays a
+  /// small upward-pointing arrow in the bottom-right corner.
+  Q_INVOKABLE virtual QIcon visibilityIconWithParentHidden(int visible);
+
   /// Returns true if the module can edit properties of this item using editProperties.
   Q_INVOKABLE virtual bool canEditProperties(vtkIdType itemID);
 
@@ -325,6 +332,13 @@ public:
   /// Switch to module with given name
   /// \return Widget representation of the module if found, nullptr otherwise
   Q_INVOKABLE static qSlicerAbstractModuleWidget* switchToModule(QString moduleName);
+
+  /// Apply the "parent hidden" visual effect to a visibility icon: render it at
+  /// reduced opacity and overlay a small upward-pointing arrow in the bottom-right
+  /// corner to indicate that the item's own visibility setting is irrelevant because
+  /// a parent item is hidden.
+  /// Plugins can call this helper when implementing visibilityIconWithParentHidden().
+  static QIcon applyParentHiddenEffect(const QIcon& icon);
 
 public:
   /// Get the name of the plugin

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyDefaultPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyDefaultPlugin.cxx
@@ -57,6 +57,10 @@ public:
   QIcon HiddenIcon;
   QIcon PartiallyVisibleIcon;
 
+  QIcon VisibleWithParentHiddenIcon;
+  QIcon HiddenWithParentHiddenIcon;
+  QIcon PartiallyVisibleWithParentHiddenIcon;
+
   QAction* ShowAllChildrenAction;
   QAction* HideAllChildrenAction;
 };
@@ -113,6 +117,10 @@ void qSlicerSubjectHierarchyDefaultPlugin::setDefaultVisibilityIcons(QIcon visib
   d->VisibleIcon = visibleIcon;
   d->HiddenIcon = hiddenIcon;
   d->PartiallyVisibleIcon = partiallyVisibleIcon;
+  // Invalidate derived caches so they are rebuilt from the new base icons.
+  d->VisibleWithParentHiddenIcon = QIcon();
+  d->HiddenWithParentHiddenIcon = QIcon();
+  d->PartiallyVisibleWithParentHiddenIcon = QIcon();
 }
 
 //---------------------------------------------------------------------------
@@ -187,6 +195,30 @@ QIcon qSlicerSubjectHierarchyDefaultPlugin::visibilityIcon(int visible)
     case 2: return d->PartiallyVisibleIcon;
     default: return QIcon();
   }
+}
+
+//---------------------------------------------------------------------------
+QIcon qSlicerSubjectHierarchyDefaultPlugin::visibilityIconWithParentHidden(int visible)
+{
+  Q_D(qSlicerSubjectHierarchyDefaultPlugin);
+
+  QIcon* cached = nullptr;
+  switch (visible)
+  {
+    case 0: cached = &d->HiddenWithParentHiddenIcon; break;
+    case 1: cached = &d->VisibleWithParentHiddenIcon; break;
+    case 2: cached = &d->PartiallyVisibleWithParentHiddenIcon; break;
+  }
+  if (cached && !cached->isNull())
+  {
+    return *cached;
+  }
+  QIcon result = applyParentHiddenEffect(this->visibilityIcon(visible));
+  if (cached)
+  {
+    *cached = result;
+  }
+  return result;
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyDefaultPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyDefaultPlugin.h
@@ -69,6 +69,10 @@ public:
   /// Get visibility icon for a visibility state
   QIcon visibilityIcon(int visible) override;
 
+  /// Get the visibility icon for an item whose effective visibility is overridden
+  /// because a parent item is hidden. Icons are lazily created and cached.
+  QIcon visibilityIconWithParentHidden(int visible) override;
+
   /// Get visibility context menu item actions to add to tree view.
   /// These item visibility context menu actions can be shown in the implementations of \sa showVisibilityContextMenuActionsForItem
   QList<QAction*> visibilityContextMenuActions() const override;


### PR DESCRIPTION
If a subject hierarchy item tree visibility is disable (eye icon is closed) then that makes children invisible as well. To give a hint to the user that child items are invisible, despite the enabled visibility (eye icon is open), this commit makes the item visibility icon grayed out.

Volume nodes may be visible in slice views, despite the parent is hidden, but volume rendering in 3D view is controller by parent visibility, too, therefore we do not make an exception for volume nodes.

see #8190