### PR TITLE
BUG: Show folder opacity before visibility toggle

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/CMakeLists.txt
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/CMakeLists.txt
@@ -1,5 +1,6 @@
 #-----------------------------------------------------------------------------
 set(EXTENSION_TEST_PYTHON_SCRIPTS
+  SubjectHierarchyFolderOpacityTest.py
   SubjectHierarchyFoldersTest1.py
   )
 

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyFolderOpacityTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyFolderOpacityTest.py
@@ -1,0 +1,53 @@
+import unittest
+
+import slicer
+
+
+class SubjectHierarchyFolderOpacityTest(unittest.TestCase):
+
+    def setUp(self):
+        slicer.mrmlScene.Clear(0)
+
+    def runTest(self):
+        self.setUp()
+        self.test_FolderOpacityAvailableBeforeVisibilityToggle()
+
+    def test_FolderOpacityAvailableBeforeVisibilityToggle(self):
+        subjectHierarchyModule = slicer.app.moduleManager().module("SubjectHierarchy")
+        self.assertIsNotNone(subjectHierarchyModule)
+        subjectHierarchyModule.logic()
+
+        shNode = slicer.mrmlScene.GetSubjectHierarchyNode()
+        self.assertIsNotNone(shNode)
+
+        pluginHandler = slicer.qSlicerSubjectHierarchyPluginHandler.instance()
+        opacityPlugin = pluginHandler.pluginByName("Opacity")
+        self.assertIsNotNone(opacityPlugin)
+
+        folderItem = shNode.CreateFolderItem(shNode.GetSceneItemID(), "FolderWithoutDisplayNode")
+        self.assertNotEqual(folderItem, slicer.vtkMRMLSubjectHierarchyNode.GetInvalidItemID())
+        self.assertIsNone(shNode.GetItemDataNode(folderItem))
+
+        pluginHandler.setCurrentItem(folderItem)
+        opacityAction = opacityPlugin.visibilityContextMenuActions()[0]
+
+        # Opening the visibility menu should expose opacity without creating
+        # the folder display node as a side effect.
+        opacityPlugin.showVisibilityContextMenuActionsForItem(folderItem)
+
+        self.assertTrue(opacityAction.visible)
+        self.assertIsNone(shNode.GetItemDataNode(folderItem))
+
+        opacityMenu = opacityAction.menu()
+        self.assertIsNotNone(opacityMenu)
+        opacitySlider = opacityMenu.actions()[0].defaultWidget()
+        self.assertIsNotNone(opacitySlider)
+        self.assertEqual(opacitySlider.value, 1.0)
+
+        # Moving the slider is the user action that creates the display node.
+        opacitySlider.setValue(0.5)
+
+        folderDisplayNode = shNode.GetItemDataNode(folderItem)
+        self.assertIsNotNone(folderDisplayNode)
+        self.assertTrue(folderDisplayNode.IsA("vtkMRMLFolderDisplayNode"))
+        self.assertAlmostEqual(folderDisplayNode.GetOpacity(), 0.5)

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.h
@@ -146,6 +146,9 @@ public:
   /// Create display node for given item.
   vtkMRMLDisplayNode* createDisplayNodeForItem(vtkIdType itemID);
 
+  /// Retrieve display node for given item.
+  vtkMRMLDisplayNode* displayNodeForItem(vtkIdType itemID) const;
+
   /// Add tree view to the list of view from which empty folders have been created.
   /// This function is called from the DICOM plugin, which can create patient and study items (which are special folders).
   void emptyFolderCreatedFromTreeView(qMRMLSubjectHierarchyTreeView* treeView);
@@ -164,10 +167,6 @@ protected slots:
   void onShowEmptyFoldersToggled(bool);
 
 protected:
-  /// Retrieve display node for given item.
-  /// with a display node.
-  vtkMRMLDisplayNode* displayNodeForItem(vtkIdType itemID) const;
-
   /// Determine if apply color to branch option is enabled to a given item or not
   bool isApplyColorToBranchEnabledForItem(vtkIdType itemID) const;
   /// Determine if apply color to branch option is enabled to a given item or not

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyOpacityPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyOpacityPlugin.cxx
@@ -21,6 +21,7 @@
 ==============================================================================*/
 
 // SubjectHierarchy Plugins includes
+#include "qSlicerSubjectHierarchyFolderPlugin.h"
 #include "qSlicerSubjectHierarchyPluginHandler.h"
 #include "qSlicerSubjectHierarchyOpacityPlugin.h"
 
@@ -144,27 +145,45 @@ void qSlicerSubjectHierarchyOpacityPlugin::showVisibilityContextMenuActionsForIt
     return;
   }
 
