### PR TITLE
BUG: Fix unwanted markup measurements

### DIFF
--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -2614,6 +2614,7 @@ void qSlicerMarkupsModuleWidget::setMRMLMarkupsNode(vtkMRMLMarkupsNode* markupsN
   {
     qvtkDisconnect(d->MarkupsNode->Measurements, vtkCommand::ModifiedEvent, this, SLOT(onMeasurementsCollectionModified()));
   }
+  this->unobserveMeasurementsInCurrentMarkupsNode();
   if (markupsNode)
   {
     qvtkConnect(markupsNode->Measurements, vtkCommand::ModifiedEvent, this, SLOT(onMeasurementsCollectionModified()));
@@ -3011,6 +3012,30 @@ void qSlicerMarkupsModuleWidget::observeMeasurementsInCurrentMarkupsNode()
     if (!qvtkIsConnected(currentMeasurement, vtkCommand::ModifiedEvent, this, SLOT(onMeasurementModified(vtkObject*))))
     {
       qvtkConnect(currentMeasurement, vtkCommand::ModifiedEvent, this, SLOT(onMeasurementModified(vtkObject*)));
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerMarkupsModuleWidget::unobserveMeasurementsInCurrentMarkupsNode()
+{
+  Q_D(qSlicerMarkupsModuleWidget);
+  if (!d->MarkupsNode)
+  {
+    return;
+  }
+
+  for (int i = 0; i < d->MarkupsNode->Measurements->GetNumberOfItems(); ++i)
+  {
+    vtkMRMLMeasurement* currentMeasurement = vtkMRMLMeasurement::SafeDownCast(d->MarkupsNode->Measurements->GetItemAsObject(i));
+    if (!currentMeasurement)
+    {
+      continue;
+    }
+
+    if (qvtkIsConnected(currentMeasurement, vtkCommand::ModifiedEvent, this, SLOT(onMeasurementModified(vtkObject*))))
+    {
+      qvtkDisconnect(currentMeasurement, vtkCommand::ModifiedEvent, this, SLOT(onMeasurementModified(vtkObject*)));
     }
   }
 }

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
@@ -235,6 +235,8 @@ public slots:
 
   /// Make sure all measurements in the current markups node are observed
   void observeMeasurementsInCurrentMarkupsNode();
+  /// Stop observing all measurements in the current markups node
+  void unobserveMeasurementsInCurrentMarkupsNode();
   /// Update measurements description label
   void updateMeasurementsDescriptionLabel();
   /// Populate measurement settings frame from the available measurements in the current markup


### PR DESCRIPTION
When a new markup was added, measurements from previously selected markup node were added to the new markup.

Root cause: When switching the active markups node, individual measurement objects were left connected to onMeasurementModified. When the previously selected node's measurements (enabled by the user) subsequently fired ModifiedEvent, the handler found the new node's checkboxes by name and set them to checked.

Fixed by disconnecting individual measurement observers from the old node in setMRMLMarkupsNode (mirroring what observeMeasurementsInCurrentMarkupsNode does when connecting them).

fixes #9214