### PR TITLE
BUG: Fix Qt geometry warning when showing terminology selector

### DIFF
--- a/Modules/Loadable/Colors/Widgets/qSlicerTerminologyEditorDialog.cxx
+++ b/Modules/Loadable/Colors/Widgets/qSlicerTerminologyEditorDialog.cxx
@@ -136,6 +136,10 @@ bool qSlicerTerminologyEditorDialog::exec()
   // Initialize dialog
   d->EditorWidget->setTerminologyInfo(d->TerminologyInfo);
 
+  // Pre-size the dialog so Qt's WA_Resized flag is set before exec() creates the platform window.
+  // Without this, Qt creates the window at a small default size, which Windows rejects and logs a geometry warning in debug mode.
+  d->adjustSize();
+
   // Show dialog
   bool result = false;
   if (d->exec() != QDialog::Accepted)

--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologySelectorDialog.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologySelectorDialog.cxx
@@ -137,6 +137,10 @@ bool qSlicerTerminologySelectorDialog::exec()
   // Initialize dialog
   d->NavigatorWidget->setTerminologyInfo(d->TerminologyInfo);
 
+  // Pre-size the dialog so Qt's WA_Resized flag is set before exec() creates the platform window.
+  // Without this, Qt creates the window at a small default size, which Windows rejects and logs a geometry warning in debug mode.
+  d->adjustSize();
+
   // Show dialog
   bool result = false;
   if (d->exec() != QDialog::Accepted)


### PR DESCRIPTION
In debug mode on Windows, this warning was displayed each time the terminology selector popup was displayed:

[Qt] QWindowsWindow::setGeometry: Unable to set geometry 200x60+1622+714 (frame: 222x116+1611+669) on QWidgetWindow/"QDialogClassWindow" on "\\.\DISPLAY1". Resulting geometry: 344x448+1622+714 (frame: 366x504+1611+669) margins: 11, 45, 11, 11 minimum size: 172x224 MINMAXINFO maxSize=0,0 maxpos=0,0 mintrack=366,504 maxtrack=0,0)

Fix: Pre-size the dialog before exec() so the platform window is created at the correct size. Without this, Qt creates the window at its default 100x30 size, which Windows rejects as smaller than the dialog's minimum track size, logging a QWindowsWindow::setGeometry warning.

fixes #8038