### PR TITLE
BUG: Install full Python include/ tree, not just pyconfig.h

### DIFF
--- a/CMake/SlicerBlockInstallDCMTKApps.cmake
+++ b/CMake/SlicerBlockInstallDCMTKApps.cmake
@@ -5,7 +5,7 @@
 set(DCMTK_Apps storescu storescp dcmdump dump2dcm img2dcm dcmdjpeg dcmqrscp dcm2xml xml2dcm dsr2html dsr2xml xml2dsr dsrdump echoscu)
 set(int_dir "")
 if(CMAKE_CONFIGURATION_TYPES)
-  set(int_dir "Release/")
+  set(int_dir "$<CONFIG>/")
 endif()
 foreach(dcmtk_App ${DCMTK_Apps})
   install(PROGRAMS ${DCMTK_DIR}/bin/${int_dir}${dcmtk_App}${CMAKE_EXECUTABLE_SUFFIX}

--- a/CMake/SlicerBlockInstallDCMTKLibs.cmake
+++ b/CMake/SlicerBlockInstallDCMTKLibs.cmake
@@ -6,7 +6,7 @@ find_package(DCMTK REQUIRED)
 foreach(dcmtk_Lib ${DCMTK_LIBRARIES})
   if(WIN32)
     if(CMAKE_CONFIGURATION_TYPES)
-      set(int_dir "Release/")
+      set(int_dir "$<CONFIG>/")
     endif()
     install(FILES ${DCMTK_DIR}/bin/${int_dir}${dcmtk_Lib}.dll
       DESTINATION ${Slicer_INSTALL_LIB_DIR} COMPONENT Runtime)

--- a/CMake/SlicerBlockInstallPython.cmake
+++ b/CMake/SlicerBlockInstallPython.cmake
@@ -87,6 +87,12 @@ To create a Slicer package including python libraries, you can *NOT* provide you
     install(FILES "${PYTHON_LIBRARY_PATH}/python3.dll"
       DESTINATION bin
       COMPONENT Runtime)
+    # Copy the import library (e.g. python312.lib). It is not needed to run Slicer, but
+    # without it, the installed Python cannot be used to build/link native extensions
+    # against the Python C API (e.g. compiling C++ kernels with torch.compile).
+    install(FILES "${PYTHON_LIBRARY}"
+      DESTINATION ${Slicer_INSTALL_ROOT}lib/Python/libs
+      COMPONENT Runtime)
   endif()
 
   # Install interpreter

--- a/CMake/SlicerBlockInstallPython.cmake
+++ b/CMake/SlicerBlockInstallPython.cmake
@@ -140,7 +140,7 @@ To create a Slicer package including python libraries, you can *NOT* provide you
     set(python_include_subdir /include/python${Slicer_PYTHON_VERSION_DOT}${Slicer_PYTHON_ABIFLAGS}/)
   endif()
 
-  install(FILES "${PYTHON_DIR}${python_include_subdir}/pyconfig.h"
+  install(DIRECTORY "${PYTHON_DIR}${python_include_subdir}"
     DESTINATION ${Slicer_INSTALL_ROOT}lib/Python${python_include_subdir}
     COMPONENT Runtime
     )


### PR DESCRIPTION
Bundle all Python header files (Python.h, cpython/, internal/, etc.) alongside the previously-installed pyconfig.h so that tools that JIT-compile C extensions against the bundled interpreter — such as torch.compile, Cython, pybind11, and numba — can find the headers they need without requiring a separately installed Python.

Fixes https://github.com/Slicer/Slicer/issues/9254