### PR TITLE
BUG: Keep the install-tree lib layout in the macOS bundle for extensions

### DIFF
--- a/CMake/SlicerCPackBundleFixup.cmake.in
+++ b/CMake/SlicerCPackBundleFixup.cmake.in
@@ -137,7 +137,7 @@ endforeach()
 message(STATUS "Closing macOS bundle dependencies")
 execute_process(
   COMMAND python3 "@CMAKE_SOURCE_DIR@/Utilities/Scripts/SlicerBundleCloseDeps.py"
-          --app "${app_dir}" ${search_path_args}
+          --app "${app_dir}" --lib-subdir "@Slicer_LIB_DIR@" ${search_path_args}
   RESULT_VARIABLE _closedeps_result
   )
 if(NOT _closedeps_result EQUAL 0)

--- a/Utilities/Scripts/SlicerBundleCloseDeps.py
+++ b/Utilities/Scripts/SlicerBundleCloseDeps.py
@@ -15,9 +15,12 @@ locations under ``/usr/lib`` and ``/System`` -- is either:
 
   - redirected to a library of the same name already embedded in the bundle
     (avoiding a duplicate copy), or
-  - copied into the bundle (a plain dylib into ``Contents/lib``; a framework,
-    whole, into ``Contents/Frameworks``) and the reference rewritten to
-    ``@rpath/...``.
+  - copied into the bundle (an ordinary dylib into the versioned Slicer lib
+    directory given by ``--lib-subdir``, the Python runtime into
+    ``Contents/lib/Python/lib``, a framework whole into ``Contents/Frameworks``)
+    and the reference rewritten to ``@rpath/...``. The embedded location matches
+    the standard install-tree layout so an embedded library keeps the install
+    name compiled extensions were built against.
 
 The walk follows copied libraries' own dependencies, and every Mach-O *inside* a
 copied framework (for example ``QtWebEngineCore.framework``'s bundled
@@ -191,11 +194,16 @@ def resolve(ref, binary_dir, rpaths, search_dirs, exe_dir):
     return None
 
 
-def close_deps(app, search_dirs):
+def close_deps(app, search_dirs, lib_subdir):
     contents = os.path.join(app, "Contents")
     exe_dir = os.path.join(contents, "MacOS")
     frameworks_dir = os.path.join(contents, "Frameworks")
-    lib_dir = os.path.join(contents, "lib")
+    # Embedded ordinary dylibs go in the versioned Slicer lib dir (lib_subdir,
+    # e.g. lib/Slicer-5.13); the Python runtime keeps its own lib/Python/lib
+    # location. This mirrors the historical BundleUtilities layout that compiled
+    # extensions are built against -- see embed() for why the location matters.
+    lib_dir = os.path.join(contents, lib_subdir)
+    python_lib_dir = os.path.join(contents, "lib", "Python", "lib")
     contents_real = os.path.realpath(contents)
 
     def inside_bundle(path):
@@ -242,8 +250,21 @@ def close_deps(app, search_dirs):
                         worklist.append(macho)
             target = os.path.join(dest_fw, os.sep.join(inner.split(os.sep)[1:]))
         else:
-            os.makedirs(lib_dir, exist_ok=True)
-            target = os.path.join(lib_dir, os.path.basename(source))
+            base = os.path.basename(source)
+            # The embedded location determines the @rpath install name set for
+            # this library below (@rpath/<path relative to Contents>), and dyld
+            # binds an extension's dependency to an already-loaded core library
+            # only when that install name matches exactly. Compiled extensions
+            # are built against the standard install tree, where libraries live
+            # in the versioned lib dir (and the Python runtime in lib/Python/lib),
+            # so embedded libraries must land there too -- flattening them into a
+            # bare lib/ renames them and breaks every compiled extension.
+            if base.startswith("libpython") and base.endswith(".dylib"):
+                dest_dir = python_lib_dir
+            else:
+                dest_dir = lib_dir
+            os.makedirs(dest_dir, exist_ok=True)
+            target = os.path.join(dest_dir, base)
             if not os.path.exists(target):
                 shutil.copy2(source, target)
                 os.chmod(target, 0o755)
@@ -371,12 +392,17 @@ def main(argv):
                         help="Directory to resolve @rpath dependencies against "
                              "(repeatable). The referring binary's own run-paths "
                              "are always searched first.")
+    parser.add_argument("--lib-subdir", default="lib", metavar="DIR",
+                        help="Contents-relative directory for embedded ordinary "
+                             "dylibs, i.e. the versioned Slicer lib dir such as "
+                             "lib/Slicer-5.13. Must match the install-tree layout "
+                             "compiled extensions are built against.")
     options = parser.parse_args(argv)
     if not os.path.isdir(options.app):
         print("SlicerBundleCloseDeps: no such bundle: %s" % options.app, file=sys.stderr)
         return 1
     search_dirs = [d for d in options.search_path if d and os.path.isdir(d)]
