### PR TITLE
PERF: Load large Python libraries only when they are first used

### DIFF
--- a/Base/Python/slicer/__init__.py
+++ b/Base/Python/slicer/__init__.py
@@ -238,23 +238,6 @@ for kit in available_kits:
     del kit
 
 # -----------------------------------------------------------------------------
-# Import numpy and scipy early, as a workaround for application hang in import
-# of numpy or scipy at application startup on Windows 11 due to output redirection
-# (only needed for embedded Python, not for standalone).
-# See details in https://github.com/Slicer/Slicer/issues/5945
-# The workaround is only needed on Windows: on other platforms these imports
-# cost a noticeable fraction of the application startup time and the packages
-# load on first use instead.
-
-if not standalone_python and os.name == "nt":
-    try:
-        import numpy  # noqa: F401
-        import scipy  # noqa: F401
-        import scipy.linalg  # noqa: F401
-    except ImportError as detail:
-        print(detail)
-
-# -----------------------------------------------------------------------------
 # Cleanup: Removing things the user shouldn't have to see.
 
 del _createModule

--- a/Base/Python/slicer/tests/test_slicer_packaging.py
+++ b/Base/Python/slicer/tests/test_slicer_packaging.py
@@ -713,11 +713,18 @@ class FindUpdatedImportedPackagesTest(unittest.TestCase):
 
     def test_version_changed_and_imported(self):
         """Test that changed AND imported packages are flagged."""
-        before = {"numpy": "1.24.0"}
-        after = {"numpy": "1.26.0"}
+        # The distribution list is mocked below, but sys.modules is not: the tested
+        # function looks up the import name there, so a real package must be imported.
+        # certifi is used because it is always installed (as a requests dependency)
+        # and importing it is cheap (it only provides the path of a CA bundle file).
+        # Heavy packages, such as numpy, cannot be used, as they are not imported
+        # during application startup anymore, but only when they are first used.
+        import certifi  # noqa: F401
 
-        # numpy is already imported in sys.modules in Slicer
-        mock_pkg_dists = {"numpy": ["numpy"]}
+        before = {"certifi": "2025.1.31"}
+        after = {"certifi": "2026.5.20"}
+
+        mock_pkg_dists = {"certifi": ["certifi"]}
         with unittest.mock.patch(
             "importlib.metadata.packages_distributions",
             return_value=mock_pkg_dists,
@@ -725,7 +732,7 @@ class FindUpdatedImportedPackagesTest(unittest.TestCase):
             result = slicer.packaging._find_updated_imported_packages(before, after)
 
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0], ("numpy", "1.24.0", "1.26.0"))
+        self.assertEqual(result[0], ("certifi", "2025.1.31", "2026.5.20"))
 
     def test_newly_installed_not_flagged(self):
         """Test that packages absent before install are not flagged."""
