### PR TITLE
ENH: Add unique Slicerrc file for custom apps with ability to turn off

### DIFF
--- a/Applications/SlicerApp/Testing/Python/SlicerOptionIgnoreSlicerRCTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerOptionIgnoreSlicerRCTest.py
@@ -42,6 +42,19 @@ if __name__ == "__main__":
     slicer_executable = os.path.expanduser(sys.argv[1])
     common_args = ["--disable-modules", "--no-main-window"]
 
+    # Derive the RC environment variable name from the application executable name.
+    # For example: "Slicer" -> "SLICERRC", "MyApp" -> "MYAPPRC"
+    app_name = os.path.splitext(os.path.basename(slicer_executable))[0]
+    rc_env_var = f"{app_name.upper()}RC"
+
+    # Skip when Slicer_USE_SLICERRC is OFF. The --ignore-slicerrc flag is only
+    # registered when the feature is compiled in, so its presence in --help
+    # output serves as a reliable probe.
+    (_, helpStdout, helpStderr) = runSlicerAndExit(slicer_executable, ["--help"])
+    if "--ignore-slicerrc" not in (helpStdout + helpStderr):
+        print("Slicer_USE_SLICERRC is OFF: slicerrc tests skipped.")
+        exit(EXIT_SUCCESS)
+
     fd, slicerrc = tempfile.mkstemp()
     assert os.path.isfile(slicerrc)
     try:
@@ -54,10 +67,10 @@ if __name__ == "__main__":
                        "os.close(fd)\n")
 
         slicerrctestoutput = slicerrc + ".out"
-        os.environ["SLICERRC"] = slicerrc
+        os.environ[rc_env_var] = slicerrc
         os.environ["SLICERRCTESTOUTPUT"] = slicerrctestoutput
         if debug:
-            print("SLICERRC=%s" % slicerrc)
+            print(f"{rc_env_var}={slicerrc}")
             print("SLICERRCTESTOUTPUT=%s" % slicerrctestoutput)
 
         # Check that slicerrc file is loaded

--- a/Base/Python/slicerqt.py
+++ b/Base/Python/slicerqt.py
@@ -97,18 +97,26 @@ initLogging(logging.getLogger())
 
 def getSlicerRCFileName():
     """Return application startup file (Slicer resource script) file name.
-    If a .slicerrc.py file is found in slicer.app.slicerHome folder then that will be used.
-    If that is not found then it will search for a path defined in a SLICERRC environment variable.
-    If that environment variable is not specified or the path does not exist then .slicerrc.py in the user's home folder
-    will be used ('~/.slicerrc.py'). If the path does not exist then the default path in slicer.app.slicerHome will be used.
+    The filename convention is ``.<appname>rc.py`` where ``appname`` is
+    ``slicer.app.mainApplicationName.lower()``. For the base Slicer application
+    this resolves to ``.slicerrc.py``.
+    If such a file is found in the ``slicer.app.slicerHome`` folder then that will be used.
+    If that is not found then the path defined in the ``<APPNAME>RC`` environment variable
+    will be used (e.g. ``SLICERRC`` for the base Slicer application).
+    If that environment variable is not specified then the rc file in the user's home
+    folder will be used (e.g. ``~/.slicerrc.py``).
     """
     import os
 
-    # Ordered candidate paths
+    app_name = slicer.app.mainApplicationName
+    rc_filename = f".{app_name.lower()}rc.py"
+    env_var = f"{app_name.upper()}RC"
+
+    # Ordered candidate paths (highest to lowest priority)
     candidates = [
-        os.path.join(slicer.app.slicerHome, ".slicerrc.py"),
-        os.environ.get("SLICERRC"),
-        os.path.expanduser("~/.slicerrc.py"),
+        os.path.join(slicer.app.slicerHome, rc_filename),
+        os.environ.get(env_var),
+        os.path.expanduser(f"~/{rc_filename}"),
     ]
 
     # Default to application slicerHome path; pick first existing candidate
@@ -118,8 +126,7 @@ def getSlicerRCFileName():
             rcfile = c
             break
 
