### PR TITLE
DOC: Update documentation of QuantitativeReporting DICOM plugins

### DIFF
--- a/Docs/user_guide/data_loading_and_saving.md
+++ b/Docs/user_guide/data_loading_and_saving.md
@@ -93,8 +93,13 @@ Readers may support 2D, 3D, and 4D images of various types, such as scalar, vect
 
 - [**DICOM**](https://www.dicomstandard.org/) (.dcm, or any other): Slicer core supports reading and writing of some data types, while extensions add support for additional ones. Coordinate system: LPS (as defined by DICOM standard).
   - Supported DICOM information objects:
-    - Slicer core: CT, MRI, PET, X-ray, some ultrasound images; secondary capture with Slicer scene (MRB) in private tag
-    - [Quantitative Reporting extension](https://qiicr.gitbooks.io/quantitativereporting-guide): DICOM Segmentation objects (SEG modality), Parametric Maps, Encapsulated STL (M3D modality), certain flavors of Structured Reports that follow [TID 1500 Measurement report](https://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#sect_TID_1500) template
+    - Slicer core:
+      - CT, MRI, PET, X-ray, some ultrasound images
+      - DICOM Segmentation objects (SEG modality)
+      - Parametric Maps
+      - Encapsulated STL (M3D modality)
+      - Certain flavors of Structured Reports that follow [TID 1500 Measurement report](https://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#sect_TID_1500) template
+      - Secondary capture with Slicer scene (MRB) in private tag
     - [SlicerRT extension](https://www.slicerrt.org/): DICOM RT Structure Set, RT Dose, RT Plan, RT Image
     - [SlicerHeart extension](https://github.com/SlicerHeart/SlicerHeart): 2D/3D/4D ultrasound (GE, Philips, Eigen Artemis, and other)
     - [SlicerDMRI](https://dmri.slicer.org) tractography storage

--- a/Docs/user_guide/modules/dicom.md
+++ b/Docs/user_guide/modules/dicom.md
@@ -53,7 +53,7 @@ Since DICOM files are often located in several folders, they can cross-reference
 
 #### DICOM import
 
-1. Make sure that all required Slicer extensions are installed. Slicer core contains DICOM import plugin for importing images, but additional extensions may be needed for other information objects. For example, *SlicerRT extension is needed for importing/exporting radiation therapy information objects (RT structure set, dose, image, plan). Quantitative reporting extension is needed to import export DICOM segmentation objects, structured reports, and parametric maps.* See complete list in [supported data formats section](../data_loading_and_saving.md#supported-data-formats).
+1. Make sure that all required Slicer extensions are installed. Slicer core contains DICOM import plugin for importing images, segmentations, parametric maps, and some structured reports, but additional extensions may be needed for other information objects. For example, *SlicerRT extension is needed for importing/exporting radiation therapy information objects (RT structure set, dose, image, plan). SlicerHeart extension is needed for importing certain ultrasound images.* See complete list in [supported data formats section](../data_loading_and_saving.md#supported-data-formats).
 2. Go to DICOM module
 3. Select folders that contain DICOM files
     - Option A: Drag-and-drop the folder that contains DICOM files to the Slicer application window.
@@ -88,9 +88,8 @@ By right clicking on a Patient, Study, or Series, you can delete the entry from 
 
 Data in the scene can be exported to DICOM format, to be stored in DICOM database or exported to DICOM files:
 
-1. Make sure that all required Slicer extensions are installed. Slicer core contains DICOM export plugin for exporting images, but additional extensions may be needed for other information objects.
+1. Make sure that all required Slicer extensions are installed. Slicer core contains DICOM export plugin for exporting images, DICOM segmentation objects, structured reports, and parametric maps, but additional extensions may be needed for other information objects.
     - `SlicerRT` extension is needed for importing/exporting radiation therapy information objects: RT structure set, RT dose, RT image, RT plan.
-    - `Quantitative reporting` extension is needed for importing/exporting DICOM segmentation objects, structured reports, and parametric maps.
     - See complete list in [Supported data formats page](../data_loading_and_saving.md#supported-data-formats).
 2. Go to Data module or DICOM module.
 3. Right-click on a data node in the data tree that will be converted to DICOM format.
@@ -411,8 +410,8 @@ See examples and other developer information in [Developer guide](../../develope
 ## Related extensions and modules
 
 - [Add data](../data_loading_and_saving) dialog can be used to load some DICOM images directly, with bypassing the DICOM database. This may be faster in some cases, but it is not recommended, as it only supports certain kind of images and consistency and correctness of the data is not verified.
-- [Quantitative Reporting](https://github.com/QIICR/QuantitativeReporting#summary) extension reads and writes DICOM Segmentation Objects (label maps), structured reports, and parametric maps.
 - [SlicerRT](https://www.slicerrt.org/) extension reads and write DICOM Radiation Therapy objects (RT structure set, dose, image, plan, etc.) and provides tools for visualizing and analyzing them.
+- [SlicerHeart](https://github.com/slicerheart/slicerheart#slicerheart-extension-for-3d-slicer) extension reads certain Philips, GE, Eigen Artemis ultrasound images.
 - [LongitudinalPETCT](https://github.com/QIICR/LongitudinalPETCT#longitudinalpetct) extension reads all PET/CT studies for a selected patient and provides tools for tracking metabolic activity detected by PET tracers.
 - [DICOM Patcher](dicompatcher.md) module can be used before importing to fix common DICOM non-compliance errors.
 

--- a/Docs/user_guide/modules/segmentations.md
+++ b/Docs/user_guide/modules/segmentations.md
@@ -146,9 +146,7 @@ See Script repository's [Segmentations section](../../developer_guide/script_rep
 ### DICOM export
 
 - Make sure the source representation is `binary labelmap` (as the source representation is used when exporting into DICOM, and currently only binary labelmap representation is supported). The source representation can be set in `Segmentations` module, `Representations` section. If the yellow star (that designates the source representation) is in the `binary labelmap` row then the representation is already good, no further action is needed. If the yellow star is in another row then click `Make source` button in the `binary labelmap` row (if that button is not shown then click `Create` button first).
-- Make sure the necessary extensions are installed:
-  - `QuantitativeReporting` extension is required for exporting into DICOM Segmentation Object.
-  - `SlicerRT` extension is required for exporting into legacy DICOM RT Structure Set. RT Structure Sets are not recommended for storing segmentations, as they cannot store arbitrarily complex 3D shapes.
+- DICOM Segmentation Object (`DICOMSegmentation` export type) is recommended for storing segmentations in DICOM. However, if segmentations will be used for radiation therapy then it may be necessary to export to DICOM RT Structure Set. RT Structure Set export type becomes available if `SlicerRT` extension is installed. In general, RT Structure Sets are not recommended for storing segmentations, as they cannot store arbitrarily complex 3D shapes.
 - If the segmented image was not loaded from the DICOM database (for example, if the image was loaded from a NRRD or NIFTI file) then a DICOM image needs to be created in the database and the segmentation must be updated to reference this image (this is necessary because a DICOM requires a segmentation to be associated with a DICOM image) by following these steps:
   - [export the source volume to DICOM](dicom.md#export-data-from-the-scene-to-dicom-database) (agree to create patient and study when asked)
   - load the exported volume from the DICOM database

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -322,11 +322,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
             for file in loadable.files:
                 if slicer.dicomDatabase.fileValueExists(file, self.tags["pixelData"]):
                     newFiles.append(file)
-                if slicer.dicomDatabase.fileValue(file, self.tags["sopClassUID"]) == "1.2.840.10008.5.1.4.1.1.66.4":
-                    excludedLoadable = True
-                    if "DICOMSegmentationPlugin" not in slicer.modules.dicomPlugins:
-                        logging.warning("Please install Quantitative Reporting extension to enable loading of DICOM Segmentation objects")
-                elif slicer.dicomDatabase.fileValue(file, self.tags["sopClassUID"]) == "1.2.840.10008.5.1.4.1.1.481.3":
+                if slicer.dicomDatabase.fileValue(file, self.tags["sopClassUID"]) == "1.2.840.10008.5.1.4.1.1.481.3":
                     excludedLoadable = True
                     if "DicomRtImportExportPlugin" not in slicer.modules.dicomPlugins:
                         logging.warning("Please install SlicerRT extension to enable loading of DICOM RT Structure Set objects")


### PR DESCRIPTION
DICOM plugins that were provided by the QuantitativeReporting extension were moved to Slicer core, but the documentation was not updated.