### PR TITLE
PERF: Skip testing modules unless developer mode is enabled

### DIFF
--- a/Applications/SlicerApp/Testing/Python/BRAINSFitRigidRegistrationCrashIssue4139Test.py
+++ b/Applications/SlicerApp/Testing/Python/BRAINSFitRigidRegistrationCrashIssue4139Test.py
@@ -1,28 +1,30 @@
+import logging
+
 import slicer
 from slicer.ScriptedLoadableModule import *
-from slicer.util import TESTING_DATA_URL
 
 
 #
-# SlicerRestoreSceneViewCrashIssue3445
+# BRAINSFitRigidRegistrationCrashIssue4139Test
 #
 
 
-class SlicerRestoreSceneViewCrashIssue3445(ScriptedLoadableModule):
+class BRAINSFitRigidRegistrationCrashIssue4139Test(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        self.parent.title = "SceneView restore crash (Issue 3445)"
+        self.parent.title = "BRAINSFit Rigid Registration vtkITKTransformConverter crash (Issue 4139)"
         self.parent.categories = ["Testing.TestCases"]
         self.parent.dependencies = []
         self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)"]  # replace with "Firstname Lastname (Organization)"
         self.parent.helpText = """This test has been added to check that
-    Slicer does not crash while restoring scene view associated with BrainAtlas2012.mrb.
+    Slicer does not crash in vtkITKTransformConverter after completing BRAINSFit rigid registration.
 
-    Problem has been documented in issue #3445.
+    Problem has been documented in issue #4139. Commit r24901 fixes the problem
+    by updating vtkITKTransformConverter class.
     """
         self.parent.acknowledgementText = """
     This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc.
@@ -31,11 +33,11 @@ class SlicerRestoreSceneViewCrashIssue3445(ScriptedLoadableModule):
 
 
 #
-# SlicerRestoreSceneViewCrashIssue3445Widget
+# BRAINSFitRigidRegistrationCrashIssue4139TestWidget
 #
 
 
-class SlicerRestoreSceneViewCrashIssue3445Widget(ScriptedLoadableModuleWidget):
+class BRAINSFitRigidRegistrationCrashIssue4139TestWidget(ScriptedLoadableModuleWidget):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -45,11 +47,11 @@ class SlicerRestoreSceneViewCrashIssue3445Widget(ScriptedLoadableModuleWidget):
 
 
 #
-# SlicerRestoreSceneViewCrashIssue3445Logic
+# BRAINSFitRigidRegistrationCrashIssue4139TestLogic
 #
 
 
-class SlicerRestoreSceneViewCrashIssue3445Logic(ScriptedLoadableModuleLogic):
+class BRAINSFitRigidRegistrationCrashIssue4139TestLogic(ScriptedLoadableModuleLogic):
     """This class should implement all the actual
     computation done by your module.  The interface
     should be such that other python code can import
@@ -59,10 +61,21 @@ class SlicerRestoreSceneViewCrashIssue3445Logic(ScriptedLoadableModuleLogic):
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
-    pass
+    def hasImageData(self, volumeNode):
+        """This is an example logic method that
+        returns true if the passed in volume
+        node has valid image data
+        """
+        if not volumeNode:
+            logging.debug("hasImageData failed: no volume node")
+            return False
+        if volumeNode.GetImageData() is None:
+            logging.debug("hasImageData failed: no image data in volume node")
+            return False
+        return True
 
 
-class SlicerRestoreSceneViewCrashIssue3445Test(ScriptedLoadableModuleTest):
+class BRAINSFitRigidRegistrationCrashIssue4139TestTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:
@@ -76,9 +89,9 @@ class SlicerRestoreSceneViewCrashIssue3445Test(ScriptedLoadableModuleTest):
     def runTest(self):
         """Run as few or as many tests as needed here."""
         self.setUp()
-        self.test_SlicerRestoreSceneViewCrashIssue3445()
+        self.test_BRAINSFitRigidRegistrationCrashIssue4139()
 
-    def test_SlicerRestoreSceneViewCrashIssue3445(self):
+    def test_BRAINSFitRigidRegistrationCrashIssue4139(self):
         """Ideally you should have several levels of tests.  At the lowest level
         tests should exercise the functionality of the logic with different inputs
         (both valid and invalid).  At higher levels your tests should emulate the
@@ -90,38 +103,35 @@ class SlicerRestoreSceneViewCrashIssue3445Test(ScriptedLoadableModuleTest):
         your test should break so they know that the feature is needed.
         """
 
-        logic = SlicerRestoreSceneViewCrashIssue3445Logic()
-
         self.delayDisplay("Starting the test")
 
-        #
-        # first, get some data
-        #
+        logic = BRAINSFitRigidRegistrationCrashIssue4139TestLogic()
+
         import SampleData
 
-        filePath = SampleData.downloadFromURL(
-            fileNames="BrainAtlas2012.mrb",
-            loadFiles=False,
-            uris=TESTING_DATA_URL + "SHA256/688ebcc6f45989795be2bcdc6b8b5bfc461f1656d677ed3ddef8c313532687f1",
-            checksums="SHA256:688ebcc6f45989795be2bcdc6b8b5bfc461f1656d677ed3ddef8c313532687f1")[0]
+        fixed = SampleData.downloadSample("MRBrainTumor1")
+        self.assertIsNotNone(logic.hasImageData(fixed))
 
-        self.delayDisplay("Finished with download")
+        moving = SampleData.downloadSample("MRBrainTumor2")
+        self.assertIsNotNone(logic.hasImageData(moving))
 
-        ioManager = slicer.app.ioManager()
+        self.delayDisplay("Finished with download and loading")
 
-        ioManager.loadFile(filePath)
+        outputTransform = slicer.vtkMRMLLinearTransformNode()
+        slicer.mrmlScene.AddNode(outputTransform)
 
-        slicer.mrmlScene.Clear(0)
-        slicer.util.selectModule("Data")
-        slicer.util.selectModule("Models")
+        outputVolume = slicer.vtkMRMLScalarVolumeNode()
+        slicer.mrmlScene.AddNode(outputVolume)
 
-        ioManager.loadFile(filePath)
-        slicer.mrmlScene.Clear(0)
-
-        ioManager.loadFile(filePath)
-        ioManager.loadFile(filePath)
-
-        slicer.modules.sceneviews.logic().RestoreSceneView(0)
+        parameters = {
+            "fixedVolume": fixed,
+            "movingVolume": moving,
+            "linearTransform": outputTransform,
+            "outputVolume": outputVolume,
+            "useRigid": True,
+        }
+        cmdLineNode = slicer.cli.runSync(slicer.modules.brainsfit, parameters=parameters)
+        self.assertIsNotNone(cmdLineNode)
 
         # If test reach this point without crashing it is a success
 

--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -479,59 +479,59 @@ if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
   slicer_add_python_unittest(SCRIPT DICOMReaders.py)
   slicer_add_python_unittest(SCRIPT DICOMPluginTests.py)
   slicer_add_python_unittest(SCRIPT KneeAtlasTest.py)
-  slicer_add_python_unittest(SCRIPT sceneImport2428.py)
+  slicer_add_python_unittest(SCRIPT sceneImport2428Test.py)
   slicer_add_python_unittest(SCRIPT SlicerDisplayNodeSequenceTest.py)
   slicer_add_python_unittest(SCRIPT SlicerMRBMultipleSaveRestoreLoopTest.py)
   slicer_add_python_unittest(SCRIPT SlicerMRBMultipleSaveRestoreTest.py)
   slicer_add_python_unittest(SCRIPT SlicerMRBSaveRestoreCheckPathsTest.py)
-  slicer_add_python_unittest(SCRIPT Slicer4Minute.py)
+  slicer_add_python_unittest(SCRIPT Slicer4MinuteTest.py)
   slicer_add_python_unittest(SCRIPT SlicerBoundsTest.py)
   if(Slicer_BUILD_WEBENGINE_SUPPORT)
-    slicer_add_python_unittest(SCRIPT WebEngine.py)
+    slicer_add_python_unittest(SCRIPT WebEngineTest.py)
   endif()
-  slicer_add_python_unittest(SCRIPT SliceLinkLogic.py)
-  slicer_add_python_unittest(SCRIPT ScenePerformance.py)
-  slicer_add_python_unittest(SCRIPT SlicerRestoreSceneViewCrashIssue3445.py)
-  slicer_add_python_unittest(SCRIPT RSNAVisTutorial.py)
-  slicer_add_python_unittest(SCRIPT RSNAQuantTutorial.py)
+  slicer_add_python_unittest(SCRIPT SliceLinkLogicTest.py)
+  slicer_add_python_unittest(SCRIPT ScenePerformanceTest.py)
+  slicer_add_python_unittest(SCRIPT SlicerRestoreSceneViewCrashIssue3445Test.py)
+  slicer_add_python_unittest(SCRIPT RSNAVisTutorialTest.py)
+  slicer_add_python_unittest(SCRIPT RSNAQuantTutorialTest.py)
   slicer_add_python_unittest(SCRIPT SlicerOrientationSelectorTest.py)
   # Currently needs to be updated for new widget. PR-7562: https://github.com/Slicer/Slicer/pull/7562
-  #slicer_add_python_unittest(SCRIPT SlicerTransformInteractionTest1.py)
+  #slicer_add_python_unittest(SCRIPT SlicerTransformInteractionTest.py)
   slicer_add_python_unittest(SCRIPT UtilTest.py)
-  slicer_add_python_unittest(SCRIPT ViewControllersSliceInterpolationBug1926.py)
-  slicer_add_python_unittest(SCRIPT RSNA2012ProstateDemo.py)
-  slicer_add_python_unittest(SCRIPT JRC2013Vis.py)
-  slicer_add_python_unittest(SCRIPT FiducialLayoutSwitchBug1914.py)
-  slicer_add_python_unittest(SCRIPT ShaderProperties.py)
+  slicer_add_python_unittest(SCRIPT ViewControllersSliceInterpolationBug1926Test.py)
+  slicer_add_python_unittest(SCRIPT RSNA2012ProstateDemoTest.py)
+  slicer_add_python_unittest(SCRIPT JRC2013VisTest.py)
+  slicer_add_python_unittest(SCRIPT FiducialLayoutSwitchBug1914Test.py)
+  slicer_add_python_unittest(SCRIPT ShaderPropertiesTest.py)
   slicer_add_python_unittest(SCRIPT SlicerScriptedFileReaderWriterTest.py)