@@ -742,11 +749,13 @@ class FindUpdatedImportedPackagesTest(unittest.TestCase):
         It won't be in before_versions (uninstalled) but its modules are still
         in sys.modules from the earlier import.
         """
-        before = {}  # Package was uninstalled before pip_ensure ran
-        after = {"numpy": "1.26.0"}  # Now reinstalled
+        # See test_version_changed_and_imported for why certifi is imported here.
+        import certifi  # noqa: F401
 
-        # numpy is already in sys.modules in Slicer
-        mock_pkg_dists = {"numpy": ["numpy"]}
+        before = {}  # Package was uninstalled before pip_ensure ran
+        after = {"certifi": "2026.5.20"}  # Now reinstalled
+
+        mock_pkg_dists = {"certifi": ["certifi"]}
         with unittest.mock.patch(
             "importlib.metadata.packages_distributions",
             return_value=mock_pkg_dists,
@@ -754,7 +763,7 @@ class FindUpdatedImportedPackagesTest(unittest.TestCase):
             result = slicer.packaging._find_updated_imported_packages(before, after)
 
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0], ("numpy", None, "1.26.0"))
+        self.assertEqual(result[0], ("certifi", None, "2026.5.20"))
 
 
 class PipEnsureRestartPromptTest(unittest.TestCase):

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -81,6 +81,7 @@ __all__ = [
     "itkImageFromVolume",
     "itkImageFromVolumeModified",
     "launchConsoleProcess",
+    "LazyImport",
     "loadAnnotationFiducial",
     "loadAnnotationROI",
     "loadAnnotationRuler",
@@ -171,6 +172,116 @@ __all__ = [
     "vtkMatrixFromArray",
     "warningDisplay",
 ]
+
+
+class LazyImport:
+    """Resolve a module (``"pkg.mod"``) or a module attribute (``"pkg.mod:name"``) on
+    first attribute access, so a heavy import (numpy, pydicom, ...) can be kept out of
+    the application startup path while existing ``name.attr`` usages keep working.
+
+    Example::
+
+        numpy = slicer.util.LazyImport("numpy")   # numpy is not imported yet
+        ...
+        numpy.array([1, 2, 3])                      # numpy is imported here, on first use
+    """
+
+    def __init__(self, target):
+        import threading
+
+        # Import target specification string: either a module name ("pkg.mod")
+        # or a module attribute in "pkg.mod:name" form (e.g. "pydicom.sr.codedict:codes").
+        self._target = target
+
+        # Stores the imported module (or module attribute) once the first access has
+        # triggered the import.
+        self._resolved = None
+
+        # Lock so that concurrent first accesses (e.g. from a worker thread and
+        # the main thread during startup) resolve the target exactly once.
+        # Python's import machinery serializes the import itself, but without
+        # this lock two threads could both run the resolution code, performing
+        # a redundant importlib.import_module call and writing the metadata
+        # attributes twice. RLock (not Lock) so that a re-entrant access from
+        # the same thread during the import cannot deadlock.
+        self._lock = threading.RLock()
+
+    def _resolve(self):
+        """Import the target if it has not been imported yet and return it.
+
+        Thread-safe: uses double-checked locking so the import runs exactly once,
+        while the common already-resolved path stays lock-free.
+        """
+        resolved = self.__dict__["_resolved"]
+        if resolved is not None:
+            return resolved
+
+        with self.__dict__["_lock"]:
+
+            # Another thread may have completed the import while this thread was waiting,
+            # so re-check if the target still has not been resolved.
+            resolved = self.__dict__["_resolved"]
+            if resolved is not None:
+                return resolved
+
+            # Not resolved yet and we own the lock, import it now.
+            import importlib
+            module, _, attr = self.__dict__["_target"].partition(":")
+            resolved = importlib.import_module(module)
+            if attr:
+                resolved = getattr(resolved, attr)
+
+            # Copy metadata attributes onto this instance so that code
+            # introspecting the "module" (help(), inspect, ...) sees the
+            # real target's metadata. In particular ``__doc__`` would
+            # otherwise be found on the LazyImport class itself and
+            # never forwarded by ``__getattr__``. Done before setting
+            # ``_resolved`` so that once resolution is observable the
+            # metadata is guaranteed to be in place.
+            for metadataAttribute in ("__name__", "__qualname__", "__doc__", "__package__",
+                                        "__file__", "__spec__", "__loader__", "__path__", "__all__"):
+                if hasattr(resolved, metadataAttribute):
+                    self.__dict__[metadataAttribute] = getattr(resolved, metadataAttribute)
+
+            self._resolved = resolved
+
+        return resolved
+
+    def __getattr__(self, name):
+        # Forward attribute access to the target, importing it on first use.
+        # This is the main entry point of the lazy import: __getattr__ is only
+        # invoked when normal attribute lookup fails, so usages like
+        # ``numpy.array(...)`` transparently trigger the import and then behave
+        # as if the real module was imported.
+        return getattr(self._resolve(), name)
+
+    def __call__(self, *args, **kwargs):
+        # Make the wrapper callable so that a "pkg.mod:name" target that
+        # resolves to a function or class (e.g. LazyImport("math:sqrt")) can be
+        # called directly, importing the target on first call.
+        return self._resolve()(*args, **kwargs)
+
+    def __dir__(self):
+        # List the target's attributes (not this wrapper's) so that
+        # introspection and tab-completion in the Python console work as if
+        # the real module was imported. Note that this triggers the import:
+        # a completion list for an unresolved target would be useless anyway.
+        return dir(self._resolve())
+
+    def __repr__(self):
+        # Identify this object as a lazy import wrapper and show its resolution
+        # state, which makes it clear in debuggers and interactive sessions
+        # that the module may not have been imported yet. Deliberately does NOT
+        # trigger the import: merely displaying the object (e.g. when listing
+        # variables in a debugger) must not have side effects.
+
+        resolved = self.__dict__["_resolved"]
+        if resolved is None:
+            return f"<LazyImport '{self._target}' (not imported yet)>"
+
+        # `!r` prints `repr(resolved)` rather than `str(resolved)`, so the target
+        # is shown unambiguously (e.g. quoted strings, full module/class info).
+        return f"<LazyImport '{self._target}' resolved to {resolved!r}>"
 
 
 EXIT_SUCCESS = 0

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentEditorLogicTest.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentEditorLogicTest.py
@@ -2,6 +2,7 @@ import SampleData
 import numpy as np
 import slicer
 import vtk
+import vtk.util.numpy_support
 
 from slicer import vtkSlicerSegmentEditorLogic, vtkSlicerSegmentationsModuleLogic
 from slicer.ScriptedLoadableModule import ScriptedLoadableModuleTest

--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -2,7 +2,6 @@ import logging
 import shutil
 from datetime import datetime
 
-import pydicom
 import slicer
 
 #########################################################
@@ -123,6 +122,11 @@ class DICOMPlugin:
         """Populate loadable.referencedInstanceUIDs and loadable.referencedSeriesUID
         by reading referenced series/image sequences from the first DICOM file.
         """
+
+        # Import here rather than at module level: this package is slow to import
+        # and is only needed when this function is actually called.
+        import pydicom
+
         dcm = pydicom.dcmread(loadable.files[0])
         loadable.referencedInstanceUIDs = []
         self._addReferencedSeries(loadable, dcm)
@@ -130,6 +134,11 @@ class DICOMPlugin:
         loadable.referencedInstanceUIDs = list(set(loadable.referencedInstanceUIDs))
 
     def _addReferencedSeries(self, loadable, dcm):
+
+        # Import here rather than at module level: this package is slow to import
+        # and is only needed when this function is actually called.
+        import pydicom
+
         if hasattr(dcm, "ReferencedSeriesSequence"):
             if hasattr(dcm.ReferencedSeriesSequence[0], "SeriesInstanceUID"):
                 for f in slicer.dicomDatabase.filesForSeries(dcm.ReferencedSeriesSequence[0].SeriesInstanceUID):

--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -1,16 +1,20 @@
+# Deferred imports for startup performance: `requests` (with its heavy transitive
+# dependencies charset_normalizer/chardet/urllib3) and `dicomweb_client` are only
+# needed for DICOMweb networking, not at application startup. They are imported
+# lazily inside the functions that use them. `from __future__ import annotations`
+# keeps the type annotations that reference them from forcing an import.
+from __future__ import annotations
+
 import logging
 import os
-import requests
 import subprocess
 import time
 
 from collections.abc import Callable
-from requests.auth import HTTPBasicAuth
 
 import ctk
 import qt
 
-import dicomweb_client
 import slicer
 
 from DICOMLib.DICOMUtils import getGlobalDICOMAuth
@@ -759,6 +763,11 @@ class DICOMSender:
         # Retrieve the token from the viewer URL and use the Kheops API URL
         # to connect to the server.
         token = destinationURL.path().replace("/view/", "")
+
+        # Import here rather than at module level: this package is slow to import
+        # and is only needed when this function is actually called.
+        from requests.auth import HTTPBasicAuth
+
         return (
             qt.QUrl("https://demo.kheops.online/api"),
             HTTPBasicAuth("token", token),

--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -1,6 +1,11 @@
+# `requests` is imported lazily (inside the functions that use it) to keep its
+# heavy transitive dependencies (charset_normalizer/chardet/urllib3) out of the
+# application startup path. `from __future__ import annotations` keeps the type
+# annotations that reference it from forcing an import.
+from __future__ import annotations
+
 import logging
 import os
-import requests
 
 import ctk
 import qt
@@ -917,6 +922,11 @@ GLOBAL_DICOMWEB_PASSWORD_KEY = "GLOBAL_DICOMWEB_PASSWORD_KEY"
 # ------------------------------------------------------------------------------
 def getGlobalDICOMAuth() -> requests.auth.HTTPBasicAuth | None:
     """Get the global authentication settings for DICOM networking, if initialized."""
+
+    # Import here rather than at module level: this package is slow to import
+    # and is only needed when this function is actually called.
+    import requests
+
     user = slicer.util.settingsValue(GLOBAL_DICOMWEB_USER_KEY, "")
     pwd = slicer.util.settingsValue(GLOBAL_DICOMWEB_PASSWORD_KEY, "")
     return requests.auth.HTTPBasicAuth(user, pwd) if user or pwd else None

--- a/Modules/Scripted/DICOMPlugins/DICOMGeAbusPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMGeAbusPlugin.py
@@ -1,9 +1,6 @@
 import logging
 
-import numpy
-import pydicom as dicom
 import vtk
-import vtk.util.numpy_support
 
 import slicer
 from slicer.i18n import tr as _
@@ -54,6 +51,10 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
         corresponding to ways of interpreting the
         files parameter.
         """
