### PR TITLE
BUG: Overflow when one view in the layout

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.cxx
@@ -2398,7 +2398,7 @@ void vtkMRMLSliceIntersectionInteractionRepresentation::ComputeSliceIntersection
 
   size_t numberOfIntersections = this->Internal->SliceIntersectionInteractionDisplayPipelines.size();
   int numberOfFoundIntersectionPoints = 0;
-  if (!this->Internal->SliceNode)
+  if (!this->Internal->SliceNode || numberOfIntersections == 0)
   {
     return;
   }

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionRepresentation2D.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionRepresentation2D.cxx
@@ -715,7 +715,7 @@ double* vtkMRMLSliceIntersectionRepresentation2D::GetSliceIntersectionPoint()
   this->SliceIntersectionPoint[0] = 0.0;
   this->SliceIntersectionPoint[1] = 0.0;
   this->SliceIntersectionPoint[2] = 0.0;
-  if (!this->Internal->SliceNode)
+  if (!this->Internal->SliceNode || numberOfIntersections == 0)
   {
     return this->SliceIntersectionPoint;
   }


### PR DESCRIPTION
The problem happens on apps with one view and when these functions are called they make a segmentation fault.

This is because when the layout contains only one view, the number of intersecting views is 0, being a size_t, substracting 1 to it makes it overflow to SIZE_MAX.



Fix by early returning in case of numberOfIntersections being 0.