### PR TITLE
BUG: Fix crash loading table with unsupported schema column type

### DIFF
--- a/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx
@@ -560,6 +560,18 @@ void vtkMRMLTableStorageNode::AddColumnToTable(vtkTable* table, vtkMRMLTableStor
     // schema is not defined or no valid column type is defined for column
     valueTypeId = VTK_STRING;
   }
+  if (valueTypeId != VTK_STRING //
+      && vtkSmartPointer<vtkDataArray>::Take(vtkDataArray::CreateDataArray(valueTypeId)) == nullptr)
+  {
+    // Some value types (such as 'variant' or 'object') cannot be represented by a vtkDataArray,
+    // so vtkDataArray::CreateDataArray() returns nullptr for them. Fall back to reading the column
+    // as string instead of dereferencing the null array (which would crash the application).
+    vtkWarningToMessageCollectionMacro(this->GetUserMessages(),
+                                       "vtkMRMLTableStorageNode::AddColumnToTable",
+                                       "Column '" << columnName << "' has unsupported value type '" //
+                                                  << vtkMRMLTableNode::GetValueTypeAsString(valueTypeId) << "'. The column is read as string.");
+    valueTypeId = VTK_STRING;
+  }
   if (valueTypeId == VTK_STRING)
   {
     if (rawComponentArrays.size() > 0)
@@ -879,7 +891,19 @@ bool vtkMRMLTableStorageNode::WriteSchema(std::string filename, vtkMRMLTableNode
         schemaRowIndex = schemaTable->InsertNextBlankRow();
         columnNameArray->SetValue(schemaRowIndex, column->GetName());
       }
-      columnTypeArray->SetValue(schemaRowIndex, vtkMRMLTableNode::GetValueTypeAsString(column->GetDataType()));
+      int columnDataType = column->GetDataType();
+      if (columnDataType == VTK_VARIANT)
+      {
+        // Slicer cannot store a per-cell data type, so a variant array cannot be saved losslessly.
+        // The cell values are written to the data file as text anyway, so save the column as string
+        // (instead of an unsupported 'variant' type that would fail to load) and warn the user.
+        vtkWarningToMessageCollectionMacro(this->GetUserMessages(),
+                                           "vtkMRMLTableStorageNode::WriteSchema",
+                                           "Column '" << column->GetName() << "' has 'variant' type, which cannot be saved. "
+                                                      << "The column is saved as string.");
+        columnDataType = VTK_STRING;
+      }
+      columnTypeArray->SetValue(schemaRowIndex, vtkMRMLTableNode::GetValueTypeAsString(columnDataType));
     }
   }
 


### PR DESCRIPTION
## Fix crash and unsavable schema for variant (and other non-data-array) table columns

### Problem
A table column whose schema `type` has no `vtkDataArray` representation
(e.g. `variant`, `object`) was mishandled on both load and save:

- **Loading crashed Slicer.** Dropping a `.csv` next to a matching
  `*.schema.csv` that declares such a type crashed the application.
  Without the sidecar the columns default to string, so the crash only
  appeared when both files coexisted — making it look like a
  "two files in the same folder" problem.
- **Saving produced an unloadable file.** A `variant` array was written
  to the schema as type `variant`, which then crashed on reload.

Fixes #9211 

### Root cause
`vtkMRMLTableStorageNode` auto-detects the schema and applies the
declared column types.

- On read, `AddColumnToTable()` did:

  ```cpp
  vtkSmartPointer<vtkDataArray> typedColumn =
      vtkSmartPointer<vtkDataArray>::Take(vtkDataArray::CreateDataArray(valueTypeId));
  typedColumn->SetName(columnName.c_str());   // null deref → crash

`vtkDataArray::CreateDataArray(VTK_VARIANT)` returns `nullptr` because
a variant array is not a `vtkDataArray`, and the return value was
never null-checked.

- On write, `WriteSchema()` saved each column's type verbatim via `GetValueTypeAsString(column->GetDataType())`, emitting `variant` — a type Slicer cannot reconstruct because it has no per-cell data type.

### Fix
- Read ([`AddColumnToTable`](vscode-webview://12o6fpet9apja57d6ijnfmdf31of9s46l9kkkkiaq0alnh2djgof/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx)): probe whether the value type can create a `vtkDataArray`; if not, read the column as string and warn instead of crashing. Guards both the column and per-component array creation.
- Write ([`WriteSchema`](vscode-webview://12o6fpet9apja57d6ijnfmdf31of9s46l9kkkkiaq0alnh2djgof/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx)): if a column is a variant array, save it as `string` and warn, since the cell values are written as text anyway and a per-cell type cannot be preserved.

### Testing
- `MRMLCore` builds and links cleanly.
- Loading `stats.csv` + `stats.schema.csv` (with `type` = `variant`) no longer crashes; the column loads as string with a warning.
- Saving a table containing a variant column writes string in the schema and round-trips without crashing.