+
+        # Import here rather than at module level: this package is slow to import
+        # and is only needed when this function is actually called.
+        import pydicom as dicom
 
         detailedLogging = self.isDetailedLogging()
 
@@ -124,6 +125,11 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
         return loadables
 
     def getMetadata(self, filePath):
+
+        # Import here rather than at module level: this package is slow to import
+        # and is only needed when this function is actually called.
+        import pydicom as dicom
+
         try:
             ds = dicom.dcmread(filePath, stop_before_pixels=True)
         except Exception as e:
@@ -235,8 +241,14 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
         if trackRadius != 0.0:
             raise ValueError(f"Curvature Radius (Track) is {trackRadius}. Currently, only volume with zero radius can be imported.")
 
-        # Create a sampling grid for the transform
+        # Import here rather than at module level: these packages are slow to import
+        # and are only needed when this function is actually called.
+        # Note that "import vtk.util.numpy_support" makes `vtk` a local name in this
+        # function, shadowing the module-level import; no `vtk.` usage occurs before it.
         import numpy as np
+        import vtk.util.numpy_support
+
+        # Create a sampling grid for the transform
 
         spacing = np.array(volumeNode.GetSpacing())
         averageSpacing = (spacing[0] + spacing[1] + spacing[2]) / 3.0
@@ -252,8 +264,6 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
 
         # create a grid transform with one vector at the corner of each slice
         # the transform is in the same space and orientation as the volume node
