### PR TITLE
ENH: Improve visibility of non-stable release version

### DIFF
--- a/CMake/SlicerVersion.cmake
+++ b/CMake/SlicerVersion.cmake
@@ -87,7 +87,7 @@ set(Slicer_VERSION      "${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR}")
 set(Slicer_VERSION_FULL "${Slicer_VERSION}.${Slicer_VERSION_PATCH}")
 
 if(NOT "${Slicer_RELEASE_TYPE}" STREQUAL "Stable")
-  set(Slicer_VERSION_FULL "${Slicer_VERSION_FULL}-${Slicer_BUILDDATE}")
+  set(Slicer_VERSION_FULL "${Slicer_VERSION_FULL}-${Slicer_BUILDDATE} (${Slicer_RELEASE_TYPE})")
 endif()
 
 message(STATUS "Configuring Slicer version [${Slicer_VERSION_FULL}]")
@@ -143,7 +143,7 @@ set(Slicer_MAIN_PROJECT_VERSION      "${Slicer_MAIN_PROJECT_VERSION_MAJOR}.${Sli
 set(Slicer_MAIN_PROJECT_VERSION_FULL "${Slicer_MAIN_PROJECT_VERSION}.${Slicer_MAIN_PROJECT_VERSION_PATCH}")
 
 if(NOT "${Slicer_RELEASE_TYPE}" STREQUAL "Stable")
-  set(Slicer_MAIN_PROJECT_VERSION_FULL "${Slicer_MAIN_PROJECT_VERSION_FULL}-${Slicer_MAIN_PROJECT_BUILDDATE}")
+  set(Slicer_MAIN_PROJECT_VERSION_FULL "${Slicer_MAIN_PROJECT_VERSION_FULL}-${Slicer_MAIN_PROJECT_BUILDDATE} (${Slicer_RELEASE_TYPE})")
 endif()
 
 if(NOT "${Slicer_MAIN_PROJECT_APPLICATION_NAME}" STREQUAL "Slicer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ if(NOT DEFINED Slicer_VERSION_MINOR)
   set(Slicer_VERSION_MINOR "12")
 endif()
 if(NOT DEFINED Slicer_VERSION_PATCH)
-  set(Slicer_VERSION_PATCH "0")
+  set(Slicer_VERSION_PATCH "1")
 endif()
 project(Slicer VERSION "${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR}.${Slicer_VERSION_PATCH}")
 

--- a/Utilities/Scripts/SlicerWizard/__version__.py
+++ b/Utilities/Scripts/SlicerWizard/__version__.py
@@ -1,7 +1,8 @@
 __version_info__ = (
     5,
     12,
-    0,
+    1,
+    "dev0",
 )
 
 __version__ = ".".join(map(str, __version_info__))


### PR DESCRIPTION
> [!NOTE]
> This is targeting the `5.12` release branch

Related to discussion at https://discourse.slicer.org/t/2026-06-30-weekly-meeting/47493/4?u=jamesobutler

This begins the 5.12.1 development period on the `5.12` maintenance branch. This PR results in all commits after the 5.12.0 tagged commit being indicated like:
"5.12.1-2026-06-29 (Preview)" which indicates a preview build of a future 5.12.1 stable release
<img width="383" height="86" alt="image" src="https://github.com/user-attachments/assets/278b517e-da93-4778-ab6d-fd65fd3756e6" />

instead of the current:
"5.12.0-2026-06-29" which indicates a date of a stable (5.12.0) release version?
<img width="379" height="82" alt="image" src="https://github.com/user-attachments/assets/5e5386a7-cdbc-4121-a4d9-f23807b6c2d8" />


The current is a bit confusing as it just seeing that string when running the application it is hard to know if that version came out before the 5.12.0 release or if it came out after the 5.12.0 release. 

`ENH: Improve visibility of non-stable release version` would also be contributed to the `main` branch as well if we want to proceed with this improved display of knowing if the version of Slicer being used is a preview release or a stable release.