### PR TITLE
BUG: Restore macOS packaged OpenSSL lookup

### DIFF
--- a/CMake/SlicerBlockCTKAppLauncherSettings.cmake
+++ b/CMake/SlicerBlockCTKAppLauncherSettings.cmake
@@ -239,6 +239,14 @@ set(SLICER_LIBRARY_PATHS_INSTALLED
   <APPLAUNCHER_SETTINGS_DIR>/../${Slicer_QTLOADABLEMODULES_LIB_DIR}
   )
 
+if(APPLE)
+  # SlicerBundleCloseDeps.py embeds external dylibs in Contents/lib. Add that
+  # directory for libraries loaded dynamically at runtime, such as OpenSSL.
+  list(APPEND SLICER_LIBRARY_PATHS_INSTALLED
+    <APPLAUNCHER_SETTINGS_DIR>/../lib
+    )
+endif()
+
 # The following lines allow Slicer to load a CLI module extension that depends
 # on libraries (i.e a logic class) provided by a loadable module extension.
 list(APPEND SLICER_LIBRARY_PATHS_INSTALLED ../${Slicer_QTLOADABLEMODULES_LIB_DIR})

--- a/CMake/Testing/CMakeLists.txt
+++ b/CMake/Testing/CMakeLists.txt
@@ -22,6 +22,10 @@ add_cmakescript_test(
   slicer_setting_variable_message_test
   CMake/UseSlicerMacros.cmake)
 
+add_cmakescript_test(
+  slicer_block_ctk_app_launcher_settings_test
+  CMake/Testing/SlicerBlockCTKAppLauncherSettingsTest.cmake)
+
 if(UNIX)
   add_test(
     NAME cmake_slicer_extension_cpack_bundle_fixup_path_test

--- a/CMake/Testing/SlicerBlockCTKAppLauncherSettingsTest.cmake
+++ b/CMake/Testing/SlicerBlockCTKAppLauncherSettingsTest.cmake
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.28.0...3.28.0 FATAL_ERROR)
+
+# Exercise the macOS launcher settings on every host platform.
+set(APPLE TRUE)
+set(Slicer_USE_SYSTEM_QT TRUE)
+set(Slicer_USE_PYTHONQT FALSE)
+set(Slicer_BIN_DIR bin)
+set(Slicer_LIB_DIR lib/Slicer-test)
+set(Slicer_CLIMODULES_LIB_DIR lib/Slicer-test/cli-modules)
+set(Slicer_QTLOADABLEMODULES_LIB_DIR lib/Slicer-test/qt-loadable-modules)
+
+include("${CMAKE_CURRENT_LIST_DIR}/../SlicerBlockCTKAppLauncherSettings.cmake")
+
+set(root_library_path "<APPLAUNCHER_SETTINGS_DIR>/../lib")
+if(NOT root_library_path IN_LIST SLICER_LIBRARY_PATHS_INSTALLED)
+  message(FATAL_ERROR "macOS installed library paths do not contain ${root_library_path}")
+endif()
+
+message("SUCCESS")


### PR DESCRIPTION
Fixes #9339 

Adds the Contents/lib directory to the installed macOS library paths


NOTE: While this makes sense to me, I did not test it myself. I am not set up properly to develop on macOS. @pieper if it's easier for you to fix this issue yourself please feel free to close this PR and open your own. Otherwise would appreciate help testing that this fixes the issue