### PR TITLE
ENH: Adapt qRestAPI consumption to the modernized CMake package

### DIFF
--- a/Base/QTCore/CMakeLists.txt
+++ b/Base/QTCore/CMakeLists.txt
@@ -39,8 +39,10 @@ include(${ITK_USE_FILE})
 # qRestAPI
 #
 if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT OR Slicer_BUILD_APPLICATIONUPDATE_SUPPORT)
+  # Include directories are provided through the imported qRestAPI target
+  # (added to KIT_target_libraries below); the legacy qRestAPI_USE_FILE was
+  # removed in the qRestAPI CMake infrastructure refactor.
   find_package(qRestAPI REQUIRED)
-  include(${qRestAPI_USE_FILE})
 endif()
 
 #

--- a/SuperBuild/External_qRestAPI.cmake
+++ b/SuperBuild/External_qRestAPI.cmake
@@ -40,7 +40,10 @@ if(NOT DEFINED qRestAPI_DIR)
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "88c02c5d90169dfe065fa068969e59ada314d3cb"
+    # CMake infrastructure modernization: removes the legacy
+    # UseqRestAPI.cmake / qRestAPI_USE_FILE and exports an imported target,
+    # which is why Base/QTCore no longer includes qRestAPI_USE_FILE.
+    "cc96cad3dfcdf489dfeb642f2a0d703f38e4a96d"
     QUIET
     )
 


### PR DESCRIPTION
> [!WARNING]
> **Depends on the qRestAPI CMake modernization PR — that PR must merge first.**
> The pinned `Slicer_qRestAPI_GIT_TAG` in this PR points at the qRestAPI PR's head commit and **must be updated to the `commontk/qRestAPI` merge commit** once it lands. **Do not merge this PR before qRestAPI is merged.**

## What

qRestAPI's CMake infrastructure has been modernized (commontk/qRestAPI#28, supersedes #27): it removes the legacy `UseqRestAPI.cmake` / `qRestAPI_USE_FILE` and instead exports an imported `qRestAPI` target. This adapts Slicer accordingly:

- **`Base/QTCore/CMakeLists.txt`**: drop `include(${qRestAPI_USE_FILE})`. The include directories now come from the imported `qRestAPI` target, which is already listed in `KIT_target_libraries`.
- **`SuperBuild/External_qRestAPI.cmake`**: bump the pinned `GIT_TAG` to the modernized qRestAPI.

## Verified locally

Full from-scratch Slicer superbuild against the modernized qRestAPI (pulled into the superbuild): Slicer builds to completion, the qRestAPI external ships `qRestAPITargets.cmake` (imported target) with **no** `UseqRestAPI.cmake`, and `libqSlicerBaseQTCore.so` links against the imported target.

## Note on CI coverage

This change edits `SuperBuild/External_qRestAPI.cmake`, so per `.github/workflows/ci.yml` the Slicer build is **skipped** ("Skipping Slicer build due to changes in SuperBuild files"): CI builds only Slicer's core against the prebuilt `slicer/slicer-base` image and does not rebuild SuperBuild dependencies per-PR. This integration was therefore validated with a **local from-scratch superbuild** rather than by CI; it will be exercised by CI only after the dependency image / nightly is regenerated with the new qRestAPI.
