### PR TITLE
Fix private storable node saving

### DIFF
--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -296,7 +296,8 @@ void qSlicerSaveDataDialogPrivate::populateScene()
   this->FileWidget->setItem(row, NodeTypeColumn, sceneTypeItem);
 
   // Scene Status
-  QTableWidgetItem* sceneModifiedItem = new QTableWidgetItem(this->MRMLScene->GetModifiedSinceRead() ? "Modified" : "Not Modified");
+  bool sceneModifiedSinceRead = this->MRMLScene->GetModifiedSinceRead();
+  QTableWidgetItem* sceneModifiedItem = new QTableWidgetItem(sceneModifiedSinceRead ? "Modified" : "Not Modified");
   sceneModifiedItem->setFlags(sceneModifiedItem->flags() & ~Qt::ItemIsEditable & ~Qt::ItemIsEnabled);
   this->FileWidget->setItem(row, NodeStatusColumn, sceneModifiedItem);
 
@@ -333,7 +334,7 @@ void qSlicerSaveDataDialogPrivate::populateScene()
   // Scene Selected
   QTableWidgetItem* selectItem = this->FileWidget->item(row, SelectColumn);
   selectItem->setFlags(selectItem->flags() | Qt::ItemIsUserCheckable);
-  selectItem->setCheckState(this->MRMLScene->GetModifiedSinceRead() ? Qt::Checked : Qt::Unchecked);
+  selectItem->setCheckState(sceneModifiedSinceRead ? Qt::Checked : Qt::Unchecked);
 
   // Options
   this->updateOptionsWidget(row);
@@ -690,18 +691,9 @@ bool qSlicerSaveDataDialogPrivate::save()
 
   if (saveSceneFile && !this->CancelRequested)
   {
-    /// If we are saving the scene file, then we also want to make sure that we are saving the hidden
-    /// nodes first into a subfolder.
-    if (!this->saveHiddenNodes())
+    if (!this->saveScene())
     {
       success = false;
-    }
-    else
-    {
-      if (!this->saveScene())
-      {
-        success = false;
-      }
     }
   }
   else
@@ -859,121 +851,6 @@ bool qSlicerSaveDataDialogPrivate::saveNodes()
     nodeStatusItem->setText(qSlicerSaveDataDialog::tr("Not Modified"));
   }
   this->updateSize();