-  slicer_add_python_unittest(SCRIPT CurvedPlanarReformation.py)
+  slicer_add_python_unittest(SCRIPT CurvedPlanarReformationTest.py)
 
   # add as hidden module for use at run time
   set(KIT_PYTHON_SCRIPTS
     AtlasTests.py
-    sceneImport2428.py
+    sceneImport2428Test.py
     SlicerDisplayNodeSequenceTest.py
     SlicerMRBMultipleSaveRestoreLoopTest.py
     SlicerMRBMultipleSaveRestoreTest.py
     SlicerMRBSaveRestoreCheckPathsTest.py
-    Slicer4Minute.py
+    Slicer4MinuteTest.py
     SlicerBoundsTest.py
-    WebEngine.py
-    SliceLinkLogic.py
-    ScenePerformance.py
-    RSNAVisTutorial.py
-    RSNAQuantTutorial.py
+    WebEngineTest.py
+    SliceLinkLogicTest.py
+    ScenePerformanceTest.py
+    RSNAVisTutorialTest.py
+    RSNAQuantTutorialTest.py
     SlicerOrientationSelectorTest.py
     # Currently needs to be updated for new widget. PR-7562: https://github.com/Slicer/Slicer/pull/7562
-    #SlicerTransformInteractionTest1.py
-    ViewControllersSliceInterpolationBug1926.py
-    RSNA2012ProstateDemo.py
-    JRC2013Vis.py
-    FiducialLayoutSwitchBug1914.py
-    ShaderProperties.py
+    #SlicerTransformInteractionTest.py
+    ViewControllersSliceInterpolationBug1926Test.py
+    RSNA2012ProstateDemoTest.py
+    JRC2013VisTest.py
+    FiducialLayoutSwitchBug1914Test.py
+    ShaderPropertiesTest.py
     UtilTest.py
     SlicerScriptedFileReaderWriterTest.py
-    CurvedPlanarReformation.py
+    CurvedPlanarReformationTest.py
     )
 
   slicer_add_python_unittest(SCRIPT CLIEventTest.py SLICER_ARGS --no-main-window)
@@ -539,15 +539,15 @@ if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
   slicer_add_python_unittest(SCRIPT TwoCLIsInParallelTest.py)
 
   if(Slicer_BUILD_BRAINSTOOLS)
-    slicer_add_python_unittest(SCRIPT BRAINSFitRigidRegistrationCrashIssue4139.py)
+    slicer_add_python_unittest(SCRIPT BRAINSFitRigidRegistrationCrashIssue4139Test.py)
 
     list(APPEND KIT_PYTHON_SCRIPTS
-      BRAINSFitRigidRegistrationCrashIssue4139.py
+      BRAINSFitRigidRegistrationCrashIssue4139Test.py
       )
   endif()
 
   set(KIT_PYTHON_RESOURCES
-    Resources/UI/ScenePerformance.ui
+    Resources/UI/ScenePerformanceTest.ui
     Resources/UI/UtilTest.ui
     )
 

--- a/Applications/SlicerApp/Testing/Python/CurvedPlanarReformationTest.py
+++ b/Applications/SlicerApp/Testing/Python/CurvedPlanarReformationTest.py
@@ -4,14 +4,14 @@ from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin
 
 #
-# CurvedPlanarReformation
+# CurvedPlanarReformationTest
 #
 
 
