### PR TITLE
BUG: Fix macOS extension dependency ownership

### DIFF
--- a/CMake/SlicerExtensionCPack.cmake
+++ b/CMake/SlicerExtensionCPack.cmake
@@ -206,13 +206,13 @@ if(APPLE)
   set(EXTENSION_SUPERBUILD_DIR ${EXTENSION_SUPERBUILD_BINARY_DIR})
   get_filename_component(Slicer_SUPERBUILD_DIR ${Slicer_DIR}/.. ABSOLUTE)
 
-  # If any, resolve synthetic firmlink  (e.g from "/D/P/A" to "/Users/svc-dashboard/D/P/A")
+  # Resolve a synthetic firmlink, if present (e.g., from "/D/P/A" to
+  # "/Users/svc-dashboard/D/P/A").
   #
-  # Since the output of "otool -L" reports paths with synthetic firmlinks resolved
-  # (see GetPrerequisitesWithRPath), we are using REAL_PATH below to also resolve
-  # Slicer_SUPERBUILD_DIR and ensure that the test in "SlicerExtensionCPackBundleFixup.cmake.in"
-  # checking if "${key}_ITEM" is a library built in Slicer itself work as expected.
-  file(REAL_PATH ${Slicer_SUPERBUILD_DIR} Slicer_SUPERBUILD_DIR)
+  # Canonicalize the Slicer root. The generated extension bundle-fixup script
+  # also canonicalizes each candidate because otool may use either the logical
+  # or physical spelling of a path containing a synthetic firmlink.
+  file(REAL_PATH "${Slicer_SUPERBUILD_DIR}" Slicer_SUPERBUILD_DIR)
 
   #------------------------------------------------------------------------------
   # <ExtensionName>_FIXUP_BUNDLE_CANDIDATES_PATTERNS

--- a/CMake/SlicerExtensionCPackBundleFixup.cmake.in
+++ b/CMake/SlicerExtensionCPackBundleFixup.cmake.in
@@ -1,5 +1,6 @@
 
-include(@Slicer_CMAKE_DIR@/BundleUtilitiesWithRPath.cmake)
+include("@Slicer_CMAKE_DIR@/BundleUtilitiesWithRPath.cmake")
+include("@Slicer_CMAKE_DIR@/SlicerExtensionCPackBundleFixupPath.cmake")
 #include(BundleUtilities)
 
 #
@@ -95,8 +96,12 @@ function(gp_item_default_embedded_path_override item default_embedded_path_var)
 
   # Libraries that are not part of the Slicer build tree and not part of the extension
   # build tree are considered as third-party libraries.
