### PR TITLE
ENH: Add ShowInAllViewsByDefault option in vtkMRMLDisplayNode

### DIFF
--- a/Libs/MRML/Core/vtkMRMLCoreTestingUtilities.cxx
+++ b/Libs/MRML/Core/vtkMRMLCoreTestingUtilities.cxx
@@ -355,18 +355,30 @@ int ExerciseBasicDisplayMRMLMethods(vtkMRMLDisplayNode* node)
   const char* yellow = "vtkMRMLSliceNodeYellow";
   const char* threeD = "vtkMRMLViewNode1";
   CHECK_INT(node->GetNumberOfViewNodeIDs(), 0);
+
+  CHECK_BOOL(node->GetVisibleInAllViews(), true);
   CHECK_BOOL(node->IsDisplayableInView(red), true);
   CHECK_BOOL(node->IsDisplayableInView(green), true);
   CHECK_BOOL(node->IsDisplayableInView(yellow), true);
   CHECK_BOOL(node->IsDisplayableInView(threeD), true);
 
+  node->ShowInAllViewsByDefaultOff();
+  CHECK_BOOL(node->GetVisibleInAllViews(), false);
+  CHECK_BOOL(node->IsDisplayableInView(red), false);
+  CHECK_BOOL(node->IsDisplayableInView(green), false);
+  CHECK_BOOL(node->IsDisplayableInView(yellow), false);
+  CHECK_BOOL(node->IsDisplayableInView(threeD), false);
+
+  node->ShowInAllViewsByDefaultOn();
   node->AddViewNodeID(green);
+  CHECK_BOOL(node->GetVisibleInAllViews(), false);
   CHECK_BOOL(node->IsDisplayableInView(red), false);
   CHECK_BOOL(node->IsDisplayableInView(green), true);
   CHECK_BOOL(node->IsDisplayableInView(yellow), false);
   CHECK_BOOL(node->IsDisplayableInView(threeD), false);
 
   node->SetDisplayableOnlyInView(red);
+  CHECK_BOOL(node->GetVisibleInAllViews(), false);
   CHECK_BOOL(node->IsDisplayableInView(red), true);
   CHECK_BOOL(node->IsDisplayableInView(green), false);
   CHECK_BOOL(node->IsDisplayableInView(yellow), false);

--- a/Libs/MRML/Core/vtkMRMLDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDisplayNode.cxx
@@ -85,6 +85,7 @@ vtkMRMLDisplayNode::vtkMRMLDisplayNode()
   this->ScalarRangeFlag = vtkMRMLDisplayNode::UseDataScalarRange;
   this->FolderDisplayOverrideAllowed = true;
   this->ShowMode = vtkMRMLDisplayNode::ShowDefault;
+  this->ShowInAllViewsByDefault = true;
 
   // Arrays
   this->ScalarRange[0] = 0;
@@ -172,6 +173,7 @@ void vtkMRMLDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLStringMacro(activeScalarName, ActiveScalarName);
   vtkMRMLWriteXMLStringMacro(activeAttributeLocation, ActiveAttributeLocationAsString);
   vtkMRMLWriteXMLStdStringVectorMacro(viewNodeRef, ViewNodeIDs, std::vector);
+  vtkMRMLWriteXMLBooleanMacro(showInAllViewsByDefault, ShowInAllViewsByDefault);
   vtkMRMLWriteXMLBooleanMacro(folderDisplayOverrideAllowed, FolderDisplayOverrideAllowed);
   if (this->GetShowMode() != vtkMRMLDisplayNode::ShowDefault)
   {
@@ -256,6 +258,7 @@ void vtkMRMLDisplayNode::ReadXMLAttributes(const char** atts)
       this->AddViewNodeID(nodeId.c_str());
     }
   }
+  vtkMRMLReadXMLBooleanMacro(showInAllViewsByDefault, ShowInAllViewsByDefault);
   vtkMRMLReadXMLEndMacro();
 }
 
@@ -307,6 +310,7 @@ void vtkMRMLDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*=true*/
   this->SetActiveScalarName(node->ActiveScalarName);
   this->SetFolderDisplayOverrideAllowed(node->FolderDisplayOverrideAllowed);
   this->SetShowMode(node->ShowMode);
+  this->SetShowInAllViewsByDefault(node->ShowInAllViewsByDefault);
 }
 
 //----------------------------------------------------------------------------
@@ -354,6 +358,7 @@ void vtkMRMLDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintStdStringVectorMacro(ViewNodeIDs, std::vector);
   vtkMRMLPrintBooleanMacro(FolderDisplayOverrideAllowed);
   vtkMRMLPrintEnumMacro(ShowMode);
+  vtkMRMLPrintBooleanMacro(ShowInAllViewsByDefault);
   vtkMRMLPrintEndMacro();
 }
 
@@ -660,7 +665,7 @@ bool vtkMRMLDisplayNode::IsViewNodeIDPresent(const char* viewNodeID) const
 //-------------------------------------------------------
 bool vtkMRMLDisplayNode::IsDisplayableInView(const char* viewNodeID) const
 {
-  return this->GetNumberOfViewNodeIDs() == 0 || this->IsViewNodeIDPresent(viewNodeID);
+  return this->GetVisibleInAllViews() ? true : this->IsViewNodeIDPresent(viewNodeID);
 }
 
 //-------------------------------------------------------
