### PR TITLE
BUG: Fix OpenXR rendering not resuming automatically after headset doff/don

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -168,7 +168,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "08210fbecda09bea2544dbb80777d634e1bfea25") # slicer-v9.5.2-2025-09-16-7c0494a68
     set(vtk_dist_info_version "9.5.2")
   elseif("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.6")
-    set(_git_tag "6181bb1223bbc499a340a1644f5356e7e152c318") # slicer-v9.6.2-2026-05-15-f49a1dbaf
+    set(_git_tag "c9cd17a377cbc7e488329e882a35b70c7f37fe76") # slicer-v9.6.2-2026-05-15-f49a1dbaf
     set(vtk_dist_info_version "9.6.2")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR.Slicer_VTK_VERSION_MINOR: ${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}")


### PR DESCRIPTION
The git hash containing the previously implemented fix to address headset doff/don wasn't included in External_VTK.cmake.

$ git shortlog 6181bb1223bbc499a340a1644f5356e7e152c318..c9cd17a377cbc7e488329e882a35b70c7f37fe76 --no-merges Andras Lasso (1):
      BUG: Resume OpenXR rendering automatically after headset doff/don