### PR TITLE
BUG: Fix lock button not hiding ROI interaction handles

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsInteractionWidget.cxx
@@ -508,6 +508,31 @@ void vtkSlicerMarkupsInteractionWidget::ScaleWidgetROI(double eventPos[2], bool 
     return;
   }
 
+  // Similarly to translation, scaling must not move locked control points.
+  bool anyControlPointLocked = false;
+  for (int controlPointIndex = 0; controlPointIndex < roiNode->GetNumberOfControlPoints(); ++controlPointIndex)
+  {
+    if (roiNode->GetNthControlPointLocked(controlPointIndex))
+    {
+      anyControlPointLocked = true;
+      break;
+    }
+  }
+  if (anyControlPointLocked)
+  {
+    if (roiNode->GetROIType() == vtkMRMLMarkupsROINode::ROITypeBox)
+    {
+      // The only control point of a box ROI is the center.
+      // The locked center is kept in place by scaling symmetrically around it.
+      symmetricScale = true;
+    }
+    else
+    {
+      // Scaling would reposition all control points, do not scale.
+      return;
+    }
+  }
+
   vtkMRMLMarkupsDisplayNode* displayNode = this->GetDisplayNode();
   if (!displayNode)
   {


### PR DESCRIPTION
When a markups ROI node was locked via the lock button, the scale/rotate/translate interaction handles remained visible and interactive. Fix by:
- Overriding CanInteract() in vtkSlicerMarkupsInteractionWidgetRepresentation to respect the node-level locked state
- Returning false from IsDisplayable() when the node is locked so handles are hidden
- Calling SetLocked() when the per-control-point lock icon is clicked in the table

Slicer 5.12.0:

https://github.com/user-attachments/assets/9e7347c4-670b-493c-8298-011b9c85f602


This PR:

https://github.com/user-attachments/assets/984bf1a4-4581-4f0d-a6d5-cfc7038b6369



