### PR TITLE
BUG: Fix std::regex crash in volume rendering (Qt WebEngine symbol interposition)

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -134,6 +134,29 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     -DVTK_MODULE_ENABLE_VTK_GUISupportQtQuick:BOOL=NO
     )
 
+  # Workaround for https://github.com/Slicer/Slicer/issues/9181
+  #
+  # VTK 9.6 uses std::regex (vtk::is_printf_format / vtk::to_std_format). The
+  # regex compiler/scanner machinery (std::__detail::_Scanner / _Compiler) is
+  # header-instantiated and emitted as weak, default-visibility symbols into
+  # every VTK library that uses std::regex. The prebuilt Qt WebEngine bundled
+  # with Slicer is built by a different toolchain (legacy std::string ABI) and
+  # exports its own copies of these symbols. Under ELF global symbol
+  # interposition, VTK's regex calls can bind to WebEngine's ABI-incompatible
+  # copy and crash in _Scanner::_M_scan_normal() (e.g. during volume rendering).
+  #
+  # Hide these libstdc++ internals in VTK's libraries with a linker version
+  # script so each VTK library binds its own matching copy. Mirrors the
+  # symbol-control approach used in Libs/krb5-gssapi-stub. ELF/Linux only:
+  # macOS uses two-level namespaces and Windows is unaffected.
+  if(UNIX AND NOT APPLE)
+    set(_vtk_regex_version_script "${CMAKE_CURRENT_LIST_DIR}/vtk-hide-stdcxx-regex.ver")
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_VTK9_CMAKE_CACHE_ARGS
+      "-DCMAKE_SHARED_LINKER_FLAGS:STRING=-Wl,--version-script=${_vtk_regex_version_script}"
+      "-DCMAKE_MODULE_LINKER_FLAGS:STRING=-Wl,--version-script=${_vtk_regex_version_script}"
+      )
+  endif()
+
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
     "${EP_GIT_PROTOCOL}://github.com/slicer/VTK.git"

--- a/SuperBuild/vtk-hide-stdcxx-regex.ver
+++ b/SuperBuild/vtk-hide-stdcxx-regex.ver
@@ -1,0 +1,26 @@
+/*
+ * Linker version script for VTK libraries -- workaround for
+ * https://github.com/Slicer/Slicer/issues/9181
+ *
+ * VTK 9.6 uses std::regex (vtk::is_printf_format / vtk::to_std_format in
+ * Common/Core/vtkStringFormatter.cxx). The std::regex compiler/scanner
+ * machinery (std::__detail::_Scanner, _Compiler, ...) is header-instantiated
+ * and emitted as *weak, default-visibility* symbols into every library that
+ * uses std::regex. The prebuilt Qt WebEngine bundled with Slicer is built by a
+ * different toolchain with the legacy std::string ABI and exports its own
+ * copies of these same symbols. Under ELF global symbol interposition, VTK's
+ * regex calls can bind to WebEngine's ABI-incompatible copy, crashing in
+ * std::__detail::_Scanner<char>::_M_scan_normal() (observed during GPU volume
+ * rendering, which loads a noise-texture JPEG through the regex path).
+ *
+ * Marking these libstdc++ internals "local" makes each VTK library bind its
+ * own matching copy and stop participating in interposition. Every other VTK
+ * symbol keeps its default (global) binding. This mirrors the symbol-control
+ * approach already used by Libs/krb5-gssapi-stub/gssapi_krb5.ver.
+ */
+{
+  local:
+    _ZNSt8__detail*;     /* std::__detail::  _Scanner / _Compiler / _Executor   */
+    _ZNKSt8__detail*;    /* std::__detail::  const members (_AnyMatcher, ...)   */
+    _ZGVZNKSt8__detail*; /* guard variables for _AnyMatcher static __nul        */
+};


### PR DESCRIPTION

Fixes #9181

## Diagnosis

Volume rendering crashes on Linux in builds from ~12 Mar 2026 onward (the VTK 9.6
upgrade). The crash is a **C++ ABI conflict caused by symbol interposition between
the bundled Qt WebEngine and VTK**, not a GPU/driver/Wayland issue.

- VTK 9.6 introduced `vtk::is_printf_format()` / `vtk::to_std_format()`
  (`Common/Core/vtkStringFormatter.cxx`), which build `static std::regex`
  objects on first use.
- `std::regex`'s engine (`std::__detail::_Scanner` / `_Compiler`) is
  **header-instantiated** — `libstdc++.so` does **not** export it. Every shared
  library that uses `std::regex` therefore emits its **own weak, default-visibility
  copies** of these symbols (in our case `libvtkCommon`, `libvtkInfovisCore`,
  `libvtkscn`, `libvtkChartsCore`, …).
- The **prebuilt Qt WebEngine** bundled with Slicer is built by a different
  toolchain using the **legacy `std::string` ABI** (`_GLIBCXX_USE_CXX11_ABI=0`)
  and **exports its own copies of these same symbols** (versioned `@@Qt_5`).
- Under ELF global symbol resolution, WebEngine loads early (it is a direct
  `NEEDED` of `SlicerApp-real`), so its copy of `_Scanner::_M_scan_normal` wins
  the binding process-wide. VTK constructs a *new-ABI* `_Scanner` and then calls
  WebEngine's *old-ABI* `_M_scan_normal`, which reads the object with the wrong
  layout → `SIGSEGV`.

The volume-rendering trigger: GPU ray casting with ray-jittering enabled calls
`vtkOpenGLRenderWindow::GetNoiseTextureUnit()`, which loads the noise texture via
`vtkJPEGReader` → `vtkImageReader2::ComputeInternalFileName` → `vtk::to_std_format`
→ `vtk::is_printf_format` → the `std::regex` compile that crashes:

```
#0  std::__detail::_Scanner<char>::_M_scan_normal()         libQt5WebEngineCore.so.5
#1  std::__detail::_Compiler<__cxx11::regex_traits<char>>   libvtkInfovisCore-9.6
#10 vtk::is_printf_format(std::__cxx11::string const&)       libvtkCommon-9.6
#11 vtk::to_std_format(...)                                  libvtkCommon-9.6
#12 vtkImageReader2::ComputeInternalFileName(int)            libvtkIO-9.6
#13 vtkJPEGReader::ExecuteInformation()                      libvtkIO-9.6
#19 vtkOpenGLRenderWindow::GetNoiseTextureUnit()             libvtkOpenGL-9.6
#20 vtkOpenGLGPUVolumeRayCastMapper::...SetMapperShaderParameters
```

## How to reproduce

Verified on the factory `Slicer-5.11.0-2026-06-11-linux-amd64` package.

GUI: load a volume (e.g. `MRHead`), enable GPU volume rendering, render the 3D
view — Slicer crashes. Equivalent, automated:

```python
import slicer, SampleData
vol = SampleData.SampleDataLogic().downloadMRHead()
dn = slicer.modules.volumerendering.logic().CreateDefaultVolumeRenderingNodes(vol)
dn.SetVisibility(True)
v = slicer.app.layoutManager().threeDWidget(0).threeDView()
v.resetFocalPoint(); v.resetCamera(); v.forceRender()
# (with GPU ray-cast jittering enabled -> GetNoiseTextureUnit -> regex -> SIGSEGV)
```

The mechanism can also be reproduced with no GUI/GPU at all — load WebEngine, then
call the regex path:

```cpp
dlopen("libQt5WebEngineCore.so.5", RTLD_NOW|RTLD_GLOBAL);   // as in the real app
vtk::is_printf_format("image_%03d.jpg");                    // SIGSEGV in _M_scan_normal
```

Confirming the leak directly:
```
$ nm -D libQt5WebEngineCore.so.5 | grep _M_scan_normal
… W std::__detail::_Scanner<char>::_M_scan_normal()@@Qt_5      # WebEngine, legacy ABI
$ nm -D libvtkCommon-9.6.so | grep _M_scan_normal
… W std::__detail::_Scanner<char>::_M_scan_normal()            # VTK, __cxx11 ABI
```

## Fix (this PR): hide the leaked libstdc++ symbols in VTK

Build VTK's libraries with a linker **version script** that marks the leaked
`std::__detail` regex machinery `local`, so each VTK library binds its **own**
matching copy and can no longer be interposed by (or interpose) Qt WebEngine's
foreign-ABI copy. Every other VTK symbol keeps its default (global) binding.

- `SuperBuild/vtk-hide-stdcxx-regex.ver` — `{ local: _ZNSt8__detail*;
  _ZNKSt8__detail*; _ZGVZNKSt8__detail*; };`
- `SuperBuild/External_VTK.cmake` — passes
  `-Wl,--version-script=…` via `CMAKE_SHARED_LINKER_FLAGS` /
  `CMAKE_MODULE_LINKER_FLAGS` to the VTK external project, guarded `UNIX AND NOT
  APPLE` (ELF-only; macOS uses two-level namespaces, Windows is unaffected).

**This follows an existing precedent in the tree.** `Libs/krb5-gssapi-stub`
already solves a structurally identical problem — a prebuilt-Qt-installer symbol
conflict on Linux — with the same tool, a `-Wl,--version-script` controlling
`global:`/`local:` symbol exposure on a Slicer-built library:

```
# Libs/krb5-gssapi-stub/gssapi_krb5.ver  — PROVIDE one symbol, hide the rest
gssapi_krb5_2_MIT { global: GSS_C_NT_HOSTBASED_SERVICE;  local: *; };

# this PR — the mirror image: HIDE the leaky symbols, keep the rest exported
{ local: _ZNSt8__detail*; _ZNKSt8__detail*; _ZGVZNKSt8__detail*; };
```

Same lever, opposite polarity. No VTK source changes, no upstream dependency,
Qt5/Qt6-agnostic.

> Note: a naive post-build `objcopy --localize-symbol` / `--strip-symbol` does
> **not** work here — those only edit `.symtab`, which the dynamic loader
> ignores; the `.dynsym` binding is unchanged. Localizing at link time (version
> script) is what actually removes the symbols from interposition.

### Verification

- Stock `2026-06-11` package: GPU volume rendering of `MRHead` → `SIGSEGV`
  (backtrace above).
- VTK libraries with the `__detail` symbols localized (same end-state this PR
  produces at build time): identical volume render → **no crash**.

## Alternative not taken: fix it in VTK

The root trigger is VTK using `std::regex` in
`Common/Core/vtkStringFormatter.cxx`. `is_printf_format` / `to_std_format` could
be rewritten to scan printf conversion specifiers by hand (the building blocks —
`has_duplicates_flags`, `printf_specifier_type_to_std_format`, the `ClassType`
groups — already exist in that file), removing the `std::regex` dependency and
the interposition landmine for **all** consumers and platforms.

This is arguably the cleaner long-term fix, but it was not taken here because it
requires an upstream Kitware MR (or a Slicer-carried VTK patch), has a larger
surface, and lands on a longer timeline. The version-script approach keeps the
fix entirely within Slicer's superbuild and unblocks the Linux preview builds
immediately. The two are not mutually exclusive — an upstream VTK change can
supersede this workaround later.

---

*Disclosure: this pull request was prepared with the assistance of an AI coding agent (Anthropic Claude, model `claude-opus-4-8`, via Claude Code) under author supervision. All changes were reviewed by the author before submission.*