-
-  return doneWithSaveDataDialog;
-}
-
-//-----------------------------------------------------------------------------
-bool qSlicerSaveDataDialogPrivate::saveHiddenNodes()
-{
-  vtkMRMLScene* mrmlScene = this->MRMLScene;
-  if (!mrmlScene)
-  {
-    qCritical() << Q_FUNC_INFO << " failed: MRML scene is invalid";
-    return false;
-  }
-
-  std::vector<vtkMRMLStorableNode*> hiddenNodes;
-  vtkCollection* nodes = mrmlScene->GetNodes();
-  for (int i = 0; i < nodes->GetNumberOfItems(); ++i)
-  {
-    vtkMRMLNode* node = vtkMRMLNode::SafeDownCast(nodes->GetItemAsObject(i));
-    if (!node)
-    {
-      continue;
-    }
-    vtkMRMLStorableNode* storableNode = vtkMRMLStorableNode::SafeDownCast(node);
-    if (!storableNode || !storableNode->GetHideFromEditors() || !storableNode->GetSaveWithScene())
-    {
-      continue;
-    }
-
-    vtkMRMLStorageNode* storageNode = storableNode->GetStorageNode();
-    if (!storageNode)
-    {
-      qDebug() << "creating a new storage node for " << storableNode->GetID();
-      storableNode->AddDefaultStorageNode();
-      storageNode = storableNode->GetStorageNode();
-      if (!storageNode)
-      {
-        // no need for storage node to store this node
-        continue;
-      }
-    }
-
-    hiddenNodes.push_back(storableNode);
-  }
-
-  bool doneWithSaveDataDialog = true;
-  const int sceneRow = this->findSceneRow();
-  for (vtkMRMLStorableNode* hiddenNode : hiddenNodes)
-  {
-    vtkMRMLStorageNode* storageNode = hiddenNode->GetStorageNode();
-    if (!storageNode)
-    {
-      continue;
-    }
-
-    storageNode->GetUserMessages()->ClearMessages();
-
-    // save the node
-    qSlicerCoreIOManager* coreIOManager = qSlicerCoreApplication::application()->coreIOManager();
-    Q_ASSERT(coreIOManager);
-
-    QString strippedFileName = qSlicerCoreIOManager::forceFileNameValidCharacters(hiddenNode->GetName());
-    strippedFileName = coreIOManager->forceFileNameMaxLength(strippedFileName, 0);
-
-    // file properties
-    QString extension = storageNode->GetDefaultWriteFileExtension();
-    QString sceneDirectory = this->sceneFile().absoluteDir().absolutePath();
-    sceneDirectory = QDir::cleanPath(sceneDirectory + QDir::separator() + "Private");
-    QFileInfo file = QFileInfo(sceneDirectory, strippedFileName + "." + extension);
-
-    qSlicerIOOptions options;
-    qSlicerIO::IOFileType fileType = coreIOManager->fileWriterFileType(hiddenNode, extension);
-    qSlicerIO::IOProperties savingParameters = options.properties();
-    savingParameters["nodeID"] = QString(hiddenNode->GetID());
-    savingParameters["fileName"] = file.absoluteFilePath();
-    savingParameters["fileFormat"] = extension;
-
-    QApplication::setOverrideCursor(QCursor(Qt::BusyCursor));
-    bool success = coreIOManager->saveNodes(fileType, savingParameters);
-    QApplication::restoreOverrideCursor();
-
-    if (!success)
-    {
-      // Make sure an error message is added if saving returns with error
-      storageNode->GetUserMessages()->AddMessage(vtkCommand::ErrorEvent, (qSlicerSaveDataDialog::tr("Cannot write data file: %1.").arg(file.absoluteFilePath())).toStdString());
-
-#ifdef Q_OS_WIN
-      // On Windows, writing may have failed due to too long path.
-      // Let the user know via a warning message.
-
-      // If filename is very long then most likely the user should shorten that.
-      if (file.fileName().length() > 50)
-      {
-        storageNode->GetUserMessages()->AddMessage(
-          vtkCommand::WarningEvent, (qSlicerSaveDataDialog::tr("File writing may have failed because filename is too long: '%1'").arg(file.fileName())).toStdString());
-      }
-      // Maximum file path is 260 characters on most Windows systems, but during saving extra temporary folders may be used,
-      // therefore warn the user when getting near the maximum.
-      if (file.absoluteFilePath().length() > 200)
-      {
-        storageNode->GetUserMessages()->AddMessage(
-          vtkCommand::WarningEvent,
-          (qSlicerSaveDataDialog::tr("File writing may have failed because the output folder name is too long: '%1'").arg(file.absoluteFilePath())).toStdString());
-      }
-#endif
-
-      // Display any warning or error messages from the storage node
-      if (storageNode->GetUserMessages()->GetNumberOfMessages() > 0)
-      {
-        doneWithSaveDataDialog = false;
-      }
-    }
-
-    this->updateStatusIconFromMessageCollection(sceneRow, storageNode->GetUserMessages(), success);
-  }
 
   return doneWithSaveDataDialog;
 }

--- a/Base/QTGUI/qSlicerSaveDataDialog_p.h
+++ b/Base/QTGUI/qSlicerSaveDataDialog_p.h
@@ -65,7 +65,6 @@ protected slots:
   void formatChanged();
   bool saveScene();
   bool saveNodes();
-  bool saveHiddenNodes();
   QFileInfo sceneFile() const; // ### Slicer 4.4: Move as protected
   void showMoreColumns(bool);
   void updateSize();

--- a/Libs/MRML/Core/vtkArchive.cxx
+++ b/Libs/MRML/Core/vtkArchive.cxx
@@ -39,6 +39,15 @@ public:
     std::cout << s;
     std::cout.flush();
   }
+
+  static void Debug(const char* title, const char* message)
+  {
+    if (vtkArchiveTools::LogDebugEnabled)
+    {
+      vtkArchiveTools::Message(title, message);
+    }
+  }
+
   static void Error(const char* m1, const char* m2)
   {
     std::string message = "vtkArchive Error: ";
@@ -53,7 +62,11 @@ public:
     }
     vtkArchiveTools::Message(message.c_str(), "Error");
   }
+
+  static bool LogDebugEnabled;
 };