-  // Show opacity for every non-scene items with display node
-  vtkMRMLDisplayNode* displayNode = nullptr;
-  vtkMRMLDisplayableNode* displayableNode = vtkMRMLDisplayableNode::SafeDownCast(shNode->GetItemDataNode(itemID));
-  vtkMRMLScalarVolumeNode* volumeNode = vtkMRMLScalarVolumeNode::SafeDownCast(displayableNode);
-  if (displayableNode)
+  vtkMRMLNode* dataNode = shNode->GetItemDataNode(itemID);
+  vtkMRMLDisplayableNode* displayableNode = vtkMRMLDisplayableNode::SafeDownCast(dataNode);
+  vtkMRMLDisplayNode* displayNode = displayableNode ? displayableNode->GetDisplayNode() : nullptr;
+  bool canCreateFolderDisplayNode = false;
+
+  if (!displayableNode)
   {
-    displayNode = displayableNode->GetDisplayNode();
+    // Folder items may have a display node directly, or none yet.
+    // Offer opacity even before the folder display node has been created.
+    qSlicerSubjectHierarchyFolderPlugin* folderPlugin =
+      qobject_cast<qSlicerSubjectHierarchyFolderPlugin*>(qSlicerSubjectHierarchyPluginHandler::instance()->pluginByName("Folder"));
+    if (folderPlugin)
+    {
+      displayNode = folderPlugin->displayNodeForItem(itemID);
+      canCreateFolderDisplayNode = !displayNode && !dataNode && folderPlugin->canOwnSubjectHierarchyItem(itemID) > 0.0;
+    }
+  }
+
+  // Opacity of volume nodes is a special case (it could be done by adjusting volume rendering opacity
+  // transfer functions and/or foreground slice opacity) but we do not implement it here.
+  vtkMRMLScalarVolumeNode* volumeNode = vtkMRMLScalarVolumeNode::SafeDownCast(displayableNode);
+  if (volumeNode)
+  {
+    displayNode = nullptr;
+  }
+
+  if (displayNode || canCreateFolderDisplayNode)
+  {
+    // Populating the menu must not create or modify MRML nodes. Block signals
+    // so setting the default folder opacity does not call setOpacityForCurrentItem().
+    bool wasBlocked = d->OpacitySlider->blockSignals(true);
+    d->OpacitySlider->setValue(displayNode ? displayNode->GetOpacity() : 1.0);
+    d->OpacitySlider->blockSignals(wasBlocked);
+    d->OpacityAction->setVisible(true);
   }
   else
   {
-    // Folder nodes may have display nodes directly associated
-    displayNode = vtkMRMLDisplayNode::SafeDownCast(shNode->GetItemDataNode(itemID));
+    d->OpacityAction->setVisible(false);
   }
-
-  if (displayNode)
-  {
-    d->OpacitySlider->setValue(displayNode->GetOpacity());
-  }
-
-  // Show opacity action if there is a valid display node and if the node is not a volume
-  d->OpacityAction->setVisible(displayNode && !volumeNode);
 }
 
 //---------------------------------------------------------------------------
@@ -184,18 +203,26 @@ void qSlicerSubjectHierarchyOpacityPlugin::setOpacityForCurrentItem(double opaci
     return;
   }
 
-  // Get display node
-  vtkMRMLDisplayNode* displayNode = nullptr;
-  vtkMRMLDisplayableNode* displayableNode = vtkMRMLDisplayableNode::SafeDownCast(shNode->GetItemDataNode(currentItemID));
-  if (displayableNode)
+  vtkMRMLNode* dataNode = shNode->GetItemDataNode(currentItemID);
+  vtkMRMLDisplayableNode* displayableNode = vtkMRMLDisplayableNode::SafeDownCast(dataNode);
+  vtkMRMLDisplayNode* displayNode = displayableNode ? displayableNode->GetDisplayNode() : nullptr;
+
+  if (!displayableNode)
   {
-    displayNode = displayableNode->GetDisplayNode();
+    // Folder items may have a display node directly, or none yet.
+    // Create one on first opacity change.
+    qSlicerSubjectHierarchyFolderPlugin* folderPlugin =
+      qobject_cast<qSlicerSubjectHierarchyFolderPlugin*>(qSlicerSubjectHierarchyPluginHandler::instance()->pluginByName("Folder"));
+    if (folderPlugin)
+    {
+      displayNode = folderPlugin->displayNodeForItem(currentItemID);
+      if (!displayNode && !dataNode && folderPlugin->canOwnSubjectHierarchyItem(currentItemID) > 0.0)
+      {
+        displayNode = folderPlugin->createDisplayNodeForItem(currentItemID);
+      }
+    }
   }
-  else
-  {
-    // Folder nodes may have display nodes directly associated
-    displayNode = vtkMRMLDisplayNode::SafeDownCast(shNode->GetItemDataNode(currentItemID));
-  }
+
   if (!displayNode)
   {
     qCritical() << Q_FUNC_INFO << ": Unable to find display node for subject hierarchy item " << shNode->GetItemName(currentItemID).c_str();


### PR DESCRIPTION
Fixes #9191.

## Summary
- Show the opacity control for subject hierarchy folder items before a folder display node exists.
- Keep menu population side-effect-free, and create the folder display node only when the user changes opacity.
- Add a regression test covering the first-open visibility menu behavior for a new folder item.

## Root cause
The opacity plugin only showed the slider when the selected item already had a display node. Newly created folder items do not get a folder display node until visibility or display state is changed, so users had to toggle visibility before opacity became available.

## Validation
- `python3 -m py_compile Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyFolderOpacityTest.py`
- `git diff --check`
- `pre-commit run --files Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyOpacityPlugin.cxx Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyFolderOpacityTest.py Modules/Loadable/SubjectHierarchy/Testing/Python/CMakeLists.txt`
- `cmake --build /Users/lamm/Slicer-build-arm64/Slicer-build --parallel 8`
- Ran `SubjectHierarchyFolderOpacityTest` against the local Slicer build with `--no-main-window --disable-cli-modules`
- Manual GUI check: a new folder item shows the opacity slider on first right-click of the visibility icon, before toggling visibility
