### PR TITLE
BUG: Fix editing of segment opacity by double-click in segments table

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
@@ -657,6 +657,18 @@ void qMRMLSegmentsTableView::onSegmentsTableDoubleClicked(const QModelIndex& mod
     return;
   }
 
+  if (modelIndex.column() == d->Model->opacityColumn())
+  {
+    // Opacity is edited with the item delegate's editor. The DoubleClicked edit trigger is disabled
+    // (double-click on the name and color columns opens the terminology selector instead),
+    // so the editor must be opened explicitly here.
+    if (!this->readOnly())
+    {
+      d->SegmentsTable->edit(modelIndex);
+    }
+    return;
+  }
+
   vtkSegment* segment = d->SegmentationNode->GetSegmentation()->GetSegment(segmentId.toStdString());
   if (modelIndex.column() == d->Model->colorColumn() || modelIndex.column() == d->Model->nameColumn())
   {

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
@@ -231,7 +231,10 @@ protected slots:
   /// Handles clicks on the show status buttons
   void onShowStatusButtonClicked();
 
-  /// Handles clicks on a table cell (name + color change / terminology change)
+  /// Opens the editor for the segment property in the given cell
+  /// (terminology / color / name / opacity).
+  /// Called when a table cell is double-clicked. Also called when the color button is
+  /// clicked: the color cell is covered by the button, so double-click cannot reach it.
   void onSegmentsTableDoubleClicked(const QModelIndex& modelIndex);
 
   /// Handle MRML scene event


### PR DESCRIPTION
Since the visibility/color button rework (94ad4fb3e8), the DoubleClicked edit trigger is disabled in the segments table (double-click on the name and color columns opens the terminology selector instead), which left F2 as the only way to edit the opacity column.

Open the opacity editor explicitly from the double-click handler to restore the previous behavior.

Fixes https://discourse.slicer.org/t/opacity-cell-5-12-2/47652