-        import vtk
-
         gridImage = vtk.vtkImageData()
         gridImage.SetOrigin(*volumeNode.GetOrigin())
         gridImage.SetDimensions(samplingPoints_shape[:3])
@@ -285,8 +295,8 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
         volumeNode.GetIJKToRASMatrix(ijkToRas)
         spacing = volumeNode.GetSpacing()
         center_IJK = [(extent[0] + extent[1]) / 2.0, extent[2], (extent[4] + extent[5]) / 2.0]
-        sourcePoints_RAS = numpy.zeros(shape=samplingPoints_shape)
-        targetPoints_RAS = numpy.zeros(shape=samplingPoints_shape)
+        sourcePoints_RAS = np.zeros(shape=samplingPoints_shape)
+        targetPoints_RAS = np.zeros(shape=samplingPoints_shape)
         for k in range(samplingPoints_shape[2]):
             for j in range(samplingPoints_shape[1]):
                 for i in range(samplingPoints_shape[0]):

--- a/Modules/Scripted/DICOMPlugins/DICOMImageSequencePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMImageSequencePlugin.py
@@ -1,6 +1,5 @@
 import logging
 
-import pydicom as dicom
 import vtk
 
 import slicer
@@ -60,6 +59,10 @@ class DICOMImageSequencePluginClass(DICOMPlugin):
         corresponding to ways of interpreting the
         files parameter.
         """
+
+        # Import here rather than at module level: this package is slow to import
+        # and is only needed when this function is actually called.
+        import pydicom as dicom
 
         self.detailedLogging = slicer.util.settingsValue("DICOM/detailedLogging", False, converter=slicer.util.toBool)
 
@@ -287,6 +290,11 @@ class DICOMImageSequencePluginClass(DICOMPlugin):
         slicer.modules.sequences.showSequenceBrowser(outputSequenceBrowserNode)
 
     def addSequenceFromImageData(self, imageData, tempFrameVolume, filePath, name, singleFileInLoadable, spacingMmPerPixel):
+
+        # Import here rather than at module level: this package is slow to import
+        # and is only needed when this function is actually called.
+        import pydicom as dicom
+
         # Rotate 180deg, otherwise the image would appear upside down
         ijkToRas = vtk.vtkMatrix4x4()
         ijkToRas.SetElement(0, 0, -1.0)

--- a/Modules/Scripted/DICOMPlugins/DICOMM3DPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMM3DPlugin.py
@@ -3,7 +3,6 @@ import io
 import shutil
 import vtkSegmentationCorePython as vtkSegmentationCore
 import logging
-import pydicom
 
 import slicer
 from DICOMLib import DICOMLoadable, DICOMPlugin
@@ -54,6 +53,10 @@ class DICOMM3DPluginClass(DICOMPlugin):
 
   def getFrameOfReferenceUID(self, candidateFile):
     """Returns the frame of referenceUID for the given loadable"""
+    # Import here rather than at module level: this package is slow to import
+    # and is only needed when this function is actually called.
+    import pydicom
+
     dcm = pydicom.dcmread(candidateFile)
     if hasattr(dcm, "FrameOfReferenceUID"):
       return dcm.FrameOfReferenceUID
@@ -61,6 +64,10 @@ class DICOMM3DPluginClass(DICOMPlugin):
       return "Unnamed FrameOfReferenceUID"
 
   def getEncapsulatedDocumentAttributes(self, candidateFile):
+    # Import here rather than at module level: this package is slow to import
+    # and is only needed when this function is actually called.
+    import pydicom
+
     dcm = pydicom.dcmread(candidateFile)
     encapsulatedDocument = b""
     encapsulatedDocumentLength = 0

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -2,13 +2,17 @@ import logging
 from functools import cmp_to_key
 
 import ctk
-import numpy
 import qt
 import vtk
 import vtkITK
 from slicer.i18n import tr as _
 
 import slicer
+
+
+# Import heavy Python packages lazily to make application startup faster
+from slicer.util import LazyImport
+numpy = LazyImport("numpy")
 
 from DICOMLib import DICOMPlugin
 from DICOMLib import DICOMLoadable

--- a/Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMTID1500Plugin.py
@@ -6,22 +6,18 @@ import vtk
 import datetime
 from collections import Counter
 
-import numpy as np
-import highdicom as hd
-import pydicom
-from pydicom.sr.codedict import codes
-
 import slicer
 from DICOMLib import DICOMLoadable, DICOMPlugin
 
 
-class DICOMTID1500PluginClass(DICOMPlugin):
+# Import heavy Python packages lazily to make application startup faster
+from slicer.util import LazyImport
+pydicom = LazyImport("pydicom")
+hd = LazyImport("highdicom")
+codes = LazyImport("pydicom.sr.codedict:codes")
+np = LazyImport("numpy")
 
-  UID_EnhancedSRStorage = pydicom.uid.EnhancedSRStorage
-  UID_ComprehensiveSRStorage = pydicom.uid.ComprehensiveSRStorage
-  UID_Comprehensive3DSRStorage = pydicom.uid.Comprehensive3DSRStorage
-  UID_SegmentationStorage = pydicom.uid.SegmentationStorage
-  UID_RealWorldValueMappingStorage = pydicom.uid.RealWorldValueMappingStorage
+class DICOMTID1500PluginClass(DICOMPlugin):
 
   def __init__(self):
     super().__init__()
@@ -100,9 +96,9 @@ class DICOMTID1500PluginClass(DICOMPlugin):
 
     try:
       isDicomTID1500 = self.getDICOMValue(dataset, "Modality") == "SR" and \
-                       (self.getDICOMValue(dataset, "SOPClassUID") == self.UID_EnhancedSRStorage or
-                        self.getDICOMValue(dataset, "SOPClassUID") == self.UID_ComprehensiveSRStorage or
-                        self.getDICOMValue(dataset, "SOPClassUID") == self.UID_Comprehensive3DSRStorage) and \
+                       self.getDICOMValue(dataset, "SOPClassUID") in (pydicom.uid.EnhancedSRStorage,
+                                                                      pydicom.uid.ComprehensiveSRStorage,
+                                                                      pydicom.uid.Comprehensive3DSRStorage) and \
                        self.getDICOMValue(dataset, "ContentTemplateSequence")[0].TemplateIdentifier == "1500"
     except (AttributeError, IndexError):
       isDicomTID1500 = False
@@ -199,11 +195,11 @@ class DICOMTID1500PluginClass(DICOMPlugin):
           for refSeriesSequence in dataset.CurrentRequestedProcedureEvidenceSequence:
             for referencedSeriesSequence in refSeriesSequence.ReferencedSeriesSequence:
               for refSOPSequence in referencedSeriesSequence.ReferencedSOPSequence:
-                if refSOPSequence.ReferencedSOPClassUID == self.UID_SegmentationStorage:
+                if refSOPSequence.ReferencedSOPClassUID == pydicom.uid.SegmentationStorage:
                   logging.debug("Found referenced segmentation")
                   loadable.ReferencedSegmentationInstanceUIDs[uid].append(referencedSeriesSequence.SeriesInstanceUID)
 
-                elif refSOPSequence.ReferencedSOPClassUID == self.UID_RealWorldValueMappingStorage: # handle SUV mapping
+                elif refSOPSequence.ReferencedSOPClassUID == pydicom.uid.RealWorldValueMappingStorage: # handle SUV mapping
                   logging.debug("Found referenced RWVM")
                   loadable.ReferencedRWVMSeriesInstanceUIDs.append(referencedSeriesSequence.SeriesInstanceUID)
                 else:

--- a/Modules/Scripted/DICOMPlugins/DICOMVolumeSequencePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMVolumeSequencePlugin.py
@@ -1,6 +1,5 @@
 import logging
 
-import pydicom
 import qt
 
 import slicer
@@ -150,6 +149,10 @@ class DICOMVolumeSequencePluginClass(DICOMPlugin):
         return datetime.datetime(year, month, day, hour, minute, second, microsecond)
 
     def export(self, exportables):
+        # Import here rather than at module level: this package is slow to import
+        # and is only needed when this function is actually called.
+        import pydicom
+
         for exportable in exportables:
             # Get volume node to export
             shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -2,10 +2,8 @@ import json
 import logging
 
 import ctk
-import numpy as np
 import qt
 import vtk
-import vtk.util.numpy_support
 
 import slicer
 from slicer.i18n import tr as _
@@ -16,6 +14,10 @@ from slicer.ScriptedLoadableModule import (
 )
 from slicer.util import VTKObservationMixin
 
+
+# Import heavy Python packages lazily to make application startup faster
+from slicer.util import LazyImport
+np = LazyImport("numpy")
 
 #
 # Endoscopy

--- a/Modules/Scripted/WebServer/WebServerLib/DICOMRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/DICOMRequestHandler.py
@@ -1,9 +1,12 @@
 import logging
-import pydicom
 import urllib
 
 import slicer
 from .BaseRequestHandler import BaseRequestHandler, BaseRequestLoggingFunction
+
+# Import heavy Python packages lazily to make application startup faster
+from slicer.util import LazyImport
+pydicom = LazyImport("pydicom")
 
 logger = logging.getLogger(__name__)
 

--- a/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
@@ -6,16 +6,19 @@ Docs/user_guide/modules/webserver.md
 
 import json
 import logging
-import numpy
 import os
 import time
 import urllib
 
 import qt
-import vtk.util.numpy_support
+import vtk
 
 import slicer
 from .BaseRequestHandler import BaseRequestHandler, BaseRequestLoggingFunction
+
+# Import heavy Python packages lazily to make application startup faster
+from slicer.util import LazyImport
+numpy = LazyImport("numpy")
 
 logger = logging.getLogger(__name__)
 
@@ -1139,7 +1142,13 @@ space origin: %%origin%%
         writer.SetCompressionLevel(0)
         writer.Write()
         result = writer.GetResult()
-        pngArray = vtk.util.numpy_support.vtk_to_numpy(result)
+        # Import here rather than at module level: numpy is slow to import
+        # and is only needed when this function is actually called.
+        # Import the function itself, as "import vtk.util.numpy_support" would make
+        # `vtk` a local name in this function and shadow the module-level import.
+        from vtk.util.numpy_support import vtk_to_numpy
+
+        pngArray = vtk_to_numpy(result)
         pngData = pngArray.tobytes()
 
         return pngData

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -235,7 +235,7 @@ list_conditional_append(Slicer_BUILD_MultiVolumeExplorer Slicer_REMOTE_DEPENDENC
 
 Slicer_Remote_Add(MultiVolumeImporter
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/fedorov/MultiVolumeImporter.git
-  GIT_TAG c8a37eb5e4f35b78ccc9287b298457a064c9d001
+  GIT_TAG 144b2e466428f6d08689eec78977982cf01d54e0
   OPTION_NAME Slicer_BUILD_MultiVolumeImporter
   OPTION_DEPENDS "Slicer_BUILD_QTLOADABLEMODULES;Slicer_BUILD_MULTIVOLUME_SUPPORT;Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -168,7 +168,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "08210fbecda09bea2544dbb80777d634e1bfea25") # slicer-v9.5.2-2025-09-16-7c0494a68
     set(vtk_dist_info_version "9.5.2")
   elseif("${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}" STREQUAL "9.6")
-    set(_git_tag "c9cd17a377cbc7e488329e882a35b70c7f37fe76") # slicer-v9.6.2-2026-05-15-f49a1dbaf
+    set(_git_tag "87a500f5baa3701fa17835760124087aa00b3a1f") # slicer-v9.6.2-2026-05-15-f49a1dbaf
     set(vtk_dist_info_version "9.6.2")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR.Slicer_VTK_VERSION_MINOR: ${Slicer_VTK_VERSION_MAJOR}.${Slicer_VTK_VERSION_MINOR}")

--- a/Utilities/Scripts/SlicerWizard/Utilities.py
+++ b/Utilities/Scripts/SlicerWizard/Utilities.py
@@ -27,14 +27,6 @@ def haveGit():
     return _haveGit
 
 
-try:
-    from charset_normalizer import detect
-
-    _haveCharDet = True
-
-except ImportError:
-    _haveCharDet = False
-
 __all__ = [
     "warn",
     "die",
@@ -250,7 +242,14 @@ def detectEncoding(data):
     input.
     """
 
