### PR TITLE
Fix SubjectHierarchyFoldersTest1, vtkMRMLMarkupsStorageNodeTest2, vtkMRMLVolumePropertyNodeTest1

### DIFF
--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest2.cxx
@@ -135,7 +135,18 @@ int TestStoragNode(vtkMRMLMarkupsNode* markupsNode, vtkMRMLMarkupsStorageNode* s
 
   storageNode->SetFileName(fileName.c_str());
   std::cout << "Writing " << storageNode->GetFileName() << std::endl;
+  // Writing fcsv files is expected to log a deprecation warning.
+  bool isDeprecatedFcsvFormat = storageNode->IsA("vtkMRMLMarkupsFiducialStorageNode") != 0;
+  if (isDeprecatedFcsvFormat)
+  {
+    TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  }
   CHECK_BOOL(storageNode->WriteData(markupsNode), true);
+  if (isDeprecatedFcsvFormat)
+  {
+    TESTING_OUTPUT_ASSERT_WARNINGS(1);
+    TESTING_OUTPUT_ASSERT_WARNINGS_END();
+  }
 
   //
   // test read
@@ -204,7 +215,16 @@ int TestStoragNode(vtkMRMLMarkupsNode* markupsNode, vtkMRMLMarkupsStorageNode* s
   // test with RAS coordinate system
   storageNode->UseRASOn();
   std::cout << "Writing file in RAS coordinate system: " << storageNode->GetFileName() << std::endl;
+  if (isDeprecatedFcsvFormat)
+  {
+    TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  }
   CHECK_BOOL(storageNode->WriteData(markupsNode), true);
+  if (isDeprecatedFcsvFormat)
+  {
+    TESTING_OUTPUT_ASSERT_WARNINGS(1);
+    TESTING_OUTPUT_ASSERT_WARNINGS_END();
+  }
 
   // read it in after clearing out the test data
   // Set to use LPS to verify that not this hint but the coordinate system that

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyFoldersTest1.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyFoldersTest1.py
@@ -11,6 +11,7 @@ from slicer.util import DATA_STORE_URL
 class SubjectHierarchyFoldersTest1(unittest.TestCase):
     def setUp(self):
         """Do whatever is needed to reset the state - typically a scene clear will be enough."""
+        print("Log file is available at: " + slicer.app.errorLogModel().filePath)
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.cxx
@@ -420,7 +420,7 @@ void qSlicerSubjectHierarchyAbstractPlugin::setDisplayColor(vtkIdType itemID, QC
     terminologyMetadataOutput.setGeneratedColor(terminologyMetadataInput[qMRMLSubjectHierarchyModel::GeneratedColorRole].value<QColor>());
   }
 
-  this->setDisplayColor(itemID, color, terminologyMetadataInput);
+  this->setDisplayColor(itemID, color, terminologyMetadataOutput);
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumePropertyNodeTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumePropertyNodeTest1.cxx
@@ -86,9 +86,13 @@ int readOldScene(const char* mrmlScenePath)
   expectedScalarOpacity->AddPoint(0., 0.00001);
   expectedScalarOpacity->AddPoint(0.1, 1.0000);
   expectedScalarOpacity->AddPoint(7.0, 0.122);
-  // precision is important as it is used for "threshold" (points are very
-  // close to each other).
-  expectedScalarOpacity->AddPoint(7.000000000001, 1.0);
+  // The file purposely encodes this point right next to the previous one (a
+  // "threshold": 7.000000000001 instead of 7.0) to represent a sharp step.
+  // vtkMRMLVolumePropertyNode::NodesFromString() spaces out x coordinates
+  // that are closer than a float32-safe minimum (see HigherAndUnique()), so
+  // the point ends up shifted to vtkMRMLVolumePropertyNode::NextHigher(7.0)
+  // rather than keeping the literal value from the file.
+  expectedScalarOpacity->AddPoint(vtkMRMLVolumePropertyNode::NextHigher(7.0), 1.0);
   expectedScalarOpacity->AddPoint(10., 0.000000001);
 
   vtkPiecewiseFunction* actualScalarOpacity = vpNode->GetScalarOpacity();
@@ -116,7 +120,12 @@ int piecewiseFunctionFromString()
 {
   std::string s("10 0 0 4.94065645841247e-324 0 69.5504608154297"
                 " 0 154.266067504883 0.699999988079071 228 1");
-  double expectedData[10] = { 0, 0, 4.94065645841247e-324, 0, 69.5504608154297, 0, 154.266067504883, 0.699999988079071, 228, 1 };
+  // The second x value in the string (the smallest positive denormalized
+  // double) is closer to the first (0) than the float32-safe minimum spacing
+  // enforced by vtkMRMLVolumePropertyNode::NodesFromString() (see
+  // HigherAndUnique()), so it gets shifted to NextHigher(0) instead of
+  // keeping its literal value.
+  double expectedData[10] = { 0, 0, vtkMRMLVolumePropertyNode::NextHigher(0.0), 0, 69.5504608154297, 0, 154.266067504883, 0.699999988079071, 228, 1 };
   vtkSmartPointer<vtkPiecewiseFunction> function = vtkSmartPointer<vtkPiecewiseFunction>::New();
   vtkMRMLVolumePropertyNode::GetPiecewiseFunctionFromString(s, function);
   CHECK_INT(function->GetSize(), 5);


### PR DESCRIPTION
This PR fixes 3 tests. SubjectHierarchyFoldersTest1 uncovered an actual error. vtkMRMLMarkupsStorageNodeTest2 and vtkMRMLVolumePropertyNodeTest1 were just tests that were not updated after corresponding code changes.
