### PR TITLE
BUG: Hide 3D angle line when fewer than 2 points

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.cxx
@@ -205,8 +205,9 @@ void vtkSlicerAngleRepresentation3D::UpdateFromMRMLInternal(vtkMRMLNode* caller,
   this->TubeFilter->SetRadius(diameter * 0.5);
   this->ArcTubeFilter->SetRadius(diameter * 0.5);
 
-  this->LineActor->SetVisibility(true);
-  this->ArcActor->SetVisibility(markupsNode->GetNumberOfDefinedControlPoints(true) == 3);
+  int numberOfDefinedControlPoints = markupsNode->GetNumberOfDefinedControlPoints(true);
+  this->LineActor->SetVisibility(numberOfDefinedControlPoints >= 2);
+  this->ArcActor->SetVisibility(numberOfDefinedControlPoints == 3);
   this->LineOccludedActor->SetVisibility(this->MarkupsDisplayNode && this->LineActor->GetVisibility() && this->MarkupsDisplayNode->GetOccludedVisibility());
   this->ArcOccludedActor->SetVisibility(this->MarkupsDisplayNode && this->ArcActor->GetVisibility() && this->MarkupsDisplayNode->GetOccludedVisibility());
 


### PR DESCRIPTION
When removing points of an angle widget, some line segments were still displayed.

fixes #8590