-class CurvedPlanarReformation(ScriptedLoadableModule):
+class CurvedPlanarReformationTest(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        self.parent.title = "CurvedPlanarReformation"
+        self.parent.title = "CurvedPlanarReformationTest"
         self.parent.categories = ["Testing.TestCases"]
         self.parent.dependencies = []
         self.parent.contributors = ["Lee Newberg (Kitware)", "Andras Lasso (PerkLab)"]
@@ -26,11 +26,11 @@ SlicerSandbox extension.
 
 
 #
-# CurvedPlanarReformationWidget
+# CurvedPlanarReformationTestWidget
 #
 
 
-class CurvedPlanarReformationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
+class CurvedPlanarReformationTestWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def __init__(self, parent=None) -> None:
         """Called when the user opens the module the first time and the widget is initialized."""
         ScriptedLoadableModuleWidget.__init__(self, parent)
@@ -41,20 +41,20 @@ class CurvedPlanarReformationWidget(ScriptedLoadableModuleWidget, VTKObservation
 
 
 #
-# CurvedPlanarReformationLogic
+# CurvedPlanarReformationTestLogic
 #
 
 
-class CurvedPlanarReformationLogic(ScriptedLoadableModuleLogic):
+class CurvedPlanarReformationTestLogic(ScriptedLoadableModuleLogic):
     pass
 
 
 #
-# CurvedPlanarReformationTest
+# CurvedPlanarReformationTestTest
 #
 
 
-class CurvedPlanarReformationTest(ScriptedLoadableModuleTest):
+class CurvedPlanarReformationTestTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:

--- a/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914Test.py
+++ b/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914Test.py
@@ -8,14 +8,14 @@ from slicer.ScriptedLoadableModule import *
 
 
 #
-# FiducialLayoutSwitchBug1914
+# FiducialLayoutSwitchBug1914Test
 #
 
 
-class FiducialLayoutSwitchBug1914(ScriptedLoadableModule):
+class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        parent.title = "FiducialLayoutSwitchBug1914"
+        parent.title = "FiducialLayoutSwitchBug1914Test"
         parent.categories = ["Testing.TestCases"]
         parent.dependencies = []
         parent.contributors = ["Nicole Aucoin (BWH)"]
@@ -28,21 +28,21 @@ class FiducialLayoutSwitchBug1914(ScriptedLoadableModule):
 
 
 #
-# qFiducialLayoutSwitchBug1914Widget
+# FiducialLayoutSwitchBug1914TestWidget
 #
 
 
-class FiducialLayoutSwitchBug1914Widget(ScriptedLoadableModuleWidget):
+class FiducialLayoutSwitchBug1914TestWidget(ScriptedLoadableModuleWidget):
     def setup(self):
         ScriptedLoadableModuleWidget.setup(self)
 
 
 #
-# FiducialLayoutSwitchBug1914Logic
+# FiducialLayoutSwitchBug1914TestLogic
 #
 
 
-class FiducialLayoutSwitchBug1914Logic(ScriptedLoadableModuleLogic):
+class FiducialLayoutSwitchBug1914TestLogic(ScriptedLoadableModuleLogic):
     """This class should implement all the actual
     computation done by your module.  The interface
     should be such that other python code can import
@@ -65,7 +65,7 @@ class FiducialLayoutSwitchBug1914Logic(ScriptedLoadableModuleLogic):
         return None
 
 
-class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
+class FiducialLayoutSwitchBug1914TestTest(ScriptedLoadableModuleTest):
     """This is the test case for your scripted module."""
 
     def setUp(self):
@@ -86,7 +86,7 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
         enableScreenshots = 0
         screenshotScaleFactor = 1
 
-        logic = FiducialLayoutSwitchBug1914Logic()
+        logic = FiducialLayoutSwitchBug1914TestLogic()
         logging.info("ctest, please don't truncate my output: CTEST_FULL_OUTPUT")
 
         self.delayDisplay("Running the algorithm")
@@ -126,7 +126,7 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
             handleRep = seedRepresentation.GetHandleRepresentation(fidIndex)
             startingSeedDisplayCoords = handleRep.GetDisplayPosition()
             print("Starting seed display coords = %d, %d, %d" % (startingSeedDisplayCoords[0], startingSeedDisplayCoords[1], startingSeedDisplayCoords[2]))
-        self.takeScreenshot("FiducialLayoutSwitchBug1914-StartingPosition", "Point starting position", slicer.qMRMLScreenShotDialog.Red)
+        self.takeScreenshot("FiducialLayoutSwitchBug1914Test-StartingPosition", "Point starting position", slicer.qMRMLScreenShotDialog.Red)
 
         # Switch to red slice only
         lm.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutOneUpRedSliceView)
@@ -147,10 +147,12 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
             handleRep = seedRepresentation.GetHandleRepresentation(fidIndex)
             endingSeedDisplayCoords = handleRep.GetDisplayPosition()
             print("Ending seed display coords = %d, %d, %d" % (endingSeedDisplayCoords[0], endingSeedDisplayCoords[1], endingSeedDisplayCoords[2]))
-        self.takeScreenshot("FiducialLayoutSwitchBug1914-EndingPosition", "Point ending position", slicer.qMRMLScreenShotDialog.Red)
+        self.takeScreenshot("FiducialLayoutSwitchBug1914Test-EndingPosition", "Point ending position", slicer.qMRMLScreenShotDialog.Red)
 
         # Compare to original seed widget location
-        diff = math.pow((startingSeedDisplayCoords[0] - endingSeedDisplayCoords[0]), 2) + math.pow((startingSeedDisplayCoords[1] - endingSeedDisplayCoords[1]), 2) + math.pow((startingSeedDisplayCoords[2] - endingSeedDisplayCoords[2]), 2)
+        diff = (math.pow((startingSeedDisplayCoords[0] - endingSeedDisplayCoords[0]), 2)
+                + math.pow((startingSeedDisplayCoords[1] - endingSeedDisplayCoords[1]), 2)
+                + math.pow((startingSeedDisplayCoords[2] - endingSeedDisplayCoords[2]), 2))
         if diff != 0.0:
             diff = math.sqrt(diff)
         self.delayDisplay("Difference between starting and ending seed display coordinates = %g" % diff)
@@ -173,9 +175,9 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
 
         if enableScreenshots == 1:
             # compare the screen snapshots
-            startView = slicer.mrmlScene.GetFirstNodeByName("FiducialLayoutSwitchBug1914-StartingPosition")
+            startView = slicer.mrmlScene.GetFirstNodeByName("FiducialLayoutSwitchBug1914Test-StartingPosition")
             startShot = startView.GetScreenShot()
-            endView = slicer.mrmlScene.GetFirstNodeByName("FiducialLayoutSwitchBug1914-EndingPosition")
+            endView = slicer.mrmlScene.GetFirstNodeByName("FiducialLayoutSwitchBug1914Test-EndingPosition")
             endShot = endView.GetScreenShot()
             imageMath = vtk.vtkImageMathematics()
             imageMath.SetOperationToSubtract()
@@ -185,7 +187,7 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
             shotDiff = imageMath.GetOutput()
             # save it as a scene view
             annotationLogic = slicer.modules.annotations.logic()
-            annotationLogic.CreateSnapShot("FiducialLayoutSwitchBug1914-Diff", "Difference between starting and ending point positions",
+            annotationLogic.CreateSnapShot("FiducialLayoutSwitchBug1914Test-Diff", "Difference between starting and ending point positions",
                                            slicer.qMRMLScreenShotDialog.Red, screenshotScaleFactor, shotDiff)
             # calculate the image difference
             imageStats = vtk.vtkImageHistogramStatistics()

--- a/Applications/SlicerApp/Testing/Python/JRC2013VisTest.py
+++ b/Applications/SlicerApp/Testing/Python/JRC2013VisTest.py
@@ -10,14 +10,14 @@ from slicer.util import TESTING_DATA_URL
 
 
 #
-# JRC2013Vis
+# JRC2013VisTest
 #
 
 
-class JRC2013Vis(ScriptedLoadableModule):
+class JRC2013VisTest(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        parent.title = "JRC2013Vis"  # TODO make this more human readable by adding spaces
+        parent.title = "JRC2013VisTest"  # TODO make this more human readable by adding spaces
         parent.categories = ["Testing.TestCases"]
         parent.dependencies = []
         parent.contributors = ["Nicholas Herlambang (AZE R&D)"]  # replace with "Firstname Lastname (Org)"
@@ -30,11 +30,11 @@ class JRC2013Vis(ScriptedLoadableModule):
 
 
 #
-# qJRC2013VisWidget
+# JRC2013VisTestWidget
 #
 
 
-class JRC2013VisWidget(ScriptedLoadableModuleWidget):
+class JRC2013VisTestWidget(ScriptedLoadableModuleWidget):
     def setup(self):
         ScriptedLoadableModuleWidget.setup(self)
         # Instantiate and connect widgets ...
@@ -65,22 +65,22 @@ class JRC2013VisWidget(ScriptedLoadableModuleWidget):
         self.layout.addStretch(1)
 
     def onPart1DICOM(self):
-        tester = JRC2013VisTest()
+        tester = JRC2013VisTestTest()
         tester.setUp()
         tester.test_Part1DICOM()
 
     def onPart2Head(self):
-        tester = JRC2013VisTest()
+        tester = JRC2013VisTestTest()
         tester.setUp()
         tester.test_Part2Head()
 
     def onPart3Liver(self):
-        tester = JRC2013VisTest()
+        tester = JRC2013VisTestTest()
         tester.setUp()
         tester.test_Part3Liver()
 
     def onPart4Lung(self):
-        tester = JRC2013VisTest()
+        tester = JRC2013VisTestTest()
         tester.setUp()
         tester.test_Part4Lung()
 
@@ -140,11 +140,11 @@ class JRC2013VisWidget(ScriptedLoadableModuleWidget):
 
 
 #
-# JRC2013VisLogic
+# JRC2013VisTestLogic
 #
 
 
-class JRC2013VisLogic(ScriptedLoadableModuleLogic):
+class JRC2013VisTestLogic(ScriptedLoadableModuleLogic):
     """This class should implement all the actual
     computation done by your module.  The interface
     should be such that other python code can import
@@ -155,7 +155,7 @@ class JRC2013VisLogic(ScriptedLoadableModuleLogic):
     pass
 
 
-class JRC2013VisTest(ScriptedLoadableModuleTest):
+class JRC2013VisTestTest(ScriptedLoadableModuleTest):
     """This is the test case for your scripted module."""
 
     def setUp(self):
@@ -329,7 +329,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
         self.delayDisplay("Finished with download and loading\n")
 
         try:
-            logic = JRC2013VisLogic()
+            logic = JRC2013VisTestLogic()
             mainWindow = slicer.util.mainWindow()
             layoutManager = slicer.app.layoutManager()
             threeDView = layoutManager.threeDWidget(0).threeDView()
@@ -403,7 +403,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
         self.delayDisplay("Finished with download and loading\n")
 
         try:
-            logic = JRC2013VisLogic()
+            logic = JRC2013VisTestLogic()
             mainWindow = slicer.util.mainWindow()
             layoutManager = slicer.app.layoutManager()
             threeDView = layoutManager.threeDWidget(0).threeDView()

--- a/Applications/SlicerApp/Testing/Python/RSNA2012ProstateDemoTest.py
+++ b/Applications/SlicerApp/Testing/Python/RSNA2012ProstateDemoTest.py
@@ -4,18 +4,18 @@ from slicer.util import TESTING_DATA_URL
 
 
 #
-# RSNA2012ProstateDemo
+# RSNA2012ProstateDemoTest
 #
 
 
-class RSNA2012ProstateDemo(ScriptedLoadableModule):
+class RSNA2012ProstateDemoTest(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        parent.title = "RSNA2012ProstateDemo"  # TODO make this more human readable by adding spaces
+        parent.title = "RSNA2012ProstateDemoTest"  # TODO make this more human readable by adding spaces
         parent.categories = ["Testing.TestCases"]
         parent.dependencies = []
         parent.contributors = ["Steve Pieper (Isomics)"]  # replace with "Firstname Lastname (Org)"
@@ -28,11 +28,11 @@ class RSNA2012ProstateDemo(ScriptedLoadableModule):
 
 
 #
-# qRSNA2012ProstateDemoWidget
+# RSNA2012ProstateDemoTestWidget
 #
 
 
-class RSNA2012ProstateDemoWidget(ScriptedLoadableModuleWidget):
+class RSNA2012ProstateDemoTestWidget(ScriptedLoadableModuleWidget):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -48,7 +48,7 @@ class RSNA2012ProstateDemoWidget(ScriptedLoadableModuleWidget):
         pass
 
 
-class RSNA2012ProstateDemoTest(ScriptedLoadableModuleTest):
+class RSNA2012ProstateDemoTestTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:
@@ -65,7 +65,7 @@ class RSNA2012ProstateDemoTest(ScriptedLoadableModuleTest):
     def test_RSNA2012ProstateDemo(self):
         """Replicate one of the crashes in issue 2512"""
 
-        print("Running RSNA2012ProstateDemo Test case:")
+        print("Running RSNA2012ProstateDemo test case:")
 
         import SampleData
 

--- a/Applications/SlicerApp/Testing/Python/RSNAQuantTutorialTest.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAQuantTutorialTest.py
@@ -7,18 +7,18 @@ from slicer.util import TESTING_DATA_URL
 
 
 #
-# RSNAQuantTutorial
+# RSNAQuantTutorialTest
 #
 
 
-class RSNAQuantTutorial(ScriptedLoadableModule):
+class RSNAQuantTutorialTest(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        parent.title = "RSNAQuantTutorial"  # TODO make this more human readable by adding spaces
+        parent.title = "RSNAQuantTutorialTest"  # TODO make this more human readable by adding spaces
         parent.categories = ["Testing.TestCases"]
         parent.dependencies = []
         parent.contributors = ["Steve Pieper (Isomics)"]  # replace with "Firstname Lastname (Org)"
@@ -31,11 +31,11 @@ class RSNAQuantTutorial(ScriptedLoadableModule):
 
 
 #
-# qRSNAQuantTutorialWidget
+# RSNAQuantTutorialTestWidget
 #
 
 
-class RSNAQuantTutorialWidget(ScriptedLoadableModuleWidget):
+class RSNAQuantTutorialTestWidget(ScriptedLoadableModuleWidget):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -94,7 +94,7 @@ class RSNAQuantTutorialWidget(ScriptedLoadableModuleWidget):
         enableScreenshotsFlag = self.enableScreenshotsFlagCheckBox.checked
         screenshotScaleFactor = int(self.screenshotScaleFactorSliderWidget.value)
 
-        tester = RSNAQuantTutorialTest()
+        tester = RSNAQuantTutorialTestTest()
         tester.setUp()
         tester.test_Part1Ruler(enableScreenshotsFlag, screenshotScaleFactor)
 
@@ -102,7 +102,7 @@ class RSNAQuantTutorialWidget(ScriptedLoadableModuleWidget):
         enableScreenshotsFlag = self.enableScreenshotsFlagCheckBox.checked
         screenshotScaleFactor = int(self.screenshotScaleFactorSliderWidget.value)
 
-        tester = RSNAQuantTutorialTest()
+        tester = RSNAQuantTutorialTestTest()
         tester.setUp()
         tester.test_Part2ChangeTracker(enableScreenshotsFlag, screenshotScaleFactor)
 
@@ -110,17 +110,17 @@ class RSNAQuantTutorialWidget(ScriptedLoadableModuleWidget):
         enableScreenshotsFlag = self.enableScreenshotsFlagCheckBox.checked
         screenshotScaleFactor = int(self.screenshotScaleFactorSliderWidget.value)
 
-        tester = RSNAQuantTutorialTest()
+        tester = RSNAQuantTutorialTestTest()
         tester.setUp()
         tester.test_Part3PETCT(enableScreenshotsFlag, screenshotScaleFactor)
 
 
 #
-# RSNAQuantTutorialLogic
+# RSNAQuantTutorialTestLogic
 #
 
 
-class RSNAQuantTutorialLogic(ScriptedLoadableModuleLogic):
+class RSNAQuantTutorialTestLogic(ScriptedLoadableModuleLogic):
     """This class should implement all the actual
     computation done by your module.  The interface
     should be such that other python code can import
@@ -131,7 +131,7 @@ class RSNAQuantTutorialLogic(ScriptedLoadableModuleLogic):
     pass
 
 
-class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
+class RSNAQuantTutorialTestTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:

--- a/Applications/SlicerApp/Testing/Python/RSNAVisTutorialTest.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAVisTutorialTest.py
@@ -7,18 +7,18 @@ from slicer.ScriptedLoadableModule import *
 from slicer.util import TESTING_DATA_URL
 
 #
-# RSNAVisTutorial
+# RSNAVisTutorialTest
 #
 
 
-class RSNAVisTutorial(ScriptedLoadableModule):
+class RSNAVisTutorialTest(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        parent.title = "RSNAVisTutorial"  # TODO make this more human readable by adding spaces
+        parent.title = "RSNAVisTutorialTest"  # TODO make this more human readable by adding spaces
         parent.categories = ["Testing.TestCases"]
         parent.dependencies = []
         parent.contributors = ["Steve Pieper (Isomics)"]  # replace with "Firstname Lastname (Org)"
@@ -31,11 +31,11 @@ class RSNAVisTutorial(ScriptedLoadableModule):
 
 
 #
-# qRSNAVisTutorialWidget
+# RSNAVisTutorialTestWidget
 #
 
 
-class RSNAVisTutorialWidget(ScriptedLoadableModuleWidget):
+class RSNAVisTutorialTestWidget(ScriptedLoadableModuleWidget):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -94,7 +94,7 @@ class RSNAVisTutorialWidget(ScriptedLoadableModuleWidget):
         enableScreenshotsFlag = self.enableScreenshotsFlagCheckBox.checked
         screenshotScaleFactor = int(self.screenshotScaleFactorSliderWidget.value)
 
-        tester = RSNAVisTutorialTest()
+        tester = RSNAVisTutorialTestTest()
         tester.setUp()
         tester.test_Part1DICOM(enableScreenshotsFlag, screenshotScaleFactor)
 
@@ -102,7 +102,7 @@ class RSNAVisTutorialWidget(ScriptedLoadableModuleWidget):
         enableScreenshotsFlag = self.enableScreenshotsFlagCheckBox.checked
         screenshotScaleFactor = int(self.screenshotScaleFactorSliderWidget.value)
 
-        tester = RSNAVisTutorialTest()
+        tester = RSNAVisTutorialTestTest()
         tester.setUp()
         tester.test_Part2Head(enableScreenshotsFlag, screenshotScaleFactor)
 
@@ -110,7 +110,7 @@ class RSNAVisTutorialWidget(ScriptedLoadableModuleWidget):
         enableScreenshotsFlag = self.enableScreenshotsFlagCheckBox.checked
         screenshotScaleFactor = int(self.screenshotScaleFactorSliderWidget.value)
 
-        tester = RSNAVisTutorialTest()
+        tester = RSNAVisTutorialTestTest()
         tester.setUp()
         tester.test_Part3Liver(enableScreenshotsFlag, screenshotScaleFactor)
 
@@ -118,17 +118,17 @@ class RSNAVisTutorialWidget(ScriptedLoadableModuleWidget):
         enableScreenshotsFlag = self.enableScreenshotsFlagCheckBox.checked
         screenshotScaleFactor = int(self.screenshotScaleFactorSliderWidget.value)
 
-        tester = RSNAVisTutorialTest()
+        tester = RSNAVisTutorialTestTest()
         tester.setUp()
         tester.test_Part4Lung(enableScreenshotsFlag, screenshotScaleFactor)
 
-    def onReload(self, moduleName="RSNAVisTutorial"):
+    def onReload(self, moduleName="RSNAVisTutorialTest"):
         """Generic reload method for any scripted module.
         ModuleWizard will substitute correct default moduleName.
         """
         globals()[moduleName] = slicer.util.reloadScriptedModule(moduleName)
 
-    def onReloadAndTest(self, moduleName="RSNAVisTutorial"):
+    def onReloadAndTest(self, moduleName="RSNAVisTutorialTest"):
         self.onReload()
         evalString = f'globals()["{moduleName}"].{moduleName}Test()'
         tester = eval(evalString)
@@ -136,11 +136,11 @@ class RSNAVisTutorialWidget(ScriptedLoadableModuleWidget):
 
 
 #
-# RSNAVisTutorialLogic
+# RSNAVisTutorialTestLogic
 #
 
 
-class RSNAVisTutorialLogic(ScriptedLoadableModuleLogic):
+class RSNAVisTutorialTestLogic(ScriptedLoadableModuleLogic):
     """This class should implement all the actual
     computation done by your module.  The interface
     should be such that other python code can import
@@ -153,7 +153,7 @@ class RSNAVisTutorialLogic(ScriptedLoadableModuleLogic):
     pass
 
 
-class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
+class RSNAVisTutorialTestTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:

--- a/Applications/SlicerApp/Testing/Python/Resources/UI/ScenePerformanceTest.ui
+++ b/Applications/SlicerApp/Testing/Python/Resources/UI/ScenePerformanceTest.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ScenePerformance</class>
- <widget class="qMRMLWidget" name="ScenePerformance">
+ <class>ScenePerformanceTest</class>
+ <widget class="qMRMLWidget" name="ScenePerformanceTest">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -198,7 +198,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>ScenePerformance</sender>
+   <sender>ScenePerformanceTest</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
    <receiver>MRMLNodeComboBox</receiver>
    <slot>setMRMLScene(vtkMRMLScene*)</slot>

--- a/Applications/SlicerApp/Testing/Python/ScenePerformanceTest.py
+++ b/Applications/SlicerApp/Testing/Python/ScenePerformanceTest.py
@@ -8,11 +8,11 @@ from slicer.util import TESTING_DATA_URL
 
 
 #
-# ScenePerformance
+# ScenePerformanceTest
 #
 
 
-class ScenePerformance(ScriptedLoadableModule):
+class ScenePerformanceTest(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
         parent.title = "Scene Performance"
@@ -28,15 +28,15 @@ class ScenePerformance(ScriptedLoadableModule):
 
 
 #
-# ScenePerformanceWidget
+# ScenePerformanceTestWidget
 #
-class ScenePerformanceWidget(ScriptedLoadableModuleWidget):
+class ScenePerformanceTestWidget(ScriptedLoadableModuleWidget):
     def setup(self):
         ScriptedLoadableModuleWidget.setup(self)
 
-        moduleName = "ScenePerformance"
+        moduleName = "ScenePerformanceTest"
         scriptedModulesPath = os.path.dirname(slicer.util.modulePath(moduleName))
-        path = os.path.join(scriptedModulesPath, "Resources", "UI", "ScenePerformance.ui")
+        path = os.path.join(scriptedModulesPath, "Resources", "UI", "ScenePerformanceTest.ui")
         widget = slicer.util.loadUI(path)
         self.layout = self.parent.layout()
         self.layout.addWidget(widget)
@@ -66,18 +66,18 @@ class ScenePerformanceWidget(ScriptedLoadableModuleWidget):
         self.updateActionProperties()
 
     def runTests(self):
-        tester = ScenePerformanceTest()
+        tester = ScenePerformanceTestTest()
         tester.testAll()
 
     def timeAction(self):
-        tester = ScenePerformanceTest()
+        tester = ScenePerformanceTestTest()
         tester.setUp()
         tester.setRepeat(self.RepeatSpinBox.value)
         if self.ActionComboBox.currentIndex == 0:  # Add Data
             if self.URLLineEdit.text == "":
                 file = self.ActionPathLineEdit.currentPath
             else:
-                logic = ScenePerformanceLogic()
+                logic = ScenePerformanceTestLogic()
                 file = logic.downloadFile(self.URLLineEdit.text, self.URLFileNameLineEdit.text)
             results = tester.addData(file)
             self.ResultsTextEdit.append(results)
@@ -113,9 +113,9 @@ class ScenePerformanceWidget(ScriptedLoadableModuleWidget):
 
 
 #
-# ScenePerformanceLogic
+# ScenePerformanceTestLogic
 #
-class ScenePerformanceLogic(ScriptedLoadableModuleLogic):
+class ScenePerformanceTestLogic(ScriptedLoadableModuleLogic):
     def downloadFile(self, downloadURL, downloadFileName, downloadFileChecksum=None):
         import SampleData
         return SampleData.downloadFromURL(
@@ -132,7 +132,7 @@ class ScenePerformanceLogic(ScriptedLoadableModuleLogic):
         return self.Timer.elapsed()
 
 
-class ScenePerformanceTest(ScriptedLoadableModuleTest):
+class ScenePerformanceTestTest(ScriptedLoadableModuleTest):
     def setUp(self):
         self.Repeat = 1
         self.delayDisplay("Setup")
@@ -183,13 +183,13 @@ class ScenePerformanceTest(ScriptedLoadableModuleTest):
         return message
 
     def addURLData(self, url, file, checksum):
-        logic = ScenePerformanceLogic()
+        logic = ScenePerformanceTestLogic()
         file = logic.downloadFile(url, file, checksum)
         self.addData(file)
 
     def addData(self, file):
         self.delayDisplay("Starting the AddData test")
-        logic = ScenePerformanceLogic()
+        logic = ScenePerformanceTestLogic()
         averageTime = 0
         for x in range(self.Repeat):
             logic.startTiming()
@@ -203,7 +203,7 @@ class ScenePerformanceTest(ScriptedLoadableModuleTest):
 
     def closeScene(self):
         self.delayDisplay("Starting the Close Scene test")
-        logic = ScenePerformanceLogic()
+        logic = ScenePerformanceTestLogic()
         averageTime = 0
         for x in range(self.Repeat):
             logic.startTiming()
@@ -216,7 +216,7 @@ class ScenePerformanceTest(ScriptedLoadableModuleTest):
 
     def restoreSceneView(self, sceneViewIndex):
         self.delayDisplay("Starting the Restore Scene test")
-        logic = ScenePerformanceLogic()
+        logic = ScenePerformanceTestLogic()
         averageTime = 0
         for x in range(self.Repeat):
             logic.startTiming()
@@ -229,7 +229,7 @@ class ScenePerformanceTest(ScriptedLoadableModuleTest):
 
     def setLayout(self, layoutIndex):
         self.delayDisplay("Starting the layout test")
-        logic = ScenePerformanceLogic()
+        logic = ScenePerformanceTestLogic()
         averageTime = 0
         for x in range(self.Repeat):
             logic.startTiming()
@@ -247,7 +247,7 @@ class ScenePerformanceTest(ScriptedLoadableModuleTest):
 
     def addNode(self, node):
         self.delayDisplay("Starting the add node test")
-        logic = ScenePerformanceLogic()
+        logic = ScenePerformanceTestLogic()
         averageTime = 0
         for x in range(self.Repeat):
             newNode = node.CreateNodeInstance()
@@ -267,7 +267,7 @@ class ScenePerformanceTest(ScriptedLoadableModuleTest):
 
     def modifyNode(self, node):
         self.delayDisplay("Starting the modify node test")
-        logic = ScenePerformanceLogic()
+        logic = ScenePerformanceTestLogic()
         averageTime = 0
         for x in range(self.Repeat):
             logic.startTiming()

--- a/Applications/SlicerApp/Testing/Python/ShaderPropertiesTest.py
+++ b/Applications/SlicerApp/Testing/Python/ShaderPropertiesTest.py
@@ -9,11 +9,11 @@ from slicer.util import TESTING_DATA_URL
 
 
 #
-# ShaderProperties
+# ShaderPropertiesTest
 #
 
 
-class ShaderProperties(ScriptedLoadableModule):
+class ShaderPropertiesTest(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
         parent.title = "Shader Properties"
@@ -29,38 +29,38 @@ class ShaderProperties(ScriptedLoadableModule):
 
 
 #
-# ShaderPropertiesWidget
+# ShaderPropertiesTestWidget
 #
-class ShaderPropertiesWidget(ScriptedLoadableModuleWidget):
+class ShaderPropertiesTestWidget(ScriptedLoadableModuleWidget):
     def setup(self):
         ScriptedLoadableModuleWidget.setup(self)
 
-        moduleName = "ShaderProperties"
+        moduleName = "ShaderPropertiesTest"
 
         self.sphereTestButton = qt.QPushButton()
         self.sphereTestButton.text = "Sphere test"
         self.layout.addWidget(self.sphereTestButton)
-        self.sphereTestButton.connect("clicked()", lambda: ShaderPropertiesTest().testSphereCut())
+        self.sphereTestButton.connect("clicked()", lambda: ShaderPropertiesTestTest().testSphereCut())
 
         self.wedgeTestButton = qt.QPushButton()
         self.wedgeTestButton.text = "Wedge test"
         self.layout.addWidget(self.wedgeTestButton)
-        self.wedgeTestButton.connect("clicked()", lambda: ShaderPropertiesTest().testWedgeCut())
+        self.wedgeTestButton.connect("clicked()", lambda: ShaderPropertiesTestTest().testWedgeCut())
 
         # Add vertical spacer
         self.layout.addStretch(1)
 
     def runTests(self):
-        tester = ShaderPropertiesTest()
+        tester = ShaderPropertiesTestTest()
         tester.testAll()
 
 
 #
-# ShaderPropertiesTest
+# ShaderPropertiesTestTest
 #
 
 
-class ShaderPropertiesTest(ScriptedLoadableModuleTest):
+class ShaderPropertiesTestTest(ScriptedLoadableModuleTest):
     def setUp(self):
         self.delayDisplay("Setup")
         layoutManager = slicer.app.layoutManager()

--- a/Applications/SlicerApp/Testing/Python/SliceLinkLogicTest.py
+++ b/Applications/SlicerApp/Testing/Python/SliceLinkLogicTest.py
@@ -7,18 +7,18 @@ from slicer.util import TESTING_DATA_URL
 
 
 #
-# SliceLinkLogic
+# SliceLinkLogicTest
 #
 
 
-class SliceLinkLogic(ScriptedLoadableModule):
+class SliceLinkLogicTest(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        parent.title = "SliceLinkLogic"  # TODO make this more human readable by adding spaces
+        parent.title = "SliceLinkLogicTest"  # TODO make this more human readable by adding spaces
         parent.categories = ["Testing.TestCases"]
         parent.dependencies = []
         parent.contributors = ["Jim Miller (GE)"]  # replace with "Firstname Lastname (Org)"
@@ -31,11 +31,11 @@ class SliceLinkLogic(ScriptedLoadableModule):
 
 
 #
-# qSliceLinkLogicWidget
+# SliceLinkLogicTestWidget
 #
 
 
-class SliceLinkLogicWidget(ScriptedLoadableModuleWidget):
+class SliceLinkLogicTestWidget(ScriptedLoadableModuleWidget):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -69,11 +69,11 @@ class SliceLinkLogicWidget(ScriptedLoadableModuleWidget):
 
 
 #
-# SliceLinkLogicLogic
+# SliceLinkLogicTestLogic
 #
 
 
-class SliceLinkLogicLogic(ScriptedLoadableModuleLogic):
+class SliceLinkLogicTestLogic(ScriptedLoadableModuleLogic):
     """This class should implement all the actual
     computation done by your module.  The interface
     should be such that other python code can import
@@ -97,7 +97,7 @@ class SliceLinkLogicLogic(ScriptedLoadableModuleLogic):
         return True
 
 
-class SliceLinkLogicTest(ScriptedLoadableModuleTest):
+class SliceLinkLogicTestTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:
@@ -141,7 +141,7 @@ class SliceLinkLogicTest(ScriptedLoadableModuleTest):
         print("")
 
         volumeNode = slicer.util.getNode(pattern="FA")
-        logic = SliceLinkLogicLogic()
+        logic = SliceLinkLogicTestLogic()
         self.assertIsNotNone(logic.hasImageData(volumeNode))
 
         eps = 0.02  # on high-DPI screens FOV difference can be up to 1.25%, so set the tolerance to 2%

--- a/Applications/SlicerApp/Testing/Python/Slicer4MinuteTest.py
+++ b/Applications/SlicerApp/Testing/Python/Slicer4MinuteTest.py
@@ -7,18 +7,18 @@ from slicer.util import TESTING_DATA_URL
 
 
 #
-# Slicer4Minute
+# Slicer4MinuteTest
 #
 
 
-class Slicer4Minute(ScriptedLoadableModule):
+class Slicer4MinuteTest(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        parent.title = "Slicer4Minute"  # TODO make this more human readable by adding spaces
+        parent.title = "Slicer4MinuteTest"  # TODO make this more human readable by adding spaces
         parent.categories = ["Testing.TestCases"]
         parent.dependencies = []
         parent.contributors = ["Jim Miller (GE)"]  # replace with "Firstname Lastname (Org)"
@@ -31,11 +31,11 @@ class Slicer4Minute(ScriptedLoadableModule):
 
 
 #
-# qSlicer4MinuteWidget
+# Slicer4MinuteTestWidget
 #
 
 
-class Slicer4MinuteWidget(ScriptedLoadableModuleWidget):
+class Slicer4MinuteTestWidget(ScriptedLoadableModuleWidget):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -69,11 +69,11 @@ class Slicer4MinuteWidget(ScriptedLoadableModuleWidget):
 
 
 #
-# Slicer4MinuteLogic
+# Slicer4MinuteTestLogic
 #
 
 
-class Slicer4MinuteLogic(ScriptedLoadableModuleLogic):
+class Slicer4MinuteTestLogic(ScriptedLoadableModuleLogic):
     """This class should implement all the actual
     computation done by your module.  The interface
     should be such that other python code can import
@@ -97,7 +97,7 @@ class Slicer4MinuteLogic(ScriptedLoadableModuleLogic):
         return True
 
 
-class Slicer4MinuteTest(ScriptedLoadableModuleTest):
+class Slicer4MinuteTestTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:
@@ -120,7 +120,7 @@ class Slicer4MinuteTest(ScriptedLoadableModuleTest):
         """
         self.delayDisplay("Starting the test")
 
-        logic = Slicer4MinuteLogic()
+        logic = Slicer4MinuteTestLogic()
 
         #
         # first, get some data

--- a/Applications/SlicerApp/Testing/Python/SlicerRestoreSceneViewCrashIssue3445Test.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerRestoreSceneViewCrashIssue3445Test.py
@@ -1,30 +1,28 @@
-import logging
-
 import slicer
 from slicer.ScriptedLoadableModule import *
+from slicer.util import TESTING_DATA_URL
 
 
 #
-# BRAINSFitRigidRegistrationCrashIssue4139
+# SlicerRestoreSceneViewCrashIssue3445Test
 #
 
 
-class BRAINSFitRigidRegistrationCrashIssue4139(ScriptedLoadableModule):
+class SlicerRestoreSceneViewCrashIssue3445Test(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        self.parent.title = "BRAINSFit Rigid Registration vtkITKTransformConverter crash (Issue 4139)"
+        self.parent.title = "SceneView restore crash (Issue 3445)"
         self.parent.categories = ["Testing.TestCases"]
         self.parent.dependencies = []
         self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)"]  # replace with "Firstname Lastname (Organization)"
         self.parent.helpText = """This test has been added to check that
-    Slicer does not crash in vtkITKTransformConverter after completing BRAINSFit rigid registration.
+    Slicer does not crash while restoring scene view associated with BrainAtlas2012.mrb.
 
-    Problem has been documented in issue #4139. Commit r24901 fixes the problem
-    by updating vtkITKTransformConverter class.
+    Problem has been documented in issue #3445.
     """
         self.parent.acknowledgementText = """
     This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc.
@@ -33,11 +31,11 @@ class BRAINSFitRigidRegistrationCrashIssue4139(ScriptedLoadableModule):
 
 
 #
-# BRAINSFitRigidRegistrationCrashIssue4139Widget
+# SlicerRestoreSceneViewCrashIssue3445TestWidget
 #
 
 
-class BRAINSFitRigidRegistrationCrashIssue4139Widget(ScriptedLoadableModuleWidget):
+class SlicerRestoreSceneViewCrashIssue3445TestWidget(ScriptedLoadableModuleWidget):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -47,11 +45,11 @@ class BRAINSFitRigidRegistrationCrashIssue4139Widget(ScriptedLoadableModuleWidge
 
 
 #
-# BRAINSFitRigidRegistrationCrashIssue4139Logic
+# SlicerRestoreSceneViewCrashIssue3445TestLogic
 #
 
 
-class BRAINSFitRigidRegistrationCrashIssue4139Logic(ScriptedLoadableModuleLogic):
+class SlicerRestoreSceneViewCrashIssue3445TestLogic(ScriptedLoadableModuleLogic):
     """This class should implement all the actual
     computation done by your module.  The interface
     should be such that other python code can import
@@ -61,21 +59,10 @@ class BRAINSFitRigidRegistrationCrashIssue4139Logic(ScriptedLoadableModuleLogic)
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
-    def hasImageData(self, volumeNode):
-        """This is an example logic method that
-        returns true if the passed in volume
-        node has valid image data
-        """
-        if not volumeNode:
-            logging.debug("hasImageData failed: no volume node")
-            return False
-        if volumeNode.GetImageData() is None:
-            logging.debug("hasImageData failed: no image data in volume node")
-            return False
-        return True
+    pass
 
 
-class BRAINSFitRigidRegistrationCrashIssue4139Test(ScriptedLoadableModuleTest):
+class SlicerRestoreSceneViewCrashIssue3445TestTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:
@@ -89,9 +76,9 @@ class BRAINSFitRigidRegistrationCrashIssue4139Test(ScriptedLoadableModuleTest):
     def runTest(self):
         """Run as few or as many tests as needed here."""
         self.setUp()
-        self.test_BRAINSFitRigidRegistrationCrashIssue4139()
+        self.test_SlicerRestoreSceneViewCrashIssue3445()
 
-    def test_BRAINSFitRigidRegistrationCrashIssue4139(self):
+    def test_SlicerRestoreSceneViewCrashIssue3445(self):
         """Ideally you should have several levels of tests.  At the lowest level
         tests should exercise the functionality of the logic with different inputs
         (both valid and invalid).  At higher levels your tests should emulate the
@@ -103,35 +90,38 @@ class BRAINSFitRigidRegistrationCrashIssue4139Test(ScriptedLoadableModuleTest):
         your test should break so they know that the feature is needed.
         """
 
+        logic = SlicerRestoreSceneViewCrashIssue3445TestLogic()
+
         self.delayDisplay("Starting the test")
 
-        logic = BRAINSFitRigidRegistrationCrashIssue4139Logic()
-
+        #
+        # first, get some data
+        #
         import SampleData
 
-        fixed = SampleData.downloadSample("MRBrainTumor1")
-        self.assertIsNotNone(logic.hasImageData(fixed))
+        filePath = SampleData.downloadFromURL(
+            fileNames="BrainAtlas2012.mrb",
+            loadFiles=False,
+            uris=TESTING_DATA_URL + "SHA256/688ebcc6f45989795be2bcdc6b8b5bfc461f1656d677ed3ddef8c313532687f1",
+            checksums="SHA256:688ebcc6f45989795be2bcdc6b8b5bfc461f1656d677ed3ddef8c313532687f1")[0]
 
-        moving = SampleData.downloadSample("MRBrainTumor2")
-        self.assertIsNotNone(logic.hasImageData(moving))
+        self.delayDisplay("Finished with download")
 
-        self.delayDisplay("Finished with download and loading")
+        ioManager = slicer.app.ioManager()
 
-        outputTransform = slicer.vtkMRMLLinearTransformNode()
-        slicer.mrmlScene.AddNode(outputTransform)
+        ioManager.loadFile(filePath)
 
-        outputVolume = slicer.vtkMRMLScalarVolumeNode()
-        slicer.mrmlScene.AddNode(outputVolume)
+        slicer.mrmlScene.Clear(0)
+        slicer.util.selectModule("Data")
+        slicer.util.selectModule("Models")
 
-        parameters = {
-            "fixedVolume": fixed,
-            "movingVolume": moving,
-            "linearTransform": outputTransform,
-            "outputVolume": outputVolume,
-            "useRigid": True,
-        }
-        cmdLineNode = slicer.cli.runSync(slicer.modules.brainsfit, parameters=parameters)
-        self.assertIsNotNone(cmdLineNode)
+        ioManager.loadFile(filePath)
+        slicer.mrmlScene.Clear(0)
+
+        ioManager.loadFile(filePath)
+        ioManager.loadFile(filePath)
+
+        slicer.modules.sceneviews.logic().RestoreSceneView(0)
 
         # If test reach this point without crashing it is a success
 

--- a/Applications/SlicerApp/Testing/Python/SlicerStartupCompletedHelperModuleTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerStartupCompletedHelperModuleTest.py
@@ -4,7 +4,7 @@ import os
 from slicer.ScriptedLoadableModule import *
 
 
-class SlicerStartupCompletedTestHelperModule(ScriptedLoadableModule):
+class SlicerStartupCompletedHelperModuleTest(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = "SlicerStartupCompletedTest"
@@ -18,7 +18,7 @@ class SlicerStartupCompletedTestHelperModule(ScriptedLoadableModule):
 
         slicer.app.connect("startupCompleted()", self.onStartupCompleted)
 
-        print("SlicerStartupCompletedTestHelperModule initialized")
+        print("SlicerStartupCompletedHelperModuleTest initialized")
 
     def onStartupCompleted(self):
         print("StartupCompleted emitted")
@@ -26,6 +26,6 @@ class SlicerStartupCompletedTestHelperModule(ScriptedLoadableModule):
         import os
 
         fd = os.open(self.testOutputFileName, os.O_RDWR | os.O_CREAT)
-        os.write(fd, "SlicerStartupCompletedTestHelperModule.py generated this file")
+        os.write(fd, "SlicerStartupCompletedHelperModuleTest.py generated this file")
         os.write(fd, "when slicer.app emitted startupCompleted() signal\n")
         os.close(fd)

--- a/Applications/SlicerApp/Testing/Python/SlicerStartupCompletedTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerStartupCompletedTest.py
@@ -49,8 +49,8 @@ if __name__ == "__main__":
         # Copy helper module that creates a file when startup completed event is received
         currentDirPath = os.path.dirname(__file__).replace("\\", "/")
         from shutil import copyfile
-        copyfile(currentDirPath + "/SlicerStartupCompletedTestHelperModule.py",
-                 temporaryModuleDirPath + "/SlicerStartupCompletedTestHelperModule.py")
+        copyfile(currentDirPath + "/SlicerStartupCompletedHelperModuleTest.py",
+                 temporaryModuleDirPath + "/SlicerStartupCompletedHelperModuleTest.py")
 
         slicer_executable = os.path.expanduser(sys.argv[1])
         common_args = [

--- a/Applications/SlicerApp/Testing/Python/SlicerStartupPreserveSysPathHelperModuleTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerStartupPreserveSysPathHelperModuleTest.py
@@ -10,7 +10,7 @@ sys.path.append(currentDir)
 
 from SlicerStartupPreserveSysPathTestHelperPackage import *
 
-class SlicerStartupPreserveSysPathTestHelperModule(ScriptedLoadableModule):
+class SlicerStartupPreserveSysPathHelperModuleTest(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = "SlicerStartupPreserveSysPathTest"
@@ -22,4 +22,4 @@ class SlicerStartupPreserveSysPathTestHelperModule(ScriptedLoadableModule):
         if os.path.isfile(self.testOutputFileName):
             os.remove(self.testOutputFileName)
 
-        print("SlicerStartupPreserveSysPathTestHelperModule initialized")
+        print("SlicerStartupPreserveSysPathHelperModuleTest initialized")

--- a/Applications/SlicerApp/Testing/Python/SlicerStartupPreserveSysPathTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerStartupPreserveSysPathTest.py
@@ -37,7 +37,7 @@ ensures `sys.path` modifications performed during module discovery remain
 in effect after startup completes.
 
 This test was based on `SlicerStartupCompletedTest.py` and it relies on
-`SlicerStartupPreserveSysPathTestHelperModule.py` and the `SlicerStartupPreserveSysPathTestHelperPackage`
+`SlicerStartupPreserveSysPathHelperModuleTest.py` and the `SlicerStartupPreserveSysPathTestHelperPackage`
 Python package.
 
 It uses an output file for communication because on Windows,
@@ -65,8 +65,8 @@ if __name__ == "__main__":
         # (2) removes the output file if it already exists (the startup script recreates it)
         currentDirPath = os.path.dirname(__file__).replace("\\", "/")
         from shutil import copyfile, copytree
-        copyfile(currentDirPath + "/SlicerStartupPreserveSysPathTestHelperModule.py",
-                 temporaryModuleDirPath + "/SlicerStartupPreserveSysPathTestHelperModule.py")
+        copyfile(currentDirPath + "/SlicerStartupPreserveSysPathHelperModuleTest.py",
+                 temporaryModuleDirPath + "/SlicerStartupPreserveSysPathHelperModuleTest.py")
         copytree(currentDirPath + "/SlicerStartupPreserveSysPathTestHelperPackage",
                  temporaryModuleDirPath + "/SlicerStartupPreserveSysPathTestHelperPackage")
 

--- a/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest.py
@@ -9,11 +9,11 @@ from slicer.ScriptedLoadableModule import *
 
 
 #
-# SlicerTransformInteractionTest1
+# SlicerTransformInteractionTest
 #
 
 
-class SlicerTransformInteractionTest1(ScriptedLoadableModule):
+class SlicerTransformInteractionTest(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -31,21 +31,21 @@ class SlicerTransformInteractionTest1(ScriptedLoadableModule):
 
 
 #
-# SlicerTransformInteractionTest1Widget
+# SlicerTransformInteractionTestWidget
 #
 
 
-class SlicerTransformInteractionTest1Widget(ScriptedLoadableModuleWidget):
+class SlicerTransformInteractionTestWidget(ScriptedLoadableModuleWidget):
     def setup(self):
         ScriptedLoadableModuleWidget.setup(self)
 
 
 #
-# SlicerTransformInteractionTest1Logic
+# SlicerTransformInteractionTestLogic
 #
 
 
-class SlicerTransformInteractionTest1Logic(ScriptedLoadableModuleLogic):
+class SlicerTransformInteractionTestLogic(ScriptedLoadableModuleLogic):
     def addTransform(self):
         """Create and add a transform node with a display node to the
         mrmlScene.
@@ -67,7 +67,7 @@ class SlicerTransformInteractionTest1Logic(ScriptedLoadableModuleLogic):
         return None
 
 
-class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
+class SlicerTransformInteractionTestTest(ScriptedLoadableModuleTest):
     def setUp(self):
         """Do whatever is needed to reset the state - typically a scene clear will be enough."""
         slicer.mrmlScene.Clear(0)
@@ -92,10 +92,10 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
 
     def test_3D_interactionDefaults(self):
         """Test that the interaction widget exists in the 3D view."""
-        logic = SlicerTransformInteractionTest1Logic()
+        logic = SlicerTransformInteractionTestLogic()
 
         # self.delayDisplay("Starting test_3D_interactionDefaults")
-        logic = SlicerTransformInteractionTest1Logic()
+        logic = SlicerTransformInteractionTestLogic()
         _tNode, tdNode = logic.addTransform()
         self.assertFalse(tdNode.GetEditorVisibility())
         self.assertFalse(tdNode.GetEditorSliceIntersectionVisibility())
@@ -129,14 +129,14 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
 
     def test_3D_interactionVolume(self):
         """Test that the interaction widget interacts correctly in the 3D view."""
-        logic = SlicerTransformInteractionTest1Logic()
+        logic = SlicerTransformInteractionTestLogic()
 
         import SampleData
 
         volume = SampleData.downloadSample("CTAAbdomenPanoramix")
 
         # self.delayDisplay("Starting test_3D_interactionVolume")
-        logic = SlicerTransformInteractionTest1Logic()
+        logic = SlicerTransformInteractionTestLogic()
         tNode, tdNode = logic.addTransform()
         self.assertFalse(tdNode.GetEditorVisibility())
         self.assertFalse(tdNode.GetEditorSliceIntersectionVisibility())
@@ -330,7 +330,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         movedCubeNode.SetPolyDataConnection(applyTransform.GetOutputPort())
 
         # Get the widget
-        logic = SlicerTransformInteractionTest1Logic()
+        logic = SlicerTransformInteractionTestLogic()
         tNode, tdNode = logic.addTransform()
         slicer.app.layoutManager().layout = slicer.vtkMRMLLayoutNode.SlicerLayoutOneUp3DView
         manager = logic.getModel3DDisplayableManager()
@@ -422,7 +422,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         markupNode.AddControlPoint([1000.0, 1000.0, 200.0])
         markupNode.AddControlPoint([-1500.0, -200.0, -100.0])
 
-        logic = SlicerTransformInteractionTest1Logic()
+        logic = SlicerTransformInteractionTestLogic()
         parentNode, _parendDisplayNode = logic.addTransform()
 
         leafNode, tdNode = logic.addTransform()
@@ -500,7 +500,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
 
     def test_3D_interactionSerialization(self):
         """Test that the serialization the interaction properties."""
-        logic = SlicerTransformInteractionTest1Logic()
+        logic = SlicerTransformInteractionTestLogic()
 
         # self.delayDisplay("Starting test_3D_interactionSerialization")
         # Setup
@@ -540,7 +540,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
 
     def test_3D_boundsUpdateROI(self):
         """Test that the bounds update with an ROI."""
-        logic = SlicerTransformInteractionTest1Logic()
+        logic = SlicerTransformInteractionTestLogic()
 
         # self.delayDisplay("Starting test_3D_boundsUpdateROI")
         # Setup
@@ -548,7 +548,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
         roiNode.SetXYZ(100, 300, -0.689)
         roiNode.SetRadiusXYZ(700, 8, 45)
 
-        logic = SlicerTransformInteractionTest1Logic()
+        logic = SlicerTransformInteractionTestLogic()
         tNode, tdNode = logic.addTransform()
 
         slicer.app.layoutManager().layout = slicer.vtkMRMLLayoutNode.SlicerLayoutOneUp3DView

--- a/Applications/SlicerApp/Testing/Python/ViewControllersSliceInterpolationBug1926Test.py
+++ b/Applications/SlicerApp/Testing/Python/ViewControllersSliceInterpolationBug1926Test.py
@@ -6,11 +6,11 @@ from slicer.ScriptedLoadableModule import *
 
 
 #
-# ViewControllersSliceInterpolationBug1926
+# ViewControllersSliceInterpolationBug1926Test
 #
 
 
-class ViewControllersSliceInterpolationBug1926(ScriptedLoadableModule):
+class ViewControllersSliceInterpolationBug1926Test(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -35,11 +35,11 @@ class ViewControllersSliceInterpolationBug1926(ScriptedLoadableModule):
 
 
 #
-# qViewControllersSliceInterpolationBug1926Widget
+# ViewControllersSliceInterpolationBug1926TestWidget
 #
 
 
-class ViewControllersSliceInterpolationBug1926Widget(ScriptedLoadableModuleWidget):
+class ViewControllersSliceInterpolationBug1926TestWidget(ScriptedLoadableModuleWidget):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -72,7 +72,7 @@ class ViewControllersSliceInterpolationBug1926Widget(ScriptedLoadableModuleWidge
         print("Hello World !")
 
 
-class ViewControllersSliceInterpolationBug1926Test(ScriptedLoadableModuleTest):
+class ViewControllersSliceInterpolationBug1926TestTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:

--- a/Applications/SlicerApp/Testing/Python/WebEngineTest.py
+++ b/Applications/SlicerApp/Testing/Python/WebEngineTest.py
@@ -6,18 +6,18 @@ from slicer.ScriptedLoadableModule import *
 
 
 #
-# WebEngine
+# WebEngineTest
 #
 
 
-class WebEngine(ScriptedLoadableModule):
+class WebEngineTest(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        parent.title = "WebEngine"
+        parent.title = "WebEngineTest"
         parent.categories = ["Testing.TestCases"]
         parent.dependencies = []
         parent.contributors = ["Steve Pieper (Isomics)"]
@@ -30,11 +30,11 @@ class WebEngine(ScriptedLoadableModule):
 
 
 #
-# qWebEngineWidget
+# WebEngineTestWidget
 #
 
 
-class WebEngineWidget(ScriptedLoadableModuleWidget):
+class WebEngineTestWidget(ScriptedLoadableModuleWidget):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -108,7 +108,7 @@ class WebEngineWidget(ScriptedLoadableModuleWidget):
         self.webWidgets = []
 
 
-class WebEngineTest(ScriptedLoadableModuleTest):
+class WebEngineTestTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:

--- a/Applications/SlicerApp/Testing/Python/sceneImport2428Test.py
+++ b/Applications/SlicerApp/Testing/Python/sceneImport2428Test.py
@@ -6,11 +6,11 @@ import slicer
 from slicer.ScriptedLoadableModule import *
 
 #
-# sceneImport2428
+# sceneImport2428Test
 #
 
 
-class sceneImport2428(ScriptedLoadableModule):
+class sceneImport2428Test(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -31,11 +31,11 @@ class sceneImport2428(ScriptedLoadableModule):
 
 
 #
-# qsceneImport2428Widget
+# sceneImport2428TestWidget
 #
 
 
-class sceneImport2428Widget(ScriptedLoadableModuleWidget):
+class sceneImport2428TestWidget(ScriptedLoadableModuleWidget):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -68,7 +68,7 @@ class sceneImport2428Widget(ScriptedLoadableModuleWidget):
         print("Hello World !")
 
 
-class sceneImport2428Test(ScriptedLoadableModuleTest):
+class sceneImport2428TestTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:
@@ -209,7 +209,8 @@ class sceneImport2428Test(ScriptedLoadableModuleTest):
             for dn in range(modelNode.GetNumberOfDisplayNodes()):
                 displayNode = modelNode.GetNthDisplayNode(dn)
                 if modelNode.GetPolyData() != displayNode.GetInputPolyData():
-                    self.delayDisplay("Model %d does not match its display node %d! (name: %s, ids: %s and %s)" % (n, dn, modelNode.GetName(), modelNode.GetID(), displayNode.GetID()))
+                    self.delayDisplay("Model %d does not match its display node %d! (name: %s, ids: %s and %s)"
+                                      % (n, dn, modelNode.GetName(), modelNode.GetID(), displayNode.GetID()))
                     success = False
             for sn in range(modelNode.GetNumberOfStorageNodes()):
                 storageNode = modelNode.GetNthStorageNode(sn)

--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -136,6 +136,17 @@ void qSlicerApplicationHelper::setupModuleFactoryManager(qSlicerModuleFactoryMan
     return;
   }
 
+  // Modules that only exist to be exercised by a test are of no use to an end user, and
+  // several of them are scripted, so registering them means importing Python modules
+  // that will never be used. Skip them unless developer mode is on, matching the
+  // existing behavior of the module menu and the module list, which already hide them.
+  //
+  // Testing mode is excluded as well, because that is how the automated tests launch the
+  // application and they do need their own modules.
+  const bool developerModeEnabled = app->userSettings()->value("Developer/DeveloperMode", false).toBool();
+  const bool testingEnabled = app->testAttribute(qSlicerCoreApplication::AA_EnableTesting);
+  moduleFactoryManager->setIgnoreTestingModules(!developerModeEnabled && !testingEnabled);
+
   if (!options->disableLoadableModules())
   {
     moduleFactoryManager->registerFactory(new qSlicerLoadableModuleFactory);

--- a/Base/QTCore/qSlicerAbstractModuleFactoryManager.cxx
+++ b/Base/QTCore/qSlicerAbstractModuleFactoryManager.cxx
@@ -24,6 +24,7 @@
 // Slicer includes
 #include "qSlicerCoreApplication.h"
 #include "qSlicerAbstractModuleFactoryManager.h"
+#include "qSlicerUtils.h"
 #include "qSlicerAbstractCoreModule.h"
 
 // STD includes
@@ -55,6 +56,7 @@ public:
   QStringList SearchPaths;
   QStringList ExplicitModules;
   QStringList ModulesToIgnore;
+  bool IgnoreTestingModules{ false };
   QMap<QString, QFileInfo> IgnoredModules;
   QMap<qSlicerModuleFactory*, int> Factories;
   QMap<QString, qSlicerModuleFactory*> RegisteredModules;
@@ -234,6 +236,20 @@ QStringList qSlicerAbstractModuleFactoryManager::modulesToIgnore() const
 }
 
 //-----------------------------------------------------------------------------
+void qSlicerAbstractModuleFactoryManager::setIgnoreTestingModules(bool ignore)
+{
+  Q_D(qSlicerAbstractModuleFactoryManager);
+  d->IgnoreTestingModules = ignore;
+}
+
+//-----------------------------------------------------------------------------
+bool qSlicerAbstractModuleFactoryManager::ignoreTestingModules() const
+{
+  Q_D(const qSlicerAbstractModuleFactoryManager);
+  return d->IgnoreTestingModules;
+}
+
+//-----------------------------------------------------------------------------
 QStringList qSlicerAbstractModuleFactoryManager::ignoredModuleNames() const
 {
   Q_D(const qSlicerAbstractModuleFactoryManager);
@@ -335,6 +351,16 @@ void qSlicerAbstractModuleFactoryManager::registerModule(const QFileInfo& file)
     if (d->Verbose)
     {
       qDebug() << " file: " << file.absoluteFilePath() << " is in ignore list";
+    }
+    d->IgnoredModules[moduleName] = file;
+    emit moduleIgnored(moduleName);
+    return;
+  }
+  if (d->IgnoreTestingModules && qSlicerUtils::isTestingModuleName(moduleName))
+  {
+    if (d->Verbose)
+    {
+      qDebug() << " file: " << file.absoluteFilePath() << " is a testing module";
     }
     d->IgnoredModules[moduleName] = file;
     emit moduleIgnored(moduleName);

--- a/Base/QTCore/qSlicerAbstractModuleFactoryManager.h
+++ b/Base/QTCore/qSlicerAbstractModuleFactoryManager.h
@@ -151,6 +151,20 @@ public:
   /// \sa addModuleToIgnore(const QString& moduleName)
   inline void removeModuleToIgnore(const QString& moduleName);
 
+  /// Set or get whether modules that only exist to be exercised by a test are skipped.
+  ///
+  /// When enabled, a module whose name identifies it as a test (see
+  /// qSlicerUtils::isTestingModuleName()) is never registered, and therefore never
+  /// instantiated. This is deliberately decided from the name: the category that
+  /// qSlicerUtils::isTestingModule() reads is only known once the module has been
+  /// instantiated, and for a scripted module that already means importing it, which is
+  /// the cost worth avoiding.
+  ///
+  /// Disabled by default, so that nothing changes for an application that does not ask
+  /// for it.
+  void setIgnoreTestingModules(bool ignore);
+  bool ignoreTestingModules() const;
+
   /// After the modules are registered, ignoredModules contains the list
   /// of all the modules that were ignored.
   QStringList ignoredModuleNames() const;

--- a/Base/QTCore/qSlicerUtils.cxx
+++ b/Base/QTCore/qSlicerUtils.cxx
@@ -101,17 +101,17 @@ bool qSlicerUtils::isLoadableModule(const QString& filePath)
 }
 
 //-----------------------------------------------------------------------------
+bool qSlicerUtils::isTestingModuleName(const QString& moduleName)
+{
+  // Both the singular and the plural are in use ("AddManyMarkupsFiducialTest",
+  // "AtlasTests"), as are the "SelfTest" variants, which these suffixes already cover.
+  return moduleName.endsWith("Test") || moduleName.endsWith("Tests");
+}
+
+//-----------------------------------------------------------------------------
 bool qSlicerUtils::isTestingModule(qSlicerAbstractCoreModule* module)
 {
-  const QStringList& categories = module->categories();
-  for (const QString& category : categories)
-  {
-    if (category.split('.').takeFirst() != "Testing")
-    {
-      return false;
-    }
-  }
-  return true;
+  return qSlicerUtils::isTestingModuleName(module->name());
 }
 
 //------------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerUtils.h
+++ b/Base/QTCore/qSlicerUtils.h
@@ -57,8 +57,17 @@ public:
 
   /// Return \a true is the module is for testing purposes.
   /// These modules are for testing and for troubleshooting and normally should not be displayed
-  /// to end users.
+  /// to end users. Convenience overload of isTestingModuleName() that takes the name from
+  /// \a module.
   static bool isTestingModule(qSlicerAbstractCoreModule* module);
+
+  /// Return \a true if the module name follows the convention for a module that only
+  /// exists to be exercised by a test, which is a name ending in "Test" or "Tests".
+  ///
+  /// The name is used instead of the module category because it is known before the module
+  /// is instantiated. That is what makes it useful: instantiating a scripted module imports
+  /// it, and the import is the expensive part.
+  static bool isTestingModuleName(const QString& moduleName);
 
   /// Look for target file in build intermediate directory.
   /// On Windows, the intermediate directory includes: . Debug RelWithDebInfo Release MinSizeRel

--- a/Modules/Loadable/VolumeRendering/Testing/Python/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/Testing/Python/CMakeLists.txt
@@ -1,14 +1,14 @@
 if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
 
   # add tests
-  slicer_add_python_unittest(SCRIPT VolumeRenderingSceneClose.py)
+  slicer_add_python_unittest(SCRIPT VolumeRenderingSceneCloseTest.py)
   slicer_add_python_unittest(SCRIPT VolumeRenderingThreeDOnlyLayout.py)
   set_tests_properties(
     py_VolumeRenderingThreeDOnlyLayout
     PROPERTIES FAIL_REGULAR_EXPRESSION "OpenGL errors detected"
     )
   set(KIT_PYTHON_SCRIPTS
-    VolumeRenderingSceneClose.py
+    VolumeRenderingSceneCloseTest.py
      )
   ctkMacroCompilePythonScript(
     TARGET_NAME ApplicationSelfTests

--- a/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingSceneCloseTest.py
+++ b/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingSceneCloseTest.py
@@ -6,18 +6,18 @@ from slicer.ScriptedLoadableModule import *
 
 
 #
-# VolumeRenderingSceneClose
+# VolumeRenderingSceneCloseTest
 #
 
 
-class VolumeRenderingSceneClose(ScriptedLoadableModule):
+class VolumeRenderingSceneCloseTest(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        parent.title = "VolumeRenderingSceneClose"
+        parent.title = "VolumeRenderingSceneCloseTest"
         parent.categories = ["Testing.TestCases"]
         parent.dependencies = []
         parent.contributors = ["Nicole Aucoin (BWH)"]
@@ -31,11 +31,11 @@ class VolumeRenderingSceneClose(ScriptedLoadableModule):
 
 
 #
-# qVolumeRenderingSceneCloseWidget
+# VolumeRenderingSceneCloseTestWidget
 #
 
 
-class VolumeRenderingSceneCloseWidget(ScriptedLoadableModuleWidget):
+class VolumeRenderingSceneCloseTestWidget(ScriptedLoadableModuleWidget):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -72,17 +72,17 @@ class VolumeRenderingSceneCloseWidget(ScriptedLoadableModuleWidget):
         pass
 
     def onApplyButton(self):
-        logic = VolumeRenderingSceneCloseLogic()
+        logic = VolumeRenderingSceneCloseTestLogic()
         print("Run the algorithm")
         logic.run()
 
 
 #
-# VolumeRenderingSceneCloseLogic
+# VolumeRenderingSceneCloseTestLogic
 #
 
 
-class VolumeRenderingSceneCloseLogic(ScriptedLoadableModuleLogic):
+class VolumeRenderingSceneCloseTestLogic(ScriptedLoadableModuleLogic):
     """This class should implement all the actual
     computation done by your module.  The interface
     should be such that other python code can import
@@ -127,7 +127,7 @@ class VolumeRenderingSceneCloseLogic(ScriptedLoadableModuleLogic):
         return True
 
 
-class VolumeRenderingSceneCloseTest(ScriptedLoadableModuleTest):
+class VolumeRenderingSceneCloseTestTest(ScriptedLoadableModuleTest):
     """
     This is the test case for your scripted module.
     Uses ScriptedLoadableModuleTest base class, available at:
@@ -146,7 +146,7 @@ class VolumeRenderingSceneCloseTest(ScriptedLoadableModuleTest):
     def test_VolumeRenderingSceneClose1(self):
         self.delayDisplay("Starting the test")
 
-        logic = VolumeRenderingSceneCloseLogic()
+        logic = VolumeRenderingSceneCloseTestLogic()
         logic.run()
 
         self.delayDisplay("Test passed!")

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/qSlicerTemplateKeyModule.cxx
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/qSlicerTemplateKeyModule.cxx
@@ -98,7 +98,7 @@ QIcon qSlicerTemplateKeyModule::icon() const
 //-----------------------------------------------------------------------------
 QStringList qSlicerTemplateKeyModule::categories() const
 {
-  return QStringList() << "Testing.TestCases";
+  return QStringList() << "Examples";
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Modules whose name ends in "Test" or "Tests" did not appear in the module list but they were still loaded, thereby slightly increasing the startup time. On Windows, they increased the cold startup time at least by 0.5 second, but if tests import in numpy, scipy, or pydicom then they could increase the startup time by several seconds.

They are now skipped during registration, which is early enough to avoid the import entirely. The decision is made from the module name, because the module category is only known once the module has been instantiated.

The name is therefore the single rule: qSlicerUtils::isTestingModule() now delegates to qSlicerUtils::isTestingModuleName() instead of inspecting the category, so the registration filter, the module menu and the module list all agree.

To keep name and category consistent, every module in the "Testing" category whose name did not already follow the convention was renamed:

  sceneImport2428, Slicer4Minute, WebEngine, SliceLinkLogic,
  ScenePerformance, RSNAVisTutorial, RSNAQuantTutorial, ShaderProperties,
  ViewControllersSliceInterpolationBug1926, RSNA2012ProstateDemo, JRC2013Vis,
  FiducialLayoutSwitchBug1914, CurvedPlanarReformation,
  BRAINSFitRigidRegistrationCrashIssue4139,
  SlicerRestoreSceneViewCrashIssue3445, VolumeRenderingSceneClose
      -> same name with a "Test" suffix
  SlicerTransformInteractionTest1
      -> SlicerTransformInteractionTest
  SlicerStartupCompletedTestHelperModule
      -> SlicerStartupCompletedHelperModuleTest
  SlicerStartupPreserveSysPathTestHelperModule
      -> SlicerStartupPreserveSysPathHelperModuleTest

Their module, widget, logic and test case classes are renamed to match, as the scripted module conventions require the class names to be derived from the file name.

The LoadableCustomMarkups template declared "Testing.TestCases" as its category, which would place every module generated from it in the Testing category with a name that cannot follow the convention. It now uses "Examples", like the Loadable template.

Testing mode is excluded as well as developer mode, because that is how the automated tests launch the application and they do need their own modules.

see #9203