### PR TITLE
PERF: Parallel file prefetching at startup

### DIFF
--- a/Applications/SlicerApp/Testing/Python/SlicerReportStartupTimingTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerReportStartupTimingTest.py
@@ -81,7 +81,8 @@ def parse_report(output):
         if phaseMatch:
             if phaseMatch.group(1) == TOTAL_NAME:
                 totalMs = int(phaseMatch.group(2))
-                # The total is the last line of the report.
+                # The total closes the timing report; anything after it (such as the
+                # startup library prefetching report) is not parsed here.
                 break
             phaseDurationsMs[phaseMatch.group(1)] = int(phaseMatch.group(2))
             continue

--- a/Base/QTApp/CMakeLists.txt
+++ b/Base/QTApp/CMakeLists.txt
@@ -28,6 +28,16 @@ set(KIT_SRCS
   qSlicerMainWindow.h
   )
 
+if(Slicer_BUILD_STARTUP_FILE_PREFETCH)
+  list(APPEND KIT_SRCS
+    qSlicerStartupFilePrefetcher.cxx
+    qSlicerStartupFilePrefetcher.h
+    )
+  # dl_iterate_phdr(), used to ask the loader what is mapped, is part of libc since
+  # glibc 2.34 and of libdl before that. CMAKE_DL_LIBS is empty where it is not needed.
+  list(APPEND KIT_extra_target_libraries ${CMAKE_DL_LIBS})
+endif()
+
 # UI files
 set(KIT_UI_SRCS
   Resources/UI/qSlicerAboutDialog.ui
@@ -40,6 +50,7 @@ set(KIT_target_libraries
   # ${QT_LIBRARIES} # Not needed: All dependencies are transitively satisfied by other targets
   qSlicerModulesCore
   qSlicerBaseQTCLI
+  ${KIT_extra_target_libraries}
   )
 
 # Resources

--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -65,7 +65,6 @@
 #include <itkFactoryRegistration.h>
 
 // VTK includes
-#include <vtksys/SystemTools.hxx>
 #include <vtkNew.h>
 #include <vtkLogger.h>
 
@@ -200,9 +199,7 @@ void qSlicerApplicationHelper::preInitializeApplication(const char* argv0, ctkPr
   QString applicationName("Slicer");
   if (argv0)
   {
-    std::string name = vtksys::SystemTools::GetFilenameWithoutExtension(argv0);
-    applicationName = QString::fromLocal8Bit(name.c_str());
-    applicationName.remove(QString("App-real"));
+    applicationName = qSlicerCoreApplication::applicationNameFromExecutablePath(QString::fromLocal8Bit(argv0));
   }
   QCoreApplication::setApplicationName(applicationName);
 

--- a/Base/QTApp/qSlicerApplicationHelper.hxx
+++ b/Base/QTApp/qSlicerApplicationHelper.hxx
@@ -45,6 +45,9 @@
 #include "qSlicerCommandOptions.h"
 #include "qSlicerModuleFactoryManager.h"
 #include "qSlicerModuleManager.h"
+#ifdef Slicer_BUILD_STARTUP_FILE_PREFETCH
+# include "qSlicerStartupFilePrefetcher.h"
+#endif
 
 // STD includes
 #include <algorithm>
@@ -240,6 +243,9 @@ void reportStartupTiming(const StartupPhaseTimings& timings)
   // The phases cover the whole startup, so the last one ended when the startup did.
   const double totalMs = timings.Phases.isEmpty() ? 0.0 : timings.Phases.constLast().TimeElapsedSinceProcessCreationMs;
   lines << QString("  Total, from the creation of the process: %1 ms").arg(totalMs, 0, 'f', 0);
+#ifdef Slicer_BUILD_STARTUP_FILE_PREFETCH
+  lines << qSlicerStartupFilePrefetcher::reportLines();
+#endif
   qInfo().noquote() << lines.join("\n");
 }
 
@@ -514,6 +520,11 @@ int qSlicerApplicationHelper::postInitializeApplication(qSlicerApplication& app,
   QTimer::singleShot(0, &app, SLOT(handleCommandLineArguments()));
 
   // Startup is over: the window is up and the event loop is about to take over.
+#ifdef Slicer_BUILD_STARTUP_FILE_PREFETCH
+  // Records the libraries this startup needed and stops the clock on the prefetch, so it
+  // has to run whether or not a report was asked for, and before the report is collected.
+  qSlicerStartupFilePrefetcher::finish();
+#endif
   reportStartupTiming(startupPhaseTimings);
 
   // qSlicerApplicationHelper::showMRMLEventLoggerWidget();

--- a/Base/QTApp/qSlicerApplicationMainWrapper.cxx
+++ b/Base/QTApp/qSlicerApplicationMainWrapper.cxx
@@ -21,6 +21,9 @@
 // Slicer includes
 #include "qSlicerApplicationHelper.h"
 #include "vtkSlicerConfigure.h"
+#ifdef Slicer_BUILD_STARTUP_FILE_PREFETCH
+# include "qSlicerStartupFilePrefetcher.h"
+#endif
 
 #if defined(_WIN32) && !defined(Slicer_BUILD_WIN32_CONSOLE)
 # include <windows.h>
@@ -30,6 +33,11 @@ int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdL
 {
   // This must be the first call for accurate application startup time measurements.
   qSlicerApplicationHelper::recordProcessEntryPointTime();
+# ifdef Slicer_BUILD_STARTUP_FILE_PREFETCH
+  // Every library mapped from here on is one the next run can anticipate, so this comes
+  // before any other work.
+  qSlicerStartupFilePrefetcher::start();
+# endif
   Q_UNUSED(hInstance);
   Q_UNUSED(hPrevInstance);
   Q_UNUSED(nShowCmd);
@@ -56,6 +64,11 @@ int main(int argc, char* argv[])
 {
   // This must be the first call for accurate application startup time measurements.
   qSlicerApplicationHelper::recordProcessEntryPointTime();
+# ifdef Slicer_BUILD_STARTUP_FILE_PREFETCH
+  // Every library mapped from here on is one the next run can anticipate, so this comes
+  // before any other work.
+  qSlicerStartupFilePrefetcher::start();
+# endif
   return SlicerAppMain(argc, argv);
 }
 #endif

--- a/Base/QTApp/qSlicerStartupFilePrefetcher.cxx
+++ b/Base/QTApp/qSlicerStartupFilePrefetcher.cxx
@@ -1,0 +1,894 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#include "qSlicerStartupFilePrefetcher.h"
+
+// Qt includes
+#include <QDir>
+#include <QElapsedTimer>
+#include <QFile>
+#include <QFileInfo>
+#include <QSaveFile>
+#include <QSet>
+
+// CTK includes
+#include <ctkUtils.h>
+
+// Slicer includes
+#include "qSlicerCoreApplication.h"    // For the static path helpers used before there is an application
+#include "vtkSlicerConfigure.h"        // For SLICER_REVISION_SPECIFIC_USER_SETTINGS_FILEBASENAME
+#include "vtkSlicerVersionConfigure.h" // For Slicer_REVISION
+
+// STD includes
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#if defined(_WIN32)
+# ifndef NOMINMAX
+#  define NOMINMAX
+# endif
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+// Select the PSAPI implementation exported by kernel32, so that linking against
+// psapi.lib is not required.
+# ifndef PSAPI_VERSION
+#  define PSAPI_VERSION 2
+# endif
+# include <windows.h>
+# include <psapi.h>
+#else
+# include <fcntl.h>  // for open()
+# include <unistd.h> // for read(), close(), readlink()
+# if defined(Q_OS_MACOS)
+#  include <mach-o/dyld.h> // for _dyld_image_count(), _NSGetExecutablePath()
+#  include <stdlib.h>      // for realpath()
+# else
+// dl_iterate_phdr() is a GNU extension, which needs _GNU_SOURCE to be declared. Every C++
+// compiler on a glibc system defines that itself, so there is nothing to define here.
+#  include <link.h>
+# endif
+#endif
+
+//----------------------------------------------------------------------------
+// Everything the prefetch does that the operating system does differently: finding the
+// running executable, asking the loader what is mapped, reading a file so that it is
+// cached, comparing two paths, and which libraries are not worth touching. The mechanism
+// built on top of these is the same everywhere and lives below, outside any #ifdef.
+//----------------------------------------------------------------------------
+namespace
+{
+
+/// Path in the form the platform's file API takes, so that a worker thread does not
+/// convert or allocate per library.
+#if defined(_WIN32)
+using NativePathString = std::wstring;
+#else
+using NativePathString = std::string;
+#endif
+
+//----------------------------------------------------------------------------
+NativePathString toNativePathString(const QString& path)
+{
+#if defined(_WIN32)
+  return QDir::toNativeSeparators(path).toStdWString();
+#else
+  const QByteArray encoded = QFile::encodeName(path);
+  return std::string(encoded.constData(), encoded.size());
+#endif
+}
+
+//----------------------------------------------------------------------------
+/// Full path of the running executable, with forward slashes. Read from the operating
+/// system rather than from argv[0], which is not available in WinMain() and need not be
+/// a usable path anywhere.
+QString applicationFilePath()
+{
+#if defined(_WIN32)
+  std::vector<wchar_t> buffer(32768);
+  const DWORD length = GetModuleFileNameW(nullptr, buffer.data(), static_cast<DWORD>(buffer.size()));
+  if (length == 0 || length >= buffer.size())
+  {
+    return QString();
+  }
+  return QDir::fromNativeSeparators(QString::fromWCharArray(buffer.data(), length));
+#elif defined(Q_OS_MACOS)
+  // The size is an in-out parameter: on failure it is set to what would have been needed,
+  // so a second call with the enlarged buffer succeeds.
+  std::vector<char> buffer(1024, 0);
+  uint32_t size = static_cast<uint32_t>(buffer.size());
+  if (_NSGetExecutablePath(buffer.data(), &size) != 0)
+  {
+    buffer.assign(size + 1, 0);
+    if (_NSGetExecutablePath(buffer.data(), &size) != 0)
+    {
+      return QString();
+    }
+  }
+  // What _NSGetExecutablePath returns may contain symbolic links and relative components,
+  // and the recorded list is compared against paths reported by the loader, which are
+  // resolved. realpath() allocates the result when given no buffer.
+  char* resolved = realpath(buffer.data(), nullptr);
+  if (!resolved)
+  {
+    return QFile::decodeName(buffer.data());
+  }
+  const QString path = QFile::decodeName(resolved);
+  free(resolved);
+  return path;
+#else
+  // Resolved by the kernel, so it is absolute and free of symbolic links. Its length is
+  // not reported in advance, hence growing the buffer until it fits.
+  std::vector<char> buffer(1024);
+  while (true)
+  {
+    const ssize_t length = readlink("/proc/self/exe", buffer.data(), buffer.size());
+    if (length < 0)
+    {
+      return QString();
+    }
+    if (static_cast<size_t>(length) < buffer.size())
+    {
+      return QFile::decodeName(QByteArray(buffer.data(), static_cast<int>(length)));
+    }
+    buffer.resize(buffer.size() * 2);
+  }
+#endif
+}
+
+//----------------------------------------------------------------------------
+/// Reads a file from beginning to end so that the operating system has it cached, and any
+/// on-access scanner has scanned it, by the time the loader asks for it. The contents are
+/// discarded into the caller's buffer, which is reused for every file.
+///
+/// Nothing is mapped and no module is created, so no imports are resolved, no relocations
+/// are applied, no initializer runs, and the library does not join the module list.
+///
+/// Returns the number of bytes read, or -1 if the file could not be opened, which happens
+/// to a library that has been removed or replaced since the list was recorded.
+qint64 readWholeFile(const NativePathString& path, std::vector<char>& buffer)
+{
+#if defined(_WIN32)
+  // Shared for reading, writing and deletion, so that a real load of the same library, or
+  // a build writing over it, is never blocked or refused because of this.
+  HANDLE file = CreateFileW(
+    path.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, nullptr);
+  if (file == INVALID_HANDLE_VALUE)
+  {
+    return -1;
+  }
+  qint64 readByteCount = 0;
+  while (true)
+  {
+    DWORD returnedByteCount = 0;
+    if (!ReadFile(file, buffer.data(), static_cast<DWORD>(buffer.size()), &returnedByteCount, nullptr) //
+        || returnedByteCount == 0)
+    {
+      // End of file, or a read error that leaves this library simply not anticipated.
+      break;
+    }
+    readByteCount += returnedByteCount;
+  }
+  CloseHandle(file);
+  return readByteCount;
+#else
+  // O_CLOEXEC because this races with whatever the application may be about to launch.
+  // Opening for reading only never blocks another process from writing the file.
+  const int file = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+  if (file < 0)
+  {
+    return -1;
+  }
+  qint64 readByteCount = 0;
+  while (true)
+  {
+    const ssize_t returnedByteCount = read(file, buffer.data(), buffer.size());
+    if (returnedByteCount <= 0)
+    {
+      // End of file, or a read error that leaves this library simply not anticipated.
+      // EINTR is not retried: a signal arriving here costs one library, not correctness.
+      break;
+    }
+    readByteCount += returnedByteCount;
+  }
+  close(file);
+  return readByteCount;
+#endif
+}
+
+//----------------------------------------------------------------------------
+/// Normalized form used to compare paths coming from the loader with paths read back from
+/// the recorded list. Case is folded only where the file system ignores it: doing so on a
+/// case-sensitive file system would make two different libraries compare equal.
+QString normalizedPath(const QString& path)
+{
+#if defined(_WIN32) || defined(Q_OS_MACOS)
+  return QDir::fromNativeSeparators(path).toLower();
+#else
+  return QDir::fromNativeSeparators(path);
+#endif
+}
+
+//----------------------------------------------------------------------------
+/// Directories whose libraries are not worth prefetching, as normalized prefixes ending
+/// in a separator. Empty where there is no such directory.
+QStringList systemLibraryPrefixes()
+{
+#if defined(_WIN32)
+  // Operating system libraries are signed and their scan verdict is cached system-wide,
+  // so scanning them costs time without saving any.
+  wchar_t buffer[MAX_PATH + 1] = { 0 };
+  const UINT length = GetWindowsDirectoryW(buffer, MAX_PATH);
+  if (length == 0 || length > MAX_PATH)
+  {
+    return QStringList();
+  }
+  return QStringList(normalizedPath(QString::fromWCharArray(buffer, length)) + "/");
+#elif defined(Q_OS_MACOS)
+  // Since macOS 11 the system libraries live in the dyld shared cache and no longer exist
+  // as files, so the loader reports paths that cannot be opened. Listing them would spend
+  // an open() per library only to count a failure.
+  return QStringList{ "/usr/lib/", "/system/" };
+#else
+  // Nothing: a distribution build legitimately loads Qt plugins and module libraries from
+  // /usr/lib, and there is no scanning to avoid, so the only reason to skip a library
+  // would be that it is likely cached already, which is not knowable from its path.
+  return QStringList();
+#endif
+}
+
+//----------------------------------------------------------------------------
+/// Whether the prefetch runs when SLICER_STARTUP_FILE_PREFETCH says nothing.
+///
+/// On Windows it recovers the on-access virus scan that the loader would otherwise
+/// serialize, which is worth seconds on a cold start. Elsewhere there is no such scan to
+/// recover and what is left is the file cache: on macOS that measured 0.39 s of a 7.30 s
+/// startup, small but consistent, and on Linux it depends on the storage. Both are worth
+/// measuring on a given installation before they are spent on every startup.
+#if defined(_WIN32)
+const bool PrefetchEnabledByDefault = true;
+#else
+const bool PrefetchEnabledByDefault = false;
+#endif
+
+} // end of anonymous namespace
+
+//----------------------------------------------------------------------------
+QStringList qSlicerStartupFilePrefetcher::loadedLibraryPaths()
+{
+  QStringList paths;
+#if defined(_WIN32)
+  std::vector<HMODULE> modules(1024);
+  DWORD bytesNeeded = 0;
+  while (true)
+  {
+    const DWORD bytesAvailable = static_cast<DWORD>(modules.size() * sizeof(HMODULE));
+    if (!EnumProcessModules(GetCurrentProcess(), modules.data(), bytesAvailable, &bytesNeeded))
+    {
+      return paths;
+    }
+    if (bytesNeeded <= bytesAvailable)
+    {
+      modules.resize(bytesNeeded / sizeof(HMODULE));
+      break;
+    }
+    // More modules were loaded than the buffer could hold. Grow it and ask again,
+    // with some headroom so that libraries loaded in the meantime do not force
+    // another round.
+    modules.resize(bytesNeeded / sizeof(HMODULE) + 64);
+  }
+
+  // Long paths are not exceptional in a build tree, so do not settle for MAX_PATH:
+  // GetModuleFileNameEx silently truncates, and a truncated path recorded here would
+  // be prefetched as a file that does not exist.
+  std::vector<wchar_t> buffer(32768);
+  for (HMODULE module : modules)
+  {
+    const DWORD length = GetModuleFileNameExW(GetCurrentProcess(), module, buffer.data(), static_cast<DWORD>(buffer.size()));
+    if (length > 0 && length < static_cast<DWORD>(buffer.size()))
+    {
+      paths << QString::fromWCharArray(buffer.data(), length);
+    }
+  }
+#elif defined(Q_OS_MACOS)
+  // Not safe against a library being loaded from another thread, which is why this is
+  // only ever called from the thread that runs start() and finish().
+  const uint32_t imageCount = _dyld_image_count();
+  for (uint32_t imageIndex = 0; imageIndex < imageCount; ++imageIndex)
+  {
+    const char* name = _dyld_get_image_name(imageIndex);
+    // An image built into the dyld shared cache has a path that no file answers to; those
+    // are dropped later, by the same prefix list that keeps them out of the queue.
+    if (name && name[0] == '/')
+    {
+      paths << QFile::decodeName(name);
+    }
+  }
+#else
+  // dl_iterate_phdr holds the loader lock while it walks the list, so the list cannot
+  // change underneath it.
+  dl_iterate_phdr(
+    [](struct dl_phdr_info* info, size_t, void* data) -> int
+    {
+      // The main executable is reported with an empty name, and the vDSO with a name that
+      // is not a path ("linux-vdso.so.1"). Neither is a file to prefetch.
+      if (info->dlpi_name && info->dlpi_name[0] == '/')
+      {
+        *static_cast<QStringList*>(data) << QFile::decodeName(info->dlpi_name);
+      }
+      return 0;
+    },
+    &paths);
+#endif
+  return paths;
+}
+
+namespace
+{
+
+//----------------------------------------------------------------------------
+/// Upper bound on the number of workers chosen automatically, which
+/// SLICER_STARTUP_FILE_PREFETCH_THREADS overrides in either direction.
+///
+/// On Windows the workers spend nearly all their time blocked in the anti-malware filter,
+/// so the threads cost almost no CPU of their own, but the scanning service they wake up
+/// does use a core per outstanding request. Beyond 8 the measured speedup flattens out
+/// (8.1x at 8 threads, 8.4x at 16), so there is nothing to gain from competing harder
+/// with the thread that is actually starting the application. Where there is no scanner
+/// the workers are waiting on the storage device instead, and the same bound keeps them
+/// from taking the queue away from the loader's own reads.
+const unsigned int MaximumWorkerCount = 8;
+
+//----------------------------------------------------------------------------
+class FilePrefetchState
+{
+public:
+  /// Libraries to prefetch, in the order they were recorded during the previous run.
+  /// That order is whatever the loader reported, which is not documented to be load
+  /// order; the workers share one queue, so it only affects which library happens to be
+  /// read first.
+  std::vector<NativePathString> Paths;
+  /// Index of the next entry of Paths to hand out to a worker.
+  std::atomic<size_t> NextIndex{ 0 };
+  std::vector<std::thread> Workers;
+
+  /// Libraries already loaded when start() was called, lower-cased. These were mapped
+  /// by the loader before any application code ran, so they cannot be anticipated and
+  /// must be left out of the recorded list.
+  QSet<QString> InitiallyLoaded;
+
+  /// Normalized paths of everything queued for prefetching. Compared against what the
+  /// application ends up loading, to report how much of this startup the previous run
+  /// managed to predict.
+  QSet<QString> Queued;
+
+  bool Started = false;
+
+  /// Started by start(), and read afterwards from the workers as well, which is safe
+  /// because nothing restarts it once there is another thread to read it. Every time in
+  /// the report is taken from it, so the whole report shares one origin: the moment the
+  /// prefetch began, which is the process entry point.
+  QElapsedTimer Timer;
+
+  /// Everything the report is made of except the fields the workers keep changing.
+  /// Written only from the thread that calls start() and finish(), which is the same
+  /// one, so it needs no synchronization of its own.
+  qSlicerStartupFilePrefetcher::Report Report;
+
+  /// Updated from the worker threads, and read by report() from whichever thread asks.
+  std::atomic<size_t> PrefetchedCount{ 0 };
+  std::atomic<size_t> PrefetchedBytes{ 0 };
+  std::atomic<size_t> FailedCount{ 0 };
+  std::atomic<unsigned int> ActiveWorkers{ 0 };
+  /// Set by the last worker to run out of work; stays negative while any is still going.
+  std::atomic<double> WorkersFinishedTimeMs{ -1.0 };
+};
+
+//----------------------------------------------------------------------------
+/// Returns the process-wide state.
+///
+/// The object is intentionally leaked: if the application exits before finish() runs,
+/// destroying a still joinable std::thread would call std::terminate(). Letting the
+/// state outlive the process instead lets the operating system tear the workers down.
+FilePrefetchState* filePrefetchState()
+{
+  static FilePrefetchState* state = new FilePrefetchState;
+  return state;
+}
+
+//----------------------------------------------------------------------------
+/// Records something the report cannot express as a number. Only called from the thread
+/// that drives start() and finish().
+void addNote(FilePrefetchState* state, const QString& note)
+{
+  state->Report.Notes << note;
+}
+
+//----------------------------------------------------------------------------
+/// Milliseconds from the start of the prefetch, which is what every time in the report is
+/// measured from. Zero until start() has started the clock.
+double elapsedMs(FilePrefetchState* state)
+{
+  return state->Timer.isValid() ? state->Timer.nsecsElapsed() / 1e6 : 0.0;
+}
+
+//----------------------------------------------------------------------------
+/// Renders a time recorded in a report, which is negative when the moment it stands for
+/// has not been reached.
+QString timeString(double milliseconds)
+{
+  if (milliseconds < 0.0)
+  {
+    return QString("n/a");
+  }
+  return QString("%1 ms").arg(milliseconds, 0, 'f', 0);
+}
+
+//----------------------------------------------------------------------------
+/// Size of the buffer each worker reads into. The reads are only there to make the
+/// operating system, and any scanner watching it, look at the file, so nothing is kept
+/// and one buffer per worker is reused for every library.
+const size_t ReadBufferSize = 1024 * 1024;
+
+//----------------------------------------------------------------------------
+/// Prefetches one library and records what that cost, or that it could not be done.
+///
+/// The whole file is read rather than a prefix of it: a scanner reads it whole as soon as
+/// it is touched at all, so stopping early saves nothing (measured: reading the first
+/// megabyte of each library touches 46 MB instead of 62.7 MB and costs the same).
+///
+/// Failures are counted rather than reported: a library that has been removed or
+/// replaced since the list was recorded is simply not anticipated.
+void prefetchLibrary(const NativePathString& path, FilePrefetchState* state, std::vector<char>& buffer)
+{
+  const qint64 readByteCount = readWholeFile(path, buffer);
+  if (readByteCount < 0)
+  {
+    state->FailedCount.fetch_add(1, std::memory_order_relaxed);
+    return;
+  }
+  state->PrefetchedCount.fetch_add(1, std::memory_order_relaxed);
+  state->PrefetchedBytes.fetch_add(static_cast<size_t>(readByteCount), std::memory_order_relaxed);
+}
+
+//----------------------------------------------------------------------------
+void prefetchWorker(FilePrefetchState* state)
+{
+  // Allocated once per worker rather than per library, so that the prefetch is not
+  // measuring its own allocations.
+  std::vector<char> buffer(ReadBufferSize);
+
+  while (true)
+  {
+    const size_t index = state->NextIndex.fetch_add(1, std::memory_order_relaxed);
+    if (index >= state->Paths.size())
+    {
+      break;
+    }
+    prefetchLibrary(state->Paths[index], state, buffer);
+  }
+
+  if (state->ActiveWorkers.fetch_sub(1, std::memory_order_acq_rel) != 1)
+  {
+    // Not the last worker; the one that finishes last stamps the completion time for
+    // all of them.
+    return;
+  }
+  state->WorkersFinishedTimeMs.store(elapsedMs(state), std::memory_order_release);
+}
+
+//----------------------------------------------------------------------------
+/// Whether a library is one of those systemLibraryPrefixes() rules out.
+bool isSystemLibrary(const QString& normalizedLibraryPath, const QStringList& normalizedPrefixes)
+{
+  for (const QString& prefix : normalizedPrefixes)
+  {
+    if (normalizedLibraryPath.startsWith(prefix))
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+//----------------------------------------------------------------------------
+/// Value of an environment variable, trimmed, or a null string when it is not set.
+///
+/// qEnvironmentVariable() rather than QCoreApplication or QProcessEnvironment, because
+/// this runs at the process entry point, before there is an application to ask.
+QString environmentValue(const char* name)
+{
+  return qEnvironmentVariable(name).trimmed();
+}
+
+//----------------------------------------------------------------------------
+/// Whether the prefetch may run, from SLICER_STARTUP_FILE_PREFETCH: "1" turns it on, "0"
+/// turns it off, and leaving it unset means whatever suits the platform. Any other value
+/// is reported and treated as if the variable was not set, so that a misspelled value
+/// cannot silently mean the opposite of what was intended.
+bool filePrefetchEnabled(FilePrefetchState* state)
+{
+  const QString requested = environmentValue("SLICER_STARTUP_FILE_PREFETCH");
+  if (requested.isEmpty())
+  {
+    return PrefetchEnabledByDefault;
+  }
+  if (requested == "1")
+  {
+    return true;
+  }
+  if (requested == "0")
+  {
+    return false;
+  }
+  addNote(state, QString("SLICER_STARTUP_FILE_PREFETCH is \"%1\", which is neither 1 nor 0; using the default for this platform instead.").arg(requested));
+  return PrefetchEnabledByDefault;
+}
+
+//----------------------------------------------------------------------------
+/// Writes the list of libraries this startup needed, for the next run to replay, and
+/// records in the report how it went.
+void writeLibraryList(FilePrefetchState* state, const QStringList& librariesToRecord)
+{
+  if (state->Report.CacheFilePath.isEmpty())
+  {
+    return;
+  }
+  const QString cacheDirPath = QFileInfo(state->Report.CacheFilePath).absolutePath();
+  if (!QDir().mkpath(cacheDirPath))
+  {
+    // An installation the user cannot write to, most likely. Prefetching still works on
+    // every run that finds a list, it just cannot be refreshed here.
+    addNote(state, QString("Cannot create %1, the library list was not updated.").arg(cacheDirPath));
+    return;
+  }
+  if (librariesToRecord.isEmpty())
+  {
+    // Nothing was loaded between start() and here, which means start() ran too late to
+    // be useful. Keep the existing list rather than replacing it with an empty one.
+    addNote(state, QString("No library was loaded during startup, the existing library list was kept."));
+    return;
+  }
+
+  // QSaveFile writes to a temporary file and renames it into place, so an interrupted
+  // run cannot leave a truncated list behind.
+  QSaveFile cacheFile(state->Report.CacheFilePath);
+  if (!cacheFile.open(QIODevice::WriteOnly))
+  {
+    addNote(state, QString("Cannot write %1, the library list was not updated.").arg(state->Report.CacheFilePath));
+    return;
+  }
+  // Written as UTF-8 rather than through QTextStream, whose default encoding differs
+  // between Qt versions, so that paths containing non-ASCII characters survive.
+  QString contents;
+  contents += QString("# Shared libraries loaded while %1 was starting up.\n").arg(state->Report.ApplicationName);
+  contents += "# Read on background threads during the next run, so that the work the operating\n";
+  contents += "# system does when a library is first touched (on Windows, scanning it for\n";
+  contents += "# malware) happens in parallel instead of blocking the loader.\n";
+  contents += QString("# Paths inside the application directory are relative to %1.\n").arg(state->Report.ApplicationHome);
+  contents += "# Generated automatically; safe to delete.\n";
+  for (const QString& path : librariesToRecord)
+  {
+    contents += path + "\n";
+  }
+  const QByteArray encodedContents = contents.toUtf8();
+  if (cacheFile.write(encodedContents) != encodedContents.size())
+  {
+    cacheFile.cancelWriting();
+    addNote(state, QString("Failed to write %1, the library list was not updated.").arg(state->Report.CacheFilePath));
+    return;
+  }
+  if (!cacheFile.commit())
+  {
+    // commit() flushes and renames the temporary file into place, so it can still fail
+    // after every write succeeded, for example when the disk is full.
+    addNote(state, QString("Failed to save %1, the library list was not updated.").arg(state->Report.CacheFilePath));
+    return;
+  }
+  state->Report.RecordedLibraryCount = librariesToRecord.count();
+}
+
+} // end of anonymous namespace
+
+//----------------------------------------------------------------------------
+void qSlicerStartupFilePrefetcher::start()
+{
+  FilePrefetchState* state = filePrefetchState();
+  if (state->Started)
+  {
+    return;
+  }
+  if (!filePrefetchEnabled(state))
+  {
+    addNote(state,
+            environmentValue("SLICER_STARTUP_FILE_PREFETCH") == "0" //
+              ? QString("Turned off by setting the SLICER_STARTUP_FILE_PREFETCH environment variable to 0.")
+              : QString("Off by default on this platform; set the SLICER_STARTUP_FILE_PREFETCH environment variable to 1 to measure what it would save here."));
+    return;
+  }
+  state->Started = true;
+  state->Report.Enabled = true;
+  // First, so that everything the prefetch does is inside what it reports.
+  state->Timer.start();
+
+  const QString executablePath = applicationFilePath();
+  state->Report.ApplicationName = qSlicerCoreApplication::applicationNameFromExecutablePath(executablePath);
+  // Where this executable lives, not where SLICER_HOME points: the variable is set by the
+  // launcher, so trusting it would make the recorded list depend on how the application
+  // happened to be started.
+  state->Report.ApplicationHome = qSlicerCoreApplication::applicationHomeDirectoryFromExecutablePath(executablePath);
+  state->Report.CacheFilePath = qSlicerStartupFilePrefetcher::cacheFilePath();
+
+  // Remember what the loader mapped before the application got a chance to run, so
+  // that finish() only records the libraries loaded from this point on.
+  for (const QString& path : qSlicerStartupFilePrefetcher::loadedLibraryPaths())
+  {
+    state->InitiallyLoaded.insert(normalizedPath(path));
+  }
+  state->Report.InitiallyLoadedLibraryCount = state->InitiallyLoaded.count();
+
+  if (state->Report.CacheFilePath.isEmpty())
+  {
+    addNote(state, QString("No library list location could be determined from %1, nothing was prefetched.").arg(executablePath));
+    return;
+  }
+  QFile cacheFile(state->Report.CacheFilePath);
+  if (!cacheFile.open(QIODevice::ReadOnly))
+  {
+    // Nothing recorded yet: this is the first run after installation, or the first
+    // since the list was deleted. It will be written when this startup completes.
+    addNote(state, QString("No library list at %1 yet, nothing to prefetch this run.").arg(state->Report.CacheFilePath));
+    return;
+  }
+  const QStringList systemPrefixes = systemLibraryPrefixes();
+  while (!cacheFile.atEnd())
+  {
+    // The list is UTF-8 encoded, so it is decoded explicitly rather than through
+    // QTextStream, whose default encoding differs between Qt versions.
+    const QString line = QString::fromUtf8(cacheFile.readLine()).trimmed();
+    if (line.isEmpty() || line.startsWith('#'))
+    {
+      continue;
+    }
+    ++state->Report.ListedLibraryCount;
+    // Entries inside the application directory are stored relative to it; the rest are
+    // absolute. This is the same convention qSlicerCoreApplication::toSlicerHomeAbsolutePath()
+    // applies to settings such as Modules/AdditionalPaths, and it resolves both forms.
+    const QString path = ctk::absolutePathFromInternal(line, state->Report.ApplicationHome);
+    const QString normalized = normalizedPath(path);
+    if (isSystemLibrary(normalized, systemPrefixes))
+    {
+      ++state->Report.SystemLibraryCount;
+      continue;
+    }
+    if (state->InitiallyLoaded.contains(normalized))
+    {
+      ++state->Report.AlreadyLoadedLibraryCount;
+      continue;
+    }
+    state->Queued.insert(normalized);
+    state->Paths.push_back(toNativePathString(path));
+  }
+  cacheFile.close();
+  state->Report.QueuedLibraryCount = static_cast<int>(state->Paths.size());
+
+  if (state->Paths.empty())
+  {
+    addNote(state, QString("Every listed library was already loaded, nothing was prefetched."));
+    return;
+  }
+
+  // An explicit SLICER_STARTUP_FILE_PREFETCH_THREADS is taken at its word, including
+  // above MaximumWorkerCount, because the reason to set it is to try a pool size the
+  // automatic choice would not have picked.
+  unsigned int workerCount = 0;
+  const QString requestedWorkerCount = environmentValue("SLICER_STARTUP_FILE_PREFETCH_THREADS");
+  if (!requestedWorkerCount.isEmpty())
+  {
+    bool isNumber = false;
+    const int requested = requestedWorkerCount.toInt(&isNumber);
+    if (isNumber && requested > 0)
+    {
+      workerCount = static_cast<unsigned int>(requested);
+    }
+    else
+    {
+      addNote(state, QString("SLICER_STARTUP_FILE_PREFETCH_THREADS is \"%1\", which is not a number of threads; choosing one instead.").arg(requestedWorkerCount));
+    }
+  }
+  if (workerCount == 0)
+  {
+    workerCount = std::thread::hardware_concurrency();
+    if (workerCount == 0)
+    {
+      workerCount = 2;
+    }
+    workerCount = qBound(2u, workerCount, MaximumWorkerCount);
+  }
+  // More workers than libraries would leave the extra ones with nothing to do.
+  workerCount = qMin(workerCount, static_cast<unsigned int>(state->Paths.size()));
+
+  // Published before the first worker starts, so that the last one to finish can
+  // recognize itself and stamp the completion time.
+  state->ActiveWorkers.store(workerCount, std::memory_order_release);
+  state->Workers.reserve(workerCount);
+  for (unsigned int i = 0; i < workerCount; ++i)
+  {
+    state->Workers.emplace_back(prefetchWorker, state);
+  }
+  state->Report.WorkerCount = static_cast<int>(workerCount);
+  state->Report.WorkersStartedTimeMs = elapsedMs(state);
+}
+
+//----------------------------------------------------------------------------
+void qSlicerStartupFilePrefetcher::finish()
+{
+  FilePrefetchState* state = filePrefetchState();
+  if (!state->Started)
+  {
+    return;
+  }
+  state->Report.FinishStartTimeMs = elapsedMs(state);
+
+  // The workers are detached rather than joined: whatever is left in the list is only
+  // needed by libraries loaded on demand after startup, so finishing it is still
+  // worthwhile, and waiting for it here would stall the user interface instead. The
+  // state they run on is never destroyed, so outliving this call is safe.
+  for (std::thread& worker : state->Workers)
+  {
+    if (worker.joinable())
+    {
+      worker.detach();
+    }
+  }
+  state->Workers.clear();
+
+  const QStringList systemPrefixes = systemLibraryPrefixes();
+  QStringList librariesToRecord;
+  for (const QString& path : qSlicerStartupFilePrefetcher::loadedLibraryPaths())
+  {
+    const QString normalized = normalizedPath(path);
+    if (state->InitiallyLoaded.contains(normalized) || isSystemLibrary(normalized, systemPrefixes))
+    {
+      continue;
+    }
+    if (state->Queued.contains(normalized))
+    {
+      ++state->Report.PredictedLibraryCount;
+    }
+    // Libraries inside the application directory are recorded relative to it, so that
+    // the list keeps working when the tree is moved or renamed. Libraries outside it
+    // (Qt, and the other build trees in a development build) stay absolute.
+    librariesToRecord << ctk::internalPathFromAbsolute(path, state->Report.ApplicationHome);
+  }
+  state->Report.StartupLibraryCount = librariesToRecord.count();
+
+  writeLibraryList(state, librariesToRecord);
+
+  state->Report.FinishEndTimeMs = elapsedMs(state);
+}
+
+//----------------------------------------------------------------------------
+qSlicerStartupFilePrefetcher::Report qSlicerStartupFilePrefetcher::report()
+{
+  FilePrefetchState* state = filePrefetchState();
+  qSlicerStartupFilePrefetcher::Report report = state->Report;
+  // The workers outlive finish(), so these are read now rather than copied along with
+  // the rest, and a report taken later can legitimately show more than an earlier one.
+  report.PrefetchedLibraryCount = static_cast<int>(state->PrefetchedCount.load(std::memory_order_relaxed));
+  report.FailedLibraryCount = static_cast<int>(state->FailedCount.load(std::memory_order_relaxed));
+  report.PrefetchedByteCount = static_cast<qint64>(state->PrefetchedBytes.load(std::memory_order_relaxed));
+  report.WorkersFinishedTimeMs = state->WorkersFinishedTimeMs.load(std::memory_order_acquire);
+  return report;
+}
+
+//----------------------------------------------------------------------------
+QString qSlicerStartupFilePrefetcher::cacheFilePath()
+{
+  const QString executablePath = applicationFilePath();
+  const QString name = qSlicerCoreApplication::applicationNameFromExecutablePath(executablePath);
+  if (name.isEmpty())
+  {
+    return QString();
+  }
+
+  const QString home = qSlicerCoreApplication::applicationHomeDirectoryFromExecutablePath(executablePath);
+  if (home.isEmpty())
+  {
+    return QString();
+  }
+
+  // The list goes where the revision-specific settings go, which is the application's
+  // existing answer to where this installation may write, and it is asked of
+  // qSlicerCoreApplication rather than worked out again here so that the two cannot
+  // drift apart. The static form of the question is the one that can be asked this
+  // early: start() runs before there is an application to ask.
+  const QString directory = qSlicerCoreApplication::revisionUserSettingsDirectory(home, name);
+
+  // Named like the revision-specific settings file beside it, so that it is recognizable
+  // as belonging to the same installation, and so that two revisions sharing one user
+  // profile do not replay each other's lists.
+  return QDir(directory).filePath(QString("%1%2-%3-StartupFilePrefetch.txt") //
+                                    .arg(name)
+                                    .arg(SLICER_REVISION_SPECIFIC_USER_SETTINGS_FILEBASENAME)
+                                    .arg(Slicer_REVISION));
+}
+
+//----------------------------------------------------------------------------
+QStringList qSlicerStartupFilePrefetcher::reportLines()
+{
+  const qSlicerStartupFilePrefetcher::Report report = qSlicerStartupFilePrefetcher::report();
+
+  QStringList lines;
+  lines << QString("Startup library prefetching report");
+  if (!report.Enabled)
+  {
+    if (report.Notes.isEmpty())
+    {
+      lines << QString("  Did not run.");
+    }
+    for (const QString& note : report.Notes)
+    {
+      lines << "  " + note;
+    }
+    return lines;
+  }
+
+  lines << QString("  Application: %1 in %2").arg(report.ApplicationName, report.ApplicationHome);
+  lines << QString("  Library list: %1").arg(report.CacheFilePath.isEmpty() ? QString("none") : report.CacheFilePath);
+  lines << QString("  Loaded before the application started: %1 libraries").arg(report.InitiallyLoadedLibraryCount);
+  lines << QString("  Listed for this run: %1 libraries (%2 queued, %3 already loaded, %4 in a system directory)")
+             .arg(report.ListedLibraryCount)
+             .arg(report.QueuedLibraryCount)
+             .arg(report.AlreadyLoadedLibraryCount)
+             .arg(report.SystemLibraryCount);
+  lines << QString("  Prefetched: %1 of %2 libraries (%3 MB, %4 failed) on %5 threads")
+             .arg(report.PrefetchedLibraryCount)
+             .arg(report.QueuedLibraryCount)
+             .arg(static_cast<double>(report.PrefetchedByteCount) / 1e6, 0, 'f', 1)
+             .arg(report.FailedLibraryCount)
+             .arg(report.WorkerCount);
+  // How much of this startup the previous run managed to predict. A low percentage means
+  // the prefetch was working from a stale or unrelated list and cannot have helped,
+  // however quickly it ran.
+  lines << QString("  Needed by this startup: %1 libraries, %2 of them prefetched (%3%)")
+             .arg(report.StartupLibraryCount)
+             .arg(report.PredictedLibraryCount)
+             .arg(report.StartupLibraryCount > 0 ? (100 * report.PredictedLibraryCount / report.StartupLibraryCount) : 0);
+  lines << QString("  Recorded for the next run: %1 libraries").arg(report.RecordedLibraryCount);
+  // Said once here, because the line below is measured from the same origin: the moment
+  // the prefetch started, which is the process entry point.
+  lines << QString("  Measured from the start of the prefetch: workers started at %1, workers finished at %2")
+             .arg(timeString(report.WorkersStartedTimeMs), timeString(report.WorkersFinishedTimeMs));
+  if (report.WorkersFinishedTimeMs < 0.0 && report.WorkerCount > 0)
+  {
+    lines << QString("  Some libraries are still being prefetched in the background.");
+  }
+  // A report taken before finish() has neither, so the duration is only meaningful once
+  // both ends have been stamped.
+  const double recordingDurationMs = (report.FinishStartTimeMs < 0.0 || report.FinishEndTimeMs < 0.0) //
+                                       ? -1.0
+                                       : report.FinishEndTimeMs - report.FinishStartTimeMs;
+  lines << QString("  Startup completed at %1, recording the library list took %2") //
+             .arg(timeString(report.FinishStartTimeMs), timeString(recordingDurationMs));
+  for (const QString& note : report.Notes)
+  {
+    lines << "  " + note;
+  }
+  return lines;
+}

--- a/Base/QTApp/qSlicerStartupFilePrefetcher.h
+++ b/Base/QTApp/qSlicerStartupFilePrefetcher.h
@@ -1,0 +1,248 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __qSlicerStartupFilePrefetcher_h
+#define __qSlicerStartupFilePrefetcher_h
+
+// Qt includes
+#include <QString>
+#include <QStringList>
+
+#include "qSlicerBaseQTAppExport.h"
+
+/// \brief Overlaps the work the operating system does when the application's shared
+/// libraries are first touched.
+///
+/// On Windows, the first time a shared library is mapped after it has been created or
+/// modified (which includes the first launch after an installation, and the first after
+/// a reboot, because the scan verdict cache does not survive one), the anti-malware
+/// filter driver scans the whole file before the mapping completes. The scan is CPU
+/// bound and dwarfs the cost of reading the file.
+///
+/// The operating system loader maps libraries one at a time, on the thread that needs
+/// them, so those scans are serialized even though the scanning service is perfectly
+/// happy to run them in parallel.
+///
+/// This class recovers that parallelism. On a small pool of background threads it reads
+/// each library the application is about to need from beginning to end and throws the
+/// contents away. Nothing is mapped and no module is created, so no imports are
+/// resolved, no relocations applied, no initializer run, and the library does not join
+/// the module list. The only lasting effect is that the operating system has read the
+/// file, and whatever it does on first sight of one -- on Windows, scanning it -- is
+/// done, so the real load no longer waits for it.
+///
+/// Measured over 8 cold startups of an installed Slicer, each on a freshly copied tree
+/// so that every file was new to the scanner, anticipating the 278 libraries (62.7 MB)
+/// that startup goes on to load takes 1.8 seconds of background work and saves about
+/// 12 seconds: startup drops from 25.1 to 12.8 seconds, of which module registration,
+/// instantiation and loading drop from 11.2 to 4.1 seconds. What remains is mostly out
+/// of reach: 229 libraries are mapped by the loader before main() runs, and no list can
+/// anticipate those.
+///
+/// On macOS, measured over 20 copies of an installed Slicer, each launched once before a
+/// reboot so that the checks of a first launch were already paid, and once after it, ten
+/// with the prefetch on and ten with it off: startup drops from 7.30 to 6.92 seconds, and
+/// the two groups do not overlap. All of the saving is after main() -- module
+/// registration is 154 ms shorter, instantiation 119 ms and application initialization
+/// 93 ms -- while the phase before the entry point is 22 ms longer, the background reads
+/// competing for a cache that is already warm for what the loader maps. The first launch
+/// of a freshly copied tree spends about 10 seconds before main() on signature checks,
+/// but that is paid once per file and survives a reboot, so a later run has nothing there
+/// left to recover.
+///
+/// The whole file is read rather than a prefix of it, and reading is used rather than
+/// mapping the file as a data file, because neither alternative measured any better.
+/// Reading the first megabyte of each library touches 46 MB instead of 62.7 MB and costs
+/// the same, because the scanner reads the whole file as soon as it is touched at all.
+/// What is being bought is a scan verdict, not a warm file cache, so how much is asked
+/// for barely matters.
+///
+/// Which libraries to prefetch is not guessed from the directory layout: start() replays
+/// the list recorded by finish() during the previous run. That covers loadable modules,
+/// Python extension modules, Qt plugins and extensions wherever they are installed, and
+/// never touches a library the application does not actually use. The first run after
+/// installation has nothing to replay and is not accelerated.
+///
+/// What the prefetch did is recorded in a Report as it goes, and can be printed once
+/// startup is complete with the --report-startup-timing command-line option.
+///
+/// The mechanism is the same on every platform, but what it recovers is not, so it only
+/// runs by default where it is known to pay:
+/// - Windows: the serialized virus scan described above. Enabled by default.
+/// - macOS: the file cache. The signature and quarantine checks of a first launch are
+///   paid once per file and survive a reboot, so unlike the Windows scan they are not a
+///   recurring cold-start cost and only the cache is left to recover: 0.39 s of a 7.30 s
+///   startup on the installation measured above. Off by default.
+/// - Linux: the file cache only, so it is worth something on a cold cache, a network
+///   file system or a spinning disk, and nothing on a warm one, unless an on-access
+///   scanner is deployed. Off by default for the same reason.
+///
+/// SLICER_STARTUP_FILE_PREFETCH overrides that per run: 1 turns it on, 0 turns it off.
+/// SLICER_STARTUP_FILE_PREFETCH_THREADS sets the size of the pool instead of it being
+/// chosen from the number of cores. The class is left out of the build entirely when
+/// Slicer_BUILD_STARTUP_FILE_PREFETCH is off.
+///
+/// Typical usage, from the application entry point:
+/// \code
+/// int main(int argc, char* argv[])
+/// {
+///   qSlicerStartupFilePrefetcher::start(); // first statement of main()/WinMain()
+///   ...
+///   qSlicerStartupFilePrefetcher::finish(); // once startup is complete
+/// }
+/// \endcode
+class Q_SLICER_BASE_QTAPP_EXPORT qSlicerStartupFilePrefetcher
+{
+public:
+  /// \brief What the prefetch did during this startup.
+  ///
+  /// Filled in as the prefetch progresses and returned by report().
+  /// All times are milliseconds from the moment the prefetch started, which is the process
+  /// entry point, so that they can be compared directly with each other; a time that has
+  /// not been reached is -1. What the loader did before that point is not the prefetch's to
+  /// measure, and the startup timing report gives it as its first phase.
+  ///
+  /// The counts are what makes a report interpretable. Prefetching can be fast and still
+  /// useless (a stale list, so PredictedLibraryCount is low), or slow and yet a large win
+  /// (cold scans, so the loader was spared that time). Neither can be told from a duration
+  /// alone.
+  ///
+  /// This is plain data with no behavior, so that it can be copied and inspected freely;
+  /// reportLines() turns it into readable text.
+  struct Report
+  {
+    /// Whether the prefetch ran at all. False when SLICER_STARTUP_FILE_PREFETCH turned it
+    /// off, when it is off by default on this platform, or when start() was never called.
+    /// Notes says which.
+    bool Enabled = false;
+
+    /// Application the list belongs to, and the directory it was installed or built into,
+    /// as resolved by start() from the running executable.
+    QString ApplicationName;
+    QString ApplicationHome;
+    /// The list start() replayed and finish() rewrites. \sa cacheFilePath()
+    QString CacheFilePath;
+
+    /// Libraries the loader had already mapped when start() ran. They cannot be
+    /// anticipated by any list, so they bound what prefetching can ever cover.
+    int InitiallyLoadedLibraryCount = 0;
+
+    /// Entries read from the recorded list, and how they were dispatched: those already
+    /// mapped and those in the Windows directory are skipped, the rest are queued.
+    int ListedLibraryCount = 0;
+    int AlreadyLoadedLibraryCount = 0;
+    int SystemLibraryCount = 0;
+    int QueuedLibraryCount = 0;
+
+    /// Background threads started to work through the queue, chosen from the number of
+    /// cores unless SLICER_STARTUP_FILE_PREFETCH_THREADS asked for a particular number.
+    int WorkerCount = 0;
+
+    /// What the workers had done by the time the report was taken. The workers outlive
+    /// finish(), so these keep growing after startup is complete.
+    int PrefetchedLibraryCount = 0;
+    /// Entries that could not be opened, usually because the library has been removed or
+    /// renamed since the list was recorded.
+    int FailedLibraryCount = 0;
+    qint64 PrefetchedByteCount = 0;
+
+    /// Libraries loaded between start() and finish(), that is, the ones this startup
+    /// actually needed, and how many of them had been prefetched. The ratio of the two is
+    /// how much of this startup the previous run managed to predict; a low ratio means the
+    /// list was stale or unrelated and the prefetch cannot have helped much.
+    int StartupLibraryCount = 0;
+    int PredictedLibraryCount = 0;
+    /// Entries written back to the list for the next run, 0 if it could not be written.
+    int RecordedLibraryCount = 0;
+
+    /// When the workers were started, which is also what reading the list cost the startup
+    /// thread, the two being separated by nothing else.
+    double WorkersStartedTimeMs = -1.0;
+    /// When the last worker ran out of queued libraries, or -1 if some are still going.
+    double WorkersFinishedTimeMs = -1.0;
+    /// When finish() began and ended. Their distance is what recording the list cost.
+    double FinishStartTimeMs = -1.0;
+    double FinishEndTimeMs = -1.0;
+
+    /// Anything worth saying that is not a number: why the prefetch was skipped, a list
+    /// that could not be read or written, and so on. Empty when everything went as
+    /// expected.
+    QStringList Notes;
+  };
+
+  /// Start reading, on background threads, the shared libraries that the previous run
+  /// of the application loaded after this point. Returns immediately; the work
+  /// continues in the background.
+  ///
+  /// Also records which shared libraries are already loaded, so that finish() can tell
+  /// the ones the loader mapped before the application got a chance to run (which are
+  /// therefore not worth anticipating) from the ones loaded during startup.
+  ///
+  /// Meant to be the first statement of main() or WinMain(): every library mapped
+  /// between here and finish() is one the next run can anticipate, so anything done
+  /// before this call is coverage given away. It takes no argument and depends on
+  /// neither QCoreApplication nor qSlicerCoreApplication, neither of which exists that
+  /// early; the application name and directory are derived from the running executable.
+  static void start();
+
+  /// Record, for the next run, the shared libraries that were loaded since start() was
+  /// called, and release the background threads. Returns immediately: reads that have
+  /// not been issued yet are left to complete on their own, because they still benefit
+  /// the libraries the application loads on demand later on.
+  ///
+  /// Call once startup is complete. Calling it without a preceding start() does nothing.
+  static void finish();
+
+  /// Snapshot of what the prefetch has done so far. Meaningful at any point, but meant to
+  /// be taken after finish(), when everything but the tail of the background work is
+  /// accounted for.
+  static Report report();
+
+  /// report() rendered as one line per fact, ready to be logged. The lines carry no
+  /// timestamp or severity of their own, so that whoever prints them decides that.
+  static QStringList reportLines();
+
+  /// Path of the file that holds the list of shared libraries recorded by finish().
+  ///
+  /// It sits next to the revision-specific settings file, named after it, because that
+  /// is the application's existing answer to where this installation may write:
+  /// the application's own directory when Slicer_STORE_SETTINGS_IN_APPLICATION_HOME_DIR
+  /// is on, and the user profile when it is off, which is the configuration meant for
+  /// installations whose directory is read-only. The path is worked out from the running
+  /// executable rather than asked of
+  /// qSlicerCoreApplication::slicerRevisionUserSettingsFilePath(), which resolves to the
+  /// same place, because start() runs before there is an application to ask.
+  ///
+  /// Keying the name on the revision keeps two installations that share one user profile
+  /// from replaying each other's lists. Wherever the file ends up, the libraries inside
+  /// the application directory are recorded relative to it, following the same convention
+  /// as qSlicerCoreApplication::toSlicerHomeRelativePath(), so the list survives the tree
+  /// being moved or renamed.
+  ///
+  /// Returns an empty string if the application directory cannot be determined.
+  static QString cacheFilePath();
+
+  /// Full paths of the shared libraries currently loaded in this process, in no
+  /// particular order. Returns an empty list on platforms other than Windows.
+  static QStringList loadedLibraryPaths();
+
+private:
+  qSlicerStartupFilePrefetcher() = delete;
+  ~qSlicerStartupFilePrefetcher() = delete;
+};
+
+#endif

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -813,6 +813,57 @@ void qSlicerCoreApplicationPrivate::updateEnvironmentVariable(const QString& key
   }
 }
 
+namespace
+{
+//-----------------------------------------------------------------------------
+/// Directory that holds the application's executables (Slicer_BIN_DIR), given the
+/// directory the running executable is in.
+///
+/// This is the only place that knows how one is reached from the other, so that
+/// qSlicerCoreApplicationPrivate and callers that have no application yet
+/// (qSlicerCoreApplication::applicationHomeDirectoryFromExecutablePath()) cannot disagree
+/// about it.
+///
+/// \param intDir if not null, receives the build configuration subdirectory that was
+/// stripped: empty in an install tree, and the configuration name (such as "Release") in
+/// a build tree of a multi-configuration generator.
+QString binDirectoryFromExecutableDirectory(const QString& executableDirectory, QString* intDir)
+{
+#ifndef Q_OS_MAC
+  QString strippedIntDir;
+  const QString binDirectory = qSlicerUtils::pathWithoutIntDir(executableDirectory, Slicer_BIN_DIR, strippedIntDir);
+  if (intDir)
+  {
+    *intDir = strippedIntDir;
+  }
+  return binDirectory;
+#else
+  // There are two cases to consider, the application could be started from:
+  //   1) Install tree
+  //        Application location: /path/to/Foo.app/Contents/MacOSX/myapp
+  //        Binary directory:     /path/to/Foo.app/Contents/bin
+  //   2) Build tree
+  //        Application location: /path/to/build-dir/bin/Foo.app/Contents/MacOSX/myapp
+  //        Binary directory:     /path/to/build-dir/bin
+  //
+  // A bundle has no build configuration subdirectory to strip, so intDir stays empty.
+  if (intDir)
+  {
+    *intDir = QString();
+  }
+  QDir binAsDir(executableDirectory);
+  binAsDir.cdUp(); // Move from /path/to/Foo.app/Contents/MacOSX to /path/to/Foo.app/Contents
+  if (!binAsDir.cd(Slicer_BIN_DIR))
+  {
+    binAsDir.cdUp(); // Move from /path/to/build-dir/bin/Foo.app/Contents to /path/to/build-dir/bin/Foo.app
+    binAsDir.cdUp(); // Move from /path/to/build-dir/bin/Foo.app          to /path/to/build-dir/bin
+    binAsDir.cd(Slicer_BIN_DIR);
+  }
+  return binAsDir.path();
+#endif
+}
+} // namespace
+
 //-----------------------------------------------------------------------------
 QString qSlicerCoreApplicationPrivate::discoverSlicerBinDirectory()
 {
@@ -825,27 +876,7 @@ QString qSlicerCoreApplicationPrivate::discoverSlicerBinDirectory()
     q->showConsoleMessage(QString("Cannot find Slicer executable %1").arg(q->applicationDirPath()));
     return slicerBin;
   }
-#ifndef Q_OS_MAC
-  slicerBin = qSlicerUtils::pathWithoutIntDir(q->applicationDirPath(), Slicer_BIN_DIR, this->IntDir);
-#else
-  // There are two cases to consider, the application could be started from:
-  //   1) Install tree
-  //        Application location: /path/to/Foo.app/Contents/MacOSX/myapp
-  //        Binary directory:     /path/to/Foo.app/Contents/bin
-  //   2) Build tree
-  //        Application location: /path/to/build-dir/bin/Foo.app/Contents/MacOSX/myapp
-  //        Binary directory:     /path/to/build-dir/bin
-  //
-  QDir slicerBinAsDir(q->applicationDirPath());
-  slicerBinAsDir.cdUp(); // Move from /path/to/Foo.app/Contents/MacOSX to /path/to/Foo.app/Contents
-  if (!slicerBinAsDir.cd(Slicer_BIN_DIR))
-  {
-    slicerBinAsDir.cdUp(); // Move from /path/to/build-dir/bin/Foo.app/Contents to /path/to/build-dir/bin/Foo.app
-    slicerBinAsDir.cdUp(); // Move from /path/to/build-dir/bin/Foo.app          to /path/to/build-dir/bin
-    slicerBinAsDir.cd(Slicer_BIN_DIR);
-  }
-  slicerBin = slicerBinAsDir.path();
-#endif
+  slicerBin = binDirectoryFromExecutableDirectory(q->applicationDirPath(), &this->IntDir);
   Q_ASSERT(qSlicerUtils::pathEndsWith(slicerBin, Slicer_BIN_DIR));
   return slicerBin;
 }
@@ -1684,17 +1715,74 @@ QString qSlicerCoreApplication::slicerUserSettingsFilePath() const
 }
 
 //-----------------------------------------------------------------------------
+QString qSlicerCoreApplication::applicationNameFromExecutablePath(const QString& executablePath)
+{
+  // A custom application is named after its executable, so that differently named
+  // applications keep their settings apart. The launcher runs an executable named after
+  // the application with "App-real" appended (see SlicerMacroBuildApplication), which is
+  // an implementation detail of how the application is started and not part of its name.
+  QString applicationName = QFileInfo(executablePath).completeBaseName();
+  applicationName.remove(QString("App-real"));
+  return applicationName;
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerCoreApplication::applicationHomeDirectoryFromExecutablePath(const QString& executablePath, QString* intDir)
+{
+  if (executablePath.isEmpty())
+  {
+    // Without a starting point, QFileInfo would resolve against the current working
+    // directory and quietly produce an unrelated path.
+    return QString();
+  }
+  QDir homeDirectory(binDirectoryFromExecutableDirectory(QFileInfo(executablePath).absolutePath(), intDir));
+  if (!homeDirectory.cdUp())
+  {
+    return QString();
+  }
+  return homeDirectory.canonicalPath();
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerCoreApplication::revisionUserSettingsDirectory(const QString& slicerHome, const QString& applicationName)
+{
+  // The directory Qt derives the settings location from: the organization name where
+  // there is one and the domain otherwise, the other way round on macOS. This is what
+  // ctkAppLauncherSettings::organizationDir() answers, but it reads QCoreApplication,
+  // which does not exist yet when this is called from the startup file prefetching. The
+  // compile-time values are the ones the application sets those to, so falling back to
+  // them gives the same answer earlier rather than an empty string.
+  QString organizationName = QCoreApplication::organizationName();
+  QString organizationDomain = QCoreApplication::organizationDomain();
+  if (organizationName.isEmpty() && organizationDomain.isEmpty())
+  {
+    organizationName = Slicer_ORGANIZATION_NAME;
+    organizationDomain = Slicer_ORGANIZATION_DOMAIN;
+  }
+#ifdef Q_OS_DARWIN
+  const QString organizationDir = organizationDomain.isEmpty() ? organizationName : organizationDomain;
+#else
+  const QString organizationDir = organizationName.isEmpty() ? organizationDomain : organizationName;
+#endif
+
+#ifdef Slicer_STORE_SETTINGS_IN_APPLICATION_HOME_DIR
+  Q_UNUSED(applicationName);
+  return QDir(slicerHome).filePath(organizationDir);
+#else
+  Q_UNUSED(slicerHome);
+  // Where QSettings itself would put the user settings of this application, asked of Qt
+  // rather than assembled here, and given the organization and application explicitly
+  // because there may be no QCoreApplication yet to take them from.
+  return QFileInfo(QSettings(QSettings::IniFormat, QSettings::UserScope, organizationDir, applicationName).fileName()).absolutePath();
+#endif
+}
+
+//-----------------------------------------------------------------------------
 QString qSlicerCoreApplication::slicerRevisionUserSettingsFilePath() const
 {
-#ifdef Slicer_STORE_SETTINGS_IN_APPLICATION_HOME_DIR
   this->userSettings(); // ensure applicationName is initialized
-  QString filePath = QString("%1/%2").arg(this->slicerHome()).arg(ctkAppLauncherSettings().organizationDir());
-  QString prefix = this->applicationName();
-#else
-  QFileInfo fileInfo = QFileInfo(this->userSettings()->fileName());
-  QString filePath = fileInfo.path();
-  QString prefix = fileInfo.completeBaseName();
-#endif
+  const QString filePath = qSlicerCoreApplication::revisionUserSettingsDirectory(this->slicerHome(), this->applicationName());
+  const QString prefix = this->applicationName();
 
   QString suffix = "-" + this->revision();
   bool useTmp = this->coreCommandOptions()->settingsDisabled();

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -301,6 +301,57 @@ public:
   /// \sa revisionUserSettings()
   QString slicerRevisionUserSettingsFilePath() const;
 
+  /// Name that an application started from the given executable keys its settings on:
+  /// the file name without its extension, and without the "App-real" suffix that the
+  /// executable behind the launcher carries. Empty if \a executablePath is empty.
+  /// Static, so that it can be called before a qSlicerCoreApplication exists.
+  ///
+  /// This is the only place the name is derived from a path:
+  /// qSlicerApplicationHelper::preInitializeApplication() calls it to set the name on
+  /// QCoreApplication, and code running before that call (such as the startup file
+  /// prefetching, which runs at the process entry point) calls it to get the same name.
+  ///
+  /// \param executablePath path of the running executable.
+  ///
+  /// \sa revisionUserSettingsDirectory()
+  static QString applicationNameFromExecutablePath(const QString& executablePath);
+
+  /// Directory that an application started from the given executable was installed or
+  /// built into, which is what slicerHome() returns once there is an application: the
+  /// executable's directory without the build configuration subdirectory, if any, and
+  /// then without the binary subdirectory (Slicer_BIN_DIR). Empty if \a executablePath is
+  /// empty or the directories do not have that shape.
+  /// Static, so that it can be called before a qSlicerCoreApplication exists.
+  ///
+  /// The environment is not consulted, so this is the location of this executable and not
+  /// wherever SLICER_HOME happens to point. A caller that wants the environment to win,
+  /// as the application itself does, has to check it before calling this.
+  ///
+  /// \param executablePath path of the running executable.
+  /// \param intDir if not null, receives the build configuration subdirectory that was
+  /// stripped: empty in an install tree, and the configuration name (such as "Release")
+  /// in a build tree of a multi-configuration generator.
+  ///
+  /// \sa slicerHome()
+  static QString applicationHomeDirectoryFromExecutablePath(const QString& executablePath, QString* intDir = nullptr);
+
+  /// Directory that holds the revision-specific settings file (such as Slicer-12345.ini)
+  /// and any other configuration files, extensions, etc. specific to this revision.
+  /// Static, so that it can be called before a qSlicerCoreApplication exists.
+  ///
+  /// The location depends on the Slicer_STORE_SETTINGS_IN_APPLICATION_HOME_DIR build configuration option:
+  /// - enabled (this is the default, and it makes the installation self-contained): location is
+  ///   a subdirectory of \a slicerHome named after the organization. \a applicationName is unused.
+  /// - disabled (this is needed if the application is installed in a read-only directory): location is
+  ///   the directory in the user profile where QSettings keeps the settings file of \a applicationName.
+  ///   \a slicerHome is unused.
+  ///
+  /// \param slicerHome directory the application was installed or built into.
+  /// \param applicationName name the application gives QSettings.
+  ///
+  /// \sa slicerRevisionUserSettingsFilePath()
+  static QString revisionUserSettingsDirectory(const QString& slicerHome, const QString& applicationName);
+
   /// Get slicer default extensions path
   QString defaultExtensionsInstallPath() const;
 

--- a/CMake/vtkSlicerConfigure.h.in
+++ b/CMake/vtkSlicerConfigure.h.in
@@ -72,6 +72,7 @@
 #cmakedefine Slicer_BUILD_MULTIMEDIA_SUPPORT
 #cmakedefine Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT
 #cmakedefine Slicer_BUILD_WEBENGINE_SUPPORT
+#cmakedefine Slicer_BUILD_STARTUP_FILE_PREFETCH
 #cmakedefine Slicer_USE_SLICERRC
 
 // CLI support is always enabled and cannot be disabled.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,14 @@ mark_as_superbuild(Slicer_BUILD_USAGE_LOGGING_SUPPORT)
 option(Slicer_BUILD_WEBENGINE_SUPPORT "Build Slicer with Qt WebEngine support" ON)
 mark_as_superbuild(Slicer_BUILD_WEBENGINE_SUPPORT)
 
+# Built on all platforms, but only enabled by default on Windows, where the loader
+# serializes the on-access virus scan of every shared library it maps. Elsewhere it can be
+# turned on for a run with the SLICER_STARTUP_FILE_PREFETCH environment variable.
+# See Base/QTApp/qSlicerStartupFilePrefetcher.h.
+option(Slicer_BUILD_STARTUP_FILE_PREFETCH "Build Slicer with startup library prefetching" ON)
+mark_as_advanced(Slicer_BUILD_STARTUP_FILE_PREFETCH)
+mark_as_superbuild(Slicer_BUILD_STARTUP_FILE_PREFETCH)
+
 option(Slicer_BUILD_QTLOADABLEMODULES "Build Slicer Qt Loadable Modules" ON)
 mark_as_advanced(Slicer_BUILD_QTLOADABLEMODULES)
 mark_as_superbuild(Slicer_BUILD_QTLOADABLEMODULES)

--- a/Docs/user_guide/settings.md
+++ b/Docs/user_guide/settings.md
@@ -148,13 +148,16 @@ If the application takes a long time to start up then the `--report-startup-timi
 - how much time was spent before the application's entry point was reached, which is the time the operating system needed to load the application's own libraries,
 - how much time each startup phase took (initializing the application, registering, instantiating and loading modules, initializing the user interface, and showing the main window),
 - the slowest 15 modules, each with the time it took to instantiate and to load it,
-- the total time measured from the creation of the process.
+- the total time measured from the creation of the process,
+- what the startup file prefetcher did, if it is available in the build (see below).
 
 For example:
 
     Slicer.exe --report-startup-timing
 
 The option can be combined with `--exit-after-startup`, which quits the application as soon as the startup is complete, and with `--disable-modules` or `--disable-scripted-loadable-modules`, to see how much of the startup time a group of modules is responsible for.
+
+The application libraries can be read into the file system cache on background threads while the application starts up, so that the work the operating system does when a library is first touched overlaps with the startup instead of delaying it. On Windows that work is on-access virus scanning, which is slow enough that this prefetching is enabled by default there. On Linux and macOS there is no such scanning and only the file cache is gained, which is worth a lot on a cold cache, a network file system or a spinning disk and nothing on a warm one, so prefetching is disabled by default and can be turned on with the `SLICER_STARTUP_FILE_PREFETCH` environment variable described below. Startup timing reports include how many libraries were prefetched and how many of the libraries this startup needed were predicted by the previous run, which tells if the prefetching could help at all.
 
 Testing modules are not loaded unless [developer mode](#developer-mode) is enabled, which also shortens the startup time.
 
@@ -170,6 +173,13 @@ The following environment variables can be set before the application is started
   and `compatibility` (compatibility profile). Default value is `compatibility` on Windows systems.
 - `SLICER_BACKGROUND_THREAD_PRIORITY`: Set priority for background processing tasks. On Linux, it may affect the
   entire process priority. An integer value is expected, default = `20` on Linux and macOS, and `-1` on Windows.
+- `SLICER_STARTUP_FILE_PREFETCH`: If it is set to `1` then the application libraries are read into the file system cache
+  while the application starts up, and if it is set to `0` then they are not. If the variable is left unset (or set to any
+  other value) then prefetching is enabled on Windows, where parallel file prefetching significantly improve startup time, and
+  disabled on Linux and macOS, where only the file cache is gained and whether that helps depends on the computer.
+  It has an effect only in builds configured with `Slicer_BUILD_STARTUP_FILE_PREFETCH` enabled.
+- `SLICER_STARTUP_FILE_PREFETCH_THREADS`: Number of threads used for prefetching the application libraries at startup.
+  A positive integer value is expected, by default the number of CPU cores is used, limited to the range of `2` to `8`.
 - `SLICERRC`: Custom application startup file path. Contains a full path to a Python script. By default it is `~/.slicerrc.py` (where ~ is the user profile a.k.a user home folder).
 - `SLICER_EXTENSIONS_MANAGER_SERVER_URL`: URL of the extensions manager backend with the `/api` path. Default value is retrieved from the settings using the key `Extensions/ServerUrl`.
 - `SLICER_EXTENSIONS_MANAGER_FRONTEND_SERVER_URL`: URL of the extension manager frontend displaying the web page. Default value is retrieved from the settings using the key `Extensions/FrontendServerUrl`.


### PR DESCRIPTION
This pull request implements parallel prefetching of libraries, which makes application startup about 5 seconds faster on Windows.

At application startup, thousands of files are read from disk and some go through heavy processing (e.g., libraries are scanned for malware before being loaded). This is mostly done on a single thread, without saturating disk and CPU resources.

This commit adds a file prefetcher component that reads a list of files from disk in parallel, to make loading of those files later during startup faster.

On Windows the first time a shared library is mapped after it has been created or modified (which includes the first launch after an installation and the first after a reboot), the Microsoft Defender anti-malware filter scans the whole file before the mapping completes. The scan is CPU bound and far outweighs the read. The loader maps libraries one at a time, on the thread that needs them, so the scans are serialized even though the scanning service can run them in parallel. Therefore, on Windows, prefetching all shared library files in parallel makes the cold application startup (i.e., after a reboot) up to about 5-10 seconds faster. Therefore, prefetching is enabled by default on Windows.

The same mechanism on macOS, only results in modest improvement (about 0.4 seconds), because malware and signature scanning only happens once, after installation. The operating system checks all signatures on a single thread, so making this operation parallel does not decrease the startup time. Therefore, prefetching is disabled by default on macOS.

There has been no thorough testing on Linux, but it seems that library loading is supposed to be already fast on Linux, so significant startup speed improvement is only expected in certain environments (e.g., slow network drives). Therefore, prefetching is disabled by default on Linux.

Whole files are read rather than a prefix, and read rather than mapped as data files, because reading just the first 1MB of the files or loading them as libraries did not improved the speed.

List of files to be prefetched is determined by recording the list of loaded libraries at each startup and storing it in a file. Therefore libraries needed by Slicer extensions, Python packages, and Qt plugins are all covered. The list lives beside the revision-specific settings file, which is the application's existing answer to where an installation may write, so an installation in a read-only directory can still refresh it.

What the prefetch did is added to the --report-startup-timing report.

Two environment variables can adjust the behavior. SLICER_STARTUP_FILE_PREFETCH can force enable/disable library prefetch by setting it to 1 or 0. SLICER_STARTUP_FILE_PREFETCH_THREADS can set a maximum number of threads that may prefetch the files.

The file prefetching mechanism can be excluded from the build by setting Slicer_BUILD_STARTUP_FILE_PREFETCH CMake variable to OFF.

see #9203