### PR TITLE
Fix quit/save dialog issues on exit

### DIFF
--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -606,7 +606,25 @@ bool qSlicerMainWindowPrivate::confirmCloseApplication()
   }
   else
   {
-    close = ctkMessageBox::confirmExit("MainWindow/DontConfirmExit", q);
+    // If the user previously ticked "Don't show this message again", skip the
+    // confirmation dialog entirely instead of letting ctkMessageBox auto-accept
+    // it. ctkMessageBox suppresses a dialog by briefly realizing it off-screen
+    // and clicking the accept button on the next event-loop turn; when that
+    // happens synchronously from closeEvent (as opposed to the deferred
+    // singleShot(exec()) path used by disclaimer()), the off-screen suppression
+    // loses the race with the window server on macOS/Qt6 and the dialog flashes
+    // on screen. Reading the setting directly avoids constructing the dialog.
+    static const QString dontConfirmExitKey = "MainWindow/DontConfirmExit";
+    QSettings settings;
+    bool confirmationDisabled = settings.value(dontConfirmExitKey, static_cast<int>(QMessageBox::InvalidRole)).toInt() != QMessageBox::InvalidRole;
+    if (confirmationDisabled)
+    {
+      close = true;
+    }
+    else
+    {
+      close = ctkMessageBox::confirmExit(dontConfirmExitKey, q);
+    }
   }
   return close;
 }

--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -570,22 +570,35 @@ bool qSlicerMainWindowPrivate::confirmCloseApplication()
                                               qSlicerMainWindow::tr("The scene has been modified. Do you want to save it before exit?"),
                                               QMessageBox::NoButton,
                                               q);
-    QAbstractButton* saveButton = messageBox->addButton(qSlicerMainWindow::tr("Save"), QMessageBox::ActionRole);
-    QAbstractButton* exitButton = messageBox->addButton(qSlicerMainWindow::tr("Exit (discard modifications)"), QMessageBox::ActionRole);
-    messageBox->addButton(qSlicerMainWindow::tr("Cancel exit"), QMessageBox::RejectRole);
+    // Give each button a distinct role. Previously "Save" and
+    // "Exit (discard modifications)" were both added with ActionRole; because
+    // the dispatch below relies on clickedButton() pointer identity and no
+    // default/escape button was set, the shared role let the native button
+    // layout (observed on macOS with Qt6) return the wrong button, so clicking
+    // "Exit" was handled as "Save" and re-opened the Save Data dialog instead
+    // of quitting.
+    QAbstractButton* saveButton = messageBox->addButton(qSlicerMainWindow::tr("Save"), QMessageBox::AcceptRole);
+    QAbstractButton* exitButton = messageBox->addButton(qSlicerMainWindow::tr("Exit (discard modifications)"), QMessageBox::DestructiveRole);
+    QPushButton* cancelButton = messageBox->addButton(qSlicerMainWindow::tr("Cancel exit"), QMessageBox::RejectRole);
+
+    // Make the non-destructive "Cancel exit" the default/escape action so that
+    // no button is silently activated by the platform's button layout.
+    messageBox->setDefaultButton(cancelButton);
+    messageBox->setEscapeButton(cancelButton);
 
     if (!details.isEmpty())
     {
       messageBox->setDetailedText(details);
     }
     messageBox->exec();
-    if (messageBox->clickedButton() == saveButton)
+    QAbstractButton* clickedButton = messageBox->clickedButton();
+    if (clickedButton == saveButton)
     {
-      // \todo Check if the save data dialog was "applied" and close the
-      // app in that case
-      this->FileSaveSceneAction->trigger();
+      // Save the scene, then exit only if the user actually completed the save
+      // (the save data dialog returns false if it was cancelled).
+      close = qSlicerApplication::application()->ioManager()->openSaveDataDialog();
     }
-    else if (messageBox->clickedButton() == exitButton)
+    else if (clickedButton == exitButton)
     {
       close = true;
     }

--- a/Base/QTGUI/Testing/Cxx/CMakeLists.txt
+++ b/Base/QTGUI/Testing/Cxx/CMakeLists.txt
@@ -47,6 +47,7 @@ if(BUILD_TESTING)
     qSlicerModulePanelTest1.cxx
     qSlicerMouseModeToolBarTest1.cxx
     qSlicerSaveDataDialogCustomFileWriterTest.cxx