-    rcfile = rcfile.replace("\\", "/")  # make slashes consistent on Windows
-    return rcfile
+    return rcfile.replace("\\", "/")  # make slashes consistent on Windows
 
 
 # -----------------------------------------------------------------------------

--- a/Base/Python/slicerqt.py
+++ b/Base/Python/slicerqt.py
@@ -98,19 +98,27 @@ initLogging(logging.getLogger())
 def getSlicerRCFileName():
     """Return application startup file (Slicer resource script) file name.
     If a .slicerrc.py file is found in slicer.app.slicerHome folder then that will be used.
-    If that is not found then the path defined in SLICERRC environment variable will be used.
-    If that environment variable is not specified then .slicerrc.py in the user's home folder
-    will be used ('~/.slicerrc.py').
+    If that is not found then it will search for a path defined in a SLICERRC environment variable.
+    If that environment variable is not specified or the path does not exist then .slicerrc.py in the user's home folder
+    will be used ('~/.slicerrc.py'). If the path does not exist then the default path in slicer.app.slicerHome will be used.
     """
     import os
 
-    rcfile = os.path.join(slicer.app.slicerHome, ".slicerrc.py")
-    if not os.path.exists(rcfile):
-        if "SLICERRC" in os.environ:
-            rcfile = os.environ["SLICERRC"]
-        else:
-            rcfile = os.path.expanduser("~/.slicerrc.py")
-    rcfile = rcfile.replace("\\", "/")  # make slashed consistent on Windows
+    # Ordered candidate paths
+    candidates = [
+        os.path.join(slicer.app.slicerHome, ".slicerrc.py"),
+        os.environ.get("SLICERRC"),
+        os.path.expanduser("~/.slicerrc.py"),
+    ]
+
+    # Default to application slicerHome path; pick first existing candidate
+    rcfile = candidates[0]
+    for c in candidates:
+        if c and os.path.exists(c):
+            rcfile = c
+            break
+
+    rcfile = rcfile.replace("\\", "/")  # make slashes consistent on Windows
     return rcfile
 
 

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -1361,11 +1361,13 @@ void qSlicerCoreApplication::handleCommandLineArguments()
     pythonArgc = 0;
 
     // Attempt to load Slicer RC file only if 'display...AndExit' options are not True
+# ifdef Slicer_USE_SLICERRC
     if (!(options->displayMessageAndExit() || //
           options->ignoreSlicerRC()))
     {
       this->corePythonManager()->executeString("loadSlicerRCFile()");
     }
+# endif
 
     if (this->testAttribute(AA_EnableTesting))
     {

--- a/Base/QTCore/qSlicerCoreCommandOptions.cxx
+++ b/Base/QTCore/qSlicerCoreCommandOptions.cxx
@@ -156,9 +156,13 @@ bool qSlicerCoreCommandOptions::ignoreRest() const
 //-----------------------------------------------------------------------------
 bool qSlicerCoreCommandOptions::ignoreSlicerRC() const
 {
+#ifdef Slicer_USE_SLICERRC
   Q_D(const qSlicerCoreCommandOptions);
   return d->ParsedArgs.value("ignore-slicerrc").toBool() || //
          this->isTestingEnabled();
+#else
+  return false;
+#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -418,7 +422,7 @@ void qSlicerCoreCommandOptions::addArguments()
 #endif
                     /*no tr*/ "Display available command line arguments.");
 
-#ifdef Slicer_USE_PYTHONQT
+#if defined(Slicer_USE_PYTHONQT) && defined(Slicer_USE_SLICERRC)
   QString testingDescription = /*no tr*/ "Activate testing mode. It implies --disable-settings and --ignore-slicerrc.";
 #else
   QString testingDescription = /*no tr*/ "Activate testing mode. It implies --disable-settings.";
@@ -470,14 +474,16 @@ void qSlicerCoreCommandOptions::addArguments()
 # endif
                     /*no tr*/ "Python code to execute after slicer loads. By default, no modules are loaded and Slicer exits afterward.");
 
