### PR TITLE
ENH: Speed up macOS packaging and make developer builds distributable

### DIFF
--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -42,6 +42,7 @@
 #include "qSlicerLoadableModuleFactory.h"
 #include "qSlicerModuleFactoryManager.h"
 #include "qSlicerModuleManager.h"
+#include "vtkSlicerConfigure.h"        // For Slicer_QtPlugins_DIR
 #include "vtkSlicerVersionConfigure.h" // For Slicer_MAIN_PROJECT_VERSION_FULL
 
 #ifdef Slicer_USE_PYTHONQT
@@ -51,6 +52,7 @@
 #include <vtkSystemInformation.h>
 
 // CTK includes
+#include <ctkAppLauncherEnvironment.h>
 #include <ctkMessageBox.h>
 #include <ctkProxyStyle.h>
 #ifdef Slicer_USE_PYTHONQT
@@ -193,6 +195,29 @@ void qSlicerApplicationHelper::preInitializeApplication(const char* argv0, ctkPr
   vtkLogger::SetStderrVerbosity(vtkLogger::VERBOSITY_OFF);
   itk::itkFactoryRegistration();
   qMRMLWidget::preInitializeApplication();
+
+#ifdef Q_OS_MACOS
+  // An installed macOS application bundle has no separate launcher process to
+  // set up the environment (unlike Linux and Windows, and unlike the build
+  // tree where the CTK application launcher is used). The Qt platform plugin
+  // ("cocoa") is loaded by the QApplication base class constructor, before
+  // qSlicerCoreApplication is able to apply the launcher settings, so
+  // QT_PLUGIN_PATH must already point at the Qt plugins bundled in the
+  // application. Without it the application aborts at startup with
+  // "Could not find the Qt platform plugin cocoa".
+  // This is only needed when running without a launcher (currentLevel() == 0):
+  // when a launcher is used, it has already set QT_PLUGIN_PATH.
+  if (argv0 && ctkAppLauncherEnvironment::currentLevel() == 0 && !qEnvironmentVariableIsSet("QT_PLUGIN_PATH"))
+  {
+    std::string executableDir = vtksys::SystemTools::GetFilenamePath(vtksys::SystemTools::CollapseFullPath(argv0));
+    // <bundle>/Contents/MacOS -> <bundle>/Contents/<Slicer_QtPlugins_DIR>
+    std::string pluginPath = vtksys::SystemTools::CollapseFullPath(executableDir + "/../" + Slicer_QtPlugins_DIR);
+    if (vtksys::SystemTools::FileIsDirectory(pluginPath))
+    {
+      qputenv("QT_PLUGIN_PATH", QByteArray::fromStdString(pluginPath));
+    }
+  }
+#endif
 
   // Allow a custom application name so that the settings
   // can be distinct for differently named applications

--- a/CMake/SlicerBlockInstallQtPlugins.cmake
+++ b/CMake/SlicerBlockInstallQtPlugins.cmake
@@ -37,11 +37,21 @@ if(NOT "${QT_PLUGINS_DIR}" STREQUAL "")
     endforeach()
 
     foreach(qpi ${qt_plugins})
-      install(PROGRAMS ${qpi}
+      get_filename_component(qpi_libname ${qpi} NAME)
+      # Some Qt deployments (notably Homebrew) expose the plugins directory as a
+      # tree of symlinks pointing into the versioned install location (e.g.
+      # ".../share/qt/plugins/platforms/libqcocoa.dylib" -> "../../../../Cellar/...").
+      # install(PROGRAMS) copies such a symlink verbatim, so the installed plugin
+      # is a relative link that dangles as soon as the bundle is moved off the
+      # build machine, and the application then aborts at startup because the Qt
+      # platform plugin ("cocoa") cannot be loaded. Resolve to the real file so an
+      # actual binary is installed and can be fixed up and embedded in the bundle.
+      get_filename_component(qpi_realpath "${qpi}" REALPATH)
+      install(PROGRAMS ${qpi_realpath}
         DESTINATION ${Slicer_INSTALL_QtPlugins_DIR}/${plugins_subdirectory}
+        RENAME ${qpi_libname}
         COMPONENT RuntimePlugins
         )
-      get_filename_component(qpi_libname ${qpi} NAME)
       slicerStripInstalledLibrary(
         FILES "${Slicer_INSTALL_QtPlugins_DIR}/${plugins_subdirectory}/${qpi_libname}"
         COMPONENT Runtime

--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -13,6 +13,13 @@ if(UNIX)
   set(CPACK_GENERATOR "TGZ")
   if(APPLE)
     set(CPACK_GENERATOR "DragNDrop")
+    # Use the LZFSE-compressed disk image format (ULFO) instead of the CPack
+    # default (UDZO, zlib). LZFSE compresses the application bundle several
+    # times faster and produces a slightly smaller image. ULFO images require
+    # macOS 10.11 or later to mount, well below the minimum supported version.
+    if(NOT DEFINED CPACK_DMG_FORMAT)
+      set(CPACK_DMG_FORMAT "ULFO")
+    endif()
   endif()
 elseif(WIN32)
   set(CPACK_GENERATOR "NSIS")

--- a/CMake/SlicerCPackBundleFixup.cmake.in
+++ b/CMake/SlicerCPackBundleFixup.cmake.in
@@ -1,484 +1,174 @@
 
-include(@CMAKE_SOURCE_DIR@/CMake/BundleUtilitiesWithRPath.cmake)
-#include(BundleUtilities)
-
-#-----------------------------------------------------------------------------
-set(PYTHON_STDLIB_SUBDIR "@PYTHON_STDLIB_SUBDIR@")
-set(PYTHON_SITE_PACKAGES_SUBDIR "@PYTHON_SITE_PACKAGES_SUBDIR@")
-
-#-----------------------------------------------------------------------------
-# gp_log_message - Convenient function allowing to both display and log a message.
-# Log file: $ENV{DESTDIR}/../complete-bundles-log.txt
-#-----------------------------------------------------------------------------
-function(gp_log_message text)
-  message(${text})
-  file(APPEND "@Slicer_BINARY_DIR@/complete-bundles-log.txt" "${text}
-")
-endfunction()
-
-#-----------------------------------------------------------------------------
-# gp_clear_log - Clear the log file
-#-----------------------------------------------------------------------------
-function(gp_clear_log)
-  file(WRITE "@Slicer_BINARY_DIR@/complete-bundles-log.txt" "")
-  gp_log_message("Log file: @Slicer_BINARY_DIR@/complete-bundles-log.txt")
-endfunction()
-
-#-----------------------------------------------------------------------------
-# gp_item_default_embedded_path_override item default_embedded_path_var
-#-----------------------------------------------------------------------------
-# Return the path that others should refer to the item by when the item
-# is embedded inside a bundle.
+# macOS bundle fixup.
 #
-# This is a project-specific override of BundleUtilities.cmake's
-# gp_item_default_embedded_path
+# Historically this step drove CMake's BundleUtilities fixup_bundle(), which
+# walks the dependency graph one binary at a time, shelling out to otool
+# repeatedly and copying/rewriting serially -- the dominant cost of
+# "make package" on a bundle the size of Slicer. It is replaced here by
+# SlicerBundleCloseDeps.py, which walks the graph once (a single otool -l per
+# binary) and applies the independent install-name rewrites in parallel,
+# producing the same self-contained bundle far faster. The only inputs it needs
+# from the build are the library search directories used to resolve @rpath and
+# bare install names; those are gathered below exactly as before.
+
+set(app_dir "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@Slicer_MAIN_PROJECT_APPLICATION_NAME@.app")
+
+set(Slicer_BUILD_DIR "@Slicer_BINARY_DIR@")
+set(Slicer_SUPERBUILD_DIR "@Slicer_SUPERBUILD_DIR@")
+foreach(path Slicer_BUILD_DIR Slicer_SUPERBUILD_DIR)
+  if(NOT EXISTS ${${path}})
+    message(FATAL_ERROR "${path} variable is defined but corresponds to nonexistent directory: ${${path}}")
+  endif()
+endforeach()
+
+#-----------------------------------------------------------------------------
+# Library search directories.
 #
-function(gp_item_default_embedded_path_override item default_embedded_path_var)
-
-  # By default, embed items as set by gp_item_default_embedded_path:
-  set(path "${${default_embedded_path_var}}")
-
-  if(item MATCHES "Contents/bin/[^/]+")
-    set(path "@fixup_path@/bin")
+# @rpath and bare install names (for example DCMTK's "libopenjp2.7.dylib") are
+# resolved against the referring binary's own run-paths first and then these
+# directories. Absolute install names (Homebrew and superbuild libraries) are
+# resolved directly and need no entry here.
+#-----------------------------------------------------------------------------
+set(search_paths)
+macro(_append_search_dir dir)
+  if(EXISTS "${dir}")
+    list(APPEND search_paths "${dir}")
   endif()
-
-  if(item MATCHES "[^/]+\\.framework/")
-    set(path "@fixup_path@/Frameworks")
-  endif()
-
-  if(item MATCHES "\\.(dylib|so)$")
-    set(path "@fixup_path@/@Slicer_LIB_DIR@")
-  endif()
-
-  set(Slicer_USE_PYTHONQT "@Slicer_USE_PYTHONQT@")
-  if(Slicer_USE_PYTHONQT)
-    # Python library
-    if(item MATCHES "libpython[^/]+\\.dylib$")
-      set(path "@fixup_path@/lib/Python/lib")
-    endif()
-    # Python extensions
-    if(item MATCHES "lib-dynload/[^/]+\\.so$")
-      set(path "@fixup_path@/lib/Python/${PYTHON_STDLIB_SUBDIR}/lib-dynload")
-    endif()
-    # VTK python modules
-    if(item MATCHES "vtkmodules/[^/]+\\.so$")
-      set(path "@fixup_path@/bin/Python/vtkmodules")
-    endif()
-  endif()
-
-  set(Slicer_USE_SimpleITK "@Slicer_USE_SimpleITK@")
-  if(Slicer_USE_SimpleITK)
-    if (item MATCHES  "site-packages/(SimpleITK.*)/_SimpleITK[^/]*\\.(so|dylib)$" )
-      # CMAKE_MATCH_1 is the over complicated egg path
-      set(python_sys_site_path "@fixup_path@/lib/Python/${PYTHON_SITE_PACKAGES_SUBDIR}")
-      set(path "${python_sys_site_path}/${CMAKE_MATCH_1}/")
-    endif()
-  endif()
-
-  if(item MATCHES "@Slicer_ITKFACTORIES_DIR@/[^/]+Plugin\\.(so|dylib)$")
-    set(path "@fixup_path@/@Slicer_ITKFACTORIES_DIR@")
-  endif()
-
-  foreach(qt_plugin_dir designer iconengines styles audio imageformats sqldrivers platforms printsupport)
-    if(item MATCHES "@Slicer_QtPlugins_DIR@/${qt_plugin_dir}/[^/]+\\.(so|dylib)$")
-      set(path "@fixup_path@/@Slicer_QtPlugins_DIR@/${qt_plugin_dir}")
-    endif()
-  endforeach()
-
-  if(item MATCHES "@Slicer_CLIMODULES_LIB_DIR@/[^/]+") # Matches library and executable
-    set(path "@fixup_path@/@Slicer_CLIMODULES_LIB_DIR@")
-  endif()
-
-  set(Slicer_BUILD_QTLOADABLEMODULES "@Slicer_BUILD_QTLOADABLEMODULES@")
-  if(Slicer_BUILD_QTLOADABLEMODULES)
-    if(item MATCHES "@Slicer_QTLOADABLEMODULES_LIB_DIR@/[^/]+\\.(so|dylib)$")
-      set(path "@fixup_path@/@Slicer_QTLOADABLEMODULES_LIB_DIR@")
-    endif()
-  endif()
-
-  set(extension_fixup_embedded_path_overrides "@EXTENSION_FIXUP_BUNDLE_EMBEDDED_PATH_OVERRIDES@")
-  foreach(pair IN LISTS extension_fixup_embedded_path_overrides)
-    string(REPLACE "|" ";" split_pair "${pair}")
-    list(LENGTH split_pair split_len)
-    if(NOT split_len EQUAL 2)
-      message(WARNING "Invalid override pair '${pair}', expected format <regex>|<relative_path>")
-      continue()
-    endif()
-    list(GET split_pair 0 regex)
-    list(GET split_pair 1 relative_path)
-
-    set(path "@fixup_path@/${relative_path}")
-  endforeach()
-
-  math(EXPR lib_current $ENV{FIXUP_LIB_CURRENT}+1)
-  set(ENV{FIXUP_LIB_CURRENT} ${lib_current})
-  gp_log_message("${lib_current} - fixing item ${item} with ${path}")
-
-  set(${default_embedded_path_var} "${path}" PARENT_SCOPE)
-endfunction()
-
-macro(_fixup_paths_append list var)
-  if(NOT EXISTS "${var}")
-    message(FATAL_ERROR "Path append to list [${list}] failed - Path [${var}:${${var}}] does NOT exist !")
-  endif()
-
-  list(APPEND ${list} ${var})
 endmacro()
 
-#-----------------------------------------------------------------------------
-# Fixup the .app bundles in the install tree:
-#-----------------------------------------------------------------------------
-function(fixup_bundle_with_plugins app)
-  set(app_dir "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${app}")
-  set(suffix "@CMAKE_SHARED_LIBRARY_SUFFIX@")
+foreach(dir "@VTK_LIBRARY_DIRS@")
+  _append_search_dir("${dir}")
+endforeach()
+_append_search_dir("@ITK_DIR@/lib")
+foreach(dir "@Teem_LIBRARY_DIRS@")
+  _append_search_dir("${dir}")
+endforeach()
+foreach(dir "@CTK_LIBRARY_DIRS@")
+  _append_search_dir("${dir}")
+endforeach()
+if(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT)
+  foreach(dir "@JsonCpp_LIBRARY_DIRS@")
+    _append_search_dir("${dir}")
+  endforeach()
+endif()
+foreach(dir "@SlicerExecutionModel_LIBRARY_DIRS@")
+  _append_search_dir("${dir}")
+endforeach()
+set(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT "@Slicer_BUILD_EXTENSIONMANAGER_SUPPORT@")
+if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
+  _append_search_dir("@LibArchive_DIR@/lib")
+endif()
+set(Slicer_USE_PYTHONQT "@Slicer_USE_PYTHONQT@")
+if(Slicer_USE_PYTHONQT)
+  _append_search_dir("@PYTHON_LIBRARY_PATH@")
+endif()
+set(Slicer_USE_PYTHONQT_WITH_OPENSSL "@Slicer_USE_PYTHONQT_WITH_OPENSSL@")
+set(Slicer_USE_DCMTK_WITH_OPENSSL "@Slicer_USE_PYTHONQT_WITH_OPENSSL@")
+if(Slicer_USE_PYTHONQT_WITH_OPENSSL OR Slicer_USE_DCMTK_WITH_OPENSSL)
+  _append_search_dir("@OPENSSL_EXPORT_LIBRARY_DIR@")
+endif()
+set(Slicer_BUILD_DICOM_SUPPORT "@Slicer_BUILD_DICOM_SUPPORT@")
+if(Slicer_BUILD_DICOM_SUPPORT)
+  _append_search_dir("@DCMTK_DIR@/lib/")
+endif()
+set(Slicer_USE_SYSTEM_OpenJPEG "@Slicer_USE_SYSTEM_OpenJPEG@")
+if(Slicer_BUILD_DICOM_SUPPORT AND NOT Slicer_USE_SYSTEM_OpenJPEG)
+  _append_search_dir("@OpenJPEG_INSTALL_DIR@/lib/")
+endif()
 
-  set(Slicer_BUILD_DIR "@Slicer_BINARY_DIR@")
-  set(Slicer_SUPERBUILD_DIR "@Slicer_SUPERBUILD_DIR@")
+_append_search_dir("${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@")
+_append_search_dir("${Slicer_BUILD_DIR}/@Slicer_LIB_DIR@")
+set(Slicer_BUILD_QTLOADABLEMODULES "@Slicer_BUILD_QTLOADABLEMODULES@")
+if(Slicer_BUILD_QTLOADABLEMODULES)
+  _append_search_dir("${Slicer_BUILD_DIR}/@Slicer_QTLOADABLEMODULES_LIB_DIR@")
+endif()
+_append_search_dir("${Slicer_BUILD_DIR}/@Slicer_CLIMODULES_LIB_DIR@")
+_append_search_dir("${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/designer")
+_append_search_dir("${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/iconengines")
+_append_search_dir("${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/styles")
 
-  # Sanity checks
-  foreach(path Slicer_BUILD_DIR Slicer_SUPERBUILD_DIR)
-    if(NOT EXISTS ${${path}})
-      message(FATAL_ERROR "${path} variable is defined but corresponds to nonexistent directory: ${${path}}")
+if(Slicer_ADDITIONAL_PROJECTS)
+  foreach(additional_project ${Slicer_ADDITIONAL_PROJECTS})
+    find_package(${additional_project})
+    if(${additional_project}_FOUND)
+      include(${${additional_project}_USE_FILE})
+      foreach(dir "${${additional_project}_LIBRARY_DIRS}")
+        _append_search_dir("${dir}")
+      endforeach()
     endif()
   endforeach()
+endif()
 
-  set(candidates_pattern
-    "${app_dir}/Contents/@Slicer_ITKFACTORIES_DIR@/*Plugin.dylib"
-    "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/designer/*Plugins.so"
-    "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/designer/*.dylib"
-    "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/iconengines/*Plugin.so"
-    "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/styles/*Plugins.so"
-    "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/audio/*${suffix}"
-    "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/imageformats/*${suffix}"
-    "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/sqldrivers/*${suffix}"
-    "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/platforms/*${suffix}"
-    "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/printsupport/*${suffix}"
-    )
+set(extension_libs_path "@EXTENSION_BUNDLE_FIXUP_LIBRARY_DIRECTORIES@")
+foreach(dir ${extension_libs_path})
+  _append_search_dir("${dir}")
+endforeach()
 
-  set(Slicer_USE_PYTHONQT "@Slicer_USE_PYTHONQT@")
-
-  set(Slicer_BUILD_QTLOADABLEMODULES "@Slicer_BUILD_QTLOADABLEMODULES@")
-  if(Slicer_BUILD_QTLOADABLEMODULES)
-    list(APPEND candidates_pattern
-      "${app_dir}/Contents/@Slicer_QTLOADABLEMODULES_LIB_DIR@/libq*Module${suffix}"
-      "${app_dir}/Contents/@Slicer_QTLOADABLEMODULES_LIB_DIR@/*Python.so"
-      )
-    if(Slicer_USE_PYTHONQT)
-      list(APPEND candidates_pattern
-        "${app_dir}/Contents/@Slicer_QTLOADABLEMODULES_LIB_DIR@/qSlicer*PythonQt.so"
-        )
-    endif()
-  endif()
-
-  if(Slicer_USE_PYTHONQT)
-    list(APPEND candidates_pattern
-      "${app_dir}/Contents/@Slicer_LIB_DIR@/*Python.so"
-      "${app_dir}/Contents/@Slicer_LIB_DIR@/*PythonQt.so"
-      # Since both core python and numpy module have no dependency beside of
-      # system library, there is no need to fix them.
-      # "${app_dir}/Contents/lib/Python/${PYTHON_SITE_PACKAGES_SUBDIR}/*.so"
-      #"${app_dir}/Contents/lib/Python/${PYTHON_STDLIB_SUBDIR}/lib-dynload/*.so"
-      )
-  endif()
-
-  if(Slicer_USE_PYTHONQT)
-    list(APPEND candidates_pattern
-      "${app_dir}/Contents/bin/Python/vtkmodules/*.so"
-      )
-  endif()
-
-  set(Slicer_USE_PYTHONQT_WITH_OPENSSL "@Slicer_USE_PYTHONQT_WITH_OPENSSL@")
-  if(Slicer_USE_PYTHONQT_WITH_OPENSSL)
-    list(APPEND candidates_pattern
-      "${app_dir}/Contents/lib/Python/${PYTHON_STDLIB_SUBDIR}/lib-dynload/_hashlib*.so"
-      "${app_dir}/Contents/lib/Python/${PYTHON_STDLIB_SUBDIR}/lib-dynload/_ssl*.so"
-      )
-  endif()
-
-  set(Slicer_USE_SimpleITK "@Slicer_USE_SimpleITK@")
-  if(Slicer_USE_SimpleITK)
-    list(APPEND candidates_pattern
-      "${app_dir}/Contents/lib/Python/${PYTHON_SITE_PACKAGES_SUBDIR}/SimpleITK*/_SimpleITK*.so"
-      )
-  endif()
-
-  set(libs "")
-  file(GLOB_RECURSE candidates ${candidates_pattern})
-  foreach(lib ${candidates})
-    if(NOT lib MATCHES "(_debug|d[0-9])${suffix}$")
-      set(libs ${libs} "${lib}")
-    endif()
-  endforeach()
-
-  set(extension_candidates_patterns "@EXTENSION_FIXUP_BUNDLE_CANDIDATES_PATTERNS@")
-  if(extension_candidates_patterns)
-    list(APPEND candidates_pattern ${extension_candidates_patterns})
-  endif()
-
-  list(REMOVE_DUPLICATES libs)
-
-  # Additional libs may be found in:
-  set(libs_path )
-  foreach(dir "@VTK_LIBRARY_DIRS@")
-    _fixup_paths_append(libs_path ${dir})
-  endforeach()
-  _fixup_paths_append(libs_path "@ITK_DIR@/lib")
-  foreach(dir "@Teem_LIBRARY_DIRS@")
-    _fixup_paths_append(libs_path ${dir})
-  endforeach()
-  foreach(dir "@CTK_LIBRARY_DIRS@")
-    _fixup_paths_append(libs_path ${dir})
-  endforeach()
-  if(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT)
-    foreach(dir "@JsonCpp_LIBRARY_DIRS@")
-      _fixup_paths_append(libs_path ${dir})
-    endforeach()
-  endif()
-  foreach(dir "@SlicerExecutionModel_LIBRARY_DIRS@")
-    _fixup_paths_append(libs_path ${dir})
-  endforeach()
-  set(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT "@Slicer_BUILD_EXTENSIONMANAGER_SUPPORT@")
-  if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
-    _fixup_paths_append(libs_path "@LibArchive_DIR@/lib")
-  endif()
-  if(Slicer_USE_PYTHONQT)
-    _fixup_paths_append(libs_path "@PYTHON_LIBRARY_PATH@")
-  endif()
-  set(Slicer_USE_PYTHONQT_WITH_OPENSSL "@Slicer_USE_PYTHONQT_WITH_OPENSSL@")
-  set(Slicer_USE_DCMTK_WITH_OPENSSL "@Slicer_USE_PYTHONQT_WITH_OPENSSL@")
-  if(Slicer_USE_PYTHONQT_WITH_OPENSSL OR Slicer_USE_DCMTK_WITH_OPENSSL)
-    _fixup_paths_append(libs_path "@OPENSSL_EXPORT_LIBRARY_DIR@")
-  endif()
-  set(Slicer_BUILD_DICOM_SUPPORT "@Slicer_BUILD_DICOM_SUPPORT@")
-  if(Slicer_BUILD_DICOM_SUPPORT)
-    _fixup_paths_append(libs_path "@DCMTK_DIR@/lib/")
-  endif()
-  set(Slicer_USE_SYSTEM_OpenJPEG "@Slicer_USE_SYSTEM_OpenJPEG@")
-  if(Slicer_BUILD_DICOM_SUPPORT AND NOT Slicer_USE_SYSTEM_OpenJPEG)
-    _fixup_paths_append(libs_path "@OpenJPEG_INSTALL_DIR@/lib/")
-  endif()
-
-  list(APPEND libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@")
-  list(APPEND libs_path "${Slicer_BUILD_DIR}/@Slicer_LIB_DIR@")
-  if(Slicer_BUILD_QTLOADABLEMODULES)
-    _fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_QTLOADABLEMODULES_LIB_DIR@")
-  endif()
-  _fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_CLIMODULES_LIB_DIR@")
-  _fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/designer")
-  _fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/iconengines")
-  _fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/styles")
-  #_fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/audio")
-  #_fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/imageformats")
-  #_fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/sqldrivers")
-  #_fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/platforms")
-  if (Slicer_ADDITIONAL_PROJECTS)
-    foreach(additional_project ${Slicer_ADDITIONAL_PROJECTS})
-      find_package(${additional_project})
-      if (${additional_project}_FOUND)
-        include(${${additional_project}_USE_FILE})
-        foreach(dir "${${additional_project}_LIBRARY_DIRS}")
-          _fixup_paths_append(libs_path ${dir})
-        endforeach()
+# On macOS a binary Qt distribution keeps each framework's binary inside a
+# versioned subdirectory, and its transitive dependencies (brotli, freetype,
+# ...) next to the Qt libraries use bare "@rpath/<library>" install names. Add
+# the Qt library directory and every framework's Versions/* directory so those
+# resolve.
+set(Slicer_USE_SYSTEM_QT "@Slicer_USE_SYSTEM_QT@")
+if(NOT Slicer_USE_SYSTEM_QT)
+  set(_qt_libs_dir "@qt_root_dir@")
+  _append_search_dir("${_qt_libs_dir}")
+  file(GLOB _qt_fw_dirs "${_qt_libs_dir}/Qt*.framework")
+  foreach(_fw_dir ${_qt_fw_dirs})
+    file(GLOB _ver_subdirs "${_fw_dir}/Versions/*/")
+    foreach(_ver_dir ${_ver_subdirs})
+      if(IS_DIRECTORY "${_ver_dir}")
+        list(APPEND search_paths "${_ver_dir}")
       endif()
     endforeach()
-  endif()
-
-  set(extension_libs_path "@EXTENSION_BUNDLE_FIXUP_LIBRARY_DIRECTORIES@")
-  if(extension_libs_path)
-    list(APPEND libs_path ${extension_libs_path})
-  endif()
-
-  # On macOS with Qt6, framework binaries live inside versioned subdirectories
-  # (e.g. QtCore.framework/Versions/A/QtCore). BundleUtilities resolves @rpath
-  # references by stripping the @rpath prefix and searching for the bare filename
-  # via find_file(). That search only succeeds when the containing directory is
-  # listed in libs_path, so add every Qt framework Versions/* dir here.
-  set(Slicer_USE_SYSTEM_QT "@Slicer_USE_SYSTEM_QT@")
-  if(APPLE AND NOT Slicer_USE_SYSTEM_QT)
-    set(_qt_libs_dir "@qt_root_dir@")
-    file(GLOB _qt_fw_dirs "${_qt_libs_dir}/Qt*.framework")
-    foreach(_fw_dir ${_qt_fw_dirs})
-      file(GLOB _ver_subdirs "${_fw_dir}/Versions/*/")
-      foreach(_ver_dir ${_ver_subdirs})
-        if(IS_DIRECTORY "${_ver_dir}")
-          list(APPEND libs_path "${_ver_dir}")
-        endif()
-      endforeach()
-    endforeach()
-    unset(_qt_libs_dir)
-    unset(_qt_fw_dirs)
-    unset(_ver_subdirs)
-    unset(_fw_dir)
-    unset(_ver_dir)
-  endif()
-
-  list(REMOVE_DUPLICATES libs_path)
-
-  gp_clear_log()
-
-  gp_log_message("Calling fixup_bundle with")
-  gp_log_message("app=${app_dir}")
-  gp_log_message("<Slicer_SUPERBUILD_DIR>=${Slicer_SUPERBUILD_DIR}")
-  gp_log_message("libs=")
-  foreach(lib ${libs})
-    file(RELATIVE_PATH relative_lib ${Slicer_SUPERBUILD_DIR} ${lib})
-    if(NOT "${relative_lib}" STREQUAL "${lib}")
-      set(lib "<Slicer_SUPERBUILD_DIR>/${relative_lib}")
-    endif()
-    gp_log_message("  ${lib}")
   endforeach()
-  gp_log_message("libs_path=")
-  foreach(path ${libs_path})
-    file(RELATIVE_PATH relative_path ${Slicer_SUPERBUILD_DIR} ${path})
-    if(NOT "${relative_path}" STREQUAL "${path}")
-      set(path "<Slicer_SUPERBUILD_DIR>/${relative_path}")
-    endif()
-    gp_log_message("  ${path}")
-  endforeach()
+endif()
 
-  # Keep track of libs count and current lib being fixed
-  set(ENV{FIXUP_LIB_CURRENT} 0)
+list(REMOVE_DUPLICATES search_paths)
 
-  set(inner_re "1|a|bat|bmp|c|cc|cfg|cmake|conf|css|ctypes|cxx|dat|def|doc|dylib|egg-info|enc")
-  set(inner_re "${inner_re}|eps|example|f|f90|fits|gif|gz|h|hxx|i|icns|ico|in|ini|itk|log|md5")
-  set(inner_re "${inner_re}|mhd|mrml|mrml_remote|msg|nhdr|nib|nrrd|pkl|plist|png|ps|py|pyc|pyf")
-  set(inner_re "${inner_re}|pyw|pyx|raw|sample|so|supp|tcl|txt|ui|xml|exe|mexw32|mexw64")
-  set(GP_IS_FILE_EXECUTABLE_EXCLUDE_REGEX "\\.(${inner_re})$")
+set(search_path_args)
+foreach(dir ${search_paths})
+  list(APPEND search_path_args --search-path "${dir}")
+endforeach()
 
-  fixup_bundle(
-    "${app_dir}"
-    "${libs}"
-    "${libs_path}"
-    )
+#-----------------------------------------------------------------------------
+# Embed the dependency closure and rewrite it to @rpath.
+#-----------------------------------------------------------------------------
+message(STATUS "Closing macOS bundle dependencies")
+execute_process(
+  COMMAND python3 "@CMAKE_SOURCE_DIR@/Utilities/Scripts/SlicerBundleCloseDeps.py"
+          --app "${app_dir}" ${search_path_args}
+  RESULT_VARIABLE _closedeps_result
+  )
+if(NOT _closedeps_result EQUAL 0)
+  message(FATAL_ERROR "Closing macOS bundle dependencies failed")
+endif()
 
-  set(Slicer_USE_SYSTEM_QT "@Slicer_USE_SYSTEM_QT@")
-  if(NOT Slicer_USE_SYSTEM_QT)
-    set(qt_root_dir "@qt_root_dir@")
-
-    # Since BundleUtilities function do not copy the "Helpers" directory found
-    # in frameworks. The following will explicitly copy and fixup
-    # QtWebEngineCore.framework/Versions/5/Helpers/QtWebEngineProcess.app
-    set(Slicer_BUILD_WEBENGINE_SUPPORT "@Slicer_BUILD_WEBENGINE_SUPPORT@")
-    set(qtwebenginecore_app_subdir "Helpers/QtWebEngineProcess.app")
-    set(qtwebenginecore_src_dir "${qt_root_dir}/QtWebEngineCore.framework/${qtwebenginecore_app_subdir}")
-    set(qtwebenginecore_dest_dir "${app_dir}/Contents/Frameworks/QtWebEngineCore.framework/Versions/Current/${qtwebenginecore_app_subdir}")
-    if(Slicer_BUILD_WEBENGINE_SUPPORT AND EXISTS ${qtwebenginecore_src_dir})
-      file(COPY "${qtwebenginecore_src_dir}/Contents" DESTINATION "${qtwebenginecore_dest_dir}/" USE_SOURCE_PERMISSIONS)
-      set(qtwebengineprocess_executable "${qtwebenginecore_dest_dir}/Contents/MacOS/QtWebEngineProcess")
-      # Collect list of Qt framework dependencies
-      set(prereqs )
-      get_prerequisites(${qtwebengineprocess_executable} "prereqs" 1 0 "" "")
-      # Generate list of "-change" arguments
-      set(changes "")
-      foreach(item ${prereqs})
-        gp_item_default_embedded_path_override("${item}" path)
-        get_filename_component(item_name "${item}" NAME)
-        # Examples of values:
-        #  item          : /Volumes/Dashboards/Support/qt-everywhere-build-5.10.0/lib/QtNetwork.framework/Versions/5/QtNetwork
-        #  item_name     : QtNetwork
-        #  path          : @rpath/Frameworks
-        #  embedded_item : @rpath/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
-        string(REGEX REPLACE "^.*(${item_name}.framework/.*/?${item_name}).*$" "${path}/\\1" embedded_item "${item}")
-        set(changes ${changes} "-change" "${item}" "${embedded_item}")
-      endforeach()
-      # Update executable
-      execute_process(COMMAND install_name_tool
-        -add_rpath "@loader_path/../../../../../../../../"
-        ${changes} "${qtwebengineprocess_executable}"
-        )
-      # Create relative symlinks in <package_root>/Contents/Frameworks/QtWebEngineCore.framework
-      #  from Versions/Current/Helpers
-      #    to Helpers
-      execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-        "Versions/Current/Helpers"
-        "Helpers"
-        WORKING_DIRECTORY "${app_dir}/Contents/Frameworks/QtWebEngineCore.framework"
-        )
-    endif()
-
-   # Since BundleUtilities module does not know how to install .app directory within
-   # an existing app, the following explicitly install the designer application as well
-   # as the QtDesignerComponents.framework.
-   set(Slicer_BUILD_QT_DESIGNER_PLUGINS "@Slicer_BUILD_QT_DESIGNER_PLUGINS@")
-   set(designer_app_subdir "Designer.app")
-   set(designer_src_dir "${qt_root_dir}/../bin/${designer_app_subdir}")
-   set(designer_dest_dir "${app_dir}/Contents/bin/${designer_app_subdir}")
-   if(Slicer_BUILD_QT_DESIGNER_PLUGINS AND EXISTS ${designer_src_dir})
-     # Designer
-     file(COPY "${designer_src_dir}/Contents" DESTINATION "${designer_dest_dir}/" USE_SOURCE_PERMISSIONS)
-     set(designer_executable "${designer_dest_dir}/Contents/MacOS/Designer")
-     # Collect list of Qt framework dependencies
-     set(prereqs )
-     get_prerequisites(${designer_executable} "prereqs" 1 0 "" "")
-     # Generate list of "-change" arguments
-     set(changes "")
-     foreach(item ${prereqs})
-       gp_item_default_embedded_path_override("${item}" path)
-       get_filename_component(item_name "${item}" NAME)
-       # Examples of values:
-       #  item          : /Volumes/Dashboards/Support/qt-everywhere-build-5.10.0/lib/QtNetwork.framework/Versions/5/QtNetwork
-       #  item_name     : QtNetwork
-       #  path          : @rpath/Frameworks
-       #  embedded_item : @rpath/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
-       string(REGEX REPLACE "^.*(${item_name}.framework/.*/?${item_name}).*$" "${path}/\\1" embedded_item "${item}")
-       set(changes ${changes} "-change" "${item}" "${embedded_item}")
-     endforeach()
-     # Update executable
-     # Remove the Qt-install-tree rpath if present (Qt5 has it; Qt6 may not,
-     # so ignore the error rather than using "-rpath old new" which requires old to exist).
-     execute_process(COMMAND install_name_tool
-       -delete_rpath "@executable_path/../Frameworks"
-       "${designer_executable}"
-       RESULT_VARIABLE _rpath_delete_result
-       OUTPUT_QUIET ERROR_QUIET
-       )
-     # Add the bundle-relative rpath and apply all LC_LOAD_DYLIB changes.
-     execute_process(COMMAND install_name_tool
-       -add_rpath "@loader_path/../../../../"
-       ${changes} "${designer_executable}"
-       )
-     # Generate qt.conf file to override plugin paths and ensure plugins provided
-     # by Slicer package are loaded
-     file(WRITE "${designer_dest_dir}/Contents/Resources/qt.conf" "[Paths]
-Plugins=../../../@Slicer_QtPlugins_DIR@
-")
-
-     # QtDesignerComponents.framework
-     # Dynamically resolve the versioned binary path (e.g. Versions/A for Qt6, Versions/5 for Qt5)
-     # to avoid hardcoding the framework version string.
-     file(GLOB _qtdc_candidates
-       "${qt_root_dir}/QtDesignerComponents.framework/Versions/*/QtDesignerComponents")
-     list(FILTER _qtdc_candidates EXCLUDE REGEX "/Versions/Current/")
-     if(_qtdc_candidates)
-       list(GET _qtdc_candidates 0 resolved_item)
-       string(REGEX REPLACE ".*/Versions/([^/]+)/QtDesignerComponents$" "\\1"
-         _qtdc_version "${resolved_item}")
-       set(resolved_embedded_item "${app_dir}/Contents/Frameworks/QtDesignerComponents.framework/Versions/${_qtdc_version}/QtDesignerComponents")
-       copy_resolved_framework_into_bundle("${resolved_item}" "${resolved_embedded_item}")
-       # Collect list of Qt framework dependencies
-       set(prereqs )
-       get_prerequisites(${resolved_embedded_item} "prereqs" 1 0 "" "")
-       # Generate list of "-change" arguments
-       set(changes "")
-       foreach(item ${prereqs})
-         gp_item_default_embedded_path_override("${item}" path)
-         get_filename_component(item_name "${item}" NAME)
-         string(REGEX REPLACE "^.*(${item_name}.framework/.*/?${item_name}).*$" "${path}/\\1" embedded_item "${item}")
-         set(changes ${changes} "-change" "${item}" "${embedded_item}")
-       endforeach()
-       # Update executable
-       execute_process(COMMAND install_name_tool
-         ${changes} -id "@rpath/Frameworks/QtDesignerComponents.framework/Versions/${_qtdc_version}/QtDesignerComponents"
-         "${resolved_embedded_item}"
-         )
-     endif()
-   endif()
-  endif()
-
-endfunction()
-
-set(app_name "@Slicer_MAIN_PROJECT_APPLICATION_NAME@.app")
-fixup_bundle_with_plugins(${app_name})
+#-----------------------------------------------------------------------------
+# Re-sign the bundle.
+#
+# install_name_tool invalidates the ad-hoc code signature of every Mach-O file
+# it modifies. On Apple Silicon the kernel refuses to map pages of a binary
+# whose signature does not match, killing the process at load time with
+# EXC_BAD_ACCESS ("Code Signature Invalid"), so the whole bundle must be
+# re-signed once all install_name_tool operations are complete.
+#
+# "codesign --deep" is unreliable on a bundle of this size and nesting depth
+# (the CFBundleExecutable is a small bootstrap, so the real application binary
+# and every module/plugin/framework is nested code): it can leave individual
+# binaries with an invalid signature that then fault at load. Sign inside-out
+# instead -- every Mach-O on its own, deepest first, and the .app last.
+#-----------------------------------------------------------------------------
+message(STATUS "Re-signing application bundle after fixup")
+execute_process(
+  COMMAND python3 "@CMAKE_SOURCE_DIR@/Utilities/Scripts/SlicerSignBundleMacOS.py"
+          --app "${app_dir}"
+  RESULT_VARIABLE _codesign_result
+  ERROR_VARIABLE _codesign_error
+  )
+if(NOT _codesign_result EQUAL 0)
+  message(WARNING "Re-signing the application bundle failed:\n${_codesign_error}")
+endif()
 
 #-----------------------------------------------------------------------------
 # Rename the bundle to use the full application name (e.g. "3D Slicer 5.10.0")
@@ -494,6 +184,7 @@ fixup_bundle_with_plugins(${app_name})
 # "5.13.0-2026-07-04"). Finder elides long unbroken names in the middle, which
 # would hide the version number, so the separator before the date is replaced
 # with a space ("5.13.0 2026-07-04") to give Finder a place to wrap the name.
+set(app_name "@Slicer_MAIN_PROJECT_APPLICATION_NAME@.app")
 set(installed_app_version "@Slicer_MAIN_PROJECT_VERSION_FULL@")
 string(REGEX REPLACE "^([^-]+)-(.*)$" "\\1 \\2" installed_app_version "${installed_app_version}")
 set(installed_app_name "@Slicer_MAIN_PROJECT_APPLICATION_DISPLAY_NAME@ ${installed_app_version}.app")

--- a/Utilities/Scripts/SlicerBundleCloseDeps.py
+++ b/Utilities/Scripts/SlicerBundleCloseDeps.py
@@ -1,0 +1,387 @@
+"""Embed a macOS bundle's external dependency closure and rewrite it to @rpath.
+
+This replaces CMake's BundleUtilities ``fixup_bundle()`` for the macOS package.
+``fixup_bundle()`` walks the dependency graph one binary at a time, shelling out
+to ``otool`` repeatedly and copying/rewriting serially; on a bundle the size of
+Slicer that is the dominant cost of ``make package`` (many minutes). The same
+result is produced here far faster: the dependency graph is walked once with a
+single ``otool -l`` per binary, and the (independent) install-name rewrites are
+applied in parallel at the end.
+
+Starting from every Mach-O already installed in the bundle (the application
+binary, every module, plugin, CLI executable and Python extension), each
+dependency that resolves to a file *outside* the bundle -- excluding the system
+locations under ``/usr/lib`` and ``/System`` -- is either:
+
+  - redirected to a library of the same name already embedded in the bundle
+    (avoiding a duplicate copy), or
+  - copied into the bundle (a plain dylib into ``Contents/lib``; a framework,
+    whole, into ``Contents/Frameworks``) and the reference rewritten to
+    ``@rpath/...``.
+
+The walk follows copied libraries' own dependencies, and every Mach-O *inside* a
+copied framework (for example ``QtWebEngineCore.framework``'s bundled
+``Helpers/QtWebEngineProcess``), so the closure ends fully internal. ``@rpath``
+resolves to ``Contents`` through the application executable's ``@loader_path/..``
+run-path, so embedded libraries are referenced relative to ``Contents``.
+
+External references may be absolute (Homebrew and superbuild install names are
+absolute paths) or ``@rpath``/``@loader_path``/``@executable_path`` relative (for
+example a binary Qt distribution's bare ``@rpath/libbrotlicommon.dylib``). The
+relative forms are resolved against the referring binary's own ``LC_RPATH``
+entries and an optional ``--search-path`` list (the library search directories
+the build already knows about), mirroring how BundleUtilities resolved them.
+
+Finally every standalone Mach-O executable (the PythonSlicer launcher, the CLI
+module executables, ``QtWebEngineProcess``) is given its own ``@loader_path``
+relative run-path to ``Contents`` so ``@rpath`` resolves when it is launched on
+its own rather than loaded by the application, and every remaining run-path that
+points outside the bundle (a build-tree or Homebrew directory) is removed so the
+bundle carries no reference to the machine it was built on.
+
+Run before code-signing: rewriting install names invalidates signatures.
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+_MACHO_MAGIC = {
+    b"\xcf\xfa\xed\xfe", b"\xce\xfa\xed\xfe",
+    b"\xfe\xed\xfa\xcf", b"\xfe\xed\xfa\xce",
+    b"\xca\xfe\xba\xbe", b"\xbe\xba\xfe\xca",
+}
+
+_DYLIB_LOAD_COMMANDS = {
+    "LC_LOAD_DYLIB", "LC_LOAD_WEAK_DYLIB",
+    "LC_REEXPORT_DYLIB", "LC_LOAD_UPWARD_DYLIB",
+}
+
+_NAME_RE = re.compile(r"^\s*name (.+) \(offset")
+_PATH_RE = re.compile(r"^\s*path (.+) \(offset")
+
+
+def is_macho(path):
+    try:
+        if os.path.islink(path) or not os.path.isfile(path):
+            return False
+        with open(path, "rb") as handle:
+            return handle.read(4) in _MACHO_MAGIC
+    except OSError:
+        return False
+
+
+def scan(path):
+    """Parse a single ``otool -l`` into (loads, rpaths, install_id).
+
+    One subprocess yields every load command, so the whole graph is walked with
+    one ``otool`` invocation per binary instead of the three (``-L``/``-D``/``-l``)
+    the equivalent separate queries would need.
+    """
+    out = subprocess.run(["otool", "-l", path],
+                         capture_output=True, text=True, check=False).stdout
+    loads, rpaths, install_id = [], [], None
+    command = None
+    for line in out.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("cmd "):
+            command = stripped[4:]
+            continue
+        if command in _DYLIB_LOAD_COMMANDS:
+            match = _NAME_RE.match(line)
+            if match:
+                loads.append(match.group(1))
+        elif command == "LC_ID_DYLIB":
+            match = _NAME_RE.match(line)
+            if match:
+                install_id = match.group(1)
+        elif command == "LC_RPATH":
+            match = _PATH_RE.match(line)
+            if match:
+                rpaths.append(match.group(1))
+    return loads, rpaths, install_id
+
+
+def is_system(ref):
+    return ref.startswith("/usr/lib") or ref.startswith("/System/")
+
+
+def framework_relative(path):
+    """For a path inside a ``*.framework``, return (framework_dir, inner) where
+    inner is the path from the framework directory's parent (i.e. begins with
+    ``Name.framework/``); otherwise None.
+    """
+    parts = path.split(os.sep)
+    for index, part in enumerate(parts):
+        if part.endswith(".framework"):
+            return os.sep.join(parts[: index + 1]), os.sep.join(parts[index:])
+    return None
+
+
+def is_executable_macho(path):
+    """True for a Mach-O main executable (MH_EXECUTE) -- a binary that can be
+    launched on its own and so must carry its own run-path for @rpath to resolve.
+    """
+    out = subprocess.run(["file", "-b", path],
+                         capture_output=True, text=True, check=False).stdout
+    return "Mach-O" in out and "executable" in out
+
+
+def _expand_rpath_entry(entry, binary_dir, exe_dir):
+    """An LC_RPATH entry may itself be @loader_path/@executable_path relative."""
+    if entry.startswith("@loader_path"):
+        return os.path.normpath(os.path.join(binary_dir, entry[len("@loader_path"):].lstrip("/")))
+    if entry.startswith("@executable_path"):
+        return os.path.normpath(os.path.join(exe_dir, entry[len("@executable_path"):].lstrip("/")))
+    return entry
+
+
+def resolve(ref, binary_dir, rpaths, search_dirs, exe_dir):
+    """Resolve an install name to an existing file, or None.
+
+    Absolute references are taken as-is; @rpath is searched against the binary's
+    own run-paths first, then the supplied search directories (with a bare
+    filename fallback, as BundleUtilities does); @loader_path/@executable_path
+    are resolved relative to the binary and the application executable.
+    """
+    if ref.startswith("@rpath/"):
+        suffix = ref[len("@rpath/"):]
+        search = [_expand_rpath_entry(entry, binary_dir, exe_dir) for entry in rpaths]
+        search += search_dirs
+        for directory in search:
+            candidate = os.path.join(directory, suffix)
+            if os.path.exists(candidate):
+                return candidate
+        name = os.path.basename(suffix)
+        for directory in search:
+            candidate = os.path.join(directory, name)
+            if os.path.exists(candidate):
+                return candidate
+        return None
+    if ref.startswith("@loader_path/"):
+        candidate = os.path.normpath(os.path.join(binary_dir, ref[len("@loader_path/"):]))
+        return candidate if os.path.exists(candidate) else None
+    if ref.startswith("@executable_path/"):
+        candidate = os.path.normpath(os.path.join(exe_dir, ref[len("@executable_path/"):]))
+        return candidate if os.path.exists(candidate) else None
+    if ref.startswith("/"):
+        if os.path.exists(ref):
+            return ref
+        real = os.path.realpath(ref)
+        return real if os.path.exists(real) else None
+    # A bare or relative install name (for example DCMTK's "libopenjp2.7.dylib"):
+    # dyld would find it via a run-path or a system directory. Search the same
+    # places and embed it only if it is found in the build's own library
+    # directories; a name not found there is a system library, left untouched.
+    search = [_expand_rpath_entry(entry, binary_dir, exe_dir) for entry in rpaths]
+    search += search_dirs
+    for directory in search:
+        candidate = os.path.join(directory, ref)
+        if os.path.exists(candidate):
+            return candidate
+    name = os.path.basename(ref)
+    for directory in search:
+        candidate = os.path.join(directory, name)
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def close_deps(app, search_dirs):
+    contents = os.path.join(app, "Contents")
+    exe_dir = os.path.join(contents, "MacOS")
+    frameworks_dir = os.path.join(contents, "Frameworks")
+    lib_dir = os.path.join(contents, "lib")
+    contents_real = os.path.realpath(contents)
+
+    def inside_bundle(path):
+        return os.path.realpath(path).startswith(contents_real)
+
+    def bundle_machos(root):
+        found = []
+        for directory, _dirs, files in os.walk(root):
+            for name in files:
+                path = os.path.join(directory, name)
+                if is_macho(path):
+                    found.append(path)
+        return found
+
+    # Index every Mach-O already in the bundle by basename, so a reference to an
+    # external library of that name is redirected to the embedded copy.
+    embedded = {}
+    worklist = bundle_machos(app)
+    for path in worklist:
+        embedded.setdefault(os.path.basename(path), path)
+
+    # Deferred install_name_tool work, applied in parallel once the graph is
+    # fully walked (each binary's rewrite is independent of the others).
+    id_resets = {}          # path -> new LC_ID_DYLIB
+    changes = {}            # path -> list of (old_ref, new_ref)
+    copied = []
+    seen = set()
+
+    def embed(source):
+        """Copy an external library (or its whole framework) into the bundle and
+        return the embedded path, reindexing any Mach-O it brings along.
+        """
+        framework = framework_relative(source)
+        if framework is not None:
+            src_fw, inner = framework
+            dest_fw = os.path.join(frameworks_dir, os.path.basename(src_fw))
+            if not os.path.exists(dest_fw):
+                shutil.copytree(src_fw, dest_fw, symlinks=True)
+                # A framework carries its own nested code (its versioned binary,
+                # and helpers such as QtWebEngineProcess); register and walk them.
+                for macho in bundle_machos(dest_fw):
+                    embedded.setdefault(os.path.basename(macho), macho)
+                    if macho not in seen:
+                        worklist.append(macho)
+            target = os.path.join(dest_fw, os.sep.join(inner.split(os.sep)[1:]))
+        else:
+            os.makedirs(lib_dir, exist_ok=True)
+            target = os.path.join(lib_dir, os.path.basename(source))
+            if not os.path.exists(target):
+                shutil.copy2(source, target)
+                os.chmod(target, 0o755)
+                worklist.append(target)
+        embedded.setdefault(os.path.basename(target), target)
+        copied.append(os.path.basename(target))
+        return target
+
+    while worklist:
+        current = worklist.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        loads, rpaths, install_id = scan(current)
+        binary_dir = os.path.dirname(current)
+
+        # An install id that still points outside the bundle (an absolute
+        # build/Homebrew path, or a copied library keeping its original id)
+        # would leak that path; reset it to @rpath relative to Contents.
+        if install_id and install_id.startswith("/") and not is_system(install_id) \
+                and not inside_bundle(install_id):
+            id_resets[current] = "@rpath/" + os.path.relpath(current, contents)
+
+        for ref in loads:
+            if is_system(ref):
+                continue
+            source = resolve(ref, binary_dir, rpaths, search_dirs, exe_dir)
+            if source is None or inside_bundle(source):
+                # Unresolvable (leave as-is) or already internal (resolves via
+                # the application's @loader_path/.. run-path).
+                continue
+            name = os.path.basename(source)
+            target = embedded[name] if name in embedded else embed(source)
+            new_ref = "@rpath/" + os.path.relpath(target, contents)
+            if new_ref != ref:
+                changes.setdefault(current, []).append((ref, new_ref))
+
+    # Apply every install_name_tool rewrite in parallel.
+    def apply(path):
+        args = []
+        if path in id_resets:
+            args += ["-id", id_resets[path]]
+        for old_ref, new_ref in changes.get(path, []):
+            args += ["-change", old_ref, new_ref]
+        if not args:
+            return
+        subprocess.run(["install_name_tool"] + args + [path],
+                       capture_output=True, check=False)
+
+    targets = set(id_resets) | set(changes)
+    with ThreadPoolExecutor(max_workers=os.cpu_count()) as executor:
+        list(executor.map(apply, targets))
+
+    print("SlicerBundleCloseDeps: embedded %d libraries, rewrote %d files, reset %d ids"
+          % (len(set(copied)), len(changes), len(id_resets)))
+    for base in sorted(set(copied)):
+        print("  embedded:", base)
+    return True
+
+
+def fix_executable_rpaths(app):
+    """Give every standalone Mach-O executable in the bundle a run-path pointing
+    at Contents, so its @rpath dependencies resolve when it is launched on its
+    own rather than loaded by the application (which supplies that run-path).
+    """
+    contents = os.path.join(app, "Contents")
+    fixed = 0
+    for directory, _dirs, files in os.walk(app):
+        for name in files:
+            path = os.path.join(directory, name)
+            if not is_macho(path) or not is_executable_macho(path):
+                continue
+            loads, rpaths, _id = scan(path)
+            if not any(ref.startswith("@rpath/") for ref in loads):
+                continue
+            relative = os.path.relpath(contents, os.path.dirname(path))
+            wanted = "@loader_path" if relative == "." else "@loader_path/" + relative
+            if wanted.rstrip("/") in [entry.rstrip("/") for entry in rpaths]:
+                continue
+            subprocess.run(["install_name_tool", "-add_rpath", wanted, path],
+                           capture_output=True, check=False)
+            fixed += 1
+    print("SlicerBundleCloseDeps: added a bundle-relative run-path to %d executables" % fixed)
+    return fixed
+
+
+def strip_external_rpaths(app):
+    """Remove run-paths that point outside the bundle (build-tree or Homebrew
+    directories left over from linking). After the closure every dependency
+    resolves through a @loader_path-relative run-path, so these absolute entries
+    are dead weight -- and a lingering Qt directory could load a second copy of a
+    framework. Removing them also means the bundle names no build-machine path.
+    """
+    contents_real = os.path.realpath(os.path.join(app, "Contents"))
+
+    def strip(path):
+        _loads, rpaths, _id = scan(path)
+        removed = 0
+        for entry in rpaths:
+            if entry.startswith("@"):
+                continue
+            if os.path.realpath(entry).startswith(contents_real):
+                continue
+            subprocess.run(["install_name_tool", "-delete_rpath", entry, path],
+                           capture_output=True, check=False)
+            removed += 1
+        return removed
+
+    machos = []
+    for directory, _dirs, files in os.walk(app):
+        for name in files:
+            path = os.path.join(directory, name)
+            if is_macho(path):
+                machos.append(path)
+    with ThreadPoolExecutor(max_workers=os.cpu_count()) as executor:
+        removed = sum(executor.map(strip, machos))
+    print("SlicerBundleCloseDeps: removed %d external run-paths" % removed)
+    return removed
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--app", required=True, help="Path to the .app bundle")
+    parser.add_argument("--search-path", action="append", default=[], metavar="DIR",
+                        help="Directory to resolve @rpath dependencies against "
+                             "(repeatable). The referring binary's own run-paths "
+                             "are always searched first.")
+    options = parser.parse_args(argv)
+    if not os.path.isdir(options.app):
+        print("SlicerBundleCloseDeps: no such bundle: %s" % options.app, file=sys.stderr)
+        return 1
+    search_dirs = [d for d in options.search_path if d and os.path.isdir(d)]
+    if not close_deps(options.app, search_dirs):
+        return 1
+    fix_executable_rpaths(options.app)
+    strip_external_rpaths(options.app)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/Utilities/Scripts/SlicerSignBundleMacOS.py
+++ b/Utilities/Scripts/SlicerSignBundleMacOS.py
@@ -1,0 +1,112 @@
+"""Ad-hoc (or identity) code-sign a macOS application bundle, inside-out.
+
+``install_name_tool`` invalidates the code signature of every Mach-O file it
+rewrites during bundle fixup. On Apple Silicon the kernel refuses to map a page
+whose signature does not match the binary, so an unsigned or stale-signed file
+is killed at load time with EXC_BAD_ACCESS ("Code Signature Invalid").
+
+``codesign --deep`` is unreliable on a bundle this large and deeply nested (the
+application's CFBundleExecutable is a small bootstrap, so the real application
+binary and every module, plugin and framework are *nested* code): it can leave
+individual binaries with an invalid signature, which then fault at load time.
+
+Signing inside-out -- every Mach-O signed on its own, deepest path first, and
+the enclosing .app signed last -- avoids that: each file is sealed
+independently and the umbrella signature seals the directory tree on top.
+
+Only the ad-hoc identity ("-") is used by default, which is enough for the
+binary to load on the machine it was built for and for internal testing (users
+still clear the quarantine attribute manually). Pass --identity to sign with a
+Developer ID for distribution/notarization.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+# Mach-O magic numbers (thin and fat, both byte orders).
+_MACHO_MAGIC = {
+    b"\xcf\xfa\xed\xfe",  # 64-bit LE
+    b"\xce\xfa\xed\xfe",  # 32-bit LE
+    b"\xfe\xed\xfa\xcf",  # 64-bit BE
+    b"\xfe\xed\xfa\xce",  # 32-bit BE
+    b"\xca\xfe\xba\xbe",  # fat BE
+    b"\xbe\xba\xfe\xca",  # fat LE
+}
+
+
+def is_macho(path):
+    try:
+        if os.path.islink(path) or not os.path.isfile(path):
+            return False
+        with open(path, "rb") as handle:
+            return handle.read(4) in _MACHO_MAGIC
+    except OSError:
+        return False
+
+
+def find_machos(root):
+    paths = []
+    for directory, _dirs, files in os.walk(root):
+        for name in files:
+            path = os.path.join(directory, name)
+            if is_macho(path):
+                paths.append(path)
+    return paths
+
+
+def sign(path, identity):
+    result = subprocess.run(
+        ["codesign", "--force", "--sign", identity, path],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return path, result.returncode, result.stderr.strip()
+
+
+def sign_bundle(app, identity):
+    machos = find_machos(app)
+    # Deepest paths first so nested code is sealed before its container.
+    machos.sort(key=lambda path: path.count(os.sep), reverse=True)
+
+    failures = []
+    with ThreadPoolExecutor(max_workers=os.cpu_count()) as executor:
+        for path, code, error in executor.map(lambda p: sign(p, identity), machos):
+            if code != 0:
+                failures.append((path, error))
+    print("SlicerSignBundleMacOS: signed %d Mach-O files (%d failures)"
+          % (len(machos), len(failures)))
+    for path, error in failures[:20]:
+        print(f"  failed: {path}: {error}")
+
+    # Seal the application bundle itself last.
+    result = subprocess.run(
+        ["codesign", "--force", "--sign", identity, app],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print("SlicerSignBundleMacOS: signing the application bundle failed:\n"
+              + result.stderr, file=sys.stderr)
+    return len(failures) == 0 and result.returncode == 0
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--app", required=True, help="Path to the .app bundle")
+    parser.add_argument("--identity", default="-",
+                        help="codesign identity (default: '-', ad-hoc)")
+    options = parser.parse_args(argv)
+    if not os.path.isdir(options.app):
+        print("SlicerSignBundleMacOS: no such bundle: %s" % options.app,
+              file=sys.stderr)
+        return 1
+    return 0 if sign_bundle(options.app, options.identity) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## What this does

3D Slicer's macOS package is assembled by CPack and made relocatable by CMake's BundleUtilities `fixup_bundle()`, which has produced working, distributable disk images for years. This preserves that result while making three improvements:

**1. Much faster.** `fixup_bundle()` walks the dependency graph one binary at a time, calling `otool` repeatedly and copying/rewriting serially — minutes of wall clock on a bundle with ~1000 Mach-O files, and the dominant cost of `make package`. It is replaced by `Utilities/Scripts/SlicerBundleCloseDeps.py`, which walks the graph once (one `otool -l` per binary) and applies the independent install-name rewrites in parallel: the fixup drops from minutes to about half a minute. The disk image is also written as LZFSE (ULFO) rather than the CPack default (UDZO/zlib) — several times faster to compress and slightly smaller.

**2. Much simpler.** Copying each framework whole (so nested code such as `QtWebEngineCore.framework`'s bundled `Helpers/QtWebEngineProcess` comes along and is fixed up automatically) removes the per-file placement table and the hand-written WebEngine / Designer / mis-embedded-framework special cases — roughly 400 lines of the fixup script go away.

**3. Makes developer builds distributable.** Building against a Homebrew Qt on Apple Silicon — as a developer typically does, rather than the Qt the build farm builds itself — left a few references to the Homebrew tree: Qt plugins installed as symlinks, `QT_PLUGIN_PATH` not set before the `QApplication` is constructed, and standalone executables (PythonSlicer, the CLI modules) carrying only build-machine run-paths. The closure installs real plugin files, sets `QT_PLUGIN_PATH` first, embeds and rewrites every external reference — absolute, `@rpath`, or a bare install name — to `@rpath`, gives the standalone executables a bundle-relative run-path, and strips every run-path that pointed outside the bundle, so the result names no build-machine path.

The bundle is re-signed after the fixup (install_name_tool invalidates each signature it rewrites, and on Apple Silicon an invalid signature faults at load) — inside-out, ad-hoc by default (`--identity` for a Developer ID), in parallel.

## Validation

Verified on a clean arm64 macOS VM with **no Homebrew, no Qt, and no build tree**: the packaged application, `python-real`, and the DCMTK CLI executables all launch, and the bundle references no library outside itself across all ~1000 of its Mach-O files.

## Follow-ups (separate PRs)

- Extend the signer toward a notarizable release (hardened runtime + entitlements + notarize/staple). Ad-hoc signing is enough to load and test; testers of an unsigned build clear the quarantine attribute manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
