### PR TITLE
ENH: Add option to report application startup timing

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -460,6 +460,17 @@ add_test(
     ${Slicer_LAUNCHER_EXECUTABLE}
   )
 
+# Check that "--report-startup-timing" writes the startup timing report. The report is
+# read back from the application log rather than from the standard streams, so the test
+# does not need console IO support and runs whether the launcher and the application are
+# console or GUI executables.
+add_test(
+  NAME py_report_startup_timing
+  COMMAND ${PYTHON_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/SlicerReportStartupTimingTest.py
+    ${Slicer_LAUNCHER_EXECUTABLE}
+  )
+
 # Check that stand-alone Python interpreter, without PythonQt support, can `import slicer` safely (#945)
 add_test(
   NAME py_standalonepython_import_slicer

--- a/Applications/SlicerApp/Testing/Python/SlicerReportStartupTimingTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerReportStartupTimingTest.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+
+#
+#  Program: 3D Slicer
+#
+#  Copyright (c) Kitware Inc.
+#
+#  See COPYRIGHT.txt
+#  or http://www.slicer.org/copyright/copyright.txt for details.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import os
+import re
+import sys
+import tempfile
+
+from SlicerAppTesting import *
+
+"""
+This test verifies the --report-startup-timing command-line option: that the startup
+timing report is written once startup is complete, that it contains every startup phase
+and the per-module breakdown, that the phases add up to the reported total, that the
+total fits within the process runtime measured from the outside, and that without the
+option no report is written.
+
+The report is read back from the application's error log, retrieved by a --python-code
+snippet that writes it to a file, rather than from the standard streams: whether anything
+reaches those depends on whether the launcher and the application were built as console
+or GUI executables, and the log is the one place the report goes in every combination.
+
+Usage:
+    SlicerReportStartupTimingTest.py /path/to/Slicer
+"""
+
+# Runs inside Slicer after startup (and therefore after the report has been logged):
+# writes the log entry holding the report, or nothing, to the file named by the
+# environment variable.
+EXTRACT_REPORT_PYTHON_CODE = (
+    "import os;"
+    " m = slicer.app.errorLogModel();"
+    " entries = [m.logEntryDescription(i) for i in range(m.logEntryCount())];"
+    " report = next((e for e in entries if 'Startup timing report' in e), '');"
+    " open(os.environ['SLICER_REPORT_STARTUP_TIMING_TEST_OUTPUT'], 'w').write(report)"
+)
+
+# One line per startup phase, in the order the phases finish. The wording is part of the
+# report's contract with the user, so a wording change is expected to fail this test.
+PHASE_NAMES = [
+    "Before the process entry point, loading the application's own libraries",
+    "Initializing the application",
+    "Registering modules",
+    "Instantiating modules",
+    "Initializing the user interface",
+    "Loading modules",
+    "Showing the main window",
+]
+
+TOTAL_NAME = "Total, from the creation of the process"
+
+
+def parse_report(output):
+    """Return (phase durations in ms by name, total ms, module rows) parsed from the report."""
+    phaseDurationsMs = {}
+    totalMs = None
+    # (name, total, instantiated, loaded), all in fractional milliseconds
+    moduleRows = []
+    inReport = False
+    for line in output.splitlines():
+        if line.strip() == "Startup timing report":
+            inReport = True
+            continue
+        if not inReport:
+            continue
+        phaseMatch = re.match(r"^  (.+): (\d+) ms$", line)
+        if phaseMatch:
+            if phaseMatch.group(1) == TOTAL_NAME:
+                totalMs = int(phaseMatch.group(2))
+                # The total is the last line of the report.
+                break
+            phaseDurationsMs[phaseMatch.group(1)] = int(phaseMatch.group(2))
+            continue
+        moduleMatch = re.match(r"^    (.+): (\d+\.\d) ms \((\d+\.\d) ms \+ (\d+\.\d) ms\)$", line)
+        if moduleMatch:
+            moduleRows.append((moduleMatch.group(1),
+                               float(moduleMatch.group(2)),
+                               float(moduleMatch.group(3)),
+                               float(moduleMatch.group(4))))
+    return (phaseDurationsMs, totalMs, moduleRows)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(os.path.basename(sys.argv[0]) + " /path/to/Slicer")
+        exit(EXIT_FAILURE)
+    slicer_executable = os.path.expanduser(sys.argv[1])
+
+    reportFile = tempfile.NamedTemporaryFile(suffix=".txt", delete=False)
+    reportFile.close()
+    os.environ["SLICER_REPORT_STARTUP_TIMING_TEST_OUTPUT"] = reportFile.name
+
+    def read_extracted_report():
+        with open(reportFile.name) as f:
+            return f.read()
+
+    # CLI modules are disabled only to shorten the test; loadable and scripted modules
+    # still register, instantiate and load, which is what the per-module rows report.
+    common_args = [
+        "--testing",
+        "--disable-builtin-cli-modules",
+        "--python-code", EXTRACT_REPORT_PYTHON_CODE,
+    ]
+
+    # Test that the report is written and adds up. The run is timed from the outside so
+    # that the reported total can be checked against reality, not only against itself.
+    args = list(common_args)
+    args.append("--report-startup-timing")
+    runSlicerAndExitWithTime = timecall(runSlicerAndExit)
+    (wallClockSeconds, (returnCode, stdout, stderr)) = runSlicerAndExitWithTime(slicer_executable, args)
+    assert returnCode == EXIT_SUCCESS
+    output = read_extracted_report()
+    assert "Startup timing report" in output, "report not found in the application log"
+
+    (phaseDurationsMs, totalMs, moduleRows) = parse_report(output)
+    for phaseName in PHASE_NAMES:
+        assert phaseName in phaseDurationsMs, "missing phase: " + phaseName
+        assert phaseDurationsMs[phaseName] >= 0, "negative duration for phase: " + phaseName
+    assert totalMs is not None, "missing total"
+
+    # The reported total covers the creation of the process to the end of the startup,
+    # which lies strictly inside what was measured from the outside: the wall clock also
+    # covers the launcher, the event loop and the teardown. A reported total that is zero
+    # or exceeds the wall clock is not a rounding problem but a wrong measurement, such as
+    # the process creation time having been read from the wrong source.
+    wallClockMs = wallClockSeconds * 1000.0
+    assert 0 < totalMs <= wallClockMs, \
+        f"reported total of {totalMs} ms is not within the measured process runtime of {wallClockMs:.0f} ms"
+
+    # Each phase is rounded to a whole millisecond independently of the total, so the sum
+    # may be off by half a millisecond per line.
+    roundingToleranceMs = len(PHASE_NAMES) + 1
+    sumMs = sum(phaseDurationsMs.values())
+    assert abs(sumMs - totalMs) <= roundingToleranceMs, \
+        f"phases add up to {sumMs} ms but the total says {totalMs} ms"
+
+    assert len(moduleRows) > 0, "no per-module rows found"
+    headerMatch = re.search(r"Modules, slowest first, as instantiate \+ load \((\d+) of (\d+)\):", output)
+    assert headerMatch, "module list header not found"
+    assert len(moduleRows) == int(headerMatch.group(1)), "module row count does not match the header"
+    for (name, moduleTotal, instantiated, loaded) in moduleRows:
+        assert abs(moduleTotal - (instantiated + loaded)) <= 0.25, \
+            f"module {name}: {instantiated} + {loaded} does not add up to {moduleTotal}"
+    # Slowest first
+    moduleTotals = [row[1] for row in moduleRows]
+    assert moduleTotals == sorted(moduleTotals, reverse=True), "module rows are not sorted slowest first"
+    print("Test report content - passed\n")
+
+    # Test that without the option there is no report
+    args = list(common_args)
+    args.extend(["--no-main-window", "--disable-modules"])
+    (returnCode, stdout, stderr) = runSlicerAndExit(slicer_executable, args)
+    assert returnCode == EXIT_SUCCESS
+    assert read_extracted_report() == "", "report written without --report-startup-timing"
+    print("Test no report without option - passed\n")
+
+    os.remove(reportFile.name)

--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -79,6 +79,25 @@
 # include <Windows.h> //for SHELLEXECUTEINFO
 #endif
 
+#ifdef __APPLE__
+# include <sys/sysctl.h> // for sysctl, which reports the creation time of the process
+# include <sys/time.h>   // for gettimeofday
+# include <unistd.h>     // for getpid
+#endif
+
+#ifdef __linux__
+# include <cstdio>   // for fopen, to read /proc/self/stat
+# include <cstring>  // for strrchr
+# include <ctime>    // for clock_gettime
+# include <unistd.h> // for sysconf
+#endif
+
+//----------------------------------------------------------------------------
+double qSlicerApplicationHelper::TimeElapsedBeforeProcessEntryPointMs = 0.0;
+
+//----------------------------------------------------------------------------
+QElapsedTimer qSlicerApplicationHelper::TimeElapsedAfterProcessEntryPointTimer;
+
 //----------------------------------------------------------------------------
 qSlicerApplicationHelper::qSlicerApplicationHelper(QObject* parent)
   : Superclass(parent)
@@ -89,8 +108,84 @@ qSlicerApplicationHelper::qSlicerApplicationHelper(QObject* parent)
 qSlicerApplicationHelper::~qSlicerApplicationHelper() = default;
 
 //----------------------------------------------------------------------------
+void qSlicerApplicationHelper::recordProcessEntryPointTime()
+{
+  // How much the loader spent before this point can only be had from the operating
+  // system, because no clock of ours was running yet. Where it will not say,
+  // TimeElapsedBeforeProcessEntryPointMs is left at 0 and the startup is reported as if
+  // it began at the entry point.
+#if defined(_WIN32)
+  FILETIME creationTime, exitTime, kernelTime, userTime;
+  if (GetProcessTimes(GetCurrentProcess(), &creationTime, &exitTime, &kernelTime, &userTime))
+  {
+    FILETIME nowTime;
+    GetSystemTimeAsFileTime(&nowTime);
+    ULARGE_INTEGER creation, now;
+    creation.LowPart = creationTime.dwLowDateTime;
+    creation.HighPart = creationTime.dwHighDateTime;
+    now.LowPart = nowTime.dwLowDateTime;
+    now.HighPart = nowTime.dwHighDateTime;
+    // FILETIME is expressed in 100-nanosecond units.
+    Self::TimeElapsedBeforeProcessEntryPointMs = static_cast<double>(now.QuadPart - creation.QuadPart) / 10000.0;
+  }
+#elif defined(__APPLE__)
+  // The kernel reports the creation time of the process as a wall-clock timestamp in
+  // kinfo_proc.
+  struct kinfo_proc processInfo;
+  size_t processInfoSize = sizeof(processInfo);
+  int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
+  timeval nowTime;
+  if (sysctl(mib, 4, &processInfo, &processInfoSize, nullptr, 0) == 0 //
+      && gettimeofday(&nowTime, nullptr) == 0)
+  {
+    const timeval& creationTime = processInfo.kp_proc.p_starttime;
+    Self::TimeElapsedBeforeProcessEntryPointMs = (nowTime.tv_sec - creationTime.tv_sec) * 1000.0 //
+                                                 + (nowTime.tv_usec - creationTime.tv_usec) / 1000.0;
+  }
+#elif defined(__linux__)
+  // The kernel reports the creation time of the process in field 22 of /proc/self/stat,
+  // in clock ticks since boot; CLOCK_BOOTTIME is the matching clock for "now". Both ends
+  // being boot-relative, this is immune to wall clock adjustments.
+  if (FILE* statFile = fopen("/proc/self/stat", "r"))
+  {
+    char stat[2048] = { 0 };
+    size_t statLength = fread(stat, 1, sizeof(stat) - 1, statFile);
+    fclose(statFile);
+    // Parsing starts after the last ')', which closes field 2, the executable name: that
+    // name may itself contain spaces and parentheses, but the fields after it cannot.
+    // Field 22 is then the 20th field, and %*s skips a field whatever its format.
+    const char* afterExecutableName = statLength > 0 ? strrchr(stat, ')') : nullptr;
+    long long creationTimeTicks = 0;
+    long ticksPerSecond = sysconf(_SC_CLK_TCK);
+    struct timespec nowTime;
+    if (afterExecutableName //
+        && sscanf(afterExecutableName + 1,
+                  " %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %lld",
+                  &creationTimeTicks)
+             == 1
+        && creationTimeTicks > 0 && ticksPerSecond > 0 //
+        && clock_gettime(CLOCK_BOOTTIME, &nowTime) == 0)
+    {
+      Self::TimeElapsedBeforeProcessEntryPointMs = (nowTime.tv_sec * 1000.0 + nowTime.tv_nsec / 1e6) //
+                                                   - creationTimeTicks * 1000.0 / ticksPerSecond;
+    }
+  }
+#endif
+
+  Self::TimeElapsedAfterProcessEntryPointTimer.start();
+}
+
+//----------------------------------------------------------------------------
 void qSlicerApplicationHelper::preInitializeApplication(const char* argv0, ctkProxyStyle* style)
 {
+  // Fall back to starting the clock here if recordProcessEntryPointTime() was not called
+  // (a custom application that provides its own main() instead of including
+  // qSlicerApplicationMainWrapper.cxx), without restarting a clock that is already running.
+  if (!Self::TimeElapsedAfterProcessEntryPointTimer.isValid())
+  {
+    Self::TimeElapsedAfterProcessEntryPointTimer.start();
+  }
+
 #if defined(Q_OS_MACOS) && (QT_VERSION < QT_VERSION_CHECK(5, 15, 10))
   // See https://github.com/Slicer/Slicer/issues/7261
   QLoggingCategory::setFilterRules("qt.qpa.fonts=false");

--- a/Base/QTApp/qSlicerApplicationHelper.h
+++ b/Base/QTApp/qSlicerApplicationHelper.h
@@ -22,6 +22,7 @@
 #define __qSlicerApplicationHelper_h
 
 // Qt includes
+#include <QElapsedTimer>
 #include <QScopedPointer>
 #include <QObject>
 #include <QSplashScreen>
@@ -45,6 +46,16 @@ public:
   ~qSlicerApplicationHelper() override;
 
   static void preInitializeApplication(const char* argv0, ctkProxyStyle* style);
+
+  /// Record the time when the process entry point is reached.
+  /// Meant to be the first statement of main() or WinMain().
+  /// Called from qSlicerApplicationMainWrapper.cxx, which every application includes into
+  /// its own Main.cxx, so custom applications are measured without having to ask for it.
+  ///
+  /// It is used for measuring the time that it takes for the operating system loader
+  /// to create the process, map the executable, load dynamic libraries that are required
+  /// for the main application, initialize the C runtime, etc.
+  static void recordProcessEntryPointTime();
 
   /// Perform initialization steps on the application.
   /// \return If return value is non-zero then the application will terminate using
@@ -72,6 +83,23 @@ public:
 
 private:
   Q_DISABLE_COPY(qSlicerApplicationHelper);
+
+  /// Milliseconds from the creation of the process to the entry point, that is, what the
+  /// loader spent before the application had any say. Stays 0 where the platform does not
+  /// report when the process was created.
+  ///
+  /// Set once by recordProcessEntryPointTime(), read afterwards from the same thread that
+  /// will report it, so it needs no synchronization of its own.
+  static double TimeElapsedBeforeProcessEntryPointMs;
+
+  /// Started by recordProcessEntryPointTime(), or, if that was never called, by
+  /// preInitializeApplication(), so it is always running by the time anything reads it.
+  ///
+  /// A second clock, because the wall clock that dates the creation of the process is
+  /// coarse and can be shifted by clock adjustments: the wall clock is read once, to
+  /// obtain TimeElapsedBeforeProcessEntryPointMs, and every duration after the entry
+  /// point is measured with this monotonic timer instead.
+  static QElapsedTimer TimeElapsedAfterProcessEntryPointTimer;
 };
 
 #include "qSlicerApplicationHelper.hxx"

--- a/Base/QTApp/qSlicerApplicationHelper.hxx
+++ b/Base/QTApp/qSlicerApplicationHelper.hxx
@@ -25,6 +25,8 @@
 #include <qSlicerApplication.h>
 
 // Qt includes
+#include <QElapsedTimer>
+#include <QMap>
 #include <QMouseEvent>
 #include <QSettings>
 #include <QSplashScreen>
@@ -45,6 +47,7 @@
 #include "qSlicerModuleManager.h"
 
 // STD includes
+#include <algorithm>
 #include <iostream>
 
 // Minimal class definition so that Qt lupdate can parse qSlicerApplicationHelper::
@@ -138,6 +141,108 @@ void splashMessage(QScopedPointer<QSplashScreen>& splashScreen, const QString& m
   splashScreen->showMessage(message, Qt::AlignBottom | Qt::AlignHCenter);
 }
 
+//----------------------------------------------------------------------------
+/// Structure to store startup timings of a module.
+/// Bringing a module up takes two steps: instantiating it (i.e., constructing it)
+/// and loading it (a module reads its settings, creates its logic, registers node types, etc.).
+struct ModuleTiming
+{
+  QString Name;
+  double InstantiatedMs = 0.0;
+  double LoadedMs = 0.0;
+  double totalMs() const { return this->InstantiatedMs + this->LoadedMs; }
+};
+
+//----------------------------------------------------------------------------
+/// A phase of the startup that has just finished, named, with the time elapsed from the
+/// creation of the process to the moment it finished.
+///
+/// Kept as a timestamp rather than as the duration of the phase, because consecutive
+/// timestamps subtract to give the duration of the phase between them, and the last one
+/// is the total startup time.
+struct StartupPhase
+{
+  QString Name;
+  double TimeElapsedSinceProcessCreationMs = 0.0;
+};
+
+//----------------------------------------------------------------------------
+/// How long each phase of the startup took.
+///
+/// Measured whether or not anyone asked for the report, because collecting it costs
+/// almost nothing, and a timing that is only collected when requested is one that cannot
+/// be added to a log after the fact.
+struct StartupPhaseTimings
+{
+  /// The phases of the startup, in the order they finished. One list rather than a field
+  /// per phase, so that adding, removing or reordering a phase is a change at the place
+  /// where the phase happens and nowhere else. The last entry is the end of the startup.
+  QList<StartupPhase> Phases;
+
+  /// The same time as the module instantiating and loading phases, broken down by module,
+  /// so that a slow phase can be traced to whichever module made it slow. Registration is
+  /// not among them: the factory reports that a module has been registered but not that
+  /// it is about to be, so there is nothing to measure between.
+  QList<ModuleTiming> ModuleTimings;
+};
+
+//----------------------------------------------------------------------------
+/// Writes to the application log how the startup went, if --report-startup-timing
+/// asked for it.
+///
+/// Called explicitly at the end of postInitializeApplication(), not from
+/// qSlicerApplication::startupCompleted(), which any number of modules also connect to:
+/// as one slot among many it would run wherever its connection happened to fall in the
+/// order, and whatever the slots after it did would be missing from the report.
+///
+/// The report goes to the log rather than to the standard output because a windowed
+/// build on Windows has no console to write to. It is written as a single entry so that
+/// nothing logged from another thread can land in the middle of it.
+void reportStartupTiming(const StartupPhaseTimings& timings)
+{
+  if (!qSlicerApplication::application()->commandOptions()->reportStartupTiming())
+  {
+    return;
+  }
+
+  QStringList lines;
+  lines << "Startup timing report";
+  // Each phase is stored as a timestamp, so a phase lasted whatever separates it from
+  // the phase before it.
+  double phaseStartMs = 0.0;
+  for (const StartupPhase& phase : timings.Phases)
+  {
+    lines << QString("  %1: %2 ms") //
+               .arg(phase.Name)
+               .arg(phase.TimeElapsedSinceProcessCreationMs - phaseStartMs, 0, 'f', 0);
+    phaseStartMs = phase.TimeElapsedSinceProcessCreationMs;
+  }
+  // Slowest first, because the question this answers is which module to look at, and only
+  // as far as the slowest few: past those the list becomes every module in the build, in
+  // an order that no longer says anything about where the startup went.
+  QList<ModuleTiming> modules = timings.ModuleTimings;
+  std::sort(modules.begin(), modules.end(), [](const ModuleTiming& a, const ModuleTiming& b) { return a.totalMs() > b.totalMs(); });
+  const int reportedModuleCount = qMin(modules.count(), 15);
+  lines << QString("  Modules, slowest first, as instantiate + load (%1 of %2):") //
+             .arg(reportedModuleCount)
+             .arg(modules.count());
+  for (int moduleIndex = 0; moduleIndex < reportedModuleCount; ++moduleIndex)
+  {
+    const ModuleTiming& module = modules.at(moduleIndex);
+    // One decimal, so that modules costing a fraction of a millisecond are not all
+    // reported as zero.
+    lines << QString("    %1: %2 ms (%3 ms + %4 ms)") //
+               .arg(module.Name)
+               .arg(module.totalMs(), 0, 'f', 1)
+               .arg(module.InstantiatedMs, 0, 'f', 1)
+               .arg(module.LoadedMs, 0, 'f', 1);
+  }
+  // The phases cover the whole startup, so the last one ended when the startup did.
+  const double totalMs = timings.Phases.isEmpty() ? 0.0 : timings.Phases.constLast().TimeElapsedSinceProcessCreationMs;
+  lines << QString("  Total, from the creation of the process: %1 ms").arg(totalMs, 0, 'f', 0);
+  qInfo().noquote() << lines.join("\n");
+}
+
 } // end of anonymous namespace
 
 //----------------------------------------------------------------------------
@@ -152,7 +257,8 @@ int qSlicerApplicationHelper::postInitializeApplication(qSlicerApplication& app,
 # ifdef Slicer_USE_QtTesting
   (void)setEnableQtTesting; // Fix -Wunused-function warning
 # endif
-  (void)splashMessage; // Fix -Wunused-function warning
+  (void)reportStartupTiming; // Fix -Wunused-function warning
+  (void)splashMessage;       // Fix -Wunused-function warning
 #endif
 
   if (app.style())
@@ -237,23 +343,64 @@ int qSlicerApplicationHelper::postInitializeApplication(qSlicerApplication& app,
     moduleFactoryManager->addModuleToIgnore(moduleToIgnore);
   }
 
+  StartupPhaseTimings startupPhaseTimings;
+
+  // Note that a phase of the startup has just finished. The entry point timer is already
+  // running, so there is nothing to start or restart: recording a phase is one call at
+  // the place where the phase ends, and the report works out the durations.
+  auto recordStartupPhaseCompletedTime = [&startupPhaseTimings](const QString& name)
+  { startupPhaseTimings.Phases.push_back({ name, Self::TimeElapsedBeforeProcessEntryPointMs + Self::TimeElapsedAfterProcessEntryPointTimer.elapsed() }); };
+
+  // What the loader did before the entry point, recorded as the first phase so that the
+  // phases account for the whole startup from the creation of the process.
+  startupPhaseTimings.Phases.push_back({ "Before the process entry point, loading the application's own libraries", Self::TimeElapsedBeforeProcessEntryPointMs });
+
+  // Everything up to here was the application getting itself ready to have modules:
+  // building qSlicerApplication, reading the settings, starting Python.
+  recordStartupPhaseCompletedTime("Initializing the application");
+
   // Register and instantiate modules
   splashMessage(splashScreen, qSlicerApplication::tr("Registering modules..."));
   moduleFactoryManager->registerModules();
+  recordStartupPhaseCompletedTime("Registering modules");
   if (app.commandOptions()->verboseModuleDiscovery())
   {
     qDebug() << "Number of registered modules:" << moduleFactoryManager->registeredModuleNames().count();
   }
 
   splashMessage(splashScreen, qSlicerApplication::tr("Instantiating modules..."));
-  // Show the name of each module that is being instantiated to make it easier to see if a module
-  // inappropriately performs some lengthy operations during instantiation.
-  QMetaObject::Connection moduleAboutToBeInstantiatedConnection =
+
+  // Time each module separately. instantiateModules() below brackets every construction
+  // with these two signals (instantiateModule() on its own emits only the second, but
+  // these connections do not outlive the call below). Showing the name of each module on
+  // the splash screen also makes it easier to see if a module inappropriately performs
+  // some lengthy operations during instantiation.
+  QMap<QString, ModuleTiming> moduleTimings;
+  QElapsedTimer moduleTimer;
+  moduleTimer.start();
+  QMetaObject::Connection moduleAboutToBeInstantiatedConnection = //
     QObject::connect(moduleFactoryManager,
                      &qSlicerAbstractModuleFactoryManager::moduleAboutToBeInstantiated,
-                     [&splashScreen](QString moduleName) { splashMessage(splashScreen, qSlicerApplication::tr("Instantiating module \"%1\"...").arg(moduleName)); });
+                     [&splashScreen, &moduleTimer](QString moduleName)
+                     {
+                       splashMessage(splashScreen, qSlicerApplication::tr("Instantiating module \"%1\"...").arg(moduleName));
+                       // Last, so that updating the splash screen is not charged to the module.
+                       moduleTimer.restart();
+                     });
+  QMetaObject::Connection moduleInstantiatedConnection = //
+    QObject::connect(moduleFactoryManager,
+                     &qSlicerAbstractModuleFactoryManager::moduleInstantiated,
+                     [&moduleTimer, &moduleTimings](QString moduleName)
+                     {
+                       ModuleTiming& timing = moduleTimings[moduleName];
+                       timing.Name = moduleName;
+                       timing.InstantiatedMs = moduleTimer.nsecsElapsed() / 1e6;
+                     });
+
   moduleFactoryManager->instantiateModules();
   QObject::disconnect(moduleAboutToBeInstantiatedConnection);
+  QObject::disconnect(moduleInstantiatedConnection);
+  recordStartupPhaseCompletedTime("Instantiating modules");
 
   if (splashScreen)
   {
@@ -302,17 +449,44 @@ int qSlicerApplicationHelper::postInitializeApplication(qSlicerApplication& app,
 #endif
   }
 
-  // Load all available modules
+  recordStartupPhaseCompletedTime("Initializing the user interface");
+
+  // Load all available modules.
+  //
+  // Loading a module first loads its not-yet-loaded dependencies, inside the same call,
+  // and a module that is already loaded is skipped. Bracketing loadModule() with a timer
+  // would therefore charge a dependency's load to whichever module happened to pull it in
+  // first, and report the dependency itself as instantaneous. Instead, listen to
+  // moduleLoaded(), which the factory emits at the end of every load, nested ones
+  // included: a dependency's own emission closes its interval before its dependee's, so
+  // each module is charged only its own time.
+  double moduleLoadStartedMs = 0.0;
+  QMetaObject::Connection moduleLoadedConnection = //
+    QObject::connect(moduleFactoryManager,
+                     &qSlicerModuleFactoryManager::moduleLoaded,
+                     [&moduleTimer, &moduleTimings, &moduleLoadStartedMs](QString moduleName)
+                     {
+                       const double nowMs = moduleTimer.nsecsElapsed() / 1e6;
+                       moduleTimings[moduleName].LoadedMs = nowMs - moduleLoadStartedMs;
+                       moduleLoadStartedMs = nowMs;
+                     });
   for (const QString& name : moduleFactoryManager->instantiatedModuleNames())
   {
     Q_ASSERT(!name.isNull());
     splashMessage(splashScreen, qSlicerApplication::tr("Loading module \"%1\"...").arg(name));
+    // Taken after the splash message, so that updating the splash screen is not charged
+    // to the module.
+    moduleLoadStartedMs = moduleTimer.nsecsElapsed() / 1e6;
     moduleFactoryManager->loadModule(name);
   }
+  QObject::disconnect(moduleLoadedConnection);
   if (app.commandOptions()->verboseModuleDiscovery())
   {
     qDebug() << "Number of loaded modules:" << moduleManager->modulesNames().count();
   }
+
+  recordStartupPhaseCompletedTime("Loading modules");
+  startupPhaseTimings.ModuleTimings = moduleTimings.values();
 
   splashMessage(splashScreen, QString());
 
@@ -334,9 +508,13 @@ int qSlicerApplicationHelper::postInitializeApplication(qSlicerApplication& app,
     window->setHomeModuleCurrent();
     window->show();
   }
+  recordStartupPhaseCompletedTime("Showing the main window");
 
   // Process command line argument after the event loop is started
   QTimer::singleShot(0, &app, SLOT(handleCommandLineArguments()));
+
+  // Startup is over: the window is up and the event loop is about to take over.
+  reportStartupTiming(startupPhaseTimings);
 
   // qSlicerApplicationHelper::showMRMLEventLoggerWidget();
   return EXIT_SUCCESS;

--- a/Base/QTApp/qSlicerApplicationMainWrapper.cxx
+++ b/Base/QTApp/qSlicerApplicationMainWrapper.cxx
@@ -19,6 +19,7 @@
 ==============================================================================*/
 
 // Slicer includes
+#include "qSlicerApplicationHelper.h"
 #include "vtkSlicerConfigure.h"
 
 #if defined(_WIN32) && !defined(Slicer_BUILD_WIN32_CONSOLE)
@@ -27,6 +28,8 @@
 
 int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
 {
+  // This must be the first call for accurate application startup time measurements.
+  qSlicerApplicationHelper::recordProcessEntryPointTime();
   Q_UNUSED(hInstance);
   Q_UNUSED(hPrevInstance);
   Q_UNUSED(nShowCmd);
@@ -51,6 +54,8 @@ int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdL
 #else
 int main(int argc, char* argv[])
 {
+  // This must be the first call for accurate application startup time measurements.
+  qSlicerApplicationHelper::recordProcessEntryPointTime();
   return SlicerAppMain(argc, argv);
 }
 #endif

--- a/Base/QTGUI/qSlicerCommandOptions.cxx
+++ b/Base/QTGUI/qSlicerCommandOptions.cxx
@@ -89,6 +89,12 @@ bool qSlicerCommandOptions::exitAfterStartup() const
 }
 
 //-----------------------------------------------------------------------------
+bool qSlicerCommandOptions::reportStartupTiming() const
+{
+  return this->parsedArgs().value("report-startup-timing").toBool();
+}
+
+//-----------------------------------------------------------------------------
 void qSlicerCommandOptions::addArguments()
 {
   this->Superclass::addArguments();
@@ -161,4 +167,14 @@ void qSlicerCommandOptions::addArguments()
                     QVariant::Bool,
 #endif
                     "Exit after startup is complete. Useful for measuring startup time");
+
+  this->addArgument("report-startup-timing",
+                    "",
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+                    QMetaType::Bool,
+#else
+                    QVariant::Bool,
+#endif
+                    "Write to the application log, once startup is complete, how long the startup took and where the time went."
+                    " Useful for diagnosing slow startup");
 }

--- a/Base/QTGUI/qSlicerCommandOptions.h
+++ b/Base/QTGUI/qSlicerCommandOptions.h
@@ -37,6 +37,7 @@ class Q_SLICER_BASE_QTGUI_EXPORT qSlicerCommandOptions : public qSlicerCoreComma
   Q_PROPERTY(bool showPythonConsole READ showPythonConsole CONSTANT)
   Q_PROPERTY(bool enableQtTesting READ enableQtTesting CONSTANT)
   Q_PROPERTY(bool exitAfterStartup READ exitAfterStartup CONSTANT)
+  Q_PROPERTY(bool reportStartupTiming READ reportStartupTiming CONSTANT)
 public:
   typedef qSlicerCoreCommandOptions Superclass;
   qSlicerCommandOptions();
@@ -56,6 +57,10 @@ public:
   bool enableQtTesting() const;
 
   bool exitAfterStartup() const;
+
+  /// Whether to write to the application log, once startup is complete, how long the
+  /// startup took and where the time went.
+  bool reportStartupTiming() const;
 
 protected:
   void addArguments() override;

--- a/Docs/user_guide/settings.md
+++ b/Docs/user_guide/settings.md
@@ -83,6 +83,7 @@ The overall theme of Slicer is controlled by the selected Style:
 
 Enable the following features:
 
+* Testing modules are loaded: modules whose name ends with `Test` or `Tests` are only loaded at application startup if developer mode is enabled. Skipping them shortens the application startup time, in particular for scripted testing modules, which would need to be imported just to be registered. Testing modules are always loaded if the application is started in testing mode, as automated tests rely on them.
 * [Module selection toolbar](user_interface.md#toolbar): Modules associated with the _Testing_ category are visible by default.
 * [WebServer module](modules/webserver.md): Javascript logging is enabled by default.
 * [Module panel](user_interface.md#module-panel): `Reload & Test` module panel section is displayed for scripted modules. It includes controls for reloading, testing and editing scripted modules as well as restarting the application.
@@ -140,6 +141,22 @@ The file is searched at multiple location and the first one that is found is use
 - User profile folder (`~/.slicerrc.py`)
 
 You can find the path to the startup script in Slicer by opening in the menu: Edit / Application Settings. ''Application startup script'' path is shown in the ''General'' section (or running `getSlicerRCFileName()` command in Slicer Python console).
+
+### Startup performance optimization
+
+If the application takes a long time to start up then the `--report-startup-timing` command-line option can be used to find out where that time is spent. Once the startup is complete, a report is written to the application log (it can be displayed by opening in the menu: View / Error Log), containing:
+- how much time was spent before the application's entry point was reached, which is the time the operating system needed to load the application's own libraries,
+- how much time each startup phase took (initializing the application, registering, instantiating and loading modules, initializing the user interface, and showing the main window),
+- the slowest 15 modules, each with the time it took to instantiate and to load it,
+- the total time measured from the creation of the process.
+
+For example:
+
+    Slicer.exe --report-startup-timing
+
+The option can be combined with `--exit-after-startup`, which quits the application as soon as the startup is complete, and with `--disable-modules` or `--disable-scripted-loadable-modules`, to see how much of the startup time a group of modules is responsible for.
+
+Testing modules are not loaded unless [developer mode](#developer-mode) is enabled, which also shortens the startup time.
 
 ### Runtime environment variables
 


### PR DESCRIPTION
Add `--report-startup-timing` command-line argument, that writes application startup time measurements into the application log once startup is completed. This is useful for evaluating effectiveness of various startup time improvement mechanisms in different environments.

Measurements include time spent before main() function is called (the operating system loader loads libraries, Microsoft Defender malware scans, etc.).

Module instantiation and loading time is reported to help pinpointing modules that perform time-consuming operations at every startup.

Startup time could already be measured with the MeasureStartupTimes.py script, but that script is not bundled with the application, so it is not available to users of an installed Slicer and does not measure other important startup time components.

see #9203
