### PR TITLE
BUG: Restore dropped Python wrapping hierarchy dependencies

### DIFF
--- a/Modules/Loadable/CMakeLists.txt
+++ b/Modules/Loadable/CMakeLists.txt
@@ -40,3 +40,21 @@ foreach(module ${qtmodules})
     add_subdirectory(${module})
   endif()
 endforeach()
+
+# With the Makefiles generator, the Python wrapping hierarchy of a module can
+# only depend on the hierarchy target of another module if that target already
+# exists when the module is configured (see vtkWrapHierarchy.cmake in
+# vtkAddon). For modules that depend on a module configured later in the list
+# above, the dependency is silently dropped and parallel builds can fail with
+# "vtkWrapHierarchy: couldn't open file ...Hierarchy.txt". Restore the known
+# forward dependencies here, where all hierarchy targets exist.
+foreach(_hierarchy_dependency IN ITEMS
+    "vtkSlicerTransformsModuleLogicHierarchy;vtkSlicerMarkupsModuleMRMLHierarchy"
+    "vtkSlicerSegmentationsModuleLogicHierarchy;vtkSlicerMarkupsModuleMRMLHierarchy"
+    )
+  list(GET _hierarchy_dependency 0 _hierarchy_target)
+  list(GET _hierarchy_dependency 1 _hierarchy_dependee)
+  if(TARGET ${_hierarchy_target} AND TARGET ${_hierarchy_dependee})
+    add_dependencies(${_hierarchy_target} ${_hierarchy_dependee})
+  endif()
+endforeach()

--- a/Modules/Loadable/CMakeLists.txt
+++ b/Modules/Loadable/CMakeLists.txt
@@ -41,13 +41,16 @@ foreach(module ${qtmodules})
   endif()
 endforeach()
 
-# With the Makefiles generator, the Python wrapping hierarchy of a module can
+# With the current cmake macros, the Python wrapping hierarchy of a module can
 # only depend on the hierarchy target of another module if that target already
 # exists when the module is configured (see vtkWrapHierarchy.cmake in
 # vtkAddon). For modules that depend on a module configured later in the list
 # above, the dependency is silently dropped and parallel builds can fail with
 # "vtkWrapHierarchy: couldn't open file ...Hierarchy.txt". Restore the known
 # forward dependencies here, where all hierarchy targets exist.
+# Note that this code may change if we use vtk_module_build() / vtk_module_wrap_python() 
+# to compute hierarchy dependencies from declared module metadata (vtk.module files), 
+# which will be independent of configure order
 foreach(_hierarchy_dependency IN ITEMS
     "vtkSlicerTransformsModuleLogicHierarchy;vtkSlicerMarkupsModuleMRMLHierarchy"
     "vtkSlicerSegmentationsModuleLogicHierarchy;vtkSlicerMarkupsModuleMRMLHierarchy"

--- a/Modules/Loadable/CMakeLists.txt
+++ b/Modules/Loadable/CMakeLists.txt
@@ -48,8 +48,8 @@ endforeach()
 # above, the dependency is silently dropped and parallel builds can fail with
 # "vtkWrapHierarchy: couldn't open file ...Hierarchy.txt". Restore the known
 # forward dependencies here, where all hierarchy targets exist.
-# Note that this code may change if we use vtk_module_build() / vtk_module_wrap_python() 
-# to compute hierarchy dependencies from declared module metadata (vtk.module files), 
+# Note that this code may change if we use vtk_module_build() / vtk_module_wrap_python()
+# to compute hierarchy dependencies from declared module metadata (vtk.module files),
 # which will be independent of configure order
 foreach(_hierarchy_dependency IN ITEMS
     "vtkSlicerTransformsModuleLogicHierarchy;vtkSlicerMarkupsModuleMRMLHierarchy"


### PR DESCRIPTION
With the Makefiles generator, the Python wrapping hierarchy custom command of a module depends on the hierarchy targets of the modules it wraps against, but only if those targets already exist when the module is configured (see vtkWrapHierarchy.cmake in vtkAddon). Transforms and Segmentations are configured before Markups, so their hierarchy rules silently lost the dependency on the Markups MRML hierarchy and parallel builds could fail with:

  vtkWrapHierarchy: couldn't open file .../vtkSlicerMarkupsModuleMRMLHierarchy.txt

Incremental build trees masked the problem because the hierarchy file from a previous build was already on disk; fresh build trees hit the race depending on scheduling.

Restore the two known forward dependencies after all modules are configured, where every hierarchy target exists. An audit of the module list found no other forward references between VTK-wrapped module libraries (the SubjectHierarchy reference to Volumes is in a PythonQt wrapped library, which has no hierarchy target). A generic fix (for example deferring the dependency wiring with cmake_language(DEFER)) belongs in vtkAddon.