-    if not close_deps(options.app, search_dirs):
+    if not close_deps(options.app, search_dirs, options.lib_subdir):
         return 1
     fix_executable_rpaths(options.app)
     strip_external_rpaths(options.app)

--- a/Utilities/Scripts/SlicerBundleCloseDeps.py
+++ b/Utilities/Scripts/SlicerBundleCloseDeps.py
@@ -281,12 +281,23 @@ def close_deps(app, search_dirs, lib_subdir):
         loads, rpaths, install_id = scan(current)
         binary_dir = os.path.dirname(current)
 
-        # An install id that still points outside the bundle (an absolute
-        # build/Homebrew path, or a copied library keeping its original id)
-        # would leak that path; reset it to @rpath relative to Contents.
-        if install_id and install_id.startswith("/") and not is_system(install_id) \
-                and not inside_bundle(install_id):
-            id_resets[current] = "@rpath/" + os.path.relpath(current, contents)
+        # A library's install id must name where it now lives in the bundle, as
+        # @rpath relative to Contents. Two reasons: an id left pointing outside
+        # the bundle (an absolute build/Homebrew path) would leak that path, and
+        # an id that no longer matches the library's location (for example a bare
+        # "libopenjp2.7.dylib" after the library is relocated into the versioned
+        # lib dir) does not match the install name dependents reference it by,
+        # so dyld can load a second, separate copy instead of coalescing onto the
+        # already-loaded one. Reset the id whenever it differs from the location.
+        # Frameworks keep their own @rpath/<Name>.framework/... convention and are
+        # only corrected when the id leaked an absolute path.
+        if install_id is not None and not is_system(install_id):
+            desired_id = "@rpath/" + os.path.relpath(current, contents)
+            if framework_relative(current) is None:
+                if install_id != desired_id:
+                    id_resets[current] = desired_id
+            elif install_id.startswith("/") and not inside_bundle(install_id):
+                id_resets[current] = desired_id
 
         for ref in loads:
             if is_system(ref):


### PR DESCRIPTION
Fixes #9347

## Problem

The macOS bundle closer introduced in c3467ecd3f (`SlicerBundleCloseDeps.py`) embedded every external dylib **flat into `Contents/lib`** and derived each install name from that flat location (`@rpath/lib/<name>`). The core application worked because all of its own binaries were rewritten to the flat names consistently — but **compiled C++ extensions could not load**:

```
Cannot load library .../Extensions-34898/SlicerVMTK/lib/Slicer-5.13/qt-loadable-modules/libqSlicerBranchClipperModule.dylib:
  Library not loaded: @rpath/lib/Slicer-5.13/libitkAdaptiveDenoising-5.4.1.dylib
```

Extensions are built by the factory against the standard install tree, where core libraries live in the versioned lib dir and are referenced as `@rpath/lib/Slicer-<ver>/<name>` (and the Python runtime as `@rpath/lib/Python/lib/libpython…`). dyld binds an extension's dependency to the already-loaded core library only when the install name matches exactly, so flattening renamed those libraries and broke every compiled extension (SlicerVMTK, ExtraMarkups, …).

## Fix

Restore the historical BundleUtilities layout the extension ABI depends on:

- ordinary dylibs → the versioned Slicer lib dir (passed from CMake as `--lib-subdir "@Slicer_LIB_DIR@"`, e.g. `lib/Slicer-5.13`)
- the Python runtime → `lib/Python/lib`
- frameworks → `Frameworks` (unchanged)

The `@rpath` install name is derived from the embedded location, so fixing the location restores the names. This also returns OpenSSL to `lib/Slicer-<ver>`, which is already on the runtime library path, so it **independently resolves the TLS lookup from #9339** (the `Contents/lib` search-path entry added in #9340 becomes unnecessary, though harmless).

## Verification

Packaged Slicer with the fix and confirmed in the resulting `.dmg`:

- `libitkAdaptiveDenoising-5.4.1.dylib` → `lib/Slicer-5.13/`, id `@rpath/lib/Slicer-5.13/libitkAdaptiveDenoising-5.4.1.dylib`
- `libpython3.12.dylib` → `lib/Python/lib/`, id `@rpath/lib/Python/lib/libpython3.12.dylib`
- `libssl.1.1.dylib` → `lib/Slicer-5.13/`
- bare `Contents/lib/*.dylib` = 0 (was 250); `lib/Slicer-5.13/*.dylib` = 288

Then built **SlicerVMTK** and **ExtraMarkups** factory-style (`Slicer_DIR` → this build, `ExtraMarkups_DIR` → the ExtraMarkups build) against the package, installed both, and loaded every one of their **18 compiled modules with 0 dependency errors** (`dlopen` in-process), plus a clean interactive launch in a vanilla arm64 VM with both extensions installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)