### PR TITLE
BUG:  Align CheckableComboBox and comboBox to same column

### DIFF
--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSegmentSelectorWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSegmentSelectorWidget.ui
@@ -80,7 +80,7 @@
          <property name="spacing">
           <number>4</number>
          </property>
-         <item row="0" column="1">
+         <item row="0" column="2">
           <widget class="ctkCheckableComboBox" name="CheckableComboBox_Segment">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">


### PR DESCRIPTION
Fixes the misalignment of the `qMRMLSegmentSelectorWidget` `CheckableComboBox` (_here the Target volumes_) and `comboBox` (_here the Body volume_) addressed in the SlicerRT [PR 319](https://github.com/SlicerRt/SlicerRT/pull/319).

<img width="600" height="70" alt="image" src="https://github.com/user-attachments/assets/36df3755-022e-4731-b56d-5475c6e15823" />
