### PR TITLE
ENH: Add an option to allow translation by clicking anywhere in the slice view

### DIFF
--- a/Docs/user_guide/modules/markups.md
+++ b/Docs/user_guide/modules/markups.md
@@ -80,6 +80,7 @@ The following keyboard shortcuts are active when the markups toolbar is displaye
   - Visibility: Check `Visible` to enable translation/rotation/scaling of the entire markups in slice and 3D views with an interactive widget.
   - Translate, Rotate, Scale: enable/disable adjustment types.
   - Size: size of the handles (relative to the application window size).
+  - Opacity: overall opacity of the handle. It is combined with the orientation-based fading of handles.
   - More options: Clicking more options will show/hide check boxes for controlling the visibility of each interaction handle axis separately.
 - Advanced:
   - View: Select which views the markup is displayed in

--- a/Docs/user_guide/modules/transforms.md
+++ b/Docs/user_guide/modules/transforms.md
@@ -101,6 +101,10 @@ For macOS, refer to [alternate macOS keybindings](../user_interface.md#alternate
 | Any | `Right-click` during interaction | Cancel and return to original state |
 | Any | `Escape` during interaction | Cancel and return to original state |
 
+:::{note}
+In slice views, if "Enable view plane translation anywhere" is enabled (Display section / Interaction / More options), left-click and drag anywhere in the slice view adjusts the translation, instead of only when clicking precisely on the small handle at the center of the transform. While this option is enabled, that handle is drawn as a crosshair (with an empty center) instead of a filled circle. Dragging this crosshair modifies the position of the center of rotation.
+:::
+
 #### Context menu
 
 ![Context menu showing the following options when right-clicking on a transform node.](https://github.com/Slicer/Slicer/releases/download/docs-resources/interaction_context_menu_1.png)
@@ -153,6 +157,11 @@ This section allows visualization of how much and what direction of displacement
 ![Display options widget for controlling interaction handle visibility.](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_transforms_display_interaction.png)
 
 The interaction section controls the visibility of interaction handles for manual positioning of transforms. Individual axes can be enabled/disabled separately for 3D and Slice views by clicking the "More options" button.
+
+In the slice view's "More options" panel, the "Enable view plane translation anywhere" option allows adjusting translation by left-clicking and dragging anywhere in the slice view, instead of only by grabbing the small handle at the center of the transform. While this option is enabled, that handle is drawn as a crosshair (with an empty center) instead of a filled circle. This option is disabled by default, and only takes effect if translation is enabled for the slice view. The "View plane translation sensitivity" slider (default 0.2) controls how much the transform moves relative to the mouse cursor movement while dragging anywhere; it does not affect dragging handles.
+
+- Size: Size of the interaction handles, relative to the application window size (or as an absolute size in mm, if `absolute` is enabled).
+- Opacity: Overall opacity of the interaction handles, in addition to the fade effect that is already applied when a handle is viewed edge-on.
 
 #### Visualization modes
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.cxx
@@ -137,6 +137,7 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   this->RotationHandleVisibility = true;
   this->ScaleHandleVisibility = false;
   this->InteractionHandleScale = 3.0; // size of the handles as percent in screen size
+  this->InteractionHandleOpacity = 1.0;
 
   // By default, all interaction handle axes are visible
   for (int i = 0; i < 4; ++i)
@@ -200,6 +201,7 @@ void vtkMRMLMarkupsDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBooleanMacro(rotationHandleVisibility, RotationHandleVisibility);
   vtkMRMLWriteXMLBooleanMacro(scaleHandleVisibility, ScaleHandleVisibility);
   vtkMRMLWriteXMLFloatMacro(interactionHandleScale, InteractionHandleScale);
+  vtkMRMLWriteXMLFloatMacro(interactionHandleOpacity, InteractionHandleOpacity);
   vtkMRMLWriteXMLBooleanMacro(fillVisibility, FillVisibility);
   vtkMRMLWriteXMLBooleanMacro(outlineVisibility, OutlineVisibility);
   vtkMRMLWriteXMLFloatMacro(fillOpacity, FillOpacity);
@@ -256,6 +258,7 @@ void vtkMRMLMarkupsDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBooleanMacro(rotationHandleVisibility, RotationHandleVisibility);
   vtkMRMLReadXMLBooleanMacro(scaleHandleVisibility, ScaleHandleVisibility);
   vtkMRMLReadXMLFloatMacro(interactionHandleScale, InteractionHandleScale);
+  vtkMRMLReadXMLFloatMacro(interactionHandleOpacity, InteractionHandleOpacity);
   vtkMRMLReadXMLBooleanMacro(fillVisibility, FillVisibility);
   vtkMRMLReadXMLBooleanMacro(outlineVisibility, OutlineVisibility);
   vtkMRMLReadXMLFloatMacro(fillOpacity, FillOpacity);
@@ -344,6 +347,7 @@ void vtkMRMLMarkupsDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*
   vtkMRMLCopyBooleanMacro(RotationHandleVisibility);
   vtkMRMLCopyBooleanMacro(ScaleHandleVisibility);
   vtkMRMLCopyFloatMacro(InteractionHandleScale);
+  vtkMRMLCopyFloatMacro(InteractionHandleOpacity);
   vtkMRMLCopyBooleanMacro(FillVisibility);
   vtkMRMLCopyBooleanMacro(OutlineVisibility);
   vtkMRMLCopyFloatMacro(FillOpacity);
@@ -549,6 +553,7 @@ void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBooleanMacro(RotationHandleVisibility);
   vtkMRMLPrintBooleanMacro(ScaleHandleVisibility);
   vtkMRMLPrintFloatMacro(InteractionHandleScale);
+  vtkMRMLPrintFloatMacro(InteractionHandleOpacity);
   vtkMRMLPrintBooleanMacro(FillVisibility);
   vtkMRMLPrintBooleanMacro(OutlineVisibility);
   vtkMRMLPrintFloatMacro(FillOpacity);

--- a/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.h
@@ -510,6 +510,13 @@ public:
   //@}
 
   //@{
+  /// Get/Set opacity of the interaction handles.
+  /// This is combined with the orientation-based fading.
+  vtkSetClampMacro(InteractionHandleOpacity, double, 0.0, 1.0);
+  vtkGetMacro(InteractionHandleOpacity, double);
+  //@}
+
+  //@{
   /// Get/Set the visibility of the individual handle axes
   /// The order of the vector is: [X, Y, Z, ViewPlane]
   /// "ViewPlane" scale/translation allows transformations to take place along the active view plane.
@@ -608,6 +615,7 @@ protected:
   bool RotationHandleVisibility;
   bool ScaleHandleVisibility;
   double InteractionHandleScale;
+  double InteractionHandleOpacity;
 
   bool RotationHandleComponentVisibility[4];
   bool ScaleHandleComponentVisibility[4];

--- a/Libs/MRML/Core/vtkMRMLTransformDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformDisplayNode.cxx
@@ -97,6 +97,8 @@ vtkMRMLTransformDisplayNode::vtkMRMLTransformDisplayNode()
   this->EditorSliceIntersectionVisibility = true;
   this->EditorTranslationEnabled = true;
   this->EditorTranslationSliceEnabled = true;
+  this->EditorTranslationSliceAnywhereEnabled = false;
+  this->EditorTranslationSliceAnywhereSensitivity = 0.2;
   this->EditorRotationEnabled = true;
   this->EditorRotationSliceEnabled = true;
   this->EditorScalingEnabled = false;
@@ -165,9 +167,12 @@ void vtkMRMLTransformDisplayNode::WriteXML(ostream& of, int nIndent)
   of << " EditorScalingEnabled=\"" << this->EditorScalingEnabled << "\"";
 
   vtkMRMLWriteXMLBooleanMacro(EditorVisibility3D, EditorVisibility3D);
+  vtkMRMLWriteXMLBooleanMacro(EditorTranslationSliceAnywhereEnabled, EditorTranslationSliceAnywhereEnabled);
+  vtkMRMLWriteXMLFloatMacro(EditorTranslationSliceAnywhereSensitivity, EditorTranslationSliceAnywhereSensitivity);
   vtkMRMLWriteXMLFloatMacro(InteractionSizeAbsolute, InteractionSizeAbsolute);
   vtkMRMLWriteXMLFloatMacro(InteractionSizeMm, InteractionSizeMm);
   vtkMRMLWriteXMLFloatMacro(InteractionScalePercent, InteractionScalePercent);
+  vtkMRMLWriteXMLFloatMacro(InteractionHandleOpacity, InteractionHandleOpacity);
   vtkMRMLWriteXMLVectorMacro(TranslationHandleComponentVisibility3D, TranslationHandleComponentVisibility3D, bool, 4);
   vtkMRMLWriteXMLVectorMacro(RotationHandleComponentVisibility3D, RotationHandleComponentVisibility3D, bool, 4);
   vtkMRMLWriteXMLVectorMacro(ScaleHandleComponentVisibility3D, ScaleHandleComponentVisibility3D, bool, 4);
@@ -234,9 +239,12 @@ void vtkMRMLTransformDisplayNode::ReadXMLAttributes(const char** atts)
   READ_FROM_ATT(EditorScalingEnabled);
 
   vtkMRMLReadXMLBooleanMacro(EditorVisibility3D, EditorVisibility3D);
+  vtkMRMLReadXMLBooleanMacro(EditorTranslationSliceAnywhereEnabled, EditorTranslationSliceAnywhereEnabled);
+  vtkMRMLReadXMLFloatMacro(EditorTranslationSliceAnywhereSensitivity, EditorTranslationSliceAnywhereSensitivity);
   vtkMRMLReadXMLFloatMacro(InteractionSizeAbsolute, InteractionSizeAbsolute);
   vtkMRMLReadXMLFloatMacro(InteractionSizeMm, InteractionSizeMm);
   vtkMRMLReadXMLFloatMacro(InteractionScalePercent, InteractionScalePercent);
+  vtkMRMLReadXMLFloatMacro(InteractionHandleOpacity, InteractionHandleOpacity);
 
   vtkMRMLReadXMLVectorMacro(RotationHandleComponentVisibility3D, RotationHandleComponentVisibility3D, bool, 4);
   vtkMRMLReadXMLVectorMacro(ScaleHandleComponentVisibility3D, ScaleHandleComponentVisibility3D, bool, 4);
@@ -296,7 +304,10 @@ void vtkMRMLTransformDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy 
   vtkMRMLCopyBooleanMacro(EditorRotationEnabled);
   vtkMRMLCopyBooleanMacro(EditorScalingEnabled);
   vtkMRMLCopyBooleanMacro(EditorVisibility3D);
+  vtkMRMLCopyBooleanMacro(EditorTranslationSliceAnywhereEnabled);
+  vtkMRMLCopyFloatMacro(EditorTranslationSliceAnywhereSensitivity);
   vtkMRMLCopyBooleanMacro(EditorScalingSliceEnabled);
+  vtkMRMLCopyFloatMacro(InteractionHandleOpacity);
   vtkMRMLCopyVectorMacro(RotationHandleComponentVisibility3D, bool, 4);
   vtkMRMLCopyVectorMacro(ScaleHandleComponentVisibility3D, bool, 4);
   vtkMRMLCopyVectorMacro(TranslationHandleComponentVisibility3D, bool, 4);
@@ -343,6 +354,9 @@ void vtkMRMLTransformDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << " EditorScalingEnabled=\"" << this->EditorScalingEnabled << "\n";
 
   vtkMRMLPrintBooleanMacro(EditorVisibility3D);
+  vtkMRMLPrintBooleanMacro(EditorTranslationSliceAnywhereEnabled);
+  vtkMRMLPrintFloatMacro(EditorTranslationSliceAnywhereSensitivity);
+  vtkMRMLPrintFloatMacro(InteractionHandleOpacity);
   vtkMRMLPrintVectorMacro(RotationHandleComponentVisibility3D, bool, 4);
   vtkMRMLPrintVectorMacro(ScaleHandleComponentVisibility3D, bool, 4);
   vtkMRMLPrintVectorMacro(TranslationHandleComponentVisibility3D, bool, 4);

--- a/Libs/MRML/Core/vtkMRMLTransformDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformDisplayNode.h
@@ -186,6 +186,20 @@ public:
   vtkGetMacro(EditorTranslationSliceEnabled, bool);
   vtkSetMacro(EditorTranslationSliceEnabled, bool);
   vtkBooleanMacro(EditorTranslationSliceEnabled, bool);
+  /// If enabled, the transform can be translated in slice views by click-and-dragging
+  /// anywhere in the slice view, not at the small view plane translation handle.
+  /// Dragging the center moves the center of rotation point instead of changing the translation.
+  /// Only affects slice views (it has no effect in 3D views).
+  vtkGetMacro(EditorTranslationSliceAnywhereEnabled, bool);
+  vtkSetMacro(EditorTranslationSliceAnywhereEnabled, bool);
+  vtkBooleanMacro(EditorTranslationSliceAnywhereEnabled, bool);
+  /// Determines how much the transform translates in response to click-and-drag, when dragging
+  /// anywhere in the slice view (see EditorTranslationSliceAnywhereEnabled). 1.0 means the transform
+  /// moves in lock-step with the mouse cursor; lower values make the drag less sensitive, which makes
+  /// high-precision alignment easier. Default is 0.2.
+  /// Does not affect dragging transform handles (as a sensitivity != 1 would move the mouse pointer off the handle).
+  vtkSetClampMacro(EditorTranslationSliceAnywhereSensitivity, double, 0.0, 1.0);
+  vtkGetMacro(EditorTranslationSliceAnywhereSensitivity, double);
   vtkGetMacro(EditorRotationEnabled, bool);
   vtkSetMacro(EditorRotationEnabled, bool);
   vtkBooleanMacro(EditorRotationEnabled, bool);
@@ -226,6 +240,11 @@ public:
   vtkSetMacro(InteractionSizeAbsolute, bool);
   vtkGetMacro(InteractionSizeAbsolute, bool);
   vtkBooleanMacro(InteractionSizeAbsolute, bool);
+
+  /// Opacity of the interaction handles, in the range (0, 1].
+  /// This is combined with the fade effect that is already applied when a handle is viewed edge-on.
+  vtkSetClampMacro(InteractionHandleOpacity, double, 0.0, 1.0);
+  vtkGetMacro(InteractionHandleOpacity, double);
 
   /// The type of the active interaction handle.
   vtkSetMacro(ActiveInteractionType, int);
@@ -298,6 +317,8 @@ protected:
   bool EditorSliceIntersectionVisibility;
   bool EditorTranslationEnabled;
   bool EditorTranslationSliceEnabled;
+  bool EditorTranslationSliceAnywhereEnabled;
+  double EditorTranslationSliceAnywhereSensitivity;
   bool EditorRotationEnabled;
   bool EditorRotationSliceEnabled;
   bool EditorScalingEnabled;
@@ -308,6 +329,7 @@ protected:
   bool InteractionSizeAbsolute{ false };
   double InteractionSizeMm{ 5.0 };
   double InteractionScalePercent{ 15.0 };
+  double InteractionHandleOpacity{ 1.0 };
 
   bool RotationHandleComponentVisibility3D[4];
   bool ScaleHandleComponentVisibility3D[4];

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidget.cxx
@@ -154,30 +154,7 @@ bool vtkMRMLInteractionWidget::ProcessMouseMove(vtkMRMLInteractionEventData* eve
       || state == WidgetStateOnRotationHandle    //
       || state == WidgetStateOnScaleHandle)
   {
-    // update state
-    int foundComponentType = InteractionNone;
-    int foundComponentIndex = -1;
-    double closestDistance2 = 0.0;
-    rep->CanInteract(eventData, foundComponentType, foundComponentIndex, closestDistance2);
-    if (foundComponentType == InteractionNone)
-    {
-      this->SetWidgetState(WidgetStateIdle);
-    }
-    else if (foundComponentType == InteractionTranslationHandle)
-    {
-      this->SetWidgetState(WidgetStateOnTranslationHandle);
-    }
-    else if (foundComponentType == InteractionRotationHandle)
-    {
-      this->SetWidgetState(WidgetStateOnRotationHandle);
-    }
-    else if (foundComponentType == InteractionScaleHandle)
-    {
-      this->SetWidgetState(WidgetStateOnScaleHandle);
-    }
-
-    this->SetActiveComponentIndex(foundComponentIndex);
-    this->SetActiveComponentType(foundComponentType);
+    this->UpdateActiveComponent(eventData);
   }
   else
   {
@@ -326,25 +303,50 @@ bool vtkMRMLInteractionWidget::ProcessEndMouseDrag(vtkMRMLInteractionEventData* 
     return false;
   }
 
-  int activeComponentType = this->GetActiveComponentType();
-  if (activeComponentType == InteractionTranslationHandle)
-  {
-    this->SetWidgetState(WidgetStateOnTranslationHandle);
-  }
-  else if (activeComponentType == InteractionRotationHandle)
-  {
-    this->SetWidgetState(WidgetStateOnRotationHandle);
-  }
-  else if (activeComponentType == InteractionScaleHandle)
-  {
-    this->SetWidgetState(WidgetStateOnScaleHandle);
-  }
-
   this->EndWidgetInteraction();
+
+  // Update the active component and hover state based on where the cursor actually is now, instead of
+  // assuming that the handle that was being dragged is still the one under the cursor. This makes sure
+  // the state is correct even if no mouse move event arrives before the next button press.
+  this->UpdateActiveComponent(eventData);
 
   // only claim this as processed if the mouse was moved (this allows the event to be interpreted as button click)
   bool processedEvent = eventData->GetMouseMovedSinceButtonDown();
   return processedEvent;
+}
+
+//-------------------------------------------------------------------------
+void vtkMRMLInteractionWidget::UpdateActiveComponent(vtkMRMLInteractionEventData* eventData)
+{
+  vtkMRMLInteractionWidgetRepresentation* rep = vtkMRMLInteractionWidgetRepresentation::SafeDownCast(this->GetRepresentation());
+  if (!rep || !eventData)
+  {
+    return;
+  }
+
+  int foundComponentType = InteractionNone;
+  int foundComponentIndex = -1;
+  double closestDistance2 = 0.0;
+  rep->CanInteract(eventData, foundComponentType, foundComponentIndex, closestDistance2);
+  if (foundComponentType == InteractionNone)
+  {
+    this->SetWidgetState(WidgetStateIdle);
+  }
+  else if (foundComponentType == InteractionTranslationHandle)
+  {
+    this->SetWidgetState(WidgetStateOnTranslationHandle);
+  }
+  else if (foundComponentType == InteractionRotationHandle)
+  {
+    this->SetWidgetState(WidgetStateOnRotationHandle);
+  }
+  else if (foundComponentType == InteractionScaleHandle)
+  {
+    this->SetWidgetState(WidgetStateOnScaleHandle);
+  }
+
+  this->SetActiveComponentIndex(foundComponentIndex);
+  this->SetActiveComponentType(foundComponentType);
 }
 
 //-------------------------------------------------------------------------
@@ -531,6 +533,8 @@ void vtkMRMLInteractionWidget::TranslateWidget(double eventPos[2])
     translationVector_World[1] = distance * translationAxis_World[1];
     translationVector_World[2] = distance * translationAxis_World[2];
   }
+
+  vtkMath::MultiplyScalar(translationVector_World, rep->GetTranslationScaleFactor());
 
   vtkNew<vtkTransform> translationTransform;
   translationTransform->Translate(translationVector_World);

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidget.h
@@ -135,6 +135,13 @@ protected:
   virtual bool ProcessJumpCursor(vtkMRMLInteractionEventData* eventData);
   virtual bool ProcessCancelEvent(vtkMRMLInteractionEventData* eventData);
 
+  /// Update the active component and hover state (WidgetStateIdle/OnTranslationHandle/OnRotationHandle/
+  /// OnScaleHandle) based on the component currently found at the event position. Used while hovering
+  /// (ProcessMouseMove) and right after ending an interaction (ProcessEndMouseDrag), so that the widget
+  /// state reflects what is actually under the cursor instead of assuming it has not changed, even if
+  /// no further mouse move event arrives before the next button press.
+  virtual void UpdateActiveComponent(vtkMRMLInteractionEventData* eventData);
+
   virtual vtkMRMLNode* GetMRMLNode() = 0;
   virtual void SaveInitialState();
   virtual void RestoreInitialState();

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.cxx
@@ -70,6 +70,16 @@ static const double INTERACTION_TRANSLATION_HANDLE_LENGTH = 0.75;
 static const double INTERACTION_TRANSLATION_HANDLE_TIP_RADIUS = 0.15;
 static const double INTERACTION_TRANSLATION_HANDLE_SHAFT_RADIUS = 0.05;
 
+// Crosshair glyph: four short bars pointing away from the center, with a gap in the middle
+// so that whatever is underneath the handle position remains visible. Rendered as thin filled
+// quads (polygons), not as line primitives: VTK's "always on top" depth-offset trick used for the
+// interaction handles is applied much less reliably to line primitives than to polygons, which made
+// a line-based crosshair disappear intermittently (e.g. when another transform's handle was also
+// visible in the same slice view).
+static const double INTERACTION_HANDLE_CROSSHAIR_INNER_RADIUS = 0.10;
+static const double INTERACTION_HANDLE_CROSSHAIR_OUTER_RADIUS = 0.28;
+static const double INTERACTION_HANDLE_CROSSHAIR_BAR_HALF_WIDTH = 0.025;
+
 //----------------------------------------------------------------------
 vtkMRMLInteractionWidgetRepresentation::vtkMRMLInteractionWidgetRepresentation()
 {
@@ -155,7 +165,7 @@ void vtkMRMLInteractionWidgetRepresentation::CanInteract(vtkMRMLInteractionEvent
       continue;
     }
 
-    if (handleInfo.GlyphType == GlyphCircle)
+    if (handleInfo.GlyphType == GlyphCircle || handleInfo.GlyphType == GlyphCrosshair)
     {
       this->CanInteractWithCircleHandle(interactionEventData, foundComponentType, foundComponentIndex, closestDistance2, handleInfo);
     }
@@ -487,6 +497,14 @@ void vtkMRMLInteractionWidgetRepresentation::UpdateHandlePolyData()
   transformRingOutlineGlyph->SetInputData(this->Pipeline->RingOutlinePolyData);
   transformRingOutlineGlyph->SetTransform(transform);
 
+  vtkNew<vtkTransformPolyDataFilter> transformCrosshairGlyph;
+  transformCrosshairGlyph->SetInputData(this->Pipeline->CrosshairPolyData);
+  transformCrosshairGlyph->SetTransform(transform);
+
+  vtkNew<vtkTransformPolyDataFilter> transformCrosshairOutlineGlyph;
+  transformCrosshairOutlineGlyph->SetInputData(this->Pipeline->CrosshairOutlinePolyData);
+  transformCrosshairOutlineGlyph->SetTransform(transform);
+
   vtkTransformPolyDataFilter* transformGlyph = transformCircleGlyph;
   vtkTransformPolyDataFilter* transformOutlineGlyph = transformCircleOutlineGlyph;
 
@@ -512,6 +530,10 @@ void vtkMRMLInteractionWidgetRepresentation::UpdateHandlePolyData()
       case GlyphRing:
         transformGlyph = transformRingGlyph;
         transformOutlineGlyph = transformRingOutlineGlyph;
+        break;
+      case GlyphCrosshair:
+        transformGlyph = transformCrosshairGlyph;
+        transformOutlineGlyph = transformCrosshairOutlineGlyph;
         break;
       default: break;
     }
@@ -547,6 +569,15 @@ void vtkMRMLInteractionWidgetRepresentation::UpdateHandlePolyData()
     if (handleInfo.ComponentType == InteractionRotationHandle && handleInfo.Index == 3)
     {
       scale *= 1.2;
+    }
+    if (!handleInfo.IsVisible())
+    {
+      // Collapse hidden handles to a single degenerate point at the origin instead of leaving their
+      // full-size geometry in place with zero opacity. Otherwise the invisible geometry can still
+      // interfere with depth testing/blending of other (visible) handles that overlap it on screen,
+      // showing up as a transparent gap cutting through them (e.g. a hidden rotation ring, viewed
+      // edge-on, cutting a line through the translation handles).
+      scale = 0.0;
     }
     transform->Scale(scale, scale, scale);
     transform->Translate(point[0], point[1], point[2]);
@@ -891,6 +922,55 @@ vtkMRMLInteractionWidgetRepresentation::InteractionPipeline::InteractionPipeline
   this->CircleOutlinePolyData->SetLines(vtkNew<vtkCellArray>());
   this->CircleOutlinePolyData->InsertNextCell(VTK_POLY_LINE, scaleLine);
 
+  // Crosshair: four short thin bars pointing away from the center (+X, -X, +Y, -Y), leaving the
+  // center empty. Each bar is a thin quad (not a line primitive, see comment above on
+  // INTERACTION_HANDLE_CROSSHAIR_BAR_HALF_WIDTH), with an outline drawn around it, same as the other
+  // handle glyphs (circle, arrow, ring).
+  vtkNew<vtkPoints> crosshairPoints;
+  vtkNew<vtkCellArray> crosshairPolys;
+  vtkNew<vtkCellArray> crosshairLines;
+  double crosshairBarDirections[4][2] = {
+    { 1.0, 0.0 },
+    { -1.0, 0.0 },
+    { 0.0, 1.0 },
+    { 0.0, -1.0 },
+  };
+  for (int barIndex = 0; barIndex < 4; ++barIndex)
+  {
+    double along[2] = { crosshairBarDirections[barIndex][0], crosshairBarDirections[barIndex][1] };
+    double across[2] = { -along[1], along[0] }; // perpendicular to "along"
+
+    double innerPoint[2] = { along[0] * INTERACTION_HANDLE_CROSSHAIR_INNER_RADIUS, along[1] * INTERACTION_HANDLE_CROSSHAIR_INNER_RADIUS };
+    double outerPoint[2] = { along[0] * INTERACTION_HANDLE_CROSSHAIR_OUTER_RADIUS, along[1] * INTERACTION_HANDLE_CROSSHAIR_OUTER_RADIUS };
+
+    double barCorners[4][3] = {
+      { innerPoint[0] - across[0] * INTERACTION_HANDLE_CROSSHAIR_BAR_HALF_WIDTH, innerPoint[1] - across[1] * INTERACTION_HANDLE_CROSSHAIR_BAR_HALF_WIDTH, 0.0 },
+      { outerPoint[0] - across[0] * INTERACTION_HANDLE_CROSSHAIR_BAR_HALF_WIDTH, outerPoint[1] - across[1] * INTERACTION_HANDLE_CROSSHAIR_BAR_HALF_WIDTH, 0.0 },
+      { outerPoint[0] + across[0] * INTERACTION_HANDLE_CROSSHAIR_BAR_HALF_WIDTH, outerPoint[1] + across[1] * INTERACTION_HANDLE_CROSSHAIR_BAR_HALF_WIDTH, 0.0 },
+      { innerPoint[0] + across[0] * INTERACTION_HANDLE_CROSSHAIR_BAR_HALF_WIDTH, innerPoint[1] + across[1] * INTERACTION_HANDLE_CROSSHAIR_BAR_HALF_WIDTH, 0.0 },
+    };
+
+    vtkNew<vtkIdList> barPoly;
+    vtkNew<vtkIdList> barLine;
+    for (int cornerIndex = 0; cornerIndex < 4; ++cornerIndex)
+    {
+      vtkIdType id = crosshairPoints->InsertNextPoint(barCorners[cornerIndex]);
+      barPoly->InsertNextId(id);
+      barLine->InsertNextId(id);
+    }
+    barLine->InsertNextId(barLine->GetId(0));
+    crosshairPolys->InsertNextCell(barPoly);
+    crosshairLines->InsertNextCell(barLine);
+  }
+
+  this->CrosshairPolyData = vtkSmartPointer<vtkPolyData>::New();
+  this->CrosshairPolyData->SetPoints(crosshairPoints);
+  this->CrosshairPolyData->SetPolys(crosshairPolys);
+
+  this->CrosshairOutlinePolyData = vtkSmartPointer<vtkPolyData>::New();
+  this->CrosshairOutlinePolyData->SetPoints(crosshairPoints);
+  this->CrosshairOutlinePolyData->SetLines(crosshairLines);
+
   this->ScaleHandlePoints = vtkSmartPointer<vtkPolyData>::New();
 
   this->Append = vtkSmartPointer<vtkAppendPolyData>::New();
@@ -912,7 +992,7 @@ vtkMRMLInteractionWidgetRepresentation::InteractionPipeline::InteractionPipeline
 
   this->Property3D = vtkSmartPointer<vtkProperty>::New();
   this->Property3D->SetPointSize(1.e-6); // NOTE: The point size value must be greater than zero. Refer to vtkOpenGLState::vtkglPointSize(float).
-  this->Property3D->SetLineWidth(2.0);
+  this->Property3D->SetLineWidth(1.0);
   this->Property3D->SetDiffuse(0.0);
   this->Property3D->SetAmbient(1.0);
   this->Property3D->SetMetallic(0.0);
@@ -1283,7 +1363,6 @@ void vtkMRMLInteractionWidgetRepresentation::CreateScaleHandles()
   orientationArray->InsertNextTuple9(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
   orientationArray->InsertNextTuple9(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
   orientationArray->InsertNextTuple9(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
-  orientationArray->InsertNextTuple9(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0); // Free translation
   this->Pipeline->ScaleHandlePoints->GetPointData()->AddArray(orientationArray);
 
   vtkNew<vtkIdTypeArray> visibilityArray;
@@ -1436,7 +1515,7 @@ void vtkMRMLInteractionWidgetRepresentation::GetHandleColor(int type, int index,
   double opacity = this->GetHandleOpacity(type, index);
   if (selected)
   {
-    opacity = 1.0;
+    opacity = this->GetInteractionHandleOpacity();
   }
 
   for (int i = 0; i < 3; ++i)
@@ -1493,7 +1572,7 @@ double vtkMRMLInteractionWidgetRepresentation::GetHandleOpacity(int type, int in
   if (axis_World[0] == 0.0 && axis_World[1] == 0.0 && axis_World[2] == 0.0)
   {
     // No axis specified. The handle should be viewable from any direction.
-    return opacity;
+    return opacity * this->GetInteractionHandleOpacity();
   }
 
   double handlePosition_World[3] = { 0.0, 0.0, 0.0 };
@@ -1534,7 +1613,7 @@ double vtkMRMLInteractionWidgetRepresentation::GetHandleOpacity(int type, int in
       opacity = (difference / fadeAngleRange);
     }
   }
-  return opacity;
+  return opacity * this->GetInteractionHandleOpacity();
 }
 
 //----------------------------------------------------------------------
@@ -1933,6 +2012,18 @@ double vtkMRMLInteractionWidgetRepresentation::GetInteractionSizeMm()
 bool vtkMRMLInteractionWidgetRepresentation::GetInteractionSizeAbsolute()
 {
   return false;
+}
+
+//----------------------------------------------------------------------
+double vtkMRMLInteractionWidgetRepresentation::GetInteractionHandleOpacity()
+{
+  return 1.0;
+}
+
+//----------------------------------------------------------------------
+double vtkMRMLInteractionWidgetRepresentation::GetTranslationScaleFactor()
+{
+  return 1.0;
 }
 
 //----------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.h
@@ -143,7 +143,8 @@ public:
   {
     GlyphArrow,
     GlyphCircle,
-    GlyphRing
+    GlyphRing,
+    GlyphCrosshair
   };
 
   virtual int GetActiveComponentType() = 0;
@@ -168,6 +169,11 @@ public:
   virtual void GetHandleColor(int type, int index, double color[4]);
   /// Get the opacity of the specified handle
   virtual double GetHandleOpacity(int type, int index);
+  /// Get the overall opacity multiplier applied to all interaction handles. Default is 1.0.
+  virtual double GetInteractionHandleOpacity();
+  /// Get the factor that the translation vector is scaled by during an interactive translate
+  /// operation. Default is 1.0 (no scaling).
+  virtual double GetTranslationScaleFactor();
   /// Get the visibility of the specified handle
   virtual bool GetHandleVisibility(int type, int index);
   ///  Get the type of glyph (Arrow, Circle, Ring, etc.) of the specified handle.
@@ -200,9 +206,11 @@ protected:
     vtkSmartPointer<vtkPolyData> ArrowPolyData;
     vtkSmartPointer<vtkPolyData> CirclePolyData;
     vtkSmartPointer<vtkPolyData> RingPolyData;
+    vtkSmartPointer<vtkPolyData> CrosshairPolyData;
     vtkSmartPointer<vtkPolyData> ArrowOutlinePolyData;
     vtkSmartPointer<vtkPolyData> CircleOutlinePolyData;
     vtkSmartPointer<vtkPolyData> RingOutlinePolyData;
+    vtkSmartPointer<vtkPolyData> CrosshairOutlinePolyData;
 
     std::map<std::pair<int, int>, vtkSmartPointer<vtkPolyData>> HandleGlyphPolyDataMap;
     std::map<std::pair<int, int>, vtkSmartPointer<vtkPolyData>> HandleOutlineGlyphPolyDataMap;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidgetRepresentation.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidgetRepresentation.cxx
@@ -619,6 +619,12 @@ bool vtkSlicerMarkupsInteractionWidgetRepresentation::GetInteractionSizeAbsolute
 }
 
 //----------------------------------------------------------------------
+double vtkSlicerMarkupsInteractionWidgetRepresentation::GetInteractionHandleOpacity()
+{
+  return this->GetDisplayNode()->GetInteractionHandleOpacity();
+}
+
+//----------------------------------------------------------------------
 bool vtkSlicerMarkupsInteractionWidgetRepresentation::GetHandleVisibility(int type, int index)
 {
   if (!this->GetDisplayNode())
@@ -876,7 +882,7 @@ void vtkSlicerMarkupsInteractionWidgetRepresentation::GetHandleColor(int type, i
   if (this->GetActiveComponentType() == type && this->GetActiveComponentIndex() == index)
   {
     currentColor = selectedColor;
-    opacity = 1.0;
+    opacity = this->GetInteractionHandleOpacity();
   }
 
   for (int i = 0; i < 3; ++i)

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidgetRepresentation.h
@@ -81,6 +81,7 @@ public:
   double GetInteractionScalePercent() override; // Size relative to screen
   double GetInteractionSizeMm() override;       // Size in mm
   bool GetInteractionSizeAbsolute() override;   // True -> size in mm; false -> relative to screen
+  double GetInteractionHandleOpacity() override;
 
   void GetInteractionHandlePositionWorld(int type, int index, double positionWorld[3]) override;
 

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsInteractionHandleWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsInteractionHandleWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>370</width>
-    <height>115</height>
+    <height>140</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -187,6 +187,29 @@
      </property>
      <property name="suffix">
       <string> %</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Opacity:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="2" colspan="9">
+    <widget class="ctkSliderWidget" name="interactionHandleOpacitySlider">
+     <property name="singleStep">
+      <double>0.010000000000000</double>
+     </property>
+     <property name="pageStep">
+      <double>0.100000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>1.000000000000000</double>
      </property>
     </widget>
    </item>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsInteractionHandleWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsInteractionHandleWidget.cxx
@@ -75,6 +75,7 @@ void qMRMLMarkupsInteractionHandleWidgetPrivate::init()
   QObject::connect(this->scaleZCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
   QObject::connect(this->scaleViewPlaneCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
   QObject::connect(this->interactionHandleScaleSlider, SIGNAL(valueChanged(double)), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->interactionHandleOpacitySlider, SIGNAL(valueChanged(double)), q, SLOT(updateMRMLFromWidget()));
 
   this->xLabel->hide();
   this->yLabel->hide();
@@ -148,6 +149,7 @@ void qMRMLMarkupsInteractionHandleWidget::updateWidgetFromMRML()
   d->scaleYCheckBox->setEnabled(d->DisplayNode != nullptr);
   d->scaleZCheckBox->setEnabled(d->DisplayNode != nullptr);
   d->interactionHandleScaleSlider->setEnabled(d->DisplayNode != nullptr);
+  d->interactionHandleOpacitySlider->setEnabled(d->DisplayNode != nullptr);
 
   if (!d->DisplayNode)
   {
@@ -247,6 +249,10 @@ void qMRMLMarkupsInteractionHandleWidget::updateWidgetFromMRML()
   }
   d->interactionHandleScaleSlider->setValue(d->DisplayNode->GetInteractionHandleScale());
   wasBlocking = d->interactionHandleScaleSlider->blockSignals(wasBlocking);
+
+  wasBlocking = d->interactionHandleOpacitySlider->blockSignals(true);
+  d->interactionHandleOpacitySlider->setValue(d->DisplayNode->GetInteractionHandleOpacity());
+  d->interactionHandleOpacitySlider->blockSignals(wasBlocking);
 }
 
 // --------------------------------------------------------------------------
@@ -276,4 +282,5 @@ void qMRMLMarkupsInteractionHandleWidget::updateMRMLFromWidget()
   d->DisplayNode->SetScaleHandleVisibility(d->scaleVisibilityCheckBox->isChecked());
 
   d->DisplayNode->SetInteractionHandleScale(d->interactionHandleScaleSlider->value());
+  d->DisplayNode->SetInteractionHandleOpacity(d->interactionHandleOpacitySlider->value());
 }

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidget.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidget.cxx
@@ -75,6 +75,26 @@ bool vtkMRMLTransformHandleWidget::CanProcessInteractionEvent(vtkMRMLInteraction
   bool canProcess = Superclass::CanProcessInteractionEvent(eventData, distance2);
   if (canProcess)
   {
+    // The "wide" hit-test area (clicking anywhere in the slice view, away from the actual handle) is
+    // given a much lower priority than a precise handle grab, so that it only claims events that no
+    // other, more specific widget wants (it does not take over events that another widget needs).
+    // Once an interaction has actually started, keep the usual high priority so that the drag is not
+    // interrupted by another widget claiming a closer hit partway through.
+    bool activelyInteracting = (this->WidgetState == WidgetStateTranslate       //
+                                || this->WidgetState == WidgetStateRotate       //
+                                || this->WidgetState == WidgetStateScale        //
+                                || this->WidgetState == WidgetStateUniformScale //
+                                || this->WidgetState == WidgetStateTranslateTransformCenter);
+    vtkMRMLTransformHandleWidgetRepresentation* rep = vtkMRMLTransformHandleWidgetRepresentation::SafeDownCast(this->GetRepresentation());
+    if (!activelyInteracting && rep && rep->GetLastInteractionWasWideHit())
+    {
+      // Lower priority than precise handle grabs and explicit single-purpose tool modes (e.g. ~1e9),
+      // but higher priority than generic view background actions (e.g. ~1e10), matching the convention
+      // used by vtkMRMLWindowLevelWidget and vtkMRMLSliceIntersectionWidget. The actual (squared) display
+      // distance to the transform center is added on top, so that if multiple transforms can be dragged
+      // from anywhere in the same slice view, the one whose center is closest to the cursor wins.
+      distance2 = 5e9 + rep->GetLastSliceWideHitDistance2();
+    }
     return true;
   }
 
@@ -194,6 +214,13 @@ vtkMRMLTransformNode* vtkMRMLTransformHandleWidget::GetTransformNode()
 bool vtkMRMLTransformHandleWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData)
 {
   unsigned long widgetEvent = this->TranslateInteractionEventToWidgetEvent(eventData);
+  if (widgetEvent == WidgetEventTranslateStart && this->ShouldTranslateTransformCenter())
+  {
+    // A plain click-and-drag of the view plane translation handle normally translates the transform,
+    // but while slice-wide translation is enabled, any other click in the slice view already does
+    // that, so grabbing the handle itself instead moves the center of transformation.
+    widgetEvent = WidgetEventTranslateTransformCenterStart;
+  }
 
   bool processedEvent = false;
   switch (widgetEvent)
@@ -204,6 +231,27 @@ bool vtkMRMLTransformHandleWidget::ProcessInteractionEvent(vtkMRMLInteractionEve
     default: processedEvent = Superclass::ProcessInteractionEvent(eventData); break;
   }
   return processedEvent;
+}
+
+//-------------------------------------------------------------------------
+bool vtkMRMLTransformHandleWidget::ShouldTranslateTransformCenter()
+{
+  vtkMRMLTransformHandleWidgetRepresentation* rep = vtkMRMLTransformHandleWidgetRepresentation::SafeDownCast(this->GetRepresentation());
+  vtkMRMLTransformDisplayNode* displayNode = this->GetDisplayNode();
+  if (!rep || !displayNode || !rep->GetSliceNode() || !displayNode->GetEditorTranslationSliceAnywhereEnabled())
+  {
+    return false;
+  }
+
+  if (this->GetActiveComponentType() != InteractionTranslationHandle //
+      || this->GetActiveComponentIndex() != vtkMRMLTransformHandleWidgetRepresentation::HandleIndexViewPlane)
+  {
+    return false;
+  }
+
+  // A precise grab of the handle moves the center of transformation; a "wide" click elsewhere in the
+  // slice view (anywhere away from the handle) translates the transform as usual.
+  return !rep->GetLastInteractionWasWideHit();
 }
 
 //-------------------------------------------------------------------------
@@ -232,13 +280,12 @@ bool vtkMRMLTransformHandleWidget::ProcessEndMouseDrag(vtkMRMLInteractionEventDa
     return Superclass::ProcessEndMouseDrag(eventData);
   }
 
-  int activeComponentType = this->GetActiveComponentType();
-  if (activeComponentType == InteractionTranslationHandle)
-  {
-    this->SetWidgetState(WidgetStateOnTranslationHandle);
-  }
-
   this->EndWidgetInteraction();
+
+  // Update the active component and hover state based on where the cursor actually is now, instead of
+  // assuming that the handle that was being dragged is still the one under the cursor. This makes sure
+  // the state is correct even if no mouse move event arrives before the next button press.
+  this->UpdateActiveComponent(eventData);
 
   // only claim this as processed if the mouse was moved (this allows the event to be interpreted as button click)
   bool processedEvent = eventData->GetMouseMovedSinceButtonDown();

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidget.h
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidget.h
@@ -82,6 +82,15 @@ protected:
   ~vtkMRMLTransformHandleWidget() override;
 
   virtual bool ProcessWidgetTranslateTransformCenterStart(vtkMRMLInteractionEventData* eventData);
+
+  /// True if a plain (non-Alt) click-and-drag of the active handle should move the center of
+  /// transformation instead of translating the transform. This is the case when the view plane
+  /// translation handle is grabbed precisely (not via the "wide" click-anywhere hit-test area) while
+  /// vtkMRMLTransformDisplayNode::GetEditorTranslationSliceAnywhereEnabled() is true in a slice view:
+  /// since any other click in the view already translates the transform, the handle itself is freed
+  /// up to adjust the center of transformation instead.
+  virtual bool ShouldTranslateTransformCenter();
+
   bool ProcessMouseMove(vtkMRMLInteractionEventData* eventData) override;
   bool ProcessEndMouseDrag(vtkMRMLInteractionEventData* eventData) override;
   bool ProcessWidgetMenu(vtkMRMLInteractionEventData* eventData) override;

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidgetRepresentation.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidgetRepresentation.cxx
@@ -20,7 +20,9 @@
 
 // VTK includes
 #include <vtkGeneralTransform.h>
+#include <vtkMath.h>
 #include <vtkMatrix4x4.h>
+#include <vtkNew.h>
 
 // Transform MRMLDM includes
 #include "vtkMRMLTransformHandleWidgetRepresentation.h"
@@ -192,6 +194,119 @@ double vtkMRMLTransformHandleWidgetRepresentation::GetInteractionSizeMm()
 bool vtkMRMLTransformHandleWidgetRepresentation::GetInteractionSizeAbsolute()
 {
   return this->GetDisplayNode()->GetInteractionSizeAbsolute();
+}
+
+//----------------------------------------------------------------------
+double vtkMRMLTransformHandleWidgetRepresentation::GetInteractionHandleOpacity()
+{
+  return this->GetDisplayNode()->GetInteractionHandleOpacity();
+}
+
+//----------------------------------------------------------------------
+double vtkMRMLTransformHandleWidgetRepresentation::GetTranslationScaleFactor()
+{
+  vtkMRMLTransformDisplayNode* displayNode = this->GetDisplayNode();
+  if (this->LastInteractionWasWideHit && displayNode)
+  {
+    return displayNode->GetEditorTranslationSliceAnywhereSensitivity();
+  }
+  return 1.0;
+}
+
+//----------------------------------------------------------------------
+int vtkMRMLTransformHandleWidgetRepresentation::GetHandleGlyphType(int type, int index)
+{
+  vtkMRMLTransformDisplayNode* displayNode = this->GetDisplayNode();
+  if (type == InteractionTranslationHandle && index == HandleIndexViewPlane && this->GetSliceNode() //
+      && displayNode && displayNode->GetEditorTranslationSliceAnywhereEnabled())
+  {
+    return GlyphCrosshair;
+  }
+  return this->Superclass::GetHandleGlyphType(type, index);
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLTransformHandleWidgetRepresentation::GetHandleColor(int type, int index, double color[4])
+{
+  if (!color)
+  {
+    return;
+  }
+
+  // Covers both the view plane translation handle (rendered as a plain circle, or as a crosshair
+  // when wide translation is enabled, see GetHandleGlyphType()) and the in-plane rotation handle.
+  bool isViewPlaneTranslation = (type == InteractionTranslationHandle && index == HandleIndexViewPlane);
+  bool isInPlaneRotation = (type == InteractionRotationHandle && index == HandleIndexViewPlane);
+  if (!isViewPlaneTranslation && !isInPlaneRotation)
+  {
+    this->Superclass::GetHandleColor(type, index, color);
+    return;
+  }
+
+  bool selected = this->GetActiveComponentType() == type && this->GetActiveComponentIndex() == index;
+  // Same value (0.8) and saturation (0.5625) as the red/green/blue axis colors below, at the cyan hue.
+  double cyan[3] = { 0.35, 0.80, 0.80 };
+  double cyanSelected[3] = { 0.07, 0.70, 0.70 };
+  double* currentColor = selected ? cyanSelected : cyan;
+
+  double opacity = this->GetHandleOpacity(type, index);
+  if (selected)
+  {
+    opacity = this->GetInteractionHandleOpacity();
+  }
+
+  for (int i = 0; i < 3; ++i)
+  {
+    color[i] = currentColor[i];
+  }
+  color[3] = opacity;
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLTransformHandleWidgetRepresentation::CanInteract(vtkMRMLInteractionEventData* interactionEventData,
+                                                             int& foundComponentType,
+                                                             int& foundComponentIndex,
+                                                             double& closestDistance2)
+{
+  this->LastInteractionWasWideHit = false;
+
+  this->Superclass::CanInteract(interactionEventData, foundComponentType, foundComponentIndex, closestDistance2);
+  if (foundComponentType != InteractionNone)
+  {
+    // A handle was hit precisely, prefer that over the wide hit-test area below.
+    return;
+  }
+
+  vtkMRMLTransformDisplayNode* displayNode = this->GetDisplayNode();
+  vtkMRMLSliceNode* sliceNode = this->GetSliceNode();
+  if (!this->IsDisplayable() || !displayNode || !displayNode->GetEditorTranslationSliceAnywhereEnabled() //
+      || !sliceNode                                                                                      // wide dragging is only supported in slice views
+      || !interactionEventData || !interactionEventData->IsDisplayPositionValid()                        //
+      || !this->GetHandleVisibility(InteractionTranslationHandle, HandleIndexViewPlane))                 // view plane translation handle must be enabled
+  {
+    return;
+  }
+
+  // Compute the (squared) display-coordinate distance between the event position and the transform
+  // center, so that if multiple transforms can be dragged from anywhere in the same slice view, the
+  // one whose center is closest to the cursor can be given priority.
+  double handleWorldPos[3] = { 0.0, 0.0, 0.0 };
+  this->GetInteractionHandlePositionWorld(InteractionTranslationHandle, HandleIndexViewPlane, handleWorldPos);
+  double handleWorldPos4[4] = { handleWorldPos[0], handleWorldPos[1], handleWorldPos[2], 1.0 };
+
+  vtkNew<vtkMatrix4x4> rasToxyMatrix;
+  vtkMatrix4x4::Invert(sliceNode->GetXYToRAS(), rasToxyMatrix);
+  double handleDisplayPos[4] = { 0.0, 0.0, 0.0, 1.0 };
+  rasToxyMatrix->MultiplyPoint(handleWorldPos4, handleDisplayPos);
+  handleDisplayPos[2] = 0.0; // Handles are always projected
+
+  const int* displayPosition = interactionEventData->GetDisplayPosition();
+  double displayPosition3[3] = { static_cast<double>(displayPosition[0]), static_cast<double>(displayPosition[1]), 0.0 };
+
+  foundComponentType = InteractionTranslationHandle;
+  foundComponentIndex = HandleIndexViewPlane;
+  this->LastSliceWideHitDistance2 = vtkMath::Distance2BetweenPoints(handleDisplayPos, displayPosition3);
+  this->LastInteractionWasWideHit = true;
 }
 
 //----------------------------------------------------------------------

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidgetRepresentation.h
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformHandleWidgetRepresentation.h
@@ -52,6 +52,17 @@ public:
   void PrintSelf(ostream& os, vtkIndent indent) override;
   ///@}
 
+  /// Indices used for handle axes within a handle group (rotation, scale, translation).
+  /// X, Y, Z are the per-axis handles; ViewPlane is the free-movement handle (e.g. used for grabbing
+  /// the transform anywhere in the slice view, when wide translation is enabled).
+  enum
+  {
+    HandleIndexX,
+    HandleIndexY,
+    HandleIndexZ,
+    HandleIndexViewPlane
+  };
+
   virtual int GetActiveComponentType() override;
   virtual void SetActiveComponentType(int type) override;
   virtual int GetActiveComponentIndex() override;
@@ -73,16 +84,52 @@ public:
   double GetInteractionSizeMm() override;
   /// True -> size in mm; false -> relative to screen
   bool GetInteractionSizeAbsolute() override;
+  double GetInteractionHandleOpacity() override;
+
+  /// Scales the translation vector by vtkMRMLTransformDisplayNode::GetEditorTranslationSliceAnywhereSensitivity()
+  /// when the most recent translate interaction was started from a "wide" hit (see LastInteractionWasWideHit).
+  /// Otherwise (e.g. dragging the small translation handle itself) no scaling is applied.
+  double GetTranslationScaleFactor() override;
 
   bool GetHandleVisibility(int type, int index) override;
 
+  /// Renders the view plane translation handle as a crosshair (instead of the default filled circle)
+  /// when vtkMRMLTransformDisplayNode::GetEditorTranslationSliceAnywhereEnabled() is true in a slice view,
+  /// so that the transform center underneath the handle is not occluded.
+  int GetHandleGlyphType(int type, int index) override;
+
+  /// Renders the view plane translation handle (whether shown as a circle or as a crosshair, see
+  /// GetHandleGlyphType()) and the in-plane (view plane) rotation handle in cyan, instead of their
+  /// default color, so that these "free"/view-plane handles are easy to recognize and tell apart
+  /// from the axis-constrained (red/green/blue) handles.
+  void GetHandleColor(int type, int index, double color[4]) override;
+
   bool IsDisplayable() override;
+
+  /// In addition to the default handle hit-testing performed by the superclass, when
+  /// vtkMRMLTransformDisplayNode::GetEditorTranslationSliceAnywhereEnabled() is true, clicking anywhere
+  /// in a slice view is treated as grabbing the view plane translation handle, so the transform can be
+  /// dragged from anywhere in the slice view, not just from the small handle at the center of the transform.
+  void CanInteract(vtkMRMLInteractionEventData* interactionEventData, int& foundComponentType, int& foundComponentIndex, double& closestDistance2) override;
+
+  /// True if the component found by the most recent call to CanInteract() was found using the "wide"
+  /// hit-test area (clicking anywhere in the slice view) rather than a precise handle grab.
+  /// Used by vtkMRMLTransformHandleWidget to give the wide hit-test a lower interaction priority.
+  vtkGetMacro(LastInteractionWasWideHit, bool);
+
+  /// Squared display-coordinate distance between the event position and the transform center, computed
+  /// by the most recent "wide" hit-test performed by CanInteract(). Used by vtkMRMLTransformHandleWidget
+  /// so that, when multiple transforms can be dragged from anywhere in the same slice view, the one
+  /// whose center is closest to the cursor is the one that is picked.
+  vtkGetMacro(LastSliceWideHitDistance2, double);
 
 protected:
   vtkMRMLTransformHandleWidgetRepresentation();
   ~vtkMRMLTransformHandleWidgetRepresentation() override;
 
   vtkSmartPointer<vtkMRMLTransformDisplayNode> DisplayNode;
+  bool LastInteractionWasWideHit{ false };
+  double LastSliceWideHitDistance2{ 0.0 };
 
 private:
   vtkMRMLTransformHandleWidgetRepresentation(const vtkMRMLTransformHandleWidgetRepresentation&) = delete;

--- a/Modules/Loadable/Transforms/Widgets/Resources/UI/qMRMLTransformDisplayNodeWidget.ui
+++ b/Modules/Loadable/Transforms/Widgets/Resources/UI/qMRMLTransformDisplayNodeWidget.ui
@@ -1700,6 +1700,52 @@
            </property>
           </widget>
          </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_24">
+           <property name="text">
+            <string>Enable view plane translation anywhere: </string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QCheckBox" name="EditorTranslationSliceAnywhereEnabledCheckBox">
+           <property name="toolTip">
+            <string>Allow grabbing and dragging the transform by left clicking anywhere in the slice view, not just by grabbing the small translation handle at the center of the transform.</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="label_26">
+           <property name="text">
+            <string>View plane translation scale: </string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1" colspan="5">
+          <widget class="ctkSliderWidget" name="editorTranslationSliceAnywhereSensitivitySlider">
+           <property name="toolTip">
+            <string>How much the transform translates in response to click-and-drag, when dragging anywhere in the slice view. 1.0 means the transform moves in lock-step with the mouse cursor; lower values make the translation change less in response to the same mouse motion.</string>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+           <property name="pageStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="minimum">
+            <double>0.010000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>0.200000000000000</double>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
@@ -1723,6 +1769,29 @@
         </property>
         <property name="quantity">
          <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_25">
+        <property name="text">
+         <string>Opacity:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1" colspan="2">
+       <widget class="ctkSliderWidget" name="interactionHandleOpacitySlider">
+        <property name="singleStep">
+         <double>0.010000000000000</double>
+        </property>
+        <property name="pageStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
         </property>
        </widget>
       </item>

--- a/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.cxx
@@ -116,6 +116,8 @@ void qMRMLTransformDisplayNodeWidgetPrivate::init()
   QObject::connect(this->InteractiveScaling3DCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorScalingEnabled(bool)));
 
   QObject::connect(this->InteractiveTranslationSliceCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorTranslationSliceEnabled(bool)));
+  QObject::connect(this->EditorTranslationSliceAnywhereEnabledCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorTranslationSliceAnywhereEnabled(bool)));
+  QObject::connect(this->editorTranslationSliceAnywhereSensitivitySlider, SIGNAL(valueChanged(double)), q, SLOT(setEditorTranslationSliceAnywhereSensitivity(double)));
   QObject::connect(this->InteractiveRotationSliceCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorRotationSliceEnabled(bool)));
   QObject::connect(this->InteractiveScalingSliceCheckBox, SIGNAL(toggled(bool)), q, SLOT(setEditorScalingSliceEnabled(bool)));
 
@@ -150,6 +152,7 @@ void qMRMLTransformDisplayNodeWidgetPrivate::init()
   QObject::connect(this->scaleViewPlaneSliceCheckBox, SIGNAL(clicked()), q, SLOT(updateScalingComponentVisibility()));
 
   QObject::connect(this->interactionHandleScaleSlider, SIGNAL(valueChanged(double)), q, SLOT(updateInteractionHandleScale()));
+  QObject::connect(this->interactionHandleOpacitySlider, SIGNAL(valueChanged(double)), q, SLOT(updateInteractionHandleOpacity()));
 
   this->InteractiveAdvancedOptions3DFrame->hide();
   this->InteractiveAdvancedOptionsSliceFrame->hide();
@@ -388,6 +391,10 @@ void qMRMLTransformDisplayNodeWidget::updateWidgetFromDisplayNode()
   d->interactionHandleScaleSlider->setValue(d->TransformDisplayNode->GetInteractionScalePercent());
   d->interactionHandleScaleSlider->blockSignals(wasBlocking);
 
+  wasBlocking = d->interactionHandleOpacitySlider->blockSignals(true);
+  d->interactionHandleOpacitySlider->setValue(d->TransformDisplayNode->GetInteractionHandleOpacity());
+  d->interactionHandleOpacitySlider->blockSignals(wasBlocking);
+
   this->updateInteraction3DWidgetsFromDisplayNode();
   this->updateInteractionSliceWidgetsFromDisplayNode();
 }
@@ -540,6 +547,17 @@ void qMRMLTransformDisplayNodeWidget::updateInteractionSliceWidgetsFromDisplayNo
   d->translateViewPlaneSliceCheckBox->setChecked(translationComponentVisibility[3]);
   d->translateViewPlaneSliceCheckBox->blockSignals(wasBlocking);
   d->translateViewPlaneSliceCheckBox->setEnabled(translationEnabled && enabledSlice);
+
+  wasBlocking = d->EditorTranslationSliceAnywhereEnabledCheckBox->blockSignals(true);
+  bool translationSliceAnywhereEnabled = d->TransformDisplayNode->GetEditorTranslationSliceAnywhereEnabled();
+  d->EditorTranslationSliceAnywhereEnabledCheckBox->setChecked(translationSliceAnywhereEnabled);
+  d->EditorTranslationSliceAnywhereEnabledCheckBox->blockSignals(wasBlocking);
+  d->EditorTranslationSliceAnywhereEnabledCheckBox->setEnabled(translationEnabled && enabledSlice);
+
+  wasBlocking = d->editorTranslationSliceAnywhereSensitivitySlider->blockSignals(true);
+  d->editorTranslationSliceAnywhereSensitivitySlider->setValue(d->TransformDisplayNode->GetEditorTranslationSliceAnywhereSensitivity());
+  d->editorTranslationSliceAnywhereSensitivitySlider->blockSignals(wasBlocking);
+  d->editorTranslationSliceAnywhereSensitivitySlider->setEnabled(translationSliceAnywhereEnabled && translationEnabled && enabledSlice);
 
   //////////////
   // Rotation
@@ -937,6 +955,28 @@ void qMRMLTransformDisplayNodeWidget::setEditorTranslationSliceEnabled(bool enab
 }
 
 //-----------------------------------------------------------------------------
+void qMRMLTransformDisplayNodeWidget::setEditorTranslationSliceAnywhereEnabled(bool enabled)
+{
+  Q_D(qMRMLTransformDisplayNodeWidget);
+  if (!d->TransformDisplayNode)
+  {
+    return;
+  }
+  d->TransformDisplayNode->SetEditorTranslationSliceAnywhereEnabled(enabled);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLTransformDisplayNodeWidget::setEditorTranslationSliceAnywhereSensitivity(double sensitivity)
+{
+  Q_D(qMRMLTransformDisplayNodeWidget);
+  if (!d->TransformDisplayNode)
+  {
+    return;
+  }
+  d->TransformDisplayNode->SetEditorTranslationSliceAnywhereSensitivity(sensitivity);
+}
+
+//-----------------------------------------------------------------------------
 void qMRMLTransformDisplayNodeWidget::setEditorRotationEnabled(bool enabled)
 {
   Q_D(qMRMLTransformDisplayNodeWidget);
@@ -1155,4 +1195,16 @@ void qMRMLTransformDisplayNodeWidget::updateInteractionHandleScale()
 
   double scale = d->interactionHandleScaleSlider->value();
   d->TransformDisplayNode->SetInteractionScalePercent(scale);
+}
+
+// ----------------------------------------------------------------------------
+void qMRMLTransformDisplayNodeWidget::updateInteractionHandleOpacity()
+{
+  Q_D(qMRMLTransformDisplayNodeWidget);
+  if (!d->TransformDisplayNode)
+  {
+    return;
+  }
+
+  d->TransformDisplayNode->SetInteractionHandleOpacity(d->interactionHandleOpacitySlider->value());
 }

--- a/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.h
+++ b/Modules/Loadable/Transforms/Widgets/qMRMLTransformDisplayNodeWidget.h
@@ -92,6 +92,8 @@ public slots:
 
   void setEditorTranslationEnabled(bool enabled);
   void setEditorTranslationSliceEnabled(bool enabled);
+  void setEditorTranslationSliceAnywhereEnabled(bool enabled);
+  void setEditorTranslationSliceAnywhereSensitivity(double sensitivity);
 
   void setEditorRotationEnabled(bool enabled);
   void setEditorRotationSliceEnabled(bool enabled);
@@ -105,6 +107,7 @@ public slots:
   void updateRotationComponentVisibility();
   void updateScalingComponentVisibility();
   void updateInteractionHandleScale();
+  void updateInteractionHandleOpacity();
 
   void setColorTableNode(vtkMRMLNode* colorTableNode);
 


### PR DESCRIPTION
If Transforms module / Display / Interaction / More options / Drag from anywhere is enabled then the transform can be moved by click-and-dragging anywhere in the image. This makes is faster and easier to align objects in slice views, as the user does not need to click exactly on the center of the transform widget to translate.

<img width="1919" height="994" alt="image" src="https://github.com/user-attachments/assets/e0e45979-d5a8-4283-aeb9-65cd5eca2a12" />
