### PR TITLE
COMP: Update CTK with Qt 6.11 build support

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -78,7 +78,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "5ce99ef251f1a4d4124430abf76bf7cb282d5a18"
+    "768e2c9662c7afb51dfa322c89f4a2e0c82c3aa9"
     QUIET
     )
 


### PR DESCRIPTION
This closes https://github.com/Slicer/Slicer/issues/9142.

This adds build support for Qt 6.11. I tested on Windows 11 with Visual Studio 2026 18.6.2 (v145 toolset) and CMake 4.3.3.
```
CTK:
$ git shortlog 5ce99ef..768e2c9
James Butler (1):
      COMP: Update PythonQt to v4.1.0 based branch
```