### PR TITLE
ENH: Remove support for building against VTK <= 9.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,14 +455,14 @@ endif()
 mark_as_superbuild(Slicer_VTK_VERSION_MAJOR)
 
 set(_default_vtk_minor_version "6")
-set(Slicer_VTK_VERSION_MINOR ${_default_vtk_minor_version} CACHE STRING "VTK minor version (4, 5 or 6)")
-set_property(CACHE Slicer_VTK_VERSION_MINOR PROPERTY STRINGS "4" "5" "6")
-if(NOT "${Slicer_VTK_VERSION_MINOR}" MATCHES "^(4|5|6)$")
-  message(FATAL_ERROR "error: Slicer_VTK_VERSION_MINOR must be 4, 5 or 6.")
+set(Slicer_VTK_VERSION_MINOR ${_default_vtk_minor_version} CACHE STRING "VTK minor version (5 or 6)")
+set_property(CACHE Slicer_VTK_VERSION_MINOR PROPERTY STRINGS "5" "6")
+if(NOT "${Slicer_VTK_VERSION_MINOR}" MATCHES "^(5|6)$")
+  message(FATAL_ERROR "error: Slicer_VTK_VERSION_MINOR must be 5 or 6.")
 endif()
 mark_as_superbuild(Slicer_VTK_VERSION_MINOR)
 
-set(Slicer_VTK_MINIMUM_SUPPORTED_VERSION "9.4")
+set(Slicer_VTK_MINIMUM_SUPPORTED_VERSION "9.5")
 
 #-----------------------------------------------------------------------------
 # Install no development files by default, but allow the user to get

--- a/Libs/MRML/Widgets/qMRMLSliceView.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceView.cxx
@@ -101,7 +101,7 @@ void qMRMLSliceViewPrivate::init()
   // Disable touch event processing on macOS with Qt6 to prevent spurious
   // LeftButtonPressEvent from trackpad touch events without matching releases.
   // See https://github.com/Slicer/Slicer/issues/9068
-#if defined(Q_OS_MACOS) && (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)) && (VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 0))
+#if defined(Q_OS_MACOS) && (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
   if (q->VTKWidget() != nullptr)
   {
     q->VTKWidget()->setEnableTouchEventProcessing(false);

--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -102,7 +102,7 @@ void qMRMLThreeDViewPrivate::init()
   // LeftButtonPressEvent in VTK without matching release events, causing the
   // interactor style to remain in ROTATE state permanently.
   // See https://github.com/Slicer/Slicer/issues/9068
-#if defined(Q_OS_MACOS) && (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)) && (VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 5, 0))
+#if defined(Q_OS_MACOS) && (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
   if (q->VTKWidget() != nullptr)
   {
     q->VTKWidget()->setEnableTouchEventProcessing(false);

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -164,10 +164,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     )
 
   set(_git_tag)
-  if("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.4")
-    set(_git_tag "454bb391dff78c6ff463298a5143ab5b4f0aa083") # slicer-v9.4.2-2025-03-26-13acb1a5d
-    set(vtk_dist_info_version "9.4.2")
-  elseif("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.5")
+  if("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.5")
     set(_git_tag "08210fbecda09bea2544dbb80777d634e1bfea25") # slicer-v9.5.2-2025-09-16-7c0494a68
     set(vtk_dist_info_version "9.5.2")
   elseif("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.6")
@@ -280,15 +277,9 @@ Version: @vtk_dist_info_version@
         ${VTK_DIR}/${_library_output_subdir}/python${Slicer_REQUIRED_PYTHON_VERSION_DOT}/site-packages
         )
     else()
-      if(${vtk_dist_info_version} VERSION_GREATER_EQUAL 9.4)
-        set(${proj}_PYTHONPATH_LAUNCHER_BUILD
-          ${VTK_DIR}/lib/site-packages # Location for VTK 9.4+
-          )
-      else()
-        set(${proj}_PYTHONPATH_LAUNCHER_BUILD
-          ${VTK_DIR}/${_library_output_subdir}/Lib/site-packages # Location for VTK 9.3 or older
-          )
-      endif()
+      set(${proj}_PYTHONPATH_LAUNCHER_BUILD
+        ${VTK_DIR}/lib/site-packages
+        )
     endif()
 
   mark_as_superbuild(
@@ -328,15 +319,9 @@ Version: @vtk_dist_info_version@
         <APPLAUNCHER_SETTINGS_DIR>/../${_library_install_subdir}/python${Slicer_REQUIRED_PYTHON_VERSION_DOT}/site-packages
         )
     else()
-      if(${vtk_dist_info_version} VERSION_GREATER_EQUAL 9.4)
-        set(${proj}_PYTHONPATH_LAUNCHER_INSTALLED
-          <APPLAUNCHER_SETTINGS_DIR>/../lib/site-packages # Location for VTK 9.4+
-          )
-      else()
-        set(${proj}_PYTHONPATH_LAUNCHER_INSTALLED
-          <APPLAUNCHER_SETTINGS_DIR>/../${_library_install_subdir}/Lib/site-packages # Location for VTK 9.3 or older
-          )
-      endif()
+      set(${proj}_PYTHONPATH_LAUNCHER_INSTALLED
+        <APPLAUNCHER_SETTINGS_DIR>/../lib/site-packages
+        )
     endif()
     mark_as_superbuild(
       VARS ${proj}_PYTHONPATH_LAUNCHER_INSTALLED


### PR DESCRIPTION
This anticipates upcoming support for VTK 9.7.0 at which there will be support for VTK 9.5, 9.6 and 9.7.

This is a follow-up to https://github.com/Slicer/Slicer/commit/67a8c92f54f7972b1bca05673e26e765db11de50 where the VTK minimum version was last updated to 9.4.