### PR TITLE
COMP: Reduce actions and pre-commit update frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"
+    cooldown:
+      default-days: 14
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     commit-message:
       # Prefix all commit messages with "COMP: "
       prefix: "COMP"

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,9 +1,9 @@
 name: Pre-commit auto-update
 
 on:
-  # every day at midnight
+  # on the first day of every month at midnight UTC
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 1 * *"
   # on demand
   workflow_dispatch:
 


### PR DESCRIPTION
From [last week's discussion](https://discourse.slicer.org/t/2026-08-04-weekly-meeting/47761/7#p-135254-dependabot-6).

Reduces the updates to monthly and also groups the actions updates together into one PR