### PR TITLE
COMP: Add Meta AR video passthrough

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -171,7 +171,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "08210fbecda09bea2544dbb80777d634e1bfea25") # slicer-v9.5.2-2025-09-16-7c0494a68
     set(vtk_dist_info_version "9.5.2")
   elseif("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.6")
-    set(_git_tag "ddd10cf957df01f54eca6546e975e502ea248645") # slicer-v9.6.2-2026-05-15-f49a1dbaf
+    set(_git_tag "6181bb1223bbc499a340a1644f5356e7e152c318") # slicer-v9.6.2-2026-05-15-f49a1dbaf
     set(vtk_dist_info_version "9.6.2")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR.Slicer_VTK_VERSION_MINOR: ${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}")


### PR DESCRIPTION
Update VTK's OpenXR interface to work with OpenXR SDK release-1.1.58.

Slicer/VTK:
$ git shortlog ddd10cf957df01f54eca6546e975e502ea248645..6181bb1223bbc499a340a1644f5356e7e152c318 --no-merges Kyle Sunderland (3):
      ENH: Streamline frame state management into a single pathway
      ENH: Add Meta passthrough and environment depth occlusion support
      ENH: Add miscellaneous fixes for OpenXR update and passthrough