### PR TITLE
macOS arm64 packaging name fixes

### DIFF
--- a/CMake/SlicerMacroGetOperatingSystemArchitectureBitness.cmake
+++ b/CMake/SlicerMacroGetOperatingSystemArchitectureBitness.cmake
@@ -25,7 +25,7 @@
 # The macro defines the following variables:
 #  <var-prefix>_BITNESS - bitness of the platform: 32 or 64
 #  <var-prefix>_OS - which is on the this value: linux, macosx, win
-#  <var-prefix>_ARCHITECTURE - which is on the this value: i386, amd64, ppc
+#  <var-prefix>_ARCHITECTURE - which is on the this value: i386, amd64, arm64, ppc
 
 include(${CMAKE_CURRENT_LIST_DIR}/SlicerBlockOperatingSystemNames.cmake)
 
@@ -40,25 +40,50 @@ macro(SlicerMacroGetOperatingSystemArchitectureBitness)
     message(FATAL_ERROR "error: VAR_PREFIX should be specified !")
   endif()
 
-  set(${MY_VAR_PREFIX}_ARCHITECTURE "")
-
   set(${MY_VAR_PREFIX}_ARCHITECTURE i386)
   set(${MY_VAR_PREFIX}_BITNESS 32)
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(${MY_VAR_PREFIX}_BITNESS 64)
-    set(${MY_VAR_PREFIX}_ARCHITECTURE amd64)
+    set(${MY_VAR_PREFIX}_ARCHITECTURE amd64)  # initial default before platform specific logic below
   endif()
 
   if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set(${MY_VAR_PREFIX}_OS "${Slicer_OS_WIN_NAME}")
+    # For Visual Studio generators, CMAKE_GENERATOR_PLATFORM (e.g. set via
+    # "-A ARM64") reflects the architecture actually being targeted, and
+    # should be preferred over CMAKE_SYSTEM_PROCESSOR, which may instead
+    # reflect an amd64 build of CMake running under x64 emulation on an
+    # arm64 host.
+    if(NOT "${CMAKE_GENERATOR_PLATFORM}" STREQUAL "")
+      if(CMAKE_GENERATOR_PLATFORM MATCHES "^ARM64$")
+        set(${MY_VAR_PREFIX}_ARCHITECTURE "arm64")
+      endif()
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
+      set(${MY_VAR_PREFIX}_ARCHITECTURE "arm64")
+    endif()
 
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(${MY_VAR_PREFIX}_OS "${Slicer_OS_LINUX_NAME}")
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
+      set(${MY_VAR_PREFIX}_ARCHITECTURE "arm64")
+    endif()
 
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(${MY_VAR_PREFIX}_OS "${Slicer_OS_MAC_NAME}")
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "powerpc")
       set(${MY_VAR_PREFIX}_ARCHITECTURE "ppc")
+    endif()
+    # CMAKE_OSX_ARCHITECTURES (e.g. set via "-DCMAKE_OSX_ARCHITECTURES=arm64")
+    # reflects the architecture actually being targeted, and should be
+    # preferred over CMAKE_SYSTEM_PROCESSOR, which reflects the host machine
+    # and may be wrong, for example when CMake is run under Rosetta 2
+    # translation.
+    if(NOT "${CMAKE_OSX_ARCHITECTURES}" STREQUAL "")
+      if(CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
+        set(${MY_VAR_PREFIX}_ARCHITECTURE "arm64")
+      endif()
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
+      set(${MY_VAR_PREFIX}_ARCHITECTURE "arm64")
     endif()
 
   #elseif(CMAKE_SYSTEM_NAME STREQUAL "Solaris")

--- a/SuperBuild/External_CTKAPPLAUNCHER.cmake
+++ b/SuperBuild/External_CTKAPPLAUNCHER.cmake
@@ -25,13 +25,16 @@ if(Slicer_USE_CTKAPPLAUNCHER)
 
     SlicerMacroGetOperatingSystemArchitectureBitness(VAR_PREFIX CTKAPPLAUNCHER)
     set(launcher_version "0.1.34")
-    # On windows, use i386 launcher unconditionally
     if("${CTKAPPLAUNCHER_OS}" STREQUAL "win")
+      # CTKAppLauncher is only released as an i386 Windows binary, so use it unconditionally.
       set(CTKAPPLAUNCHER_ARCHITECTURE "i386")
       set(sha256 "8b91093a18476749b5687dc433909d61916a9983e832be3fb0a43d494b208924")
     elseif("${CTKAPPLAUNCHER_OS}" STREQUAL "linux")
       set(sha256 "e39f82151be485e2e097a254077c4f3b7c962765c0e1564cbc09360355f87b76")
     elseif("${CTKAPPLAUNCHER_OS}" STREQUAL "macosx")
+      # CTKAppLauncher is only released as an amd64 macOS binary (it runs fine
+      # on arm64 Macs through Rosetta 2), so use it unconditionally.
+      set(CTKAPPLAUNCHER_ARCHITECTURE "amd64")
       set(sha256 "9d2f08fd68071562b17a2bfc18b6510a2a19596c593bf19deda1a9f1d3038ad0")
     endif()
 


### PR DESCRIPTION
This updates the generated packaged installer name to end in "-macosx-arm64.dmg" for arm64 builds instead of "-macosx-amd64.dmg". The `Slicer_ARCHITECTURE` variable gets set correctly now to handle this.

Due to the above change it was also needed to define the CTKAppLauncher to continue to be the amd64 version as that is all that is available. Work to track a native arm64 launcher is defined in https://github.com/Slicer/Slicer/issues/9121. We similarly already define the Windows build to always use an i386 32-bit build as an amd64 Windows version is not available. 