### PR TITLE
DOC: Document CLI-test FP exception opt-out rationale in itkTestMain.h

### DIFF
--- a/Base/CLI/Testing/itkTestMain.h
+++ b/Base/CLI/Testing/itkTestMain.h
@@ -87,13 +87,58 @@ void PrintAvailableTests()
 
 int main(int ac, char* av[])
 {
-  // Floating point exceptions are trapped by default to catch genuine numerical
-  // errors in CLI modules. A few tests exercise third-party filters (e.g. VTK
-  // surface extraction) that raise benign floating point exceptions, and on
-  // macOS the operating system may even deliver a spurious SIGFPE for masked
-  // exceptions. Such test executables opt out by compiling with
-  // SLICER_CLI_TEST_DISABLE_FLOATING_POINT_EXCEPTIONS defined.
-  // See https://github.com/Slicer/Slicer/issues/9239
+  // ---------------------------------------------------------------------------
+  // Floating point exception trapping in CLI module tests
+  //
+  // By default this test driver enables ITK floating point exception trapping
+  // (itk::FloatingPointExceptions::Enable(), which unmasks FE_INVALID and
+  // FE_DIVBYZERO) so that a CLI module performing an invalid operation or a
+  // divide-by-zero aborts loudly instead of silently producing NaN/inf. Whether
+  // the capability is compiled in at all is autodetected by ITK per platform
+  // (Slicer's SuperBuild sets nothing): glibc Linux uses feenableexcept();
+  // macOS, which has no working feenableexcept(), uses the fegetenv()/fesetenv()
+  // fallback (see the _GNU_SOURCE / __APPLE__ handling in ITK's
+  // Modules/Core/Common/src/itkFloatingPointExceptions_unix.cxx).
+  //
+  // A test executable can opt OUT of this trapping by compiling with
+  // SLICER_CLI_TEST_DISABLE_FLOATING_POINT_EXCEPTIONS defined (set per target
+  // via target_compile_definitions() in the test's CMakeLists.txt). Trapping
+  // stays enabled for every other CLI test.
+  //
+  // Why some tests opt out (Slicer issue #9239, PR #9241):
+  // The ModelMaker and MergeModels CLI tests abort with SIGFPE on the macOS
+  // nightly dashboard, while the Linux and Windows nightlies of the same
+  // revision pass. Investigation showed these are false alarms, not defects in
+  // the modules under test:
+  //   - Every signal fires inside the stock VTK filter vtkDiscreteFlyingEdges3D
+  //     (Discrete Marching Cubes) during gradient/normal computation on a label
+  //     (step-function) image. Observed codes, in one run: FPE_FLTOVF ->
+  //     FPE_FLTRES -> FPE_FLTINV -> FPE_FLTRES.
+  //   - FE_UNDERFLOW (FLTUND) and FE_INEXACT (FLTRES) occur during normal,
+  //     correct floating point arithmetic; they are not errors. vtkMath::
+  //     Normalize() is zero-guarded, so a flat-region zero gradient does not
+  //     even produce a divide.
+  //   - The single FE_INVALID is a transient NaN inside that VTK filter; VTK is
+  //     not built or run with traps and produces a correct mesh. It is
+  //     third-party numerics, not a Slicer defect.
+  //   - macOS additionally over-traps: several aborts report all exceptions
+  //     masked in the FP control word (MXCSR 0x1f80 / x87 0x37f) yet a SIGFPE
+  //     was still delivered. This macOS behavior is long-standing - the Qt5/VTK8
+  //     migration recorded the same "SIGFPE with code FPE_FLTUND" on Mac for
+  //     ModelToLabelMapTest, ModelToLabelMapTestLabelValue and
+  //     N4ITKBiasFieldCorrectionTest
+  //     (https://www.slicer.org/wiki/Documentation/Labs/Qt5-and-VTK8).
+  //
+  // The same remedy was applied upstream in VTK by @RafaelPalomar in vtk!8799
+  // ("Disable floating point exceptions on some tests", vtk#17683,
+  // https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8799): disable trapping
+  // for the affected tests rather than chase benign exceptions into third-party
+  // numerics.
+  //
+  // The opt-out is currently scoped to macOS (if(APPLE) in the test
+  // CMakeLists.txt), so Linux and Windows keep real FE_INVALID/FE_DIVBYZERO
+  // coverage for these tests.
+  // ---------------------------------------------------------------------------
 #ifndef SLICER_CLI_TEST_DISABLE_FLOATING_POINT_EXCEPTIONS
   itk::FloatingPointExceptions::Enable();
 #endif


### PR DESCRIPTION
Follow-up to #9241 addressing @lassoan's review request:

> Please copy all the details from the pull request description to the source code (probably the best place is `Base\CLI\Testing\itkTestMain.h`), because both humans and AI agents are much more likely to find information in the source code; and the source code is likely to live much longer than github and PR comments.

This expands the comment at the `itk::FloatingPointExceptions::Enable()` guard in the CLI module test driver so the full rationale lives in-source rather than only in the PR/issue history. It documents:

- Why the driver traps floating point exceptions, and what `Enable()` unmasks (`FE_INVALID` / `FE_DIVBYZERO`).
- How ITK autodetects the capability per platform (glibc `feenableexcept` vs the macOS `fegetenv`/`fesetenv` fallback), with a pointer to `itkFloatingPointExceptions_unix.cxx`.
- Why the `ModelMaker` / `MergeModels` tests opt out on macOS: benign floating point from `vtkDiscreteFlyingEdges3D` (Discrete Marching Cubes) on a label image, plus macOS over-trapping (SIGFPE delivered with all exceptions masked), while Linux/Windows pass.
- The long-standing precedent — the Qt5/VTK8 migration recorded the same `FPE_FLTUND`-on-Mac for `ModelToLabelMapTest` etc., and the same remedy was applied upstream in VTK by @RafaelPalomar in [vtk!8799](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8799) (vtk#17683).
- The `SLICER_CLI_TEST_DISABLE_FLOATING_POINT_EXCEPTIONS` opt-out mechanism and its current `if(APPLE)` scoping.

Comment-only change; no functional difference. The original fix (#9241) is confirmed on the dashboard: the macOS nightly went from 14 failing tests to 2, with all eight `ModelMaker`/`MergeModels` SIGFPE aborts now passing (the 2 remaining failures are unrelated).

See #9239, #9241.

---

*This PR was prepared with AI assistance ([Claude Code](https://github.com/anthropics/claude-code), Anthropic Claude Opus 4.8 / `claude-opus-4-8`). The analysis and wording were reviewed by the author.*