+    qSlicerSaveDataDialogSaveOutcomeTest.cxx
     qSlicerWidgetTest1.cxx
     qSlicerWidgetTest2.cxx
     )
@@ -95,6 +96,7 @@ if(BUILD_TESTING)
   simple_test( qSlicerModulePanelTest1 )
   simple_test( qSlicerMouseModeToolBarTest1 )
   simple_test( qSlicerSaveDataDialogCustomFileWriterTest )
+  simple_test( qSlicerSaveDataDialogSaveOutcomeTest )
   simple_test( qSlicerWidgetTest1 )
   simple_test( qSlicerWidgetTest2 DATA{${CMAKE_SOURCE_DIR}/Libs/MRML/Core/Testing/TestData/fixed.nrrd} )
 

--- a/Base/QTGUI/Testing/Cxx/qSlicerSaveDataDialogSaveOutcomeTest.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerSaveDataDialogSaveOutcomeTest.cxx
@@ -1,0 +1,250 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// This test guards the save result that the application-exit confirmation
+// relies on. qSlicerMainWindowPrivate::confirmCloseApplication() quits only if
+// openSaveDataDialog() returns true, and that in turn is the Save Data dialog's
+// accepted/rejected result. So the exit is safe only if the dialog accepts
+// exclusively on a clean, fully successful save:
+//
+//   - a successful save     -> dialog accepts        -> the application may exit;
+//   - a failed save         -> dialog does not accept -> exit is cancelled;
+//   - a save with a warning  -> dialog does not accept -> exit is cancelled, so
+//                              the user can review the warning.
+//
+// The dialog is driven black-box: the real modal dialog is located through
+// QApplication::activeModalWidget() and its Save button is clicked, exactly as
+// a user would; no test-only hooks are added to the dialog.
+
+// Qt includes
+#include <QApplication>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QPushButton>
+#include <QTimer>
+
+// Slicer includes
+#include "qSlicerApplication.h"
+#include "qSlicerCoreApplication.h"
+#include "qSlicerCoreIOManager.h"
+#include "qSlicerFileWriter.h"
+#include "qSlicerSaveDataDialog.h"
+
+// MRML includes
+#include <vtkMRMLLinearTransformNode.h>
+#include <vtkMRMLMessageCollection.h>
+#include <vtkMRMLScene.h>
+#include <vtkMRMLStorableNode.h>
+#include <vtkMRMLStorageNode.h>
+#include <vtkMRMLTransformStorageNode.h>
+
+// VTK includes
+#include <vtkCommand.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+
+// STD includes
+#include <functional>
+#include <iostream>
+#include <memory>
+
+namespace
+{
+
+enum SaveOutcome
+{
+  Success,
+  Failure,
+  Warning
+};
+
+//-----------------------------------------------------------------------------
+// A node writer whose outcome is configurable, so a single registered writer
+// can stand in for a successful, failing, or warning save of a transform node.
+class qSlicerConfigurableFileWriter : public qSlicerFileWriter
+{
+public:
+  qSlicerConfigurableFileWriter(qSlicerIO::IOFileType fileType, QObject* parent = nullptr)
+    : qSlicerFileWriter(parent)
+    , FileType(fileType)
+    , Outcome(Success)
+  {
+  }
+  QString description() const override { return "Configurable outcome"; }
+  qSlicerIO::IOFileType fileType() const override { return this->FileType; }
+  // Must be overridden (the base returns false); otherwise the Save Data dialog
+  // does not offer the node for saving and there is nothing to exercise.
+  bool canWriteObject(vtkObject* object) const override { return vtkMRMLLinearTransformNode::SafeDownCast(object) != nullptr; }
+  // Claim the transform storage node's default extension (.h5) so this writer is
+  // the one the dialog selects for the node's file, and write() actually runs.
+  QStringList extensions(vtkObject*) const override { return QStringList(QString("Transform (.h5)")); }
+
+  bool write(const IOProperties& properties) override
+  {
+    if (this->Outcome == Failure)
+    {
+      // Report failure like a real writer that could not write the file. The
+      // dialog adds the error message itself when a writer returns false.
+      return false;
+    }
+    const QString nodeID = properties["nodeID"].toString();
+    if (this->Outcome == Warning)
+    {
+      // The write succeeded but produced a non-fatal warning. Real storage
+      // nodes report this on their own message collection; emulate that so the
+      // dialog treats the save as not fully clean.
+      vtkMRMLScene* scene = qSlicerCoreApplication::application()->mrmlScene();
+      vtkMRMLStorableNode* storableNode = vtkMRMLStorableNode::SafeDownCast(scene->GetNodeByID(nodeID.toUtf8().constData()));
+      if (storableNode && storableNode->GetStorageNode())
+      {
+        storableNode->GetStorageNode()->GetUserMessages()->AddMessage(vtkCommand::WarningEvent, "Simulated non-fatal save warning");
+      }
+    }
+    this->setWrittenNodes(QStringList() << nodeID);
+    return true;
+  }
+
+  qSlicerIO::IOFileType FileType;
+  SaveOutcome Outcome;
+};
+
+//-----------------------------------------------------------------------------
+// The Save Data dialog also offers to save the (modified) scene, but the
+// minimal test application registers no scene writer. Provide one that succeeds
+// without touching disk, so the scene save never masks the node save result
+// under test. Only successful node saves plus a successful scene save let the
+// dialog accept.
+class qSlicerNoopSceneWriter : public qSlicerFileWriter
+{
+public:
+  qSlicerNoopSceneWriter(QObject* parent = nullptr)
+    : qSlicerFileWriter(parent)
+  {
+  }
+  QString description() const override { return "No-op scene"; }
+  qSlicerIO::IOFileType fileType() const override { return QString("SceneFile"); }
+  bool canWriteObject(vtkObject* object) const override { return vtkMRMLScene::SafeDownCast(object) != nullptr; }
+  QStringList extensions(vtkObject*) const override { return QStringList(QString("MRML Scene (.mrml)")); }
+  bool write(const IOProperties& /*properties*/) override
+  {
+    this->setWrittenNodes(QStringList() << QString("Scene"));
+    return true;
+  }
+};
+
+//-----------------------------------------------------------------------------
+// Click the Save button of whatever modal Save Data dialog is currently up. If
+// the save does not accept the dialog (failure or warning), reject it so exec()
+// returns and the caller sees a not-accepted result.
+void driveSaveButton(std::shared_ptr<int> attempts, const std::function<void()>& self)
+{
+  QDialog* dialog = qobject_cast<QDialog*>(QApplication::activeModalWidget());
+  QDialogButtonBox* buttonBox = dialog ? dialog->findChild<QDialogButtonBox*>("ButtonBox") : nullptr;
+  QPushButton* saveButton = buttonBox ? buttonBox->button(QDialogButtonBox::Save) : nullptr;
+  if (!saveButton)
+  {
+    // The dialog may not be shown yet; retry briefly, then give up.
+    if (++(*attempts) < 100)
+    {
+      QTimer::singleShot(20, self);
+    }
+    else if (dialog)
+    {
+      dialog->reject();
+    }
+    return;
+  }
+  saveButton->click(); // synchronously triggers accept() -> save()
+  if (dialog->isVisible())
+  {
+    // save() returned false, so accept() did not close the dialog.
+    dialog->reject();
+  }
+}
+
+//-----------------------------------------------------------------------------
+bool runSaveCase(qSlicerConfigurableFileWriter* writer, SaveOutcome outcome)
+{
+  vtkMRMLScene* scene = qSlicerCoreApplication::application()->mrmlScene();
+  writer->Outcome = outcome;
+
+  vtkNew<vtkMRMLTransformStorageNode> storageNode;
+  scene->AddNode(storageNode);
+  vtkNew<vtkMRMLLinearTransformNode> transformNode;
+  scene->AddNode(transformNode);
+  transformNode->SetAndObserveStorageNodeID(storageNode->GetID());
+  // Modify the node so the dialog lists it and checks it for saving
+  // (populateNode() keys the check state off GetModifiedSinceRead()).
+  vtkNew<vtkMatrix4x4> matrix;
+  matrix->SetElement(0, 3, 5.0);
+  transformNode->SetMatrixTransformToParent(matrix);
+
+  qSlicerSaveDataDialog dialog;
+  auto attempts = std::make_shared<int>(0);
+  auto driver = std::make_shared<std::function<void()>>();
+  *driver = [attempts, driver]() { driveSaveButton(attempts, *driver); };
+  QTimer::singleShot(0, *driver);
+  // Safety net so the test can never hang if the dialog cannot be driven.
+  QTimer::singleShot(10000,
+                     []()
+                     {
+                       if (QApplication::activeModalWidget())
+                       {
+                         QApplication::activeModalWidget()->close();
+                       }
+                     });
+  const bool accepted = dialog.exec();
+
+  scene->RemoveNode(transformNode);
+  scene->RemoveNode(storageNode);
+  return accepted;
+}
+
+} // namespace
+
+//-----------------------------------------------------------------------------
+int qSlicerSaveDataDialogSaveOutcomeTest(int argc, char* argv[])
+{
+  qSlicerApplication app(argc, argv);
+  app.coreIOManager()->registerIO(new qSlicerNoopSceneWriter(nullptr));
+  qSlicerConfigurableFileWriter* writer = new qSlicerConfigurableFileWriter(QString("TransformFile"), nullptr);
+  app.coreIOManager()->registerIO(writer);
+
+  struct TestCase
+  {
+    SaveOutcome outcome;
+    bool expectedAccepted;
+    const char* name;
+  };
+  const TestCase cases[] = {
+    { Success, true, "successful save accepts (exit allowed)" },
+    { Failure, false, "failed save does not accept (exit cancelled)" },
+    { Warning, false, "save with warning does not accept (exit cancelled)" },
+  };
+
+  bool allPassed = true;
+  for (const TestCase& testCase : cases)
+  {
+    const bool accepted = runSaveCase(writer, testCase.outcome);
+    const bool passed = (accepted == testCase.expectedAccepted);
+    std::cout << (passed ? "PASSED: " : "FAILED: ") << testCase.name << " (accepted=" << (accepted ? "true" : "false")
+              << ", expected=" << (testCase.expectedAccepted ? "true" : "false") << ")" << std::endl;
+    allPassed = allPassed && passed;
+  }
+
+  return allPassed ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Overview

Fixes two problems in the application-exit confirmation flow in `qSlicerMainWindowPrivate::confirmCloseApplication()`. Both were observed on macOS with Qt6, but the first is a platform-independent logic fragility.

## 1. `BUG:` Save-before-exit dialog didn't honor the chosen button

When the scene has unsaved changes, quitting shows a dialog with **Save**, **Exit (discard modifications)**, and **Cancel exit**. The **Save** and **Exit** buttons were both added with `QMessageBox::ActionRole`, and the result was read via `clickedButton()` pointer identity with no default/escape button set. With two same-role buttons the native macOS/Qt6 button layout could return the wrong button, so clicking **Exit** was handled as **Save** and re-opened the Save Data dialog instead of quitting.

- Give each button a distinct role: `AcceptRole` / `DestructiveRole` / `RejectRole`.
- Set the non-destructive **Cancel exit** as the default and escape button.
- Read `clickedButton()` once.
- Also fixes the long-standing `\todo`: choosing **Save** now exits only if the save data dialog was actually completed, instead of a fire-and-forget action trigger that never exited after saving.

## 2. `STYLE:` Suppressed exit dialog flashed on screen

When there are no unsaved changes and the user previously ticked *"Don't show this message again"*, `ctkMessageBox::confirmExit()` still constructs the dialog and suppresses it by briefly realizing it off-screen and auto-clicking on the next event-loop turn. Because `confirmExit()` runs synchronously from `closeEvent` (unlike `disclaimer()`, which defers `exec()` via `singleShot`), the off-screen suppression loses the race with the window server on macOS/Qt6 and the dialog visibly flashes before the app quits.

- Read the `MainWindow/DontConfirmExit` setting directly and skip constructing the dialog when confirmation has been disabled, so exit is immediate and no dialog is ever realized.

## Testing

Built and tested on macOS (Qt6). With a modified scene: **Exit** quits immediately, **Save** saves then quits (or stays open if the save dialog is cancelled), **Cancel exit**/Esc/Return keep the app open. With no unsaved changes and confirmation disabled: Command-Q quits with no flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)