### PR TITLE
BUG: Fix duplicate Opacity slider for segments in subject hierarchy

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.cxx
@@ -196,6 +196,11 @@ double qSlicerSubjectHierarchyFolderPlugin::canOwnSubjectHierarchyItem(vtkIdType
     // Folder with no hierarchy node
     return 1.0;
   }
+  else if (shNode->IsItemLevel(itemID, vtkMRMLSubjectHierarchyConstants::GetSubjectHierarchyVirtualBranchAttributeName()))
+  {
+    // Virtual branch items (for example segments) are not folders, even though they have level information
+    return 0.0;
+  }
   else if (!shNode->GetItemLevel(itemID).empty())
   {
     // There is any level information (for example for DICOM levels which are also folders)


### PR DESCRIPTION
qSlicerSubjectHierarchyFolderPlugin::canOwnSubjectHierarchyItem recognized items in virtual branches (such as segments) as folders, which incorrectly included segment items. This made the generic Opacity subject hierarchy plugin believe it could create a folder display node for segments, causing a second, non-functional Opacity entry next to the segment's own working per-segment Opacity menu in the visibility menu.

<img width="1451" height="337" alt="image" src="https://github.com/user-attachments/assets/d18dd71e-ce69-4472-95d6-f48cdcb87d32" />
