### PR TITLE
BUG: Keep 3D picking fast when a large surface is shown

### DIFF
--- a/Libs/MRML/DisplayableManager/CMakeLists.txt
+++ b/Libs/MRML/DisplayableManager/CMakeLists.txt
@@ -107,6 +107,8 @@ set(KIT_SRCS
   vtkMRMLSliceViewInteractorStyle.cxx
   vtkMRMLThreeDViewInteractorStyle.cxx
 
+  vtkMRMLAccuratePicker.cxx
+
   # Widgets
   vtkMRMLAbstractWidget.cxx
   vtkMRMLAbstractWidgetRepresentation.cxx

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/CMakeLists.txt
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/CMakeLists.txt
@@ -11,6 +11,7 @@ set(KIT_TEST_SRCS
   vtkMRMLThreeDViewDisplayableManagerFactoryTest1.cxx
   vtkMRMLDisplayableManagerFactoriesTest1.cxx
   vtkMRMLSliceViewDisplayableManagerFactoryTest.cxx
+  vtkMRMLAccuratePickerTest.cxx
   )
 create_test_sourcelist(Tests ${KIT}CxxTests.cxx
   ${KIT_TEST_SRCS}

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLAccuratePickerTest.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLAccuratePickerTest.cxx
@@ -1,0 +1,116 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// This guards the interactive performance of accurate picking in 3D views.
+// vtkMRMLAccuratePicker is the picker shared per view (by
+// vtkMRMLThreeDViewInteractorStyle) and used on every mouse move for markup
+// dragging and hover read-out. A plain vtkCellPicker tests every cell of every
+// pickable surface, so over a large mesh (for example a segmentation closed
+// surface with millions of cells) each pick costs tens to hundreds of
+// milliseconds and interaction becomes janky. vtkMRMLAccuratePicker indexes
+// large surfaces with cell locators; this test checks that repeated picks over
+// a large mesh stay fast.
+
+// MRMLDisplayableManager includes
+#include "vtkMRMLAccuratePicker.h"
+
+// VTK includes
+#include <vtkActor.h>
+#include <vtkNew.h>
+#include <vtkPolyData.h>
+#include <vtkPolyDataMapper.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderer.h>
+#include <vtkSphereSource.h>
+#include <vtkTimerLog.h>
+
+// STD includes
+#include <cstdlib>
+#include <iostream>
+
+int vtkMRMLAccuratePickerTest(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
+{
+  // A large, pickable surface standing in for a segmentation closed surface.
+  vtkNew<vtkSphereSource> sphere;
+  sphere->SetThetaResolution(900);
+  sphere->SetPhiResolution(900);
+  sphere->Update();
+  const vtkIdType numberOfCells = sphere->GetOutput()->GetNumberOfCells();
+  std::cout << "Large surface: " << numberOfCells << " cells" << std::endl;
+
+  vtkNew<vtkPolyDataMapper> mapper;
+  // SetInputData (not a pipeline connection) so the mapper's input poly data is
+  // available for locator building without a render/update.
+  mapper->SetInputData(sphere->GetOutput());
+  vtkNew<vtkActor> actor;
+  actor->SetMapper(mapper);
+
+  vtkNew<vtkRenderer> renderer;
+  renderer->AddActor(actor);
+  vtkNew<vtkRenderWindow> renderWindow;
+  renderWindow->SetOffScreenRendering(1);
+  renderWindow->SetSize(300, 300);
+  renderWindow->AddRenderer(renderer);
+  renderer->ResetCamera();
+  renderWindow->Render();
+
+  vtkNew<vtkMRMLAccuratePicker> picker;
+  picker->SetTolerance(0.005);
+
+  const int x = 150;
+  const int y = 150;
+
+  // First pick: must hit the surface, and pays the one-time locator build.
+  if (!picker->Pick(x, y, 0, renderer))
+  {
+    std::cerr << "Failed: pick did not hit the surface at the view center" << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (picker->GetActor() == nullptr)
+  {
+    std::cerr << "Failed: pick did not report the surface actor" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Repeated picks (as during a drag or hover) must be fast because the picker
+  // is locator-accelerated. Without the locator each pick is O(number of cells)
+  // and takes tens to hundreds of milliseconds on this many cells.
+  const int numberOfPicks = 50;
+  vtkNew<vtkTimerLog> timer;
+  timer->StartTimer();
+  for (int i = 0; i < numberOfPicks; ++i)
+  {
+    picker->Pick(x + (i % 7) - 3, y + (i % 5) - 2, 0, renderer);
+  }
+  timer->StopTimer();
+  const double millisecondsPerPick = timer->GetElapsedTime() / numberOfPicks * 1000.0;
+  std::cout << "vtkMRMLAccuratePicker over " << numberOfCells << " cells: " << millisecondsPerPick << " ms/pick" << std::endl;
+
+  // Generous threshold: the accelerated pick is well under a millisecond, while
+  // an un-indexed brute-force pick over this mesh is far above 30 ms on any
+  // hardware. The wide gap keeps the test insensitive to machine speed.
+  const double thresholdMillisecondsPerPick = 30.0;
+  if (millisecondsPerPick > thresholdMillisecondsPerPick)
+  {
+    std::cerr << "Failed: " << millisecondsPerPick << " ms/pick (threshold " << thresholdMillisecondsPerPick
+              << " ms). Large-surface picks are not locator-accelerated, so control-point dragging "
+              << "and hover read-out would be janky when a large surface is shown." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLAccuratePicker.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAccuratePicker.cxx
@@ -1,0 +1,125 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#include "vtkMRMLAccuratePicker.h"
+
+// VTK includes
+#include <vtkAbstractCellLocator.h>
+#include <vtkActor.h>
+#include <vtkMapper.h>
+#include <vtkObjectFactory.h>
+#include <vtkPolyData.h>
+#include <vtkPolyDataMapper.h>
+#include <vtkPropCollection.h>
+#include <vtkRenderer.h>
+#include <vtkStaticCellLocator.h>
+
+// STD includes
+#include <set>
+
+vtkStandardNewMacro(vtkMRMLAccuratePicker);
+
+//----------------------------------------------------------------------------
+vtkMRMLAccuratePicker::vtkMRMLAccuratePicker() = default;
+
+//----------------------------------------------------------------------------
+vtkMRMLAccuratePicker::~vtkMRMLAccuratePicker() = default;
+
+//----------------------------------------------------------------------------
+void vtkMRMLAccuratePicker::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+  os << indent << "MinimumCellCountToIndex: " << this->MinimumCellCountToIndex << "\n";
+  os << indent << "Cached locators: " << this->Locators.size() << "\n";
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLAccuratePicker::UpdateLocators(vtkRenderer* renderer)
+{
+  this->RemoveAllLocators();
+  if (!renderer)
+  {
+    this->Locators.clear();
+    return;
+  }
+
+  std::set<vtkPolyData*> shownSurfaces;
+  vtkPropCollection* props = renderer->GetViewProps();
+  vtkCollectionSimpleIterator propIterator;
+  props->InitTraversal(propIterator);
+  for (vtkProp* prop = props->GetNextProp(propIterator); prop != nullptr; prop = props->GetNextProp(propIterator))
+  {
+    if (!prop->GetPickable() || !prop->GetVisibility())
+    {
+      continue;
+    }
+    vtkActor* actor = vtkActor::SafeDownCast(prop);
+    if (!actor)
+    {
+      continue;
+    }
+    vtkPolyDataMapper* mapper = vtkPolyDataMapper::SafeDownCast(actor->GetMapper());
+    if (!mapper)
+    {
+      continue;
+    }
+    vtkPolyData* polyData = vtkPolyData::SafeDownCast(mapper->GetInput());
+    if (!polyData || polyData->GetNumberOfCells() < this->MinimumCellCountToIndex)
+    {
+      continue;
+    }
+
+    shownSurfaces.insert(polyData);
+    CachedLocator& cached = this->Locators[polyData];
+    if (!cached.Locator)
+    {
+      vtkNew<vtkStaticCellLocator> locator;
+      locator->SetDataSet(polyData);
+      cached.Locator = locator;
+      cached.BuildMTime = 0;
+    }
+    // Build once, and rebuild only when the surface itself changes, so repeated
+    // picks over an unchanging surface pay the build cost at most once.
+    if (cached.BuildMTime != polyData->GetMTime())
+    {
+      cached.Locator->BuildLocator();
+      cached.BuildMTime = polyData->GetMTime();
+    }
+    this->AddLocator(cached.Locator);
+  }
+
+  // Release locators for surfaces that are no longer shown (a cached locator
+  // holds a reference to its poly data).
+  for (auto it = this->Locators.begin(); it != this->Locators.end();)
+  {
+    if (shownSurfaces.find(it->first) == shownSurfaces.end())
+    {
+      it = this->Locators.erase(it);
+    }
+    else
+    {
+      ++it;
+    }
+  }
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLAccuratePicker::Pick(double selectionX, double selectionY, double selectionZ, vtkRenderer* renderer)
+{
+  this->UpdateLocators(renderer);
+  return this->Superclass::Pick(selectionX, selectionY, selectionZ, renderer);
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLAccuratePicker.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAccuratePicker.h
@@ -1,0 +1,96 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef vtkMRMLAccuratePicker_h
+#define vtkMRMLAccuratePicker_h
+
+// MRMLDisplayableManager includes
+#include "vtkMRMLDisplayableManagerExport.h"
+
+// VTK includes
+#include <vtkCellPicker.h>
+#include <vtkSmartPointer.h>
+
+// STD includes
+#include <map>
+
+class vtkAbstractCellLocator;
+class vtkPolyData;
+class vtkRenderer;
+
+/// \brief A cell picker that stays fast when large surfaces are shown.
+///
+/// vtkCellPicker tests every cell of every pickable surface unless a spatial
+/// locator is registered for that surface's data. Over a large mesh -- for
+/// example a segmentation closed surface with millions of cells -- an
+/// un-indexed pick costs O(number of cells), tens to hundreds of milliseconds,
+/// which makes per-mouse-move picking (markup dragging, hover read-out) janky.
+///
+/// vtkMRMLAccuratePicker registers and caches a vtkStaticCellLocator for each
+/// large, pickable surface in the renderer before every pick, rebuilding a
+/// locator only when its surface changes and dropping it when the surface is no
+/// longer shown. Picks then become indexed queries. Everything else behaves
+/// exactly like vtkCellPicker (same tolerance, picked position, and normal), so
+/// it is a drop-in replacement.
+///
+/// A single instance is meant to be shared per view: vtkMRMLThreeDViewInteractorStyle
+/// owns one and exposes it through vtkMRMLInteractionEventData::GetAccuratePicker(),
+/// so every widget in the view -- and anything else that needs quick localization
+/// in world coordinates -- reuses one picker and one set of locators.
+class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLAccuratePicker : public vtkCellPicker
+{
+public:
+  static vtkMRMLAccuratePicker* New();
+  vtkTypeMacro(vtkMRMLAccuratePicker, vtkCellPicker);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Minimum number of cells for a surface to be indexed with a locator.
+  /// Smaller surfaces are already cheap to pick by brute force, and building a
+  /// locator for them would cost more than it saves. Defaults to 10000.
+  vtkSetMacro(MinimumCellCountToIndex, vtkIdType);
+  vtkGetMacro(MinimumCellCountToIndex, vtkIdType);
+
+  using vtkCellPicker::Pick;
+
+  /// Refresh the cell locators for the renderer's large surfaces, then pick as
+  /// vtkCellPicker does.
+  int Pick(double selectionX, double selectionY, double selectionZ, vtkRenderer* renderer) override;
+
+protected:
+  vtkMRMLAccuratePicker();
+  ~vtkMRMLAccuratePicker() override;
+
+  /// Register a cached locator with this picker for each large, pickable
+  /// surface currently shown in the renderer (building or rebuilding it only
+  /// when the surface changes) and drop locators for surfaces no longer shown.
+  void UpdateLocators(vtkRenderer* renderer);
+
+  struct CachedLocator
+  {
+    vtkSmartPointer<vtkAbstractCellLocator> Locator;
+    vtkMTimeType BuildMTime{ 0 };
+  };
+  std::map<vtkPolyData*, CachedLocator> Locators;
+
+  vtkIdType MinimumCellCountToIndex{ 10000 };
+
+private:
+  vtkMRMLAccuratePicker(const vtkMRMLAccuratePicker&) = delete;
+  void operator=(const vtkMRMLAccuratePicker&) = delete;
+};
+
+#endif

--- a/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewInteractorStyle.cxx
@@ -23,6 +23,8 @@
 #include "vtkMRMLScene.h"
 
 // VTK includes
+#include "vtkMRMLAccuratePicker.h"
+
 #include <vtkCallbackCommand.h>
 #include <vtkCamera.h>
 #include <vtkCellPicker.h>
@@ -43,7 +45,11 @@ vtkStandardNewMacro(vtkMRMLThreeDViewInteractorStyle);
 vtkMRMLThreeDViewInteractorStyle::vtkMRMLThreeDViewInteractorStyle()
 {
   this->CameraNode = nullptr;
-  this->AccuratePicker = vtkSmartPointer<vtkCellPicker>::New();
+  // vtkMRMLAccuratePicker keeps picking fast when large surfaces (for example
+  // segmentation closed surfaces) are shown, by indexing them with cell
+  // locators. This picker is shared with every widget in the view through
+  // vtkMRMLInteractionEventData::GetAccuratePicker().
+  this->AccuratePicker = vtkSmartPointer<vtkMRMLAccuratePicker>::New();
   this->AccuratePicker->SetTolerance(.005);
   this->QuickPicker = vtkSmartPointer<vtkWorldPointPicker>::New();
   this->QuickVolumePicker = vtkSmartPointer<vtkVolumePicker>::New();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -691,9 +691,21 @@ bool vtkSlicerMarkupsWidget::ProcessWidgetStopPlace(vtkMRMLInteractionEventData*
 }
 
 //-----------------------------------------------------------------------------
+void vtkSlicerMarkupsWidget::UpdateInteractionAccuratePicker(vtkMRMLInteractionEventData* eventData)
+{
+  vtkSlicerMarkupsWidgetRepresentation3D* rep3d = vtkSlicerMarkupsWidgetRepresentation3D::SafeDownCast(this->WidgetRep);
+  if (rep3d)
+  {
+    rep3d->SetInteractionAccuratePicker(eventData ? eventData->GetAccuratePicker() : nullptr);
+  }
+}
+
+//-----------------------------------------------------------------------------
 bool vtkSlicerMarkupsWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData)
 {
   unsigned long widgetEvent = this->TranslateInteractionEventToWidgetEvent(eventData);
+
+  this->UpdateInteractionAccuratePicker(eventData);
 
   if (this->ApplicationLogic)
   {

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
@@ -148,6 +148,13 @@ protected:
   // depth of this reference position is used.
   bool ConvertDisplayPositionToWorld(const int displayPos[2], double worldPos[3], double worldOrientationMatrix[9], double* refWorldPos = nullptr);
 
+  /// Give the 3D representation the view's shared accurate picker (from the
+  /// interaction event data) for the duration of this event, so all widgets in
+  /// the view reuse one picker and one set of cell locators. Must be called at
+  /// the start of every ProcessInteractionEvent() override that can lead to a
+  /// pick (AccuratePick / ConvertDisplayPositionToWorld).
+  void UpdateInteractionAccuratePicker(vtkMRMLInteractionEventData* eventData);
+
   /// Index of the control point that is currently being previewed (follows the mouse pointer).
   /// If <0 it means that there is currently no point being previewed.
   int PreviewPointIndex;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -235,9 +235,6 @@ vtkSlicerMarkupsWidgetRepresentation3D::vtkSlicerMarkupsWidgetRepresentation3D()
 
   this->ControlPointSize = 10; // will be set from the markup's GlyphScale
 
-  this->AccuratePicker = vtkSmartPointer<vtkCellPicker>::New();
-  this->AccuratePicker->SetTolerance(.005);
-
   // Using the minimum value of -66000 creates a lot of rendering artifacts on the occluded objects, as all of the
   // pixels in the occluded object will have the same depth buffer value (0.0).
   // Using a default value of -25000 strikes a balance between rendering the occluded objects on top of other objects,
@@ -1187,20 +1184,36 @@ void vtkSlicerMarkupsWidgetRepresentation3D::SetRenderer(vtkRenderer* ren)
   }
 }
 
-//---------------------------------------------------------------------------
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation3D::SetInteractionAccuratePicker(vtkCellPicker* picker)
+{
+  this->InteractionAccuratePicker = picker;
+}
+
+//----------------------------------------------------------------------
 bool vtkSlicerMarkupsWidgetRepresentation3D::AccuratePick(int x, int y, double pickPoint[3], double pickNormal[3] /*=nullptr*/)
 {
-  bool success = this->AccuratePicker->Pick(x, y, 0, this->Renderer);
+  // Pick with the accurate picker shared by the view (a vtkMRMLAccuratePicker,
+  // which indexes large surfaces so a pick does not scan every cell of, for
+  // example, a segmentation closed surface). The widget sets it from the
+  // interaction event data before each interaction event, which is the only
+  // time AccuratePick() is called.
+  vtkCellPicker* accuratePicker = this->InteractionAccuratePicker;
+  if (!accuratePicker)
+  {
+    return false;
+  }
+  bool success = accuratePicker->Pick(x, y, 0, this->Renderer);
   if (pickNormal)
   {
-    this->AccuratePicker->GetPickNormal(pickNormal);
+    accuratePicker->GetPickNormal(pickNormal);
   }
   if (!success)
   {
     return false;
   }
 
-  vtkPoints* pickPositions = this->AccuratePicker->GetPickedPositions();
+  vtkPoints* pickPositions = accuratePicker->GetPickedPositions();
   vtkIdType numberOfPickedPositions = pickPositions->GetNumberOfPoints();
   if (numberOfPickedPositions < 1)
   {

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -30,6 +30,8 @@
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation.h"
 
+#include <vtkWeakPointer.h>
+
 #include <map>
 #include <memory>
 
@@ -80,6 +82,13 @@ public:
   void CanInteractWithLine(vtkMRMLInteractionEventData* interactionEventData, int& foundComponentType, int& foundComponentIndex, double& closestDistance2);
 
   bool AccuratePick(int x, int y, double pickPoint[3], double pickNormal[3] = nullptr);
+
+  /// Set the accurate picker shared by the view (owned by the interactor style
+  /// and obtained from the interaction event data). When set, AccuratePick()
+  /// uses it instead of this representation's own picker, so all widgets in the
+  /// view reuse one picker and one set of cell locators. The widget sets this
+  /// for the duration of each interaction event.
+  void SetInteractionAccuratePicker(vtkCellPicker* picker);
 
   /// Return true if the control point is actually visible
   /// (displayed and not occluded by other objects in the view).
@@ -175,7 +184,11 @@ protected:
   void UpdateRelativeCoincidentTopologyOffsets(vtkMapper* mapper, vtkMapper* occludedMapper);
   using vtkMRMLAbstractWidgetRepresentation::UpdateRelativeCoincidentTopologyOffsets;
 
-  vtkSmartPointer<vtkCellPicker> AccuratePicker;
+  /// The view's shared accurate picker (a vtkMRMLAccuratePicker owned by the
+  /// interactor style), set by the widget for the duration of each interaction
+  /// event (see SetInteractionAccuratePicker) and used by AccuratePick(). Held
+  /// weakly so it never keeps the interactor style's picker alive.
+  vtkWeakPointer<vtkCellPicker> InteractionAccuratePicker;
 
   double TextActorPositionWorld[3];
   bool TextActorOccluded;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.cxx
@@ -110,6 +110,12 @@ bool vtkSlicerPlaneWidget::CanProcessInteractionEvent(vtkMRMLInteractionEventDat
 bool vtkSlicerPlaneWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData)
 {
   unsigned long widgetEvent = this->TranslateInteractionEventToWidgetEvent(eventData);
+
+  // Plane-specific events (for example placing the plane normal) are handled
+  // below without calling the base ProcessInteractionEvent, so give the
+  // representation the shared accurate picker here too.
+  this->UpdateInteractionAccuratePicker(eventData);
+
   this->ApplicationLogic->PauseRender();
 
   bool processedEvent = false;


### PR DESCRIPTION
### Symptom
Picking in a 3D view is janky whenever a large surface is shown — most commonly
a segmentation closed surface. Markup control-point dragging (default snap mode
"to visible surface") and hover read-out both pick on every mouse move; hiding
the surface makes interaction smooth again. A plain `forceRender()` of the same
scene is fast (~12 ms), so the cost is in picking, not rendering.

### Cause
`vtkCellPicker` tests **every cell of every pickable surface** unless a spatial
locator is registered for that surface's data. Over a segmentation closed
surface with millions of cells each pick costs tens to hundreds of milliseconds
(measured ~184 ms over a 2.4 M-cell surface; a warmed pick is as slow as the
first, confirming it is brute force, not a one-time build).

### Fix
Add **`vtkMRMLAccuratePicker`** (a `vtkCellPicker` subclass) that registers and
caches a `vtkStaticCellLocator` for each large, pickable surface in the renderer
before every pick — rebuilding a locator only when its surface changes and
dropping it when the surface is hidden. Picks become indexed queries; tolerance,
picked position, and returned normal are unchanged.

Following review feedback, this is **shared per view rather than per widget**:
`vtkMRMLThreeDViewInteractorStyle` now creates a `vtkMRMLAccuratePicker` as the
picker it already hands to `vtkMRMLInteractionEventData`, so every widget — and
anything that needs quick localization in world coordinates — reuses one picker
and one set of locators. This also accelerates the interaction-context / hover
pick (`ComputeAccurateWorldPosition`), not just markups. The markups widget
passes the shared picker to its representation for each interaction event, so
control-point dragging uses it too.

| | before | after |
|---|---|---|
| pick over a 2.4 M-cell surface | ~184 ms | ~0.03 ms |
| scripted control-point drag over the surface | ~184 ms/move | ~0.4 ms/move |

The only residual cost is a one-time locator build (~50 ms for a multi-million
cell surface) on the first pick after such a surface appears — a single frame,
then sub-millisecond. Helps any large surface, not only segmentations.

### Test
`vtkMRMLAccuratePickerTest` picks repeatedly over a 1.6 M-cell surface and
asserts the picks stay fast (< 30 ms/pick). It fails (~78 ms/pick) without the
locator and passes (~0.2 ms/pick) with it; the wide gap keeps it insensitive to
hardware speed.
