### PR TITLE
COMP: Add missing itkImageRegionIteratorWithIndex.h includes

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLTransformStorageNodeTest3.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTransformStorageNodeTest3.cxx
@@ -26,6 +26,7 @@
 #include <itkImage.h>
 #include <itkVector.h>
 #include <itkImageRegionIterator.h>
+#include <itkImageRegionIteratorWithIndex.h>
 #include <itkDisplacementFieldTransform.h>
 #include <itkThinPlateSplineKernelTransform.h>
 #include <itkBSplineTransform.h>

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h
@@ -16,6 +16,7 @@
 
 #include "itkDiffusionTensor3DInterpolateImageFunction.h"
 #include <itkImage.h>
+#include <itkImageRegionIteratorWithIndex.h>
 #include <itkInterpolateImageFunction.h>
 #include "itkSeparateComponentsOfADiffusionTensorImage.h"
 


### PR DESCRIPTION
Two translation units use `itk::ImageRegionIteratorWithIndex` but rely on it being pulled in transitively via `<itkImage.h>`. Modern ITK no longer includes the iterator header transitively, so they fail to compile against current ITK `main`. Add the direct include.

<details>
<summary>Affected files / errors</summary>

- `Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h`
- `Libs/MRML/Core/Testing/vtkMRMLTransformStorageNodeTest3.cxx`

```
error: 'ImageRegionIteratorWithIndex' does not name a type;
       did you mean 'itkImageRegionIteratorWithIndex_h'?
```

</details>

<details>
<summary>Backwards compatibility / testing</summary>

`itkImageRegionIteratorWithIndex.h` exists in all supported ITK versions; the added include is idempotent (include guards), so it is a no-op where the header was already pulled in transitively.

Verified by compiling both translation units:
- **ITK 5.4.6** (Slicer's pinned `5bfed9195a`): both compile cleanly with the fix.
- **Modern ITK** (current upstream `main`): both compile with the fix; without it they fail as above.

`vtkMRMLTransformStorageNodeTest3` rebuilt and passes (1/1). `pre-commit` clean on the changed files.

</details>

<!--
provenance: surfaced while validating ITK PR InsightSoftwareConsortium/ITK#6421 (stripped-vxl VNL update) against a full Slicer + ExtensionsIndex build. The VNL change was clean; these two pre-existing missing-include drift bugs were the only Slicer-side blockers to building against modern ITK.
files:
  Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h:19
  Libs/MRML/Core/Testing/vtkMRMLTransformStorageNodeTest3.cxx:29
-->
