### PR TITLE
COMP: Update DCMTKcs to fix OpenJPEG over-linking on macOS

### DIFF
--- a/SuperBuild/External_DCMTKcs.cmake
+++ b/SuperBuild/External_DCMTKcs.cmake
@@ -27,7 +27,7 @@ if(NOT DEFINED DCMTKcs_SOURCE_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "fbfd93318d32fabc86704cdd279bcb3e9028dd41" # main 2026-05-11
+    "da8821c8d163e635ea5a1a5016fb01b86d8c76d8" # main 2026-06-29
     QUIET
     )
 


### PR DESCRIPTION
Update DCMTKcs revision from fbfd933 to da8821c, which links OpenJPEG privately to the dcmjp2kcs module for shared builds instead of exposing it through the public link interface.

Previously dcmjp2kcs published the openjp2 target as part of its INTERFACE_LINK_LIBRARIES and the DCMTK umbrella target re-exported it, so every consumer of DCMTK transitively linked libopenjp2 - even when it never used JPEG 2000. On macOS this broke extension packaging: an extension unrelated to JPEG 2000 (e.g. MarkupsToModel) ended up referencing libopenjp2 and failed to load, since OpenJPEG is bundled centrally by the application rather than within each extension.

With this update, OpenJPEG is a private dependency of the shared dcmjp2kcs library: its symbols are fully resolved into libdcmjp2kcs and consumers no longer reference libopenjp2. Verified by building a full macOS package: libopenjp2 is still bundled and resolved for dcmjp2kcs, the number of bundled binaries referencing it dropped from 207 to 3 (libopenjp2 itself, libdcmjp2kcs, libITKIODCMTK), and an extension that does not use JPEG 2000 no longer references it at all.

DCMTKcs:
$ git shortlog fbfd933..da8821c --no-merges
Andras Lasso (1):
      Link OpenJPEG privately to dcmjp2kcs for shared builds