### PR TITLE
BUG: Apply pending layout when the layout manager is enabled

### DIFF
--- a/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
@@ -802,7 +802,21 @@ bool qMRMLLayoutManager::isEnabled() const
 void qMRMLLayoutManager::setEnabled(bool enable)
 {
   Q_D(qMRMLLayoutManager);
+  if (d->Enabled == enable)
+  {
+    return;
+  }
   d->Enabled = enable;
+  if (enable)
+  {
+    // Apply layout node changes that were ignored while the layout manager
+    // was disabled. Without this, the viewport remains empty when no further
+    // layout node modification arrives after enabling: at application
+    // startup the layout is applied while the layout manager is disabled and
+    // the main window enables it from its first show event, so whether the
+    // views appeared depended on the ordering of these events.
+    d->onLayoutNodeModifiedEvent(d->MRMLLayoutNode);
+  }
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
At startup the main window disables the layout manager so that detached viewports do not appear before the main window, and enables it from the first show event. However, setEnabled(true) only set the flag: layout node modifications that arrived while the layout manager was disabled were ignored, and the subsequent refresh() call re-applies only the CTK layout document, which was never populated. Whether the views appeared therefore depended on whether some layout node modification happened to arrive after the first show event.

With Qt 6 the startup event ordering shifted so that the last layout notification consistently lands before the first show event, leaving the view area of the main window empty until the user manually switched to a different layout.

Diagnosed on a live session by inspecting the layout manager state through the WebServer module's exec endpoint: the view widgets existed but were not visible, the view arrangement was never applied, and a single MRMLLayoutNode->Modified() call healed the session, proving the update chain worked but was never triggered.

Fix by re-applying the current layout node state when the layout manager transitions from disabled to enabled. The existing guards still apply (nothing happens without a scene or during batch processing, and the batch-end observation covers that case).