-  if(NOT item MATCHES "@Slicer_SUPERBUILD_DIR@"
-      AND NOT item MATCHES "${extension_build_dir}"
+  slicer_extension_cpack_is_path_in_directory(
+    "${item}" "@Slicer_SUPERBUILD_DIR@" item_in_slicer_build_dir)
+  slicer_extension_cpack_is_path_in_directory(
+    "${item}" "${extension_build_dir}" item_in_extension_build_dir)
+  if(NOT item_in_slicer_build_dir
+      AND NOT item_in_extension_build_dir
       AND item MATCHES "\\.(so|dylib)$"
       )
     set(path "@fixup_path@/@Slicer_BUNDLE_EXTENSIONS_LOCATION@@Slicer_THIRDPARTY_LIB_DIR@")
@@ -248,22 +253,11 @@ function(fixup_extension ext libs dirs)
 
       set(key_skip 0)
 
-      # Check if the item belong to an extension package itself built within a
-      # "Slicer" build tree. This may be done in custom application (e.g SlicerSALT)
-      # where bundling a specific extension (through -DSlicer_EXTENSION_SOURCE_DIRS=...)
-      # is not possible and instead the extension is packaged first and its content
-      # is then copied into the custom application package.
-      set(in_extension_build_dir_within_slicer_build_dir 0)
-      string(FIND "${extension_build_dir}" "@Slicer_SUPERBUILD_DIR@" pos)
-      if(${pos} EQUAL 0)
-        string(FIND "${${key}_ITEM}" "${extension_build_dir}" pos)
-        if(${pos} EQUAL 0)
-          set(in_extension_build_dir_within_slicer_build_dir 1)
-        endif()
-      endif()
-
-      string(FIND "${${key}_ITEM}" "@Slicer_SUPERBUILD_DIR@" pos)
-      if(${pos} EQUAL 0 AND NOT in_extension_build_dir_within_slicer_build_dir)
+      # Skip libraries owned by Slicer. Extensions built inside the Slicer tree
+      # retain ownership of files in their own build directory.
+      slicer_extension_cpack_item_is_slicer_owned(
+        "${${key}_ITEM}" "${extension_build_dir}" "@Slicer_SUPERBUILD_DIR@" item_is_slicer_owned)
+      if(item_is_slicer_owned)
         message(STATUS "${i}/${n}: skipping '${${key}_ITEM}'")
         set(key_skip 1)
       endif()

--- a/CMake/SlicerExtensionCPackBundleFixupPath.cmake
+++ b/CMake/SlicerExtensionCPackBundleFixupPath.cmake
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.28.0...3.28.0 FATAL_ERROR)
+
+# Return whether an existing absolute candidate path is contained by an
+# existing absolute directory. Resolve path aliases and normalize path
+# components before comparing them.
+function(slicer_extension_cpack_is_path_in_directory candidate directory output_var)
+  set(is_in_directory FALSE)
+  if(IS_ABSOLUTE "${candidate}"
+      AND IS_ABSOLUTE "${directory}"
+      AND EXISTS "${candidate}"
+      AND IS_DIRECTORY "${directory}")
+    file(REAL_PATH "${candidate}" real_candidate)
+    file(REAL_PATH "${directory}" real_directory)
+    cmake_path(IS_PREFIX real_directory "${real_candidate}" NORMALIZE is_in_directory)
+  endif()
+  set(${output_var} ${is_in_directory} PARENT_SCOPE)
+endfunction()
+
+# Return whether an item is owned by the Slicer build. An extension built
+# inside the Slicer tree continues to own files from its own build directory.
+# This supports custom applications (e.g., SlicerSALT) that cannot bundle a
+# specific extension through Slicer_EXTENSION_SOURCE_DIRS and instead package
+# it separately and copy its contents into the custom application package.
+function(slicer_extension_cpack_item_is_slicer_owned
+    item extension_build_dir slicer_superbuild_dir output_var)
+  slicer_extension_cpack_is_path_in_directory(
+    "${item}" "${slicer_superbuild_dir}" item_in_slicer_build_dir)
+  slicer_extension_cpack_is_path_in_directory(
+    "${extension_build_dir}" "${slicer_superbuild_dir}" extension_built_within_slicer_build_dir)
+  slicer_extension_cpack_is_path_in_directory(
+    "${item}" "${extension_build_dir}" item_in_extension_build_dir)
+
+  set(is_slicer_owned FALSE)
+  if(item_in_slicer_build_dir)
+    if(NOT extension_built_within_slicer_build_dir OR NOT item_in_extension_build_dir)
+      set(is_slicer_owned TRUE)
+    endif()
+  endif()
+  set(${output_var} ${is_slicer_owned} PARENT_SCOPE)
+endfunction()

