### PR TITLE
BUG: Apply slice intersection thickness to planar contour points in 2D

### DIFF
--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
@@ -859,6 +859,8 @@ void vtkMRMLSegmentationsDisplayableManager2D::vtkInternal::UpdateDisplayNodePip
       pipeline->PolyDataOutlineActor->GetProperty()->SetColor(color);
       pipeline->PolyDataOutlineActor->GetProperty()->SetOpacity(outlineOpacity);
       pipeline->PolyDataOutlineActor->GetProperty()->SetLineWidth(genericDisplayNode->GetSliceIntersectionThickness());
+      // Representation may be point-based (e.g. RT planar contours), so set point size as well from the same setting.
+      pipeline->PolyDataOutlineActor->GetProperty()->SetPointSize(genericDisplayNode->GetSliceIntersectionThickness());
       pipeline->PolyDataOutlineActor->SetPosition(0, 0);
       pipeline->PolyDataFillActor->SetVisibility(segmentFillVisible);
       pipeline->PolyDataFillActor->GetProperty()->SetColor(color[0], color[1], color[2]);


### PR DESCRIPTION
Planar contour segment representations have VERTEX cells using PointSize, not LineWidth, so the "Slice intersection thickness" setting (which only set LineWidth) had no visible effect for this representation, unlike closed surface or ribbon.

<img width="1715" height="1091" alt="image" src="https://github.com/user-attachments/assets/aa7e22e1-ccaa-47e1-b4f2-02852e82a338" />
