### PR TITLE
COMP: Give the SuperBuild OpenJPEG an absolute install name on macOS (consistency)

### DIFF
--- a/SuperBuild/External_OpenJPEG.cmake
+++ b/SuperBuild/External_OpenJPEG.cmake
@@ -60,6 +60,22 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       # Install directories
       -DCMAKE_INSTALL_LIBDIR:STRING=lib  # Override value set in GNUInstallDirs CMake module
       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+      # Give the installed library an absolute install name (LC_ID_DYLIB), for
+      # consistency with the rest of the SuperBuild -- this is not a fix for a
+      # functional bug. Slicer forces CMAKE_MACOSX_RPATH off for all external
+      # projects (see UseSlicer.cmake.in), and OpenJPEG, unlike ITK, VTK and
+      # DCMTK, sets no install-name directory of its own, so libopenjp2 is the
+      # one SuperBuild library installed with a bare install name
+      # ("libopenjp2.7.dylib"). Consumers that link it (DCMTK's dcmjp2kcs
+      # JPEG 2000 codec and ITK's GDCM) record that bare name. In normal use it
+      # still resolves: the Slicer launcher adds the OpenJPEG lib dir to the
+      # library path, and the macOS bundle fixup (CPack BundleUtilities or
+      # Slicer's packager) rewrites the dependency when packaging. So this is a
+      # robustness/consistency change, not a crash fix -- an absolute install
+      # name makes the recorded dependency self-describing and relocatable
+      # without relying on the launcher environment or on the packager having to
+      # resolve a bare name.
+      -DCMAKE_INSTALL_NAME_DIR:STRING=<INSTALL_DIR>/lib
     DEPENDS
       ${${proj}_DEPENDENCIES}
     )


### PR DESCRIPTION
## What this is

A **consistency/robustness** change — **not a fix for a functional bug**. Nothing is broken today; this makes the SuperBuild OpenJPEG behave like every other SuperBuild library.

Slicer forces `CMAKE_MACOSX_RPATH` off for all external projects (`UseSlicer.cmake.in`). OpenJPEG — unlike ITK, VTK and DCMTK — sets no install-name directory of its own, so `libopenjp2` is the **one** SuperBuild library installed with a **bare** `LC_ID_DYLIB` (`libopenjp2.7.dylib`, no directory). Consumers that link it — DCMTK's `dcmjp2kcs` JPEG 2000 codec and ITK's GDCM (built against this same OpenJPEG) — record that bare name.

## Why it isn't a bug in practice

A bare install name still resolves in every real path:
- **Launcher-based use** (the app, `PythonSlicer`, CLI modules launched by Slicer): the launcher adds the OpenJPEG lib directory to the library path.
- **Packaged app**: the macOS bundle fixup — CPack's `BundleUtilities` for factory builds, or Slicer's own packager — copies `libopenjp2` into the bundle and rewrites the dependents' references at packaging time.

So both the shipped product and normal development already work. (This surfaced during off-machine packaging development, where the custom packager initially didn't resolve a bare name; that path now handles it too.)

## Why do it anyway

- The recorded dependency becomes **self-describing and relocatable** without relying on the launcher environment or on the packager having to resolve a bare name — the packager's bare-name special case can then be dropped.
- OpenJPEG stops being an install-name **outlier**, removing a latent footgun for future packaging/tooling.

## Fix

Set `CMAKE_INSTALL_NAME_DIR` to the install `lib` directory so the installed `libopenjp2` gets an absolute install name, matching ITK/VTK/DCMTK. One line plus an explanatory comment in `SuperBuild/External_OpenJPEG.cmake`.

## Verification

A standalone OpenJPEG v2.5.4 build with these flags (`-DCMAKE_MACOSX_RPATH=0 -DCMAKE_INSTALL_NAME_DIR=<install>/lib`) installs the dylib with an absolute id:

```
LC_ID_DYLIB: <install>/lib/libopenjp2.7.dylib     (was: libopenjp2.7.dylib)
```
