### PR TITLE
BUG: Fix terminology selector opening with empty content on repeated opens

### DIFF
--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
@@ -938,21 +938,15 @@ void qSlicerTerminologyNavigatorWidgetPrivate::setCurrentTerminology(QString ter
         terminologyOrColorName = QString::fromUtf8(colorNode->GetName());
       }
     }
-    if (!lastTerminologyContextNames.isEmpty())
+    // Remove the terminology name from the list so that there are no duplicate entries in the list
+    lastTerminologyContextNames.removeOne(terminologyOrColorName);
+    // Prepend terminology name to the list so that the last used terminology is first
+    lastTerminologyContextNames.insert(0, terminologyOrColorName);
+    // Trim to a reasonable maximum to prevent unbounded growth
+    const int maxLastTerminologyContextNames = 30;
+    if (lastTerminologyContextNames.size() > maxLastTerminologyContextNames)
     {
-      if (lastTerminologyContextNames.size() == 1 && lastTerminologyContextNames[0] == terminologyOrColorName)
-      {
-        // Nothing to change
-        return;
-      }
-      // Remove the terminology name from the list so that there are no duplicate entries in the list
-      lastTerminologyContextNames.removeOne(terminologyOrColorName);
-      // Prepend terminology name to the list so that the last used terminology is first
-      lastTerminologyContextNames.insert(0, terminologyOrColorName);
-    }
-    else
-    {
-      lastTerminologyContextNames.push_back(terminologyOrColorName);
+      lastTerminologyContextNames = lastTerminologyContextNames.mid(0, maxLastTerminologyContextNames);
     }
     settings->setValue("Terminology/LastTerminologyContexts", lastTerminologyContextNames);
   }


### PR DESCRIPTION
When the terminology selector dialog is opened, it reads the last-used terminology context from the application settings file under `[Terminology] / LastTerminologyContexts` and uses it to populate the dialog content. 

After the very first use of the dialog, this list contains exactly one entry. On every subsequent open, the code detects that the list already contains that one entry and returns early to avoid writing the same value back to the settings file. However, that early return also skipped the initialization of the dialog content, leaving the category list, type list, and color table all empty. 

Selecting a different context from the dropdown worked around the issue for that session by going through a different code path, but the next open would show the problem again. The bug is most noticeable on a clean install, where the settings file starts empty and the list builds from scratch, reaching exactly one entry after the first use and staying there until the user switches between contexts.

<div align=center>
<img width="302" height="677" alt="image" src="https://github.com/user-attachments/assets/302da184-07c7-4a91-8af1-b62d5d387138" />
</div>

The proposed fix remove the early return that was only there as a small optimization, the logic that follows already handles this case correctly.

To reproduce the bug, set the saved context list to a single entry from the Python console:

`slicer.app.userSettings().setValue("Terminology/LastTerminologyContexts", ["Segmentation category and type - 3D Slicer General Anatomy list"])`

Then open the terminology selector twice and confirm the category list, type list, and color table are all empty.

To verify the fix, apply the change, rebuild, and repeat the same steps.

The dialog should now open with all content correctly populated.