@@ -708,6 +713,12 @@ void vtkMRMLDisplayNode::SetViewNodeIDs(const std::vector<std::string>& viewNode
   {
     this->Modified();
   }
+}
+
+//-------------------------------------------------------
+bool vtkMRMLDisplayNode::GetVisibleInAllViews() const
+{
+  return this->ViewNodeIDs.empty() ? this->ShowInAllViewsByDefault : false;
 }
 
 //-------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLDisplayNode.h
@@ -612,6 +612,30 @@ public:
   /// \sa GetViewNodeIDs(), AddViewNodeID()
   void SetViewNodeIDs(const std::vector<std::string>& viewNodeIDs);
 
+  /// When ViewNodeIDs list is empty then this flag specifies if the
+  /// displayable node shall appear in all the views
+  /// (when ShowInAllViewsByDefault is set to true, which is the default)
+  /// or in none of them (when ShowInAllViewsByDefault is set to false).
+  /// \sa ShowInAllViewsByDefault, GetShowInAllViewsByDefault(),
+  /// ShowInAllViewsByDefaultOn(), ShowInAllViewsByDefaultOff()
+  vtkSetMacro(ShowInAllViewsByDefault, bool);
+  /// Get show in all views by default.
+  /// \sa ShowInAllViewsByDefault, SetShowInAllViewsByDefault(),
+  /// ShowInAllViewsByDefaultOn(), ShowInAllViewsByDefaultOff()
+  vtkGetMacro(ShowInAllViewsByDefault, bool);
+  /// Set show in all views by default.
+  /// \sa ShowInAllViewsByDefault, SetShowInAllViewsByDefault(),
+  /// GetShowInAllViewsByDefault(),
+  vtkBooleanMacro(ShowInAllViewsByDefault, bool);
+
+  /// Return true if the display node is visible in all views.
+  /// This is true when the ViewNodeIDs list is empty and
+  /// ShowInAllViewsByDefault is true. This convenience method does not
+  /// evaluate per-view visibility overrides or subject hierarchy folder
+  /// visibility settings.
+  /// \sa ViewNodeIDs, ShowInAllViewsByDefault, IsDisplayableInView()
+  bool GetVisibleInAllViews() const;
+
   /// Converts attribute location (point or cell data) to string
   static const char* GetAttributeLocationAsString(int id);
   /// Gets attribute location (point or cell data) from string
@@ -860,8 +884,7 @@ protected:
   double SelectedColor[3];
 
   /// List of view node ID's for which the display node should be visible into.
-  /// If the list is empty, it means the display node should be visible in all
-  /// the view nodes.
+
   /// The displayable managers are responsible for reading this property.
   /// Visible in all views (empty) by default.
   /// \sa AddViewNodeID(), RemoveViewNodeID(), RemoveAllViewNodeIDs(),
@@ -869,6 +892,13 @@ protected:
   /// IsDisplayableInView(),
   /// vtkMRMLAbstractDisplayableManager
   std::vector<std::string> ViewNodeIDs;
+
+  /// A flag that changes the interpretation of ViewNodeIDs.
+  /// If true (default), an empty ViewNodeIDs list means the display node
+  /// is visible in all views.
+  /// If false, an empty ViewNodeIDs list means the display node is not
+  /// visible in any view.
+  bool ShowInAllViewsByDefault;
 
   /// A flag to determine which scalar range will be used when mapping
   /// scalars to colors.

--- a/Libs/MRML/Widgets/qMRMLDisplayNodeViewComboBox.cxx
+++ b/Libs/MRML/Widgets/qMRMLDisplayNodeViewComboBox.cxx
@@ -168,7 +168,11 @@ void qMRMLDisplayNodeViewComboBox::updateMRMLFromWidget()
   }
   int wasModifying = d->MRMLDisplayNode->StartModify();
 
-  if (this->allChecked() || this->noneChecked())
+  if (this->allChecked() && d->MRMLDisplayNode->GetShowInAllViewsByDefault())
+  {
+    d->MRMLDisplayNode->RemoveAllViewNodeIDs();
+  }
+  else if (this->noneChecked())
   {
     d->MRMLDisplayNode->RemoveAllViewNodeIDs();
   }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyVisibilityPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyVisibilityPlugin.cxx
@@ -174,7 +174,7 @@ void qSlicerSubjectHierarchyVisibilityPlugin::showVisibilityContextMenuActionsFo
     visible2DVisible = true;
     visible3D = visible3D && (displayNode->GetVisibility3D() > 0);
     visible3DVisible = true;
-    visibleInAllViews = visibleInAllViews && (displayNode->GetViewNodeIDs().empty());
+    visibleInAllViews = visibleInAllViews && (displayNode->GetVisibleInAllViews());
   }
 
   bool wasBlocked = d->ToggleVisibility2DAction->blockSignals(true);


### PR DESCRIPTION
This PR adds a `ShowInAllViewsByDefault` variable to `vtkMRMLDisplayNode` to clarify and control the behavior of `ViewNodeIDs`.

By default (`ShowInAllViewsByDefault = true`), an empty `ViewNodeIDs` list means that the display node is visible in **all view nodes**, preserving the existing behavior.

When `ShowInAllViewsByDefault = false`, an empty `ViewNodeIDs` list means that the display node is **not visible in any view node**.

This is useful when we need to keep track of the views in which a display node is actually shown, without relying on a combination of `ViewNodeIDs` and the visibility parameter. Currently, both "visible in all views" and "visible in no views" can result in an empty `ViewNodeIDs` list, making these two states ambiguous.

NOTE: in default `ViewNodeIDs` is an empty vector.

@lassoan 