--- a/CMake/Testing/CMakeLists.txt
+++ b/CMake/Testing/CMakeLists.txt
@@ -21,3 +21,17 @@ add_cmakescript_test(
 add_cmakescript_test(
   slicer_setting_variable_message_test
   CMake/UseSlicerMacros.cmake)
+
+if(UNIX)
+  add_test(
+    NAME cmake_slicer_extension_cpack_bundle_fixup_path_test
+    COMMAND ${CMAKE_COMMAND}
+      "-DSlicer_SOURCE_DIR=${Slicer_SOURCE_DIR}"
+      "-DTEST_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}/SlicerExtensionCPackBundleFixupPathTest"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/SlicerExtensionCPackBundleFixupPathTest.cmake"
+    )
+  set_tests_properties(cmake_slicer_extension_cpack_bundle_fixup_path_test PROPERTIES
+    LABELS CMake
+    PASS_REGULAR_EXPRESSION "SUCCESS"
+    )
+endif()

--- a/CMake/Testing/SlicerExtensionCPackBundleFixupPathTest.cmake
+++ b/CMake/Testing/SlicerExtensionCPackBundleFixupPathTest.cmake
@@ -1,0 +1,137 @@
+cmake_minimum_required(VERSION 3.28.0...3.28.0 FATAL_ERROR)
+
+if(NOT DEFINED Slicer_SOURCE_DIR)
+  message(FATAL_ERROR "Slicer_SOURCE_DIR is required")
+endif()
+if(NOT DEFINED TEST_BINARY_DIR)
+  message(FATAL_ERROR "TEST_BINARY_DIR is required")
+endif()
+
+include("${Slicer_SOURCE_DIR}/CMake/SlicerExtensionCPackBundleFixupPath.cmake")
+
+function(assert_path_in_directory candidate directory expected description)
+  slicer_extension_cpack_is_path_in_directory("${candidate}" "${directory}" actual)
+  set(failed FALSE)
+  if(expected AND NOT actual)
+    set(failed TRUE)
+  elseif(NOT expected AND actual)
+    set(failed TRUE)
+  endif()
+  if(failed)
+    message(FATAL_ERROR
+      "${description}\n"
+      "  candidate: ${candidate}\n"
+      "  directory: ${directory}\n"
+      "  expected:  ${expected}\n"
+      "  actual:    ${actual}")
+  endif()
+endfunction()
+
+function(assert_slicer_owned item extension_build_dir slicer_superbuild_dir expected description)
+  slicer_extension_cpack_item_is_slicer_owned(
+    "${item}" "${extension_build_dir}" "${slicer_superbuild_dir}" actual)
+  set(failed FALSE)
+  if(expected AND NOT actual)
+    set(failed TRUE)
+  elseif(NOT expected AND actual)
+    set(failed TRUE)
+  endif()
+  if(failed)
+    message(FATAL_ERROR
+      "${description}\n"
+      "  item:                ${item}\n"
+      "  extension build dir: ${extension_build_dir}\n"
+      "  Slicer build dir:    ${slicer_superbuild_dir}\n"
+      "  expected:            ${expected}\n"
+      "  actual:              ${actual}")
+  endif()
+endfunction()
+
+file(REMOVE_RECURSE "${TEST_BINARY_DIR}")
+
+set(physical_dashboard_dir "${TEST_BINARY_DIR}/Users/svc-dashboard/D")
+set(physical_slicer_dir "${physical_dashboard_dir}/S/A")
+set(logical_dashboard_dir "${TEST_BINARY_DIR}/D")
+set(logical_slicer_dir "${logical_dashboard_dir}/S/A")
+set(physical_extension_dir "${physical_dashboard_dir}/S/S-0-E-b/MarkupsToModel-build")
+set(logical_extension_dir "${logical_dashboard_dir}/S/S-0-E-b/MarkupsToModel-build")
+set(physical_nested_extension_dir "${physical_slicer_dir}/E/EmbeddedExtension-build")
+set(logical_nested_extension_dir "${logical_slicer_dir}/E/EmbeddedExtension-build")
+
+set(physical_slicer_item "${physical_slicer_dir}/DCMTK-build/lib/libdcmjp2kcs.20.dylib")
+set(logical_slicer_item "${logical_slicer_dir}/DCMTK-build/lib/libdcmjp2kcs.20.dylib")
+set(physical_extension_item "${physical_extension_dir}/lib/libMarkupsToModel.dylib")
+set(logical_extension_item "${logical_extension_dir}/lib/libMarkupsToModel.dylib")
+set(physical_nested_extension_item "${physical_nested_extension_dir}/lib/libEmbeddedExtension.dylib")
+set(prefix_sibling_item "${physical_dashboard_dir}/S/A-other/lib/libSibling.dylib")
+set(external_item "${TEST_BINARY_DIR}/opt/lib/libExternal.dylib")
+
+foreach(item IN ITEMS
+    "${physical_slicer_item}"
+    "${physical_extension_item}"
+    "${physical_nested_extension_item}"
+    "${prefix_sibling_item}"
+    "${external_item}")
+  get_filename_component(item_dir "${item}" DIRECTORY)
+  file(MAKE_DIRECTORY "${item_dir}")
+  file(TOUCH "${item}")
+endforeach()
+
+file(CREATE_LINK "${physical_dashboard_dir}" "${logical_dashboard_dir}" SYMBOLIC RESULT link_result)
+if(NOT link_result STREQUAL "0")
+  message(FATAL_ERROR "Failed to create dashboard path alias: ${link_result}")
+endif()
+
+file(REAL_PATH "${logical_slicer_dir}" canonical_logical_slicer_dir)
+file(REAL_PATH "${physical_slicer_dir}" canonical_physical_slicer_dir)
+if(NOT canonical_logical_slicer_dir STREQUAL canonical_physical_slicer_dir)
+  message(FATAL_ERROR
+    "Test fixture does not reproduce the path alias\n"
+    "  logical:  ${logical_slicer_dir}\n"
+    "  expected: ${canonical_physical_slicer_dir}\n"
+    "  actual:   ${canonical_logical_slicer_dir}")
+endif()
+
+assert_path_in_directory(
+  "${physical_slicer_item}" "${physical_slicer_dir}" TRUE
+  "A physical Slicer item must be inside the physical Slicer root")
+assert_path_in_directory(
+  "${logical_slicer_item}" "${physical_slicer_dir}" TRUE
+  "A logical Slicer item must match the equivalent physical Slicer root")
+assert_path_in_directory(
+  "${physical_slicer_item}" "${logical_slicer_dir}" TRUE
+  "A physical Slicer item must match the equivalent logical Slicer root")
+assert_path_in_directory(
+  "${logical_extension_item}" "${physical_extension_dir}" TRUE
+  "A logical extension item must match the equivalent physical extension root")
+assert_path_in_directory(
+  "${physical_slicer_dir}/../A/DCMTK-build/lib/libdcmjp2kcs.20.dylib"
+  "${physical_slicer_dir}" TRUE
+  "Parent path components must be normalized")
+assert_path_in_directory(
+  "${prefix_sibling_item}" "${physical_slicer_dir}" FALSE
+  "A similarly named sibling must not be treated as a child")
+assert_path_in_directory(
+  "@rpath/libdcmjp2kcs.20.dylib" "${physical_slicer_dir}" FALSE
+  "A relative load command is not an owned build-tree path")
+assert_path_in_directory(
+  "${physical_slicer_dir}/missing/libMissing.dylib" "${physical_slicer_dir}" FALSE
+  "A missing path must not be classified as owned")
+
+assert_slicer_owned(
+  "${logical_slicer_item}" "${physical_extension_dir}" "${physical_slicer_dir}" TRUE
+  "A logical Slicer item must be recognized with a physical Slicer root")
+assert_slicer_owned(
+  "${physical_extension_item}" "${logical_extension_dir}" "${physical_slicer_dir}" FALSE
+  "An ordinary extension must retain ownership of its files")
+assert_slicer_owned(
+  "${physical_nested_extension_item}" "${logical_nested_extension_dir}" "${physical_slicer_dir}" FALSE
+  "An extension nested in the Slicer tree must retain ownership across path aliases")
+assert_slicer_owned(
+  "${external_item}" "${physical_extension_dir}" "${physical_slicer_dir}" FALSE
+  "An external library must not be classified as Slicer-owned")
+assert_slicer_owned(
+  "${prefix_sibling_item}" "${physical_extension_dir}" "${physical_slicer_dir}" FALSE
+  "A prefix-collision sibling must not be classified as Slicer-owned")
+
+message("SUCCESS")


### PR DESCRIPTION
~~Warning: I haven't fully vetted this and do not claim to understand it yet. Putting this up to think about how to solve #9295~~

Okay I do think this looks good and I stand behind it pending build and package tests whose progress I am reporting below. The functions `slicer_extension_cpack_is_path_in_directory` and `slicer_extension_cpack_item_is_slicer_owned` that were added are sound. They do fix a path based check as to which dependencies belong to slicer, and that check really was previously broken. The test confirms that, but we can exclude it from the PR to keep it more minimal if we want to.

I am building and packaging on linux just to make sure nothing was horribly broken in the superbuild along the way:

Linux:
- Build: :heavy_check_mark: 
- Package: :heavy_check_mark: 
- Test: :heavy_check_mark: 

It would be good if someone could try on macOS or windows but we can also rely on the preview build for that