### PR TITLE
BUG: Run SlicerOptionDisableSettingsTest serially to fix flaky failures

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -154,6 +154,15 @@ add_test(
     ${CMAKE_CURRENT_SOURCE_DIR}/SlicerOptionDisableSettingsTest.py
     ${Slicer_LAUNCHER_EXECUTABLE}
   )
+# This test launches several Slicer processes with '--disable-settings' and relies
+# on '--keep-temporary-settings' preserving values across those runs. The temporary
+# settings files have process-global names (e.g. "Slicer-tmp.ini"), so another test
+# starting Slicer with '--disable-settings' in parallel clears them at startup and
+# intermittently wipes the value between this test's write and read. Run it serially
+# so no other test can touch the shared temporary settings while it is running.
+set_tests_properties(py_nomainwindow_SlicerOptionDisableSettingsTest PROPERTIES
+  RUN_SERIAL TRUE
+  )
 
 add_test(
   NAME py_nomainwindow_SlicerOptionIgnoreSlicerRCTest


### PR DESCRIPTION
## Problem

`py_nomainwindow_SlicerOptionDisableSettingsTest` has been failing intermittently on the preview dashboards. It launches several Slicer processes with `--disable-settings` and relies on `--keep-temporary-settings` preserving a value written by one run and read back by the next.

The temporary settings files use **process-global names** (`userSettings` -> `Slicer-tmp.ini`, `revisionUserSettings` -> `Slicer-tmp-<REV>-tmp.ini`), and any Slicer startup with `--disable-settings` (without `--keep-temporary-settings`) clears them. Under `ctest -j`, another test starting Slicer that way in parallel clears the shared file **between this test's write and read**, so the subsequent `--keep-temporary-settings` check intermittently reads an empty value.

That is why the failure is intermittent and lands on either settings object depending on timing:

- 2026-08-07 (Linux, Windows), `checkRevisionUserSettings(keep_temporary_settings=True)`:
  - https://slicer.cdash.org/tests/33903444
  - https://slicer.cdash.org/tests/33904833
- 2026-08-03 (Linux), `checkUserSettings(keep_temporary_settings=True)` (i.e. not revision-specific):
  - https://slicer.cdash.org/tests/33857715
- 2026-07-21, 2026-07-22 (Linux), and recurring on macOS for months.

## Fix

The sibling tests in this file that launch Slicer are created via `slicer_add_python_test` / `slicer_add_python_unittest`, which already set `RUN_SERIAL TRUE` ([CMake/SlicerMacroPythonTesting.cmake](https://github.com/Slicer/Slicer/blob/main/CMake/SlicerMacroPythonTesting.cmake)). This test uses a raw `add_test()` and so was missing that property. Setting `RUN_SERIAL TRUE` on it brings it in line so no other test can touch the shared temporary settings while it runs.

## Verification

Reproduced and verified locally: with two concurrent `--disable-settings` Slicer startups clobbering the shared file, the write / read-back sequence failed **6/6**; run in isolation (as `RUN_SERIAL` guarantees) it passes (3/3 via `ctest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)