### PR TITLE
COMP: Add MSVC compatibility check when using Qt 5

### DIFF
--- a/CMake/SlicerBlockFindQtAndCheckVersion.cmake
+++ b/CMake/SlicerBlockFindQtAndCheckVersion.cmake
@@ -47,6 +47,14 @@ macro(__SlicerBlockFindQtAndCheckVersion_find_qt)
                         "-- you cannot use Qt ${_major}.${_minor}.${_patch}. ${extra_error_message}")
   endif()
 
+  # MSVC 1951 (VS 2022 17.11) introduced ABI changes that require Qt 5.15.17 or newer.
+  if(WIN32 AND MSVC_VERSION VERSION_GREATER_EQUAL 1951)
+    if("${_major}.${_minor}.${_patch}" VERSION_LESS "5.15.17")
+      message(FATAL_ERROR "error: MSVC toolset version ${MSVC_VERSION} requires that Qt 5 is 5.15.17 or newer "
+                          "-- you cannot use Qt ${_major}.${_minor}.${_patch} with this compiler.")
+    endif()
+  endif()
+
   set(command_separated_module_list)
   # Check if all expected Qt modules have been discovered
   foreach(module ${Slicer_REQUIRED_QT_MODULES})


### PR DESCRIPTION
This closes #9199.

Slicer with Qt 5.15.2 does not build successfully when using MSVC 1451 (Visual Studio 2026 18.6) due to stdext no longer being available.

49>C:\Qt\5.15.2\msvc2019_64\include\QtCore\qlist.h(915,29): error C2653: 'stdext': is not a class or namespace name [C:\S5R\CTK-build\PythonQtGenerator-build\PythonQtGenerator.vcxproj] [C:\S5R\CTK-build\PythonQtGenerator.vcxproj]

A guard was added for older MSVC versions for Qt 5.15 branch in https://github.com/qt/qtbase/commit/165daa88c1e5a768cce18c10bf570fe22a741411.

The guard was added for Qt6 in
https://github.com/qt/qtbase/commit/52b6258ec846cc53ebdb1c8167edd30db39c7891 which started with Qt 6.7 and backported to some older branches. Slicer currently requires Qt 6.8 or newer so we don't need checks for older Qt 6 versions.


Example of this change if using Qt 5.15.2 with MSVC 1951 from Visual Studio 2026 18.6:
```
CMake Error at CMake/SlicerBlockFindQtAndCheckVersion.cmake:53 (message):
  error: MSVC toolset version 1951 requires that Qt 5 is 5.15.17 or newer --
  you cannot use Qt 5.15.2 with this compiler.
Call Stack (most recent call first):
  CMake/SlicerBlockFindQtAndCheckVersion.cmake:88 (__SlicerBlockFindQtAndCheckVersion_find_qt)
  CMakeLists.txt:744 (include)


Configuring incomplete, errors occurred!
```