+
+bool vtkArchiveTools::LogDebugEnabled{ false };
 
 // --------------------------------------------------------------------------
 #define BSDTAR_FILESIZE_PRINTF "%lu"
@@ -420,7 +433,7 @@ bool vtkArchive::Zip(const char* zipFileName, const char* directoryToZip)
   sit = files.begin();
   while (sit != files.end() && success)
   {
-    vtkArchiveTools::Message("Zip: adding:", sit->c_str());
+    vtkArchiveTools::Debug("Zip: adding:", sit->c_str());
     const char* fileName = sit->c_str();
     ++sit;
 
@@ -431,7 +444,7 @@ bool vtkArchive::Zip(const char* zipFileName, const char* directoryToZip)
     // use a relative path for the entry file name, including the top
     // directory so it unzips into a directory of it's own
     std::string relFileName = vtksys::SystemTools::RelativePath(vtksys::SystemTools::GetParentDirectory(directoryToZip).c_str(), fileName);
-    vtkArchiveTools::Message("Zip: adding rel:", relFileName.c_str());
+    vtkArchiveTools::Debug("Zip: adding rel:", relFileName.c_str());
     archive_entry_set_pathname(entry, relFileName.c_str());
     // size is required, for now use the vtksys call though it uses struct stat
     // and may not be portable

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -1107,6 +1107,12 @@ int vtkMRMLScene::Commit(const char* url, vtkMRMLMessageCollection* userMessages
     // set the root directory from the URL
     this->RootDirectory = vtksys::SystemTools::GetParentDirectory(url);
 
+    // Save "private" storable nodes' data into a "<SceneFileName>_Private" subfolder next to
+    // the scene file, before writing node XML, so that storage nodes reference their final
+    // location. Always done (even if not modified since last read) to make sure no private
+    // node's data is lost.
+    this->SavePrivateStorableNodes(url, userMessages);
+
     // Open file
 #ifdef _WIN32
     ofs.open(url, std::ios::out | std::ios::binary);
@@ -3769,6 +3775,13 @@ bool vtkMRMLScene::GetModifiedSinceRead(vtkCollection* modifiedNodes /*=nullptr*
   }
 
   bool sceneModified = false;
+
+  if (this->GetPrivateStorableNodesModifiedSinceRead(modifiedNodes))
+  {
+    // At least one private storable node's data needs to be (re)written, so saving the
+    // scene now would change what is on disk, even if no node's MTime has changed.
+    sceneModified = true;
+  }
   vtkMRMLNode* node;
   vtkCollectionSimpleIterator it;
   for (this->Nodes->InitTraversal(it); (node = (vtkMRMLNode*)this->Nodes->GetNextItemAsObject(it));)
@@ -3803,6 +3816,35 @@ bool vtkMRMLScene::GetStorableNodesModifiedSinceRead(vtkCollection* modifiedStor
   for (storableNodes->InitTraversal(it); (storableNode = vtkMRMLStorableNode::SafeDownCast(storableNodes->GetNextItemAsObject(it)));)
   {
     if (!storableNode->GetHideFromEditors() && //
+        storableNode->GetModifiedSinceRead())
+    {
+      if (!storableNode->GetStorageNode() && storableNode->GetDefaultStorageNodeClassName().empty())
+      {
+        // The storable node does not have a storage node, but it does not need one (because content is stored in the scene
+        // (for example vtkMRMLTextNode containing short text).
+        continue;
+      }
+      found = true;
+      if (modifiedStorableNodes)
+      {
+        modifiedStorableNodes->AddItem(storableNode);
+      }
+    }
+  }
+  return found;
+}
+
+//-----------------------------------------------------------------------------
+bool vtkMRMLScene::GetPrivateStorableNodesModifiedSinceRead(vtkCollection* modifiedStorableNodes /*=nullptr*/)
+{
+  bool found = false;
+  vtkSmartPointer<vtkCollection> storableNodes;
+  storableNodes.TakeReference(this->GetNodesByClass("vtkMRMLStorableNode"));
+  vtkCollectionSimpleIterator it;
+  vtkMRMLStorableNode* storableNode;
+  for (storableNodes->InitTraversal(it); (storableNode = vtkMRMLStorableNode::SafeDownCast(storableNodes->GetNextItemAsObject(it)));)
+  {
+    if (storableNode->GetHideFromEditors() && storableNode->GetSaveWithScene() && //
         storableNode->GetModifiedSinceRead())
     {
       if (!storableNode->GetStorageNode() && storableNode->GetDefaultStorageNodeClassName().empty())
@@ -4306,23 +4348,6 @@ bool vtkMRMLScene::SaveSceneToSlicerDataBundleDirectory(const char* sdbDir, vtkI
     }
   }
 
-  // the new private directory
-  vtksys::SystemTools::SplitPath(rootDir.c_str(), pathComponents);
-  pathComponents.emplace_back(vtkMRMLScene::GetPrivateFolderName());
-  std::string privateDir = vtksys::SystemTools::JoinPath(pathComponents);
-  vtkDebugMacro("using private dir of " << privateDir);
-
-  // create the private dir
-  if (!vtksys::SystemTools::FileExists(privateDir.c_str()))
-  {
-    if (!vtksys::SystemTools::MakeDirectory(privateDir.c_str()))
-    {
-      vtkErrorToMessageCollectionMacro(
-        userMessages, "vtkMRMLScene::SaveSceneToSlicerDataBundleDirectory", "Save scene to data bundle directory failed: Unable to make private directory " << privateDir);
-      return false;
-    }
-  }
-
   //
   // start changing the scene - don't return from below here
   // until scene has been restored to original state
@@ -4361,13 +4386,31 @@ bool vtkMRMLScene::SaveSceneToSlicerDataBundleDirectory(const char* sdbDir, vtkI
       // and store them in the map by ID to avoid duplicates for the scene views
       vtkMRMLStorableNode* storableNode = vtkMRMLStorableNode::SafeDownCast(mrmlNode);
 
-      std::string saveDir = dataDir;
       if (storableNode->GetHideFromEditors())
       {
-        saveDir = privateDir;
+        if (storableNode->GetSaveWithScene())
+        {
+          // The scene's storage location has changed, so the hidden node's data needs to be
+          // (re)written, too. Commit() (called below) saves the data of all hidden storable
+          // nodes that are "ModifiedSinceRead" into a "<SceneFileName>_Private" subfolder.
+          // Record the current filenames here so that they can be restored to their original
+          // (pre-save) values further below.
+          vtkMRMLStorageNode* storageNode = storableNode->GetStorageNode();
+          if (storageNode)
+          {
+            std::vector<std::string>& fileNames = originalStorageNodeFileNames[storageNode];
+            fileNames.push_back(storageNode->GetFileName() ? storageNode->GetFileName() : "");
+            for (int fileIndex = 0; fileIndex < storageNode->GetNumberOfFileNames(); ++fileIndex)
+            {
+              fileNames.push_back(storageNode->GetNthFileName(fileIndex) ? storageNode->GetNthFileName(fileIndex) : "");
+            }
+          }
+          storableNode->StorableModified();
+        }
+        continue;
       }
 
-      if (!this->SaveStorableNodeToSlicerDataBundleDirectory(storableNode, saveDir, originalStorageNodeFileNames, userMessages))
+      if (!this->SaveStorableNodeToSlicerDataBundleDirectory(storableNode, dataDir, originalStorageNodeFileNames, userMessages))
       {
         success = false;
       }
@@ -4613,6 +4656,81 @@ bool vtkMRMLScene::SaveStorableNodeToSlicerDataBundleDirectory(vtkMRMLStorableNo
 }
 
 //----------------------------------------------------------------------------
+bool vtkMRMLScene::GetPrivateStorableNodesDirectory(const std::string& url, std::string& privateDir)
+{
+  privateDir.clear();
+
+  std::string sceneFileName = vtksys::SystemTools::GetFilenameWithoutExtension(url);
+
+  std::vector<std::string> pathComponents;
+  vtksys::SystemTools::SplitPath(this->RootDirectory.c_str(), pathComponents);
+  pathComponents.emplace_back(sceneFileName + "_Private");
+  std::string candidatePrivateDir = vtksys::SystemTools::JoinPath(pathComponents);
+
+  // Make sure the computed folder is a "<SceneFileName>_Private"-named subfolder of
+  // RootDirectory (with a non-empty SceneFileName), so that clearing it in
+  // SavePrivateStorableNodes() cannot remove an unrelated folder,
+  // for example if url or RootDirectory is empty or invalid.
+  if (sceneFileName.empty()
+      || vtksys::SystemTools::GetFilenamePath(vtksys::SystemTools::CollapseFullPath(candidatePrivateDir)) != vtksys::SystemTools::CollapseFullPath(this->RootDirectory))
+  {
+    return false;
+  }
+
+  privateDir = candidatePrivateDir;
+  return true;
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLScene::SavePrivateStorableNodes(const std::string& url, vtkMRMLMessageCollection* userMessages /*=nullptr*/)
+{
+  std::string privateDir;
+  if (!this->GetPrivateStorableNodesDirectory(url, privateDir))
+  {
+    vtkErrorToMessageCollectionMacro(userMessages, "vtkMRMLScene::SavePrivateStorableNodes", "Unable to determine private data folder for scene file " << url);
+    return false;
+  }
+
+  // Clear the private subfolder if it already exists, so that afterwards it only contains
+  // files for the private nodes that are saved below.
+  if (vtksys::SystemTools::FileIsDirectory(privateDir) && !vtksys::SystemTools::RemoveADirectory(privateDir))
+  {
+    vtkErrorToMessageCollectionMacro(userMessages, "vtkMRMLScene::SavePrivateStorableNodes", "Unable to clear directory " << privateDir);
+    return false;
+  }
+
+  std::vector<vtkMRMLNode*> storableNodes;
+  this->GetNodesByClass("vtkMRMLStorableNode", storableNodes);
+
+  bool success = true;
+  bool privateDirCreated = false;
+  std::map<vtkMRMLStorageNode*, std::vector<std::string>> originalStorageNodeFileNames;
+  for (vtkMRMLNode* node : storableNodes)
+  {
+    vtkMRMLStorableNode* storableNode = vtkMRMLStorableNode::SafeDownCast(node);
+    if (!storableNode->GetHideFromEditors() || !storableNode->GetSaveWithScene())
+    {
+      continue;
+    }
+    if (!privateDirCreated)
+    {
+      if (!vtksys::SystemTools::MakeDirectory(privateDir))
+      {
+        vtkErrorToMessageCollectionMacro(userMessages, "vtkMRMLScene::SavePrivateStorableNodes", "Unable to create directory " << privateDir);
+        return false;
+      }
+      privateDirCreated = true;
+    }
+
+    if (!this->SaveStorableNodeToSlicerDataBundleDirectory(storableNode, privateDir, originalStorageNodeFileNames, userMessages))
+    {
+      success = false;
+    }
+  }
+  return success;
+}
+
+//----------------------------------------------------------------------------
 std::string vtkMRMLScene::PercentEncode(std::string s)
 {
   std::string validchars = " -_.,@#$%^&()[]{}<>+=";
@@ -4675,10 +4793,4 @@ bool vtkMRMLScene::ParseVersion(const char* versionString, std::string& applicat
   patch = atoi(patchStr.c_str());
   revision = atoi(revisionStr.c_str());
   return true;
-}
-
-//-----------------------------------------------------------------------------
-std::string vtkMRMLScene::GetPrivateFolderName()
-{
-  return "Private";
 }

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -97,6 +97,8 @@ public:
   /// Save scene into URL
   /// If userMessages is not nullptr then the method may add messages to it about issues
   /// encountered during the operation.
+  /// Private storable nodes (i.e., storable nodes with HideFromEditors enabled) are saved
+  /// into <SceneFileName>_Private subfolder.
   /// Returns nonzero on success
   int Commit(const char* url = nullptr, vtkMRMLMessageCollection* userMessages = nullptr);
 
@@ -784,6 +786,13 @@ public:
   /// being in the list. Don't forget to clear it as soon as you don't need it.
   bool GetStorableNodesModifiedSinceRead(vtkCollection* modifiedStorableNodes = nullptr);
 
+  /// \brief Search the scene for private storable nodes (i.e., storable nodes with HideFromEditors enabled)
+  /// that are "ModifiedSinceRead".
+  ///
+  /// Returns true if at least 1 matching node is found.
+  /// If \a modifiedStorableNodes is passed the modified nodes are appended.
+  bool GetPrivateStorableNodesModifiedSinceRead(vtkCollection* modifiedStorableNodes = nullptr);
+
   /// \brief Search the scene for storable nodes that are not "ModifiedSinceRead".
   ///
   /// Useful after loading a scene from a temporary directory and deleting
@@ -850,9 +859,6 @@ public:
   /// determining extension automatically (for example, file extension of some.file.nii.gz
   /// could be gz, nii.gz, or file.nii.gz and only one of them is correct).
   static std::string CreateUniqueFileName(const std::string& filename, const std::string& knownExtension = "");
-
-  /// Returns name of the subfolder where hidden nodes (scene view nodes, etc.) are saved.
-  static std::string GetPrivateFolderName();
 
 protected:
   typedef std::map<std::string, std::set<std::string>> NodeReferencesType;
@@ -938,6 +944,30 @@ protected:
                                                    std::string& dataDir,
                                                    std::map<vtkMRMLStorageNode*, std::vector<std::string>>& originalStorageNodeFileNames,
                                                    vtkMRMLMessageCollection* userMessages);
+
+  /// \brief Computes the "<SceneFileName>_Private" subfolder path for \a url, where
+  /// SceneFileName is the scene file name without extension.
+  ///
+  /// The subfolder is prefixed with the scene file name
+  /// to avoid overwriting private files when multiple scenes are saved into the same folder.
+  ///
+  /// Returns false (and clears \a privateDir) if the folder cannot be safely determined,
+  /// for example if \a url has no file name, or if the computed folder would not be a
+  /// "<SceneFileName>_Private"-named subfolder of RootDirectory. This avoids accidentally
+  /// clearing or removing an unrelated, generically-named folder.
+  bool GetPrivateStorableNodesDirectory(const std::string& url, std::string& privateDir);
+
+  /// Saves data of all Private storable nodes (i.e., storable nodes with HideFromEditors
+  /// and SaveWithScene enabled) into a "<SceneFileName>_Private" subfolder next
+  /// to the scene file at \a url, where SceneFileName is the scene file name without extension.
+  /// Always called by Commit() (even if the private nodes are not modified since last read)
+  /// to make sure latest data is saved in the correct location.
+  /// If the private subfolder already exists and is not empty then it is cleared before
+  /// writing the new files into it.
+  /// Returns true on success.
+  /// If userMessages is not nullptr then the method may add messages to it about issues
+  /// encountered during the operation.
+  bool SavePrivateStorableNodes(const std::string& url, vtkMRMLMessageCollection* userMessages = nullptr);
 
   vtkCollection* Nodes;
 


### PR DESCRIPTION
Saving a scene as .mrb left a stray "Private" subfolder on disk next to the
bundle: private storable nodes (HideFromEditors + SaveWithScene) were written
into <sceneDir>/Private by a separate qSlicerSaveDataDialogPrivate::
saveHiddenNodes() step, run only from the GUI save dialog and unaware of the
temporary bundle directory cleanup.

Move this logic into vtkMRMLScene::Commit() instead, as
SavePrivateStorableNodes(), which writes private nodes' data into a
"<SceneFileName>_Private" subfolder colocated with the scene file. For .mrml
this is the folder next to the file; for .mrb it ends up inside the bundle
because Commit() is called with the bundle's internal .mrml path. This makes
private-node saving work for every Commit() caller (GUI save, WriteToMRB,
SaveSceneToSlicerDataBundleDirectory, scripting), not just the save dialog.

SavePrivateStorableNodes() always clears and rewrites the "_Private" folder
on every Commit() (even if private nodes are not modified since last read),
to make sure latest content is saved (otherwise the user would have no way
of forcing saving the full state of the scene).

GetModifiedSinceRead() now also returns true (and includes affected nodes in
modifiedNodes) if GetPrivateStorableNodesModifiedSinceRead() finds a private
node whose data needs (re)writing, so the Save dialog correctly flags the
scene as modified even when no node's MTime has changed.

Removed the old GetPrivateFolderName() "Private" folder convention, the
related setup in SaveSceneToSlicerDataBundleDirectory(), and the standalone
saveHiddenNodes() GUI step entirely. The private folder name is now prefixed
with the scene file's name to allow multiple scenes to be saved in a folder
without overwriting each other's private nodes on disk.

fixes #9229

Also made scene saving to MRB faster: vtkArchive logged a lot of messages
when many files were saved in the archive. Changed the behavior to not log
informational, debug-level messages by default.