-    if _haveCharDet:
+    # Import here rather than at module level: this package is slow to import
+    # and is only needed when this function is actually called.
+    try:
+        from charset_normalizer import detect
+    except ImportError:
+        detect = None
+
+    if detect is not None:
         result = detect(data)
         return result["encoding"], result["confidence"]
 


### PR DESCRIPTION
On Windows, Slicer cold start time was 20 seconds on the latest main branch.
With the fixes in this pull request, the starting time is about 14 seconds.

numpy, scipy, pydicom and the libraries they pull in were imported while the
application started, either from slicer/__init__.py or from the module bodies of
scripted modules that are registered on every launch. Profiling showed these
imports to be a large fraction of Python startup time, and a session that never
touches DICOM or does any array work never needs them.

Move the large package imports out of the application startup:

- Add slicer.util.LazyImport, which resolves a module (or a "pkg.mod:name"
  module attribute) on first attribute access or call, so existing name.attr
  usage stays unchanged.
- Stop importing numpy and scipy eagerly in slicer/__init__.py. The eager import
  was a workaround for an application hang when they were first imported under
  output redirection on Windows 11 (issue #5945); if that recurs, the removed
  block can be restored from the history of this commit.
- Defer the DICOM modules' pydicom, highdicom, requests/dicomweb_client and
  numpy imports to the functions that use them. Importing pydicom in particular
  pulls in its example-data downloader (requests, charset_normalizer) and all
  pixel-data codec handlers. The DICOM SOP Class UID constants that the TID1500
  plugin used to evaluate in its class body (which forced an import of pydicom
  when the class was defined) are now read from pydicom.uid in the two methods
  that compare against them, both of which already work with pydicom datasets.
- Defer numpy in the Endoscopy fly-through and the WebServer request handler,
  and charset_normalizer in SlicerWizard, which the ExtensionWizard module pulls
  in transitively.

Two tests relied on these packages being imported during startup and are updated
accordingly: test_slicer_packaging used numpy as an example of a package that is
present in sys.modules, and SegmentEditorLogicTest used vtk.util.numpy_support
without importing it (which only worked because another module imported it at
startup). Code in extensions may need the same change, as vtk.util is only
available after something imports it.