+# ifdef Slicer_USE_SLICERRC
   this->addArgument("ignore-slicerrc",
                     "",
-# if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#  if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
                     QMetaType::Bool,
-# else
+#  else
                     QVariant::Bool,
+#  endif
+                    /*no tr*/ "Do not load the application startup resource file.");
 # endif
-                    /*no tr*/ "Do not load the Slicer resource file (~/.slicerrc.py).");
 #endif
 
   this->addArgument("additional-module-path",

--- a/Base/QTGUI/qSlicerSettingsGeneralPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsGeneralPanel.cxx
@@ -124,6 +124,7 @@ void qSlicerSettingsGeneralPanelPrivate::init()
   this->ApplicationUpdateServerURLLineEdit->setVisible(applicationUpdateEnabled);
 
 #ifdef Slicer_USE_PYTHONQT
+# ifdef Slicer_USE_SLICERRC
   if (!qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))
   {
     PythonQt::init();
@@ -139,6 +140,11 @@ void qSlicerSettingsGeneralPanelPrivate::init()
     this->SlicerRCFileOpenButton->setVisible(false);
     this->SlicerRCFileValueLabel->setVisible(false);
   }
+# else
+  this->SlicerRCFileLabel->setVisible(false);
+  this->SlicerRCFileOpenButton->setVisible(false);
+  this->SlicerRCFileValueLabel->setVisible(false);
+# endif
 #else
   this->SlicerRCFileLabel->setVisible(false);
   this->SlicerRCFileValueLabel->setVisible(false);

--- a/CMake/vtkSlicerConfigure.h.in
+++ b/CMake/vtkSlicerConfigure.h.in
@@ -72,6 +72,7 @@
 #cmakedefine Slicer_BUILD_MULTIMEDIA_SUPPORT
 #cmakedefine Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT
 #cmakedefine Slicer_BUILD_WEBENGINE_SUPPORT
+#cmakedefine Slicer_USE_SLICERRC
 
 // CLI support is always enabled and cannot be disabled.
 // This variable is retained only for backward compatibility with dependent projects (e.g., Slicer extensions).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,11 @@ option(Slicer_USE_PYTHONQT "Integrate a Python-Qt interpreter into Slicer." ON)
 mark_as_superbuild(Slicer_USE_PYTHONQT)
 
 CMAKE_DEPENDENT_OPTION(
+  Slicer_USE_SLICERRC "Load application startup file (.<appname>rc.py or custom app equivalent)" ON
+  "Slicer_USE_PYTHONQT" OFF)
+mark_as_superbuild(Slicer_USE_SLICERRC)
+
+CMAKE_DEPENDENT_OPTION(
   Slicer_BUILD_QTSCRIPTEDMODULES "Build Slicer Python Qt Modules" ON
   "Slicer_USE_PYTHONQT" OFF)
 mark_as_advanced(Slicer_BUILD_QTSCRIPTEDMODULES)


### PR DESCRIPTION
This addresses the items discussed in https://discourse.slicer.org/t/cmake-flag-to-customapp-not-to-read-slicerrc-py-or-define-other-file/39046.

1. Per [comment](https://discourse.slicer.org/t/cmake-flag-to-customapp-not-to-read-slicerrc-py-or-define-other-file/39046/6?u=jamesobutler) the default location when no existing rc files exists is now the slicerHome location rather than in the user directory root.
2. Per [comment](https://discourse.slicer.org/t/cmake-flag-to-customapp-not-to-read-slicerrc-py-or-define-other-file/39046/2?u=jamesobutler) .slicerrc.py is no longer used by Slicer custom applications, but instead use their own application named rc file `.<mainApplicationName>rc.py`. 
3. Per suggestion in [comment](https://discourse.slicer.org/t/cmake-flag-to-customapp-not-to-read-slicerrc-py-or-define-other-file/39046?u=jamesobutler) Slicer custom applications can also configure to turn off application RC startup script usage entirely with a new build option `Slicer_USE_SLICERRC`. This is by default on, but can be configured to be turned off. When the app configures it off, the settings dialog entry for specifying the startup path location is hidden as well as the command line flag `ignore-slicerrc` not being added as it would be irrelevant.