### PR TITLE
ENH: Optimize interaction handle rendering with vtkGlyph3DMapper

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.cxx
@@ -373,10 +373,15 @@ void vtkMRMLAbstractWidget::SetRenderer(vtkRenderer* renderer)
 
   this->Renderer = renderer;
 
-  if (this->WidgetRep != nullptr && this->Renderer != nullptr)
+  if (this->WidgetRep != nullptr)
   {
+    // Always forward the renderer to the representation so that it can update its internal state
+    // (e.g. unregister from a shared handle renderer when the renderer is set to nullptr).
     this->WidgetRep->SetRenderer(this->Renderer);
-    this->Renderer->AddViewProp(this->WidgetRep);
+    if (this->Renderer != nullptr)
+    {
+      this->Renderer->AddViewProp(this->WidgetRep);
+    }
   }
 }
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.cxx
@@ -19,33 +19,22 @@
 ==============================================================================*/
 
 // VTK includes
-#include <vtkAppendPolyData.h>
+#include <vtkCallbackCommand.h>
 #include <vtkCamera.h>
-#include <vtkCellData.h>
 #include <vtkDoubleArray.h>
 #include <vtkEllipseArcSource.h>
 #include <vtkFloatArray.h>
 #include <vtkFocalPlanePointPlacer.h>
-#include <vtkGlyph3D.h>
 #include <vtkLine.h>
-#include <vtkLineSource.h>
-#include <vtkLookupTable.h>
+#include <vtkMath.h>
 #include <vtkMRMLSliceNode.h>
 #include <vtkMRMLViewNode.h>
 #include <vtkPlane.h>
 #include <vtkPointData.h>
-#include <vtkPointSetToLabelHierarchy.h>
+#include <vtkPoints.h>
 #include <vtkRenderer.h>
 #include <vtkRenderWindow.h>
-#include <vtkSphereSource.h>
-#include <vtkStringArray.h>
-#include <vtkTextActor.h>
-#include <vtkTextProperty.h>
-#include <vtkTensorGlyph.h>
 #include <vtkTransform.h>
-#include <vtkTransformPolyDataFilter.h>
-#include <vtkTriangleFilter.h>
-#include <vtkTubeFilter.h>
 
 // MRML includes
 #include <vtkMRMLAbstractThreeDViewDisplayableManager.h>
@@ -54,6 +43,153 @@
 #include <vtkMRMLTransformNode.h>
 
 #include <vtkMRMLInteractionWidgetRepresentation.h>
+
+#include <algorithm>
+#include <map>
+#include <memory>
+
+//----------------------------------------------------------------------
+// Shared handle renderer: one per vtkRenderer, collects all interaction
+// handle instances from all representations and renders them with a single
+// shared actor (one instanced draw per glyph source instead of one actor per
+// handle). Only used for 3D views; slice views keep per-representation
+// rendering because each representation has a unique WorldToSliceTransform
+// Z-offset.
+//----------------------------------------------------------------------
+struct SharedHandleRenderer
+{
+  vtkSmartPointer<vtkPolyData> InstancePolyData;
+  vtkSmartPointer<vtkFloatArray> GlyphOrientationArray;
+  vtkSmartPointer<vtkFloatArray> GlyphScaleArray;
+  vtkSmartPointer<vtkIntArray> GlyphSourceIndexArray;
+  vtkSmartPointer<vtkUnsignedCharArray> ColorArray;
+
+  vtkSmartPointer<vtkGlyph3DMapper> Mapper;
+  vtkSmartPointer<vtkProperty> Property;
+  vtkSmartPointer<vtkActor> Actor;
+
+  /// Registered representations. Uses weak pointers so that a representation
+  /// can be destroyed without first unregistering (although normal teardown
+  /// does unregister explicitly). Null entries are pruned during iteration.
+  std::vector<vtkWeakPointer<vtkMRMLInteractionWidgetRepresentation>> Representations;
+
+  /// The shared actor is rendered by a single representation, but every representation is a prop of
+  /// the renderer and is therefore asked to render itself. The first representation that is asked in
+  /// a frame claims the shared actor and renders it on behalf of all of the others, which render
+  /// nothing. Reset at the beginning of each frame.
+  /// A per-frame "already rendered" flag cannot be used instead, because a render pass may render
+  /// the same pass several times in a single frame (depth peeling renders the translucent geometry
+  /// once to initialize the depth buffers and then once per peel), and the shared actor has to be
+  /// rendered in each of those invocations.
+  vtkWeakPointer<vtkMRMLInteractionWidgetRepresentation> RenderingRepresentation;
+  bool GlyphSourcesInitialized{ false };
+
+  vtkWeakPointer<vtkRenderer> Renderer;
+  unsigned long StartEventTag{ 0 };
+  unsigned long DeleteEventTag{ 0 };
+
+  ~SharedHandleRenderer()
+  {
+    vtkRenderer* renderer = this->Renderer;
+    if (renderer)
+    {
+      if (this->StartEventTag)
+      {
+        renderer->RemoveObserver(this->StartEventTag);
+      }
+      if (this->DeleteEventTag)
+      {
+        renderer->RemoveObserver(this->DeleteEventTag);
+      }
+      if (this->Actor)
+      {
+        vtkRenderWindow* renderWindow = renderer->GetRenderWindow();
+        if (renderWindow)
+        {
+          this->Actor->ReleaseGraphicsResources(renderWindow);
+        }
+      }
+    }
+  }
+};
+
+// Static member definition
+std::map<vtkRenderer*, std::unique_ptr<SharedHandleRenderer>> vtkMRMLInteractionWidgetRepresentation::SharedHandleRenderers;
+
+//----------------------------------------------------------------------
+/// Create and wire up the instanced handle rendering pipeline: one point per handle instance in
+/// instancePolyData, with per-instance orientation, scale, glyph source index and color.
+/// The glyph sources themselves are not set here, they are assigned by the caller.
+void vtkMRMLInteractionWidgetRepresentation::ConfigureHandleInstancePipeline(vtkSmartPointer<vtkPolyData>& instancePolyData,
+                                                                             vtkSmartPointer<vtkFloatArray>& orientationArray,
+                                                                             vtkSmartPointer<vtkFloatArray>& scaleArray,
+                                                                             vtkSmartPointer<vtkIntArray>& sourceIndexArray,
+                                                                             vtkSmartPointer<vtkUnsignedCharArray>& colorArray,
+                                                                             vtkSmartPointer<vtkGlyph3DMapper>& mapper,
+                                                                             vtkSmartPointer<vtkProperty>& property,
+                                                                             vtkSmartPointer<vtkActor>& actor)
+{
+  instancePolyData = vtkSmartPointer<vtkPolyData>::New();
+  instancePolyData->SetPoints(vtkSmartPointer<vtkPoints>::New());
+
+  orientationArray = vtkSmartPointer<vtkFloatArray>::New();
+  orientationArray->SetName("orientation");
+  orientationArray->SetNumberOfComponents(4);
+  instancePolyData->GetPointData()->AddArray(orientationArray);
+
+  scaleArray = vtkSmartPointer<vtkFloatArray>::New();
+  scaleArray->SetName("scale");
+  scaleArray->SetNumberOfComponents(1);
+  instancePolyData->GetPointData()->AddArray(scaleArray);
+
+  sourceIndexArray = vtkSmartPointer<vtkIntArray>::New();
+  sourceIndexArray->SetName("glyphType");
+  sourceIndexArray->SetNumberOfComponents(1);
+  instancePolyData->GetPointData()->AddArray(sourceIndexArray);
+
+  colorArray = vtkSmartPointer<vtkUnsignedCharArray>::New();
+  colorArray->SetName("color");
+  colorArray->SetNumberOfComponents(4);
+  instancePolyData->GetPointData()->AddArray(colorArray);
+
+  mapper = vtkSmartPointer<vtkGlyph3DMapper>::New();
+  mapper->SetInputData(instancePolyData);
+  mapper->SetSourceIndexing(true);
+  mapper->SetSourceIndexArray("glyphType");
+  mapper->OrientOn();
+  mapper->SetOrientationModeToQuaternion();
+  mapper->SetOrientationArray("orientation");
+  mapper->ScalingOn();
+  mapper->SetScaleModeToScaleByMagnitude();
+  mapper->SetScaleArray("scale");
+  mapper->SetColorModeToDirectScalars();
+  mapper->ScalarVisibilityOn();
+  mapper->SetScalarModeToUsePointFieldData();
+  mapper->SelectColorArray("color");
+
+  property = vtkSmartPointer<vtkProperty>::New();
+  // Point size must be greater than zero, otherwise the instance points are not rendered at all.
+  property->SetPointSize(1.e-6);
+  property->SetLineWidth(2.0);
+  property->SetDiffuse(0.0);
+  property->SetAmbient(1.0);
+  property->SetMetallic(0.0);
+  property->SetSpecular(0.0);
+  property->SetEdgeVisibility(false);
+  property->SetOpacity(1.0);
+
+  actor = vtkSmartPointer<vtkActor>::New();
+  actor->SetProperty(property);
+  actor->SetMapper(mapper);
+}
+
+//----------------------------------------------------------------------
+/// Convert a floating-point color component (0.0–1.0) to an unsigned char, clamping and rounding.
+unsigned char vtkMRMLInteractionWidgetRepresentation::ColorComponentToUChar(double c)
+{
+  c = vtkMath::ClampValue(c, 0.0, 1.0);
+  return static_cast<unsigned char>(c * 255.0 + 0.5);
+}
 
 //----------------------------------------------------------------------
 static const double INTERACTION_HANDLE_SCALE_RADIUS = 0.1;
@@ -79,6 +215,163 @@ static const double INTERACTION_TRANSLATION_HANDLE_SHAFT_RADIUS = 0.05;
 static const double INTERACTION_HANDLE_CROSSHAIR_INNER_RADIUS = 0.10;
 static const double INTERACTION_HANDLE_CROSSHAIR_OUTER_RADIUS = 0.28;
 static const double INTERACTION_HANDLE_CROSSHAIR_BAR_HALF_WIDTH = 0.025;
+
+// The view-plane rotation ring is drawn 20% larger so it does not overlap the three axis rings.
+static const double INTERACTION_HANDLE_VIEW_PLANE_ROTATION_SCALE = 1.2;
+
+//----------------------------------------------------------------------
+// SharedHandleRenderer static helpers
+//----------------------------------------------------------------------
+
+//----------------------------------------------------------------------
+void vtkMRMLInteractionWidgetRepresentation::OnSharedRendererStartEvent(vtkObject* /*caller*/, unsigned long /*eid*/, void* clientData, void* /*callData*/)
+{
+  auto* shared = static_cast<SharedHandleRenderer*>(clientData);
+  shared->RenderingRepresentation = nullptr;
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLInteractionWidgetRepresentation::OnSharedRendererDelete(vtkObject* caller, unsigned long /*eid*/, void* /*clientData*/, void* /*callData*/)
+{
+  auto* renderer = static_cast<vtkRenderer*>(caller);
+  auto it = vtkMRMLInteractionWidgetRepresentation::SharedHandleRenderers.find(renderer);
+  if (it != vtkMRMLInteractionWidgetRepresentation::SharedHandleRenderers.end())
+  {
+    // The renderer is being destroyed — clear the weak pointer and observer tags so the
+    // SharedHandleRenderer destructor does not try to remove observers from a dead renderer.
+    it->second->Renderer = nullptr;
+    it->second->StartEventTag = 0;
+    it->second->DeleteEventTag = 0;
+    vtkMRMLInteractionWidgetRepresentation::SharedHandleRenderers.erase(it);
+  }
+}
+
+//----------------------------------------------------------------------
+SharedHandleRenderer* vtkMRMLInteractionWidgetRepresentation::GetSharedHandleRenderer(vtkRenderer* renderer, bool create)
+{
+  if (!renderer)
+  {
+    return nullptr;
+  }
+
+  auto it = vtkMRMLInteractionWidgetRepresentation::SharedHandleRenderers.find(renderer);
+  if (it != vtkMRMLInteractionWidgetRepresentation::SharedHandleRenderers.end())
+  {
+    return it->second.get();
+  }
+
+  if (!create)
+  {
+    return nullptr;
+  }
+
+  auto shared = std::make_unique<SharedHandleRenderer>();
+  shared->Renderer = renderer;
+
+  ConfigureHandleInstancePipeline(shared->InstancePolyData,
+                                  shared->GlyphOrientationArray,
+                                  shared->GlyphScaleArray,
+                                  shared->GlyphSourceIndexArray,
+                                  shared->ColorArray,
+                                  shared->Mapper,
+                                  shared->Property,
+                                  shared->Actor);
+
+  vtkNew<vtkCallbackCommand> startCB;
+  startCB->SetCallback(vtkMRMLInteractionWidgetRepresentation::OnSharedRendererStartEvent);
+  startCB->SetClientData(shared.get());
+  shared->StartEventTag = renderer->AddObserver(vtkCommand::StartEvent, startCB.Get());
+
+  vtkNew<vtkCallbackCommand> deleteCB;
+  deleteCB->SetCallback(vtkMRMLInteractionWidgetRepresentation::OnSharedRendererDelete);
+  shared->DeleteEventTag = renderer->AddObserver(vtkCommand::DeleteEvent, deleteCB.Get());
+
+  SharedHandleRenderer* result = shared.get();
+  vtkMRMLInteractionWidgetRepresentation::SharedHandleRenderers[renderer] = std::move(shared);
+  return result;
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLInteractionWidgetRepresentation::RegisterWithSharedHandleRenderer()
+{
+  if (!this->Renderer || this->GetSliceNode())
+  {
+    return;
+  }
+
+  SharedHandleRenderer* shared = vtkMRMLInteractionWidgetRepresentation::GetSharedHandleRenderer(this->Renderer, /*create=*/true);
+  if (!shared)
+  {
+    return;
+  }
+
+  // Check if already registered (weak pointers may have gone null — skip those)
+  for (auto& weakRep : shared->Representations)
+  {
+    if (weakRep.GetPointer() == this)
+    {
+      return;
+    }
+  }
+
+  shared->Representations.push_back(vtkWeakPointer<vtkMRMLInteractionWidgetRepresentation>(this));
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLInteractionWidgetRepresentation::UnregisterFromSharedHandleRenderer()
+{
+  for (auto it = vtkMRMLInteractionWidgetRepresentation::SharedHandleRenderers.begin(); it != vtkMRMLInteractionWidgetRepresentation::SharedHandleRenderers.end();)
+  {
+    SharedHandleRenderer* shared = it->second.get();
+
+    if (shared->RenderingRepresentation.GetPointer() == this)
+    {
+      shared->RenderingRepresentation = nullptr;
+    }
+
+    bool removed = false;
+    for (auto repIt = shared->Representations.begin(); repIt != shared->Representations.end();)
+    {
+      if (repIt->GetPointer() == this || repIt->GetPointer() == nullptr)
+      {
+        if (repIt->GetPointer() == this)
+        {
+          removed = true;
+        }
+        repIt = shared->Representations.erase(repIt);
+      }
+      else
+      {
+        ++repIt;
+      }
+    }
+
+    if (removed)
+    {
+      shared->GlyphSourcesInitialized = false;
+    }
+
+    // If no representations remain, remove the shared renderer entry entirely
+    if (shared->Representations.empty())
+    {
+      it = vtkMRMLInteractionWidgetRepresentation::SharedHandleRenderers.erase(it);
+    }
+    else
+    {
+      ++it;
+    }
+  }
+}
+
+//----------------------------------------------------------------------
+bool vtkMRMLInteractionWidgetRepresentation::IsSharedRenderingRepresentation(SharedHandleRenderer* shared) const
+{
+  if (!shared->RenderingRepresentation)
+  {
+    shared->RenderingRepresentation = const_cast<vtkMRMLInteractionWidgetRepresentation*>(this);
+  }
+  return shared->RenderingRepresentation.GetPointer() == this;
+}
 
 //----------------------------------------------------------------------
 vtkMRMLInteractionWidgetRepresentation::vtkMRMLInteractionWidgetRepresentation()
@@ -109,17 +402,14 @@ void vtkMRMLInteractionWidgetRepresentation::SetupInteractionPipeline()
 {
   this->Pipeline = new InteractionPipeline();
   this->InitializePipeline();
-  if (this->GetSliceNode())
-  {
-    this->Pipeline->WorldToSliceTransformFilter->SetInputConnection(this->Pipeline->HandleToWorldTransformFilter->GetOutputPort());
-    this->Pipeline->Mapper3D->SetInputConnection(this->Pipeline->WorldToSliceTransformFilter->GetOutputPort());
-  }
   this->NeedToRenderOn();
 }
 
 //----------------------------------------------------------------------
 vtkMRMLInteractionWidgetRepresentation::~vtkMRMLInteractionWidgetRepresentation()
 {
+  this->UnregisterFromSharedHandleRenderer();
+
   // Force deleting variables to prevent circular dependency keeping objects alive
   if (this->Pipeline != nullptr)
   {
@@ -151,8 +441,14 @@ void vtkMRMLInteractionWidgetRepresentation::CanInteract(vtkMRMLInteractionEvent
   closestDistance2 = VTK_DOUBLE_MAX; // in display coordinate system
   foundComponentIndex = -1;
 
+  // GetVisibility() must be checked in addition to IsDisplayable(): subclasses can hide the
+  // representation prop even when the display node flags allow display (e.g. the markups ROI
+  // representation hides itself in slice views that its ROI does not intersect). A hidden
+  // representation is never rendered, so its cached state (e.g. HandleToWorldTransform) may have
+  // never been updated, and reporting handles at those stale positions would let an invisible
+  // widget steal interaction events from visible widgets.
   vtkMRMLAbstractViewNode* viewNode = this->GetViewNode();
-  if (!viewNode || !this->IsDisplayable() || !interactionEventData)
+  if (!viewNode || !this->Pipeline || !this->GetVisibility() || !this->IsDisplayable() || !interactionEventData)
   {
     return;
   }
@@ -359,7 +655,7 @@ void vtkMRMLInteractionWidgetRepresentation::CanInteractWithRingHandle(vtkMRMLIn
   double radius = INTERACTION_HANDLE_RADIUS;
   if (handleInfo.Index == 3)
   {
-    radius *= 1.2;
+    radius *= INTERACTION_HANDLE_VIEW_PLANE_ROTATION_SCALE;
   }
 
   vtkMath::MultiplyScalar(closestPointOnRing_World, this->WidgetScale * radius);
@@ -416,6 +712,30 @@ void vtkMRMLInteractionWidgetRepresentation::UpdateFromMRML(vtkMRMLNode* vtkNotU
   }
 
   this->NeedToRenderOn();
+
+  // NeedToRenderOn() only calls Modified() when the flag actually changes, and not all displayable
+  // managers clear it after rendering. Modify unconditionally so that the render-time update gate
+  // (which compares the current state of the representation with LastRenderState) reopens on every
+  // MRML-driven update.
+  this->Modified();
+
+  // Register with the shared renderer as soon as the view node and renderer are known, so that a
+  // representation created while processing MRML events is included in the next render, even if
+  // another representation has already built the shared instance arrays for that frame.
+  if (this->ViewNode && !this->GetSliceNode() && this->Renderer)
+  {
+    this->RegisterWithSharedHandleRenderer();
+  }
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLInteractionWidgetRepresentation::SetRenderer(vtkRenderer* renderer)
+{
+  if (renderer != this->Renderer)
+  {
+    this->UnregisterFromSharedHandleRenderer();
+  }
+  this->Superclass::SetRenderer(renderer);
 }
 
 //----------------------------------------------------------------------
@@ -468,189 +788,240 @@ void vtkMRMLInteractionWidgetRepresentation::OrthoganalizeTransform(vtkTransform
 }
 
 //----------------------------------------------------------------------
-void vtkMRMLInteractionWidgetRepresentation::UpdateHandlePolyData()
+void vtkMRMLInteractionWidgetRepresentation::UpdateInstanceArrays()
 {
-  vtkNew<vtkTransform> transform;
-  transform->PostMultiply();
-
-  vtkNew<vtkTransformPolyDataFilter> transformArrowGlyph;
-  transformArrowGlyph->SetInputData(this->Pipeline->ArrowPolyData);
-  transformArrowGlyph->SetTransform(transform);
-
-  vtkNew<vtkTransformPolyDataFilter> transformArrowOutlineGlyph;
-  transformArrowOutlineGlyph->SetInputData(this->Pipeline->ArrowOutlinePolyData);
-  transformArrowOutlineGlyph->SetTransform(transform);
-
-  vtkNew<vtkTransformPolyDataFilter> transformCircleGlyph;
-  transformCircleGlyph->SetInputData(this->Pipeline->CirclePolyData);
-  transformCircleGlyph->SetTransform(transform);
-
-  vtkNew<vtkTransformPolyDataFilter> transformCircleOutlineGlyph;
-  transformCircleOutlineGlyph->SetInputData(this->Pipeline->CircleOutlinePolyData);
-  transformCircleOutlineGlyph->SetTransform(transform);
-
-  vtkNew<vtkTransformPolyDataFilter> transformRingGlyph;
-  transformRingGlyph->SetInputData(this->Pipeline->RingPolyData);
-  transformRingGlyph->SetTransform(transform);
-
-  vtkNew<vtkTransformPolyDataFilter> transformRingOutlineGlyph;
-  transformRingOutlineGlyph->SetInputData(this->Pipeline->RingOutlinePolyData);
-  transformRingOutlineGlyph->SetTransform(transform);
-
-  vtkNew<vtkTransformPolyDataFilter> transformCrosshairGlyph;
-  transformCrosshairGlyph->SetInputData(this->Pipeline->CrosshairPolyData);
-  transformCrosshairGlyph->SetTransform(transform);
-
-  vtkNew<vtkTransformPolyDataFilter> transformCrosshairOutlineGlyph;
-  transformCrosshairOutlineGlyph->SetInputData(this->Pipeline->CrosshairOutlinePolyData);
-  transformCrosshairOutlineGlyph->SetTransform(transform);
-
-  vtkTransformPolyDataFilter* transformGlyph = transformCircleGlyph;
-  vtkTransformPolyDataFilter* transformOutlineGlyph = transformCircleOutlineGlyph;
-
-  bool initializeAppendFilter = this->Pipeline->Append->GetInput() == nullptr;
-  if (initializeAppendFilter)
+  // Compute the upper bound from the same polydata that the fill loop iterates, so
+  // that a subclass overriding GetNumberOfHandles() cannot cause a size mismatch.
+  int handleTypes[] = { InteractionRotationHandle, InteractionTranslationHandle, InteractionScaleHandle };
+  int totalPolyDataPoints = 0;
+  for (int type : handleTypes)
   {
-    this->Pipeline->Append->RemoveAllInputs();
+    vtkPolyData* pd = this->GetHandlePolydata(type);
+    if (pd && pd->GetPoints())
+    {
+      totalPolyDataPoints += pd->GetNumberOfPoints();
+    }
+  }
+  // Each visible handle emits two instances (fill + outline).
+  // Invisible handles are skipped, so this is only an upper bound; the arrays are
+  // shrunk to the number of instances actually written at the end.
+  int maxInstances = totalPolyDataPoints * 2;
+
+  vtkPoints* points = this->Pipeline->InstancePolyData->GetPoints();
+  points->SetNumberOfPoints(maxInstances);
+  this->Pipeline->GlyphOrientationArray->SetNumberOfTuples(maxInstances);
+  this->Pipeline->GlyphScaleArray->SetNumberOfTuples(maxInstances);
+  this->Pipeline->GlyphSourceIndexArray->SetNumberOfTuples(maxInstances);
+  this->Pipeline->ColorArray->SetNumberOfTuples(maxInstances);
+
+  vtkTransform* worldToHandleTransform = vtkTransform::SafeDownCast(this->Pipeline->HandleToWorldTransform->GetInverse());
+
+  double viewUp_Handle[3] = { 0.0, 1.0, 0.0 };
+  if (worldToHandleTransform)
+  {
+    worldToHandleTransform->TransformVector(this->CachedViewUp_World, viewUp_Handle);
   }
 
-  HandleInfoList handleInfoList = this->GetHandleInfoList();
-  for (HandleInfo handleInfo : handleInfoList)
+  double viewDir_Handle_Const[3] = { 0.0, 0.0, 1.0 };
+  if (this->CachedParallelProjection && worldToHandleTransform)
   {
-    switch (handleInfo.GlyphType)
-    {
-      case GlyphArrow:
-        transformGlyph = transformArrowGlyph;
-        transformOutlineGlyph = transformArrowOutlineGlyph;
-        break;
-      case GlyphCircle:
-        transformGlyph = transformCircleGlyph;
-        transformOutlineGlyph = transformCircleOutlineGlyph;
-        break;
-      case GlyphRing:
-        transformGlyph = transformRingGlyph;
-        transformOutlineGlyph = transformRingOutlineGlyph;
-        break;
-      case GlyphCrosshair:
-        transformGlyph = transformCrosshairGlyph;
-        transformOutlineGlyph = transformCrosshairOutlineGlyph;
-        break;
-      default: break;
-    }
+    worldToHandleTransform->TransformVector(this->CachedCameraDirection, viewDir_Handle_Const);
+  }
 
-    vtkPolyData* handlePolyData = this->GetHandlePolydata(handleInfo.ComponentType);
-    if (!handlePolyData)
+  // In 3D views the instances of all representations are rendered by a single shared actor, which
+  // cannot apply a per-representation actor transform. Write the instances in world coordinates so
+  // that they can be copied into the shared arrays as-is.
+  // In slice views each representation is rendered by its own actor, which applies the handle to
+  // world and world to slice transforms, so the instances are written in handle coordinates.
+  const bool writeWorldCoordinates = (this->GetSliceNode() == nullptr);
+
+  // Pre-compute the HandleToWorld rotation as a quaternion: used to compose per-instance
+  // orientations (the vtkGlyph3DMapper uses quaternion orientation mode).
+  vtkMatrix4x4* h2wMatrix = this->Pipeline->HandleToWorldTransform->GetMatrix();
+  double h2wRotation[3][3];
+  for (int row = 0; row < 3; ++row)
+  {
+    for (int column = 0; column < 3; ++column)
+    {
+      h2wRotation[row][column] = h2wMatrix->GetElement(row, column);
+    }
+  }
+  double handleToWorldQuaternion[4] = { 1.0, 0.0, 0.0, 0.0 };
+  vtkMath::Matrix3x3ToQuaternion(h2wRotation, handleToWorldQuaternion);
+
+  int instanceIndex = 0;
+
+  for (int type : handleTypes)
+  {
+    vtkPolyData* handlePolyData = this->GetHandlePolydata(type);
+    if (!handlePolyData || !handlePolyData->GetPoints())
     {
       continue;
     }
 
-    double point[3] = { 0.0, 0.0, 0.0 };
-    handlePolyData->GetPoints()->GetPoint(handleInfo.Index, point);
-    if (handleInfo.ApplyScaleToPosition)
-    {
-      vtkMath::MultiplyScalar(point, this->WidgetScale);
-    }
-
-    transform->Identity();
     vtkDoubleArray* orientationArray = vtkDoubleArray::SafeDownCast(handlePolyData->GetPointData()->GetArray("orientation"));
-    if (orientationArray)
+
+    int numHandles = handlePolyData->GetNumberOfPoints();
+    for (int index = 0; index < numHandles; ++index)
     {
-      double orientation[9] = { 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0 };
-      orientationArray->GetTuple(handleInfo.Index, orientation);
-      vtkNew<vtkMatrix4x4> orientationMatrix;
-      for (int i = 0; i < 9; ++i)
+      double color[4] = { 0.0, 0.0, 0.0, 0.0 };
+      this->GetHandleColor(type, index, color);
+      if (color[3] <= 0.001)
       {
-        orientationMatrix->SetElement(i % 3, i / 3, orientation[i]);
+        // Invisible handle: do not emit any instance for it.
+        continue;
       }
-      transform->Concatenate(orientationMatrix);
-    }
 
-    double scale = this->WidgetScale;
-    if (handleInfo.ComponentType == InteractionRotationHandle && handleInfo.Index == 3)
-    {
-      scale *= 1.2;
-    }
-    if (!handleInfo.IsVisible())
-    {
-      // Collapse hidden handles to a single degenerate point at the origin instead of leaving their
-      // full-size geometry in place with zero opacity. Otherwise the invisible geometry can still
-      // interfere with depth testing/blending of other (visible) handles that overlap it on screen,
-      // showing up as a transparent gap cutting through them (e.g. a hidden rotation ring, viewed
-      // edge-on, cutting a line through the translation handles).
-      scale = 0.0;
-    }
-    transform->Scale(scale, scale, scale);
-    transform->Translate(point[0], point[1], point[2]);
+      double point[3] = { 0.0, 0.0, 0.0 };
+      handlePolyData->GetPoints()->GetPoint(index, point);
+      if (this->GetApplyScaleToPosition(type, index))
+      {
+        vtkMath::MultiplyScalar(point, this->WidgetScale);
+      }
 
-    vtkSmartPointer<vtkPolyData> handleGlyphPolyData = nullptr;
-    std::pair<int, int> handlePolyDataMapKey = std::make_pair(handleInfo.ComponentType, handleInfo.Index);
-    auto handlePolyDataMapIterator = this->Pipeline->HandleGlyphPolyDataMap.find(handlePolyDataMapKey);
-    if (handlePolyDataMapIterator != this->Pipeline->HandleGlyphPolyDataMap.end())
-    {
-      handleGlyphPolyData = handlePolyDataMapIterator->second;
-    }
-    else
-    {
-      handleGlyphPolyData = vtkSmartPointer<vtkPolyData>::New();
-      this->Pipeline->HandleGlyphPolyDataMap[handlePolyDataMapKey] = handleGlyphPolyData;
-    }
+      double quat[4] = { 1.0, 0.0, 0.0, 0.0 };
 
-    transformGlyph->SetOutput(handleGlyphPolyData);
-    transformGlyph->Update();
-    if (initializeAppendFilter)
-    {
-      this->Pipeline->Append->AddInputData(handleGlyphPolyData);
-    }
+      if (type == InteractionRotationHandle && index < 3)
+      {
+        if (orientationArray && index < orientationArray->GetNumberOfTuples())
+        {
+          double orient9[9] = { 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0 };
+          orientationArray->GetTuple(index, orient9);
+          double matrix3x3[3][3];
+          for (int i = 0; i < 3; ++i)
+          {
+            for (int j = 0; j < 3; ++j)
+            {
+              matrix3x3[j][i] = orient9[i * 3 + j];
+            }
+          }
+          vtkMath::Matrix3x3ToQuaternion(matrix3x3, quat);
+        }
+      }
+      else
+      {
+        double viewDir_Handle[3] = { 0.0, 0.0, 1.0 };
+        if (this->CachedParallelProjection)
+        {
+          viewDir_Handle[0] = viewDir_Handle_Const[0];
+          viewDir_Handle[1] = viewDir_Handle_Const[1];
+          viewDir_Handle[2] = viewDir_Handle_Const[2];
+        }
+        else if (worldToHandleTransform)
+        {
+          double posWorld[3] = { 0.0, 0.0, 0.0 };
+          this->Pipeline->HandleToWorldTransform->TransformPoint(point, posWorld);
+          double viewDir_World[3] = { 0.0, 0.0, 1.0 };
+          this->GetHandleToCameraVectorWorld(posWorld, viewDir_World);
+          worldToHandleTransform->TransformVector(viewDir_World, viewDir_Handle);
+        }
 
-    vtkSmartPointer<vtkPolyData> handleOutlineGlyphPolyData = nullptr;
-    std::pair<int, int> handleOutlinePolyDataMapKey = std::make_pair(handleInfo.ComponentType, handleInfo.Index);
-    auto handleOutlinePolyDataMapIterator = this->Pipeline->HandleOutlineGlyphPolyDataMap.find(handleOutlinePolyDataMapKey);
-    if (handleOutlinePolyDataMapIterator != this->Pipeline->HandleOutlineGlyphPolyDataMap.end())
-    {
-      handleOutlineGlyphPolyData = handleOutlinePolyDataMapIterator->second;
-    }
-    else
-    {
-      handleOutlineGlyphPolyData = vtkSmartPointer<vtkPolyData>::New();
-      this->Pipeline->HandleOutlineGlyphPolyDataMap[handleOutlinePolyDataMapKey] = handleOutlineGlyphPolyData;
-    }
-    transformOutlineGlyph->SetOutput(handleOutlineGlyphPolyData);
-    transformOutlineGlyph->Update();
-    if (initializeAppendFilter)
-    {
-      this->Pipeline->Append->AddInputData(handleOutlineGlyphPolyData);
-    }
+        double xAxis[3] = { 1.0, 0.0, 0.0 };
+        double yAxis[3] = { 0.0, 1.0, 0.0 };
+        double zAxis[3] = { 0.0, 0.0, 1.0 };
 
-    // Update color arrays
-    vtkSmartPointer<vtkFloatArray> handleColorArray = vtkFloatArray::SafeDownCast(handlePolyData->GetPointData()->GetAbstractArray("colorIndex"));
-    float handleColorIndex = handleColorArray->GetValue(handleInfo.Index);
+        if (type == InteractionTranslationHandle && index < 3)
+        {
+          xAxis[0] = xAxis[1] = xAxis[2] = 0.0;
+          xAxis[index] = 1.0;
+          vtkMath::Cross(viewDir_Handle, xAxis, yAxis);
+          vtkMath::Normalize(yAxis);
+          vtkMath::Cross(xAxis, yAxis, zAxis);
+          vtkMath::Normalize(zAxis);
+        }
+        else
+        {
+          zAxis[0] = viewDir_Handle[0];
+          zAxis[1] = viewDir_Handle[1];
+          zAxis[2] = viewDir_Handle[2];
+          vtkMath::Normalize(zAxis);
+          vtkMath::Cross(viewUp_Handle, viewDir_Handle, xAxis);
+          vtkMath::Normalize(xAxis);
+          vtkMath::Cross(viewDir_Handle, xAxis, yAxis);
+          vtkMath::Normalize(yAxis);
+        }
 
-    // Glyph color array
-    vtkSmartPointer<vtkFloatArray> glyphColorArray = vtkFloatArray::SafeDownCast(handleGlyphPolyData->GetPointData()->GetAbstractArray("colorIndex"));
-    if (!glyphColorArray)
-    {
-      glyphColorArray = vtkSmartPointer<vtkFloatArray>::New();
-      glyphColorArray->SetName("colorIndex");
-      handleGlyphPolyData->GetPointData()->AddArray(glyphColorArray);
-    }
-    glyphColorArray->SetNumberOfComponents(1);
-    glyphColorArray->SetNumberOfTuples(handleGlyphPolyData->GetNumberOfPoints());
-    glyphColorArray->Fill(handleColorIndex);
-    handleGlyphPolyData->GetPointData()->SetActiveScalars("colorIndex");
+        double matrix3x3[3][3] = { { xAxis[0], yAxis[0], zAxis[0] }, { xAxis[1], yAxis[1], zAxis[1] }, { xAxis[2], yAxis[2], zAxis[2] } };
+        vtkMath::Matrix3x3ToQuaternion(matrix3x3, quat);
+      }
 
-    // Glyph outline color array
-    vtkSmartPointer<vtkFloatArray> outlineGlyphColorArray = vtkFloatArray::SafeDownCast(handleOutlineGlyphPolyData->GetPointData()->GetAbstractArray("colorIndex"));
-    if (!outlineGlyphColorArray)
-    {
-      outlineGlyphColorArray = vtkSmartPointer<vtkFloatArray>::New();
-      outlineGlyphColorArray->SetName("colorIndex");
-      handleOutlineGlyphPolyData->GetPointData()->AddArray(outlineGlyphColorArray);
+      if (writeWorldCoordinates)
+      {
+        this->Pipeline->HandleToWorldTransform->TransformPoint(point, point);
+
+        double quat_Handle[4] = { quat[0], quat[1], quat[2], quat[3] };
+        vtkMath::MultiplyQuaternion(handleToWorldQuaternion, quat_Handle, quat);
+      }
+
+      double scale = this->WidgetScale;
+      if (type == InteractionRotationHandle && index == 3)
+      {
+        scale *= INTERACTION_HANDLE_VIEW_PLANE_ROTATION_SCALE;
+      }
+
+      int glyphType = this->GetHandleGlyphType(type, index);
+
+      // Fill instance.
+      points->SetPoint(instanceIndex, point);
+      this->Pipeline->GlyphOrientationArray->SetTuple4(instanceIndex, quat[0], quat[1], quat[2], quat[3]);
+      this->Pipeline->GlyphScaleArray->SetValue(instanceIndex, scale);
+      unsigned char fillRGBA[4] = { ColorComponentToUChar(color[0]), ColorComponentToUChar(color[1]), ColorComponentToUChar(color[2]), ColorComponentToUChar(color[3]) };
+      this->Pipeline->ColorArray->SetTypedTuple(instanceIndex, fillRGBA);
+      this->Pipeline->GlyphSourceIndexArray->SetValue(instanceIndex, glyphType);
+
+      // Outline instance. The mapper renders the instances grouped by glyph source, so the fill and
+      // outline instances can be stored as adjacent pairs.
+      int outlineIndex = instanceIndex + 1;
+      points->SetPoint(outlineIndex, point);
+      this->Pipeline->GlyphOrientationArray->SetTuple4(outlineIndex, quat[0], quat[1], quat[2], quat[3]);
+      this->Pipeline->GlyphScaleArray->SetValue(outlineIndex, scale);
+      this->Pipeline->GlyphSourceIndexArray->SetValue(outlineIndex, glyphType + GlyphArrowOutline);
+
+      bool selected = (this->GetActiveComponentType() == type && this->GetActiveComponentIndex() == index);
+      unsigned char grey = selected ? 0 : ColorComponentToUChar(0.3);
+      unsigned char outlineRGBA[4] = { grey, grey, grey, fillRGBA[3] };
+      this->Pipeline->ColorArray->SetTypedTuple(outlineIndex, outlineRGBA);
+
+      instanceIndex += 2;
     }
-    outlineGlyphColorArray->SetNumberOfComponents(1);
-    outlineGlyphColorArray->SetNumberOfTuples(handleOutlineGlyphPolyData->GetNumberOfPoints());
-    outlineGlyphColorArray->Fill(handleColorIndex + 1);
-    handleOutlineGlyphPolyData->GetPointData()->SetActiveScalars("colorIndex");
   }
+
+  // Shrink the arrays to the instances that were actually written.
+  points->SetNumberOfPoints(instanceIndex);
+  this->Pipeline->GlyphOrientationArray->SetNumberOfTuples(instanceIndex);
+  this->Pipeline->GlyphScaleArray->SetNumberOfTuples(instanceIndex);
+  this->Pipeline->GlyphSourceIndexArray->SetNumberOfTuples(instanceIndex);
+  this->Pipeline->ColorArray->SetNumberOfTuples(instanceIndex);
+
+  this->HasVisibleHandles = instanceIndex > 0;
+
+  // Writing array values does not modify the arrays themselves, but the cached point bounds and the
+  // cached array ranges are only recomputed when the array that they were computed from is modified.
+  // Stale bounds can cause the handles to be culled, and a stale color range makes the mapper render
+  // faded handles in the opaque pass instead of the translucent pass.
+  points->Modified();
+  this->Pipeline->GlyphOrientationArray->Modified();
+  this->Pipeline->GlyphScaleArray->Modified();
+  this->Pipeline->GlyphSourceIndexArray->Modified();
+  this->Pipeline->ColorArray->Modified();
+  this->Pipeline->InstancePolyData->Modified();
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLInteractionWidgetRepresentation::UpdateActorTransform()
+{
+  this->Pipeline->ActorTransform->Identity();
+  this->Pipeline->ActorTransform->PostMultiply();
+
+  // In 3D views the instances are already stored in world coordinates (see UpdateInstanceArrays),
+  // so the actor transform must remain identity to avoid transforming them twice.
+  if (this->GetSliceNode())
+  {
+    this->Pipeline->ActorTransform->Concatenate(this->Pipeline->HandleToWorldTransform);
+    this->Pipeline->ActorTransform->Concatenate(this->Pipeline->WorldToSliceTransform);
+  }
+
+  this->Pipeline->Actor->SetUserTransform(this->Pipeline->ActorTransform);
 }
 
 //----------------------------------------------------------------------
@@ -662,33 +1033,131 @@ vtkPointPlacer* vtkMRMLInteractionWidgetRepresentation::GetPointPlacer()
 //----------------------------------------------------------------------
 void vtkMRMLInteractionWidgetRepresentation::GetActors(vtkPropCollection* pc)
 {
-  vtkProp* actor = this->GetInteractionActor();
-  if (actor)
+  if (this->Pipeline)
   {
-    actor->GetActors(pc);
+    this->Pipeline->Actor->GetActors(pc);
   }
 }
 
 //----------------------------------------------------------------------
 void vtkMRMLInteractionWidgetRepresentation::ReleaseGraphicsResources(vtkWindow* window)
 {
-  vtkProp* actor = this->GetInteractionActor();
-  if (actor)
+  if (this->Pipeline)
   {
-    actor->ReleaseGraphicsResources(window);
+    this->Pipeline->Actor->ReleaseGraphicsResources(window);
   }
+  // The shared actor's GPU resources are released by the SharedHandleRenderer destructor when
+  // the last representation unregisters or when the renderer fires DeleteEvent. Releasing them
+  // here would force a re-upload for every other representation still using the shared actor.
 }
 
 //----------------------------------------------------------------------
 int vtkMRMLInteractionWidgetRepresentation::RenderOverlay(vtkViewport* viewport)
 {
   int count = 0;
-  vtkProp* actor = this->GetInteractionActor();
-  if (this->Pipeline && actor->GetVisibility())
+  if (!this->Pipeline || !this->GetVisibility() || !this->Pipeline->Actor->GetVisibility())
   {
-    count += actor->RenderOverlay(viewport);
+    return count;
+  }
+
+  if (!this->GetSliceNode() && this->Renderer)
+  {
+    SharedHandleRenderer* shared = vtkMRMLInteractionWidgetRepresentation::GetSharedHandleRenderer(this->Renderer);
+    if (shared && this->IsSharedRenderingRepresentation(shared))
+    {
+      count += shared->Actor->RenderOverlay(viewport);
+    }
+  }
+  else
+  {
+    count += this->Pipeline->Actor->RenderOverlay(viewport);
   }
   return count;
+}
+
+//----------------------------------------------------------------------
+bool vtkMRMLInteractionWidgetRepresentation::RenderState::operator==(const RenderState& other) const
+{
+  return this->RepresentationMTime == other.RepresentationMTime              //
+         && this->SliceXYToRASMTime == other.SliceXYToRASMTime               //
+         && this->CameraParallelProjection == other.CameraParallelProjection //
+         && this->CameraParallelScale == other.CameraParallelScale           //
+         && this->CameraViewAngle == other.CameraViewAngle                   //
+         && this->ActiveComponentType == other.ActiveComponentType           //
+         && this->ActiveComponentIndex == other.ActiveComponentIndex         //
+         && this->RendererSize[0] == other.RendererSize[0]                   //
+         && this->RendererSize[1] == other.RendererSize[1]                   //
+         && this->ScreenSize[0] == other.ScreenSize[0]                       //
+         && this->ScreenSize[1] == other.ScreenSize[1]                       //
+         && std::equal(this->CameraPosition, this->CameraPosition + 3, other.CameraPosition)
+         && std::equal(this->CameraDirectionOfProjection, this->CameraDirectionOfProjection + 3, other.CameraDirectionOfProjection)
+         && std::equal(this->CameraViewUp, this->CameraViewUp + 3, other.CameraViewUp);
+}
+
+//----------------------------------------------------------------------
+vtkMRMLInteractionWidgetRepresentation::RenderState vtkMRMLInteractionWidgetRepresentation::GetCurrentRenderState()
+{
+  RenderState state;
+  state.RepresentationMTime = this->GetMTime();
+  state.ActiveComponentType = this->GetActiveComponentType();
+  state.ActiveComponentIndex = this->GetActiveComponentIndex();
+
+  vtkMRMLSliceNode* sliceNode = this->GetSliceNode();
+  if (sliceNode)
+  {
+    // In slice views the handle positions and size are determined by the slice transform,
+    // which is not reflected in the camera or in the MTime of the representation.
+    state.SliceXYToRASMTime = sliceNode->GetXYToRAS()->GetMTime();
+  }
+
+  if (this->Renderer)
+  {
+    this->Renderer->GetTiledSize(&state.RendererSize[0], &state.RendererSize[1]);
+
+    vtkRenderWindow* renderWindow = this->Renderer->GetRenderWindow();
+    if (renderWindow)
+    {
+      const int* screenSize = renderWindow->GetScreenSize();
+      state.ScreenSize[0] = screenSize[0];
+      state.ScreenSize[1] = screenSize[1];
+    }
+
+    vtkCamera* camera = this->Renderer->GetActiveCamera();
+    if (camera)
+    {
+      camera->GetPosition(state.CameraPosition);
+      camera->GetDirectionOfProjection(state.CameraDirectionOfProjection);
+      camera->GetViewUp(state.CameraViewUp);
+      state.CameraParallelProjection = camera->GetParallelProjection() != 0;
+      state.CameraParallelScale = camera->GetParallelScale();
+      state.CameraViewAngle = camera->GetViewAngle();
+    }
+  }
+  return state;
+}
+
+//----------------------------------------------------------------------
+bool vtkMRMLInteractionWidgetRepresentation::UpdatePipelineIfNeeded()
+{
+  RenderState state = this->GetCurrentRenderState();
+  if (state == this->LastRenderState)
+  {
+    return false;
+  }
+
+  this->UpdateHandleToWorldTransform();
+  this->UpdateSlicePlaneFromSliceNode();
+  this->UpdateCameraState();
+  this->UpdateViewScaleFactor();
+  this->UpdateInteractionPipeline();
+  this->UpdateHandleSize();
+  this->UpdateInstanceArrays();
+  this->UpdateActorTransform();
+
+  // The update calls above may have modified the representation, so the state has to be
+  // re-sampled instead of storing the state that was computed before the update.
+  this->LastRenderState = this->GetCurrentRenderState();
+  return true;
 }
 
 //----------------------------------------------------------------------
@@ -700,20 +1169,137 @@ int vtkMRMLInteractionWidgetRepresentation::RenderOpaqueGeometry(vtkViewport* vi
   }
 
   int count = 0;
-  vtkProp* actor = this->GetInteractionActor();
-  if (actor && actor->GetVisibility())
+  if (!this->Pipeline || !this->GetVisibility() || !this->Pipeline->Actor->GetVisibility())
   {
-    this->UpdateHandleToWorldTransform();
-    this->UpdateSlicePlaneFromSliceNode();
-    this->UpdateHandleColors();
-    this->UpdateViewScaleFactor();
-    this->UpdateInteractionPipeline();
-    this->UpdateHandleOrientation();
-    this->UpdateHandleSize();
-    this->UpdateHandlePolyData();
-    count += actor->RenderOpaqueGeometry(viewport);
-    this->Pipeline->HandleToWorldTransformFilter->Update();
+    return count;
   }
+
+  // Slice views: per-representation rendering (each rep has a unique
+  // WorldToSliceTransform Z-offset so they cannot share a single actor).
+  if (this->GetSliceNode())
+  {
+    this->UpdatePipelineIfNeeded();
+    if (this->HasVisibleHandles)
+    {
+      count += this->Pipeline->Actor->RenderOpaqueGeometry(viewport);
+    }
+    return count;
+  }
+
+  // 3D view: shared rendering — one draw per glyph source for ALL representations
+  this->RegisterWithSharedHandleRenderer();
+  SharedHandleRenderer* shared = vtkMRMLInteractionWidgetRepresentation::GetSharedHandleRenderer(this->Renderer);
+  if (!shared)
+  {
+    return count;
+  }
+
+  if (!shared->GlyphSourcesInitialized)
+  {
+    shared->Mapper->SetSourceData(GlyphArrow, this->Pipeline->ArrowPolyData);
+    shared->Mapper->SetSourceData(GlyphCircle, this->Pipeline->CirclePolyData);
+    shared->Mapper->SetSourceData(GlyphRing, this->Pipeline->RingPolyData);
+    shared->Mapper->SetSourceData(GlyphCrosshair, this->Pipeline->CrosshairPolyData);
+    shared->Mapper->SetSourceData(GlyphArrowOutline, this->Pipeline->ArrowOutlinePolyData);
+    shared->Mapper->SetSourceData(GlyphCircleOutline, this->Pipeline->CircleOutlinePolyData);
+    shared->Mapper->SetSourceData(GlyphRingOutline, this->Pipeline->RingOutlinePolyData);
+    shared->Mapper->SetSourceData(GlyphCrosshairOutline, this->Pipeline->CrosshairOutlinePolyData);
+    this->UpdateRelativeCoincidentTopologyOffsets(shared->Mapper);
+    shared->GlyphSourcesInitialized = true;
+  }
+
+  if (!this->IsSharedRenderingRepresentation(shared))
+  {
+    return 0;
+  }
+
+  // Pass 1: update all representations and count total instances
+  vtkIdType totalInstances = 0;
+  bool anyVisible = false;
+  bool anyRepUpdated = false;
+
+  for (auto& weakRep : shared->Representations)
+  {
+    vtkMRMLInteractionWidgetRepresentation* rep = weakRep.GetPointer();
+    if (!rep || !rep->IsConsumer(this->Renderer))
+    {
+      continue;
+    }
+    // The representation prop visibility is how subclasses hide the handles (e.g. when handle
+    // interaction is disabled on the display node); it has to be checked in addition to the
+    // internal actor because the shared actor bypasses the renderer's per-prop visibility check.
+    if (!rep->Pipeline || !rep->GetVisibility() || !rep->Pipeline->Actor->GetVisibility())
+    {
+      continue;
+    }
+
+    anyRepUpdated |= rep->UpdatePipelineIfNeeded();
+
+    if (rep->HasVisibleHandles)
+    {
+      anyVisible = true;
+      totalInstances += rep->Pipeline->InstancePolyData->GetNumberOfPoints();
+    }
+  }
+
+  if (!anyVisible)
+  {
+    // Ensure shared actor has no stale geometry
+    if (shared->InstancePolyData->GetNumberOfPoints() > 0)
+    {
+      shared->InstancePolyData->GetPoints()->SetNumberOfPoints(0);
+      shared->GlyphOrientationArray->SetNumberOfTuples(0);
+      shared->GlyphScaleArray->SetNumberOfTuples(0);
+      shared->GlyphSourceIndexArray->SetNumberOfTuples(0);
+      shared->ColorArray->SetNumberOfTuples(0);
+      shared->InstancePolyData->Modified();
+    }
+    return 0;
+  }
+
+  if (anyRepUpdated || shared->InstancePolyData->GetNumberOfPoints() != totalInstances)
+  {
+    // Pass 2: copy the instance arrays of each representation into the shared arrays.
+    // The instances are already stored in world coordinates by UpdateInstanceArrays, so they can be
+    // copied without any per-instance computation.
+    vtkPoints* sharedPoints = shared->InstancePolyData->GetPoints();
+    sharedPoints->SetNumberOfPoints(totalInstances);
+    shared->GlyphOrientationArray->SetNumberOfTuples(totalInstances);
+    shared->GlyphScaleArray->SetNumberOfTuples(totalInstances);
+    shared->GlyphSourceIndexArray->SetNumberOfTuples(totalInstances);
+    shared->ColorArray->SetNumberOfTuples(totalInstances);
+
+    vtkIdType offset = 0;
+    for (auto& weakRep : shared->Representations)
+    {
+      vtkMRMLInteractionWidgetRepresentation* rep = weakRep.GetPointer();
+      if (!rep || !rep->IsConsumer(this->Renderer) || !rep->Pipeline || !rep->GetVisibility() || !rep->Pipeline->Actor->GetVisibility() || !rep->HasVisibleHandles)
+      {
+        continue;
+      }
+
+      vtkIdType repInstances = rep->Pipeline->InstancePolyData->GetNumberOfPoints();
+      sharedPoints->InsertPoints(offset, repInstances, 0, rep->Pipeline->InstancePolyData->GetPoints());
+      shared->GlyphOrientationArray->InsertTuples(offset, repInstances, 0, rep->Pipeline->GlyphOrientationArray);
+      shared->GlyphScaleArray->InsertTuples(offset, repInstances, 0, rep->Pipeline->GlyphScaleArray);
+      shared->GlyphSourceIndexArray->InsertTuples(offset, repInstances, 0, rep->Pipeline->GlyphSourceIndexArray);
+      shared->ColorArray->InsertTuples(offset, repInstances, 0, rep->Pipeline->ColorArray);
+
+      offset += repInstances;
+    }
+
+    sharedPoints->Modified();
+    shared->GlyphOrientationArray->Modified();
+    shared->GlyphScaleArray->Modified();
+    shared->GlyphSourceIndexArray->Modified();
+    shared->ColorArray->Modified();
+    shared->InstancePolyData->Modified();
+  }
+
+  shared->Actor->SetPropertyKeys(this->GetPropertyKeys());
+  // The actor renders itself in the opaque pass only if all of the visible handles are opaque.
+  // Faded handles are rendered by RenderTranslucentPolygonalGeometry instead.
+  count += shared->Actor->RenderOpaqueGeometry(viewport);
   return count;
 }
 
@@ -721,11 +1307,31 @@ int vtkMRMLInteractionWidgetRepresentation::RenderOpaqueGeometry(vtkViewport* vi
 int vtkMRMLInteractionWidgetRepresentation::RenderTranslucentPolygonalGeometry(vtkViewport* viewport)
 {
   int count = 0;
-  vtkProp* actor = this->GetInteractionActor();
-  if (actor && actor->GetVisibility())
+  if (!this->Pipeline || !this->GetVisibility() || !this->Pipeline->Actor->GetVisibility())
   {
-    actor->SetPropertyKeys(this->GetPropertyKeys());
-    count += actor->RenderTranslucentPolygonalGeometry(viewport);
+    return count;
+  }
+
+  if (!this->GetSliceNode() && this->Renderer)
+  {
+    // 3D view: all representations are rendered by the shared actor, which is rendered by the
+    // representation that claimed it in the opaque pass. The shared instance arrays have already
+    // been built by RenderOpaqueGeometry, which is called for every prop before the translucent
+    // pass starts.
+    // The translucent pass may be rendered several times in a single frame (once to initialize the
+    // depth buffers and then once per peel when depth peeling is enabled), so the shared actor must
+    // be rendered on every invocation and not only on the first one.
+    SharedHandleRenderer* shared = vtkMRMLInteractionWidgetRepresentation::GetSharedHandleRenderer(this->Renderer);
+    if (shared && this->IsSharedRenderingRepresentation(shared))
+    {
+      shared->Actor->SetPropertyKeys(this->GetPropertyKeys());
+      count += shared->Actor->RenderTranslucentPolygonalGeometry(viewport);
+    }
+  }
+  else if (this->HasVisibleHandles)
+  {
+    this->Pipeline->Actor->SetPropertyKeys(this->GetPropertyKeys());
+    count += this->Pipeline->Actor->RenderTranslucentPolygonalGeometry(viewport);
   }
   return count;
 }
@@ -733,11 +1339,25 @@ int vtkMRMLInteractionWidgetRepresentation::RenderTranslucentPolygonalGeometry(v
 //----------------------------------------------------------------------
 vtkTypeBool vtkMRMLInteractionWidgetRepresentation::HasTranslucentPolygonalGeometry()
 {
-  vtkProp* actor = this->GetInteractionActor();
-  if (actor && actor->GetVisibility() && //
-      actor->HasTranslucentPolygonalGeometry())
+  if (!this->Pipeline || !this->GetVisibility() || !this->Pipeline->Actor->GetVisibility())
   {
-    return true;
+    return false;
+  }
+
+  if (!this->GetSliceNode() && this->Renderer)
+  {
+    // 3D view: the shared actor decides based on the opacity of the handles of all representations.
+    SharedHandleRenderer* shared = vtkMRMLInteractionWidgetRepresentation::GetSharedHandleRenderer(this->Renderer);
+    if (shared)
+    {
+      return shared->Actor->HasTranslucentPolygonalGeometry();
+    }
+    return false;
+  }
+
+  if (this->HasVisibleHandles)
+  {
+    return this->Pipeline->Actor->HasTranslucentPolygonalGeometry();
   }
   return false;
 }
@@ -800,8 +1420,8 @@ vtkMRMLInteractionWidgetRepresentation::InteractionPipeline::InteractionPipeline
       rotationLine->InsertNextId(id);
     }
     rotationLine->InsertNextId(0);
-    this->ArrowOutlinePolyData->InsertNextCell(VTK_POLY_LINE, rotationLine);
-    this->ArrowPolyData->InsertNextCell(VTK_POLYGON, rotationPoly);
+    this->RingOutlinePolyData->InsertNextCell(VTK_POLY_LINE, rotationLine);
+    this->RingPolyData->InsertNextCell(VTK_POLYGON, rotationPoly);
   }
   else
   {
@@ -973,41 +1593,22 @@ vtkMRMLInteractionWidgetRepresentation::InteractionPipeline::InteractionPipeline
 
   this->ScaleHandlePoints = vtkSmartPointer<vtkPolyData>::New();
 
-  this->Append = vtkSmartPointer<vtkAppendPolyData>::New();
-
   this->HandleToWorldTransform = vtkSmartPointer<vtkTransform>::New();
-  this->HandleToWorldTransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
-  this->HandleToWorldTransformFilter->SetInputConnection(this->Append->GetOutputPort());
-  this->HandleToWorldTransformFilter->SetTransform(this->HandleToWorldTransform);
 
-  this->ColorTable = vtkSmartPointer<vtkLookupTable>::New();
+  ConfigureHandleInstancePipeline(
+    this->InstancePolyData, this->GlyphOrientationArray, this->GlyphScaleArray, this->GlyphSourceIndexArray, this->ColorArray, this->Mapper, this->Property, this->Actor);
 
-  this->Mapper3D = vtkSmartPointer<vtkPolyDataMapper>::New();
-  this->Mapper3D->SetInputConnection(this->HandleToWorldTransformFilter->GetOutputPort());
-  this->Mapper3D->SetColorModeToMapScalars();
-  this->Mapper3D->ColorByArrayComponent("colorIndex", 0);
-  this->Mapper3D->SetLookupTable(this->ColorTable);
-  this->Mapper3D->ScalarVisibilityOn();
-  this->Mapper3D->UseLookupTableScalarRangeOn();
-
-  this->Property3D = vtkSmartPointer<vtkProperty>::New();
-  this->Property3D->SetPointSize(1.e-6); // NOTE: The point size value must be greater than zero. Refer to vtkOpenGLState::vtkglPointSize(float).
-  this->Property3D->SetLineWidth(1.0);
-  this->Property3D->SetDiffuse(0.0);
-  this->Property3D->SetAmbient(1.0);
-  this->Property3D->SetMetallic(0.0);
-  this->Property3D->SetSpecular(0.0);
-  this->Property3D->SetEdgeVisibility(false);
-  this->Property3D->SetOpacity(1.0);
-
-  this->Actor3D = vtkSmartPointer<vtkActor>::New();
-  this->Actor3D->SetProperty(this->Property3D);
-  this->Actor3D->SetMapper(this->Mapper3D);
+  this->Mapper->SetSourceData(GlyphArrow, this->ArrowPolyData);
+  this->Mapper->SetSourceData(GlyphCircle, this->CirclePolyData);
+  this->Mapper->SetSourceData(GlyphRing, this->RingPolyData);
+  this->Mapper->SetSourceData(GlyphCrosshair, this->CrosshairPolyData);
+  this->Mapper->SetSourceData(GlyphArrowOutline, this->ArrowOutlinePolyData);
+  this->Mapper->SetSourceData(GlyphCircleOutline, this->CircleOutlinePolyData);
+  this->Mapper->SetSourceData(GlyphRingOutline, this->RingOutlinePolyData);
+  this->Mapper->SetSourceData(GlyphCrosshairOutline, this->CrosshairOutlinePolyData);
 
   this->WorldToSliceTransform = vtkSmartPointer<vtkTransform>::New();
-
-  this->WorldToSliceTransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
-  this->WorldToSliceTransformFilter->SetTransform(this->WorldToSliceTransform);
+  this->ActorTransform = vtkSmartPointer<vtkTransform>::New();
 }
 
 //----------------------------------------------------------------------
@@ -1020,12 +1621,11 @@ void vtkMRMLInteractionWidgetRepresentation::InitializePipeline()
   {
     vtkGenericWarningMacro("Unexpected resolve coincident topology value: " << vtkMapper::GetResolveCoincidentTopology());
   }
-  this->UpdateRelativeCoincidentTopologyOffsets(this->Pipeline->Mapper3D);
+  this->UpdateRelativeCoincidentTopologyOffsets(this->Pipeline->Mapper);
 
   this->CreateRotationHandles();
   this->CreateTranslationHandles();
   this->CreateScaleHandles();
-  this->UpdateHandleColors();
 }
 
 //----------------------------------------------------------------------
@@ -1133,219 +1733,44 @@ vtkProp* vtkMRMLInteractionWidgetRepresentation::GetInteractionActor()
   {
     return nullptr;
   }
-  return this->Pipeline->Actor3D;
+  return this->Pipeline->Actor;
 }
 
 //----------------------------------------------------------------------
-void vtkMRMLInteractionWidgetRepresentation::UpdateHandleOrientation()
+void vtkMRMLInteractionWidgetRepresentation::UpdateCameraState()
 {
-  this->UpdateTranslationHandleOrientation();
-  this->UpdateScaleHandleOrientation();
-  this->UpdateRotationHandleOrientation();
-}
-
-//----------------------------------------------------------------------
-void vtkMRMLInteractionWidgetRepresentation::UpdateTranslationHandleOrientation()
-{
-  vtkPolyData* handlePolyData = this->GetHandlePolydata(InteractionTranslationHandle);
-  if (!handlePolyData)
-  {
-    return;
-  }
-
-  vtkDoubleArray* orientationArray = vtkDoubleArray::SafeDownCast(handlePolyData->GetPointData()->GetAbstractArray("orientation"));
-  if (!orientationArray)
-  {
-    return;
-  }
-
-  vtkSmartPointer<vtkTransform> worldToHandleTransform = vtkTransform::SafeDownCast(this->Pipeline->HandleToWorldTransform->GetInverse());
-  vtkCamera* camera = this->GetRenderer()->GetActiveCamera();
-
-  double viewDirection_World[3] = { 0.0, 0.0, 0.0 };
-  double viewDirection_Handle[3] = { 0.0, 0.0, 0.0 };
-  double viewUp_World[3] = { 0.0, 1.0, 0.0 };
-  double viewUp_Handle[3] = { 0.0, 1.0, 0.0 };
   if (this->GetSliceNode())
   {
-    double viewUp[4] = { 0.0, 1.0, 0.0, 0.0 };
-    double viewUp2[4] = { 0.0, 1.0, 0.0, 0.0 };
-    this->GetSliceNode()->GetXYToRAS()->MultiplyPoint(viewUp, viewUp2);
-    viewUp_World[0] = viewUp2[0];
-    viewUp_World[1] = viewUp2[1];
-    viewUp_World[2] = viewUp2[2];
+    this->CachedParallelProjection = true;
+    double normal4[4] = { 0.0, 0.0, 1.0, 0.0 };
+    this->GetSliceNode()->GetXYToRAS()->MultiplyPoint(normal4, normal4);
+    this->CachedCameraDirection[0] = normal4[0];
+    this->CachedCameraDirection[1] = normal4[1];
+    this->CachedCameraDirection[2] = normal4[2];
+    vtkMath::Normalize(this->CachedCameraDirection);
+
+    double viewUp4[4] = { 0.0, 1.0, 0.0, 0.0 };
+    double viewUp4Out[4] = { 0.0, 1.0, 0.0, 0.0 };
+    this->GetSliceNode()->GetXYToRAS()->MultiplyPoint(viewUp4, viewUp4Out);
+    this->CachedViewUp_World[0] = viewUp4Out[0];
+    this->CachedViewUp_World[1] = viewUp4Out[1];
+    this->CachedViewUp_World[2] = viewUp4Out[2];
   }
-  else
+  else if (this->GetRenderer() && this->GetRenderer()->GetActiveCamera())
   {
-    camera->GetViewUp(viewUp_World);
-  }
-  worldToHandleTransform->TransformVector(viewUp_World, viewUp_Handle);
-
-  for (int i = 0; i < 3; ++i)
-  {
-    double interactionHandlePosition[3] = { 0.0, 0.0, 0.0 };
-    this->GetInteractionHandlePositionWorld(InteractionTranslationHandle, i, interactionHandlePosition);
-    this->GetHandleToCameraVectorWorld(interactionHandlePosition, viewDirection_World);
-    worldToHandleTransform->TransformVector(viewDirection_World, viewDirection_Handle);
-
-    double xAxis[3] = { 0.0, 0.0, 0.0 };
-    double yAxis[3] = { 0.0, 0.0, 0.0 };
-    double zAxis[3] = { 0.0, 0.0, 0.0 };
-    xAxis[i] = 1.0;
-
-    vtkMath::Cross(viewDirection_Handle, xAxis, yAxis);
-    vtkMath::Normalize(yAxis);
-
-    vtkMath::Cross(xAxis, yAxis, zAxis);
-    vtkMath::Normalize(zAxis);
-
-    orientationArray->SetTuple9(i, xAxis[0], xAxis[1], xAxis[2], yAxis[0], yAxis[1], yAxis[2], zAxis[0], zAxis[1], zAxis[2]);
-  }
-
-  double interactionHandlePosition[3] = { 0.0, 0.0, 0.0 };
-  this->GetInteractionHandlePositionWorld(InteractionTranslationHandle, 3, interactionHandlePosition);
-  this->GetHandleToCameraVectorWorld(interactionHandlePosition, viewDirection_World);
-  worldToHandleTransform->TransformVector(viewDirection_World, viewDirection_Handle);
-
-  double xAxis[3] = { 0.0, 0.0, 0.0 };
-  double yAxis[3] = { 0.0, 0.0, 0.0 };
-  double zAxis[3] = { 0.0, 0.0, 0.0 };
-  zAxis[0] = viewDirection_Handle[0];
-  zAxis[1] = viewDirection_Handle[1];
-  zAxis[2] = viewDirection_Handle[2];
-  vtkMath::Normalize(zAxis);
-
-  vtkMath::Cross(viewUp_Handle, viewDirection_Handle, xAxis);
-  vtkMath::Normalize(xAxis);
-
-  vtkMath::Cross(viewDirection_Handle, xAxis, yAxis);
-  vtkMath::Normalize(yAxis);
-
-  orientationArray->SetTuple9(3, xAxis[0], xAxis[1], xAxis[2], yAxis[0], yAxis[1], yAxis[2], zAxis[0], zAxis[1], zAxis[2]);
-}
-
-//----------------------------------------------------------------------
-void vtkMRMLInteractionWidgetRepresentation::UpdateScaleHandleOrientation()
-{
-  vtkPolyData* handlePolyData = this->GetHandlePolydata(InteractionScaleHandle);
-  if (!handlePolyData)
-  {
-    return;
-  }
-
-  vtkDoubleArray* orientationArray = vtkDoubleArray::SafeDownCast(handlePolyData->GetPointData()->GetAbstractArray("orientation"));
-  if (!orientationArray)
-  {
-    return;
-  }
-
-  vtkSmartPointer<vtkTransform> worldToHandleTransform = vtkTransform::SafeDownCast(this->Pipeline->HandleToWorldTransform->GetInverse());
-  vtkCamera* camera = this->GetRenderer()->GetActiveCamera();
-
-  double viewDirection_World[3] = { 0.0, 0.0, 0.0 };
-  double viewDirection_Handle[3] = { 0.0, 0.0, 0.0 };
-  double viewUp_World[3] = { 0.0, 1.0, 0.0 };
-  double viewUp_Handle[3] = { 0.0, 0.0, 0.0 };
-  if (this->GetSliceNode())
-  {
-    double viewUp[4] = { 0.0, 1.0, 0.0, 0.0 };
-    double viewUp2[4] = { 0.0, 1.0, 0.0, 0.0 };
-    this->GetSliceNode()->GetXYToRAS()->MultiplyPoint(viewUp, viewUp2);
-    viewUp_World[0] = viewUp2[0];
-    viewUp_World[1] = viewUp2[1];
-    viewUp_World[2] = viewUp2[2];
-  }
-  else
-  {
-    camera->GetViewUp(viewUp_World);
-  }
-  worldToHandleTransform->TransformVector(viewUp_World, viewUp_Handle);
-
-  for (int i = 0; i < orientationArray->GetNumberOfTuples(); ++i)
-  {
-    double interactionHandlePosition[3] = { 0.0, 0.0, 0.0 };
-    this->GetInteractionHandlePositionWorld(InteractionScaleHandle, i, interactionHandlePosition);
-    this->GetHandleToCameraVectorWorld(interactionHandlePosition, viewDirection_World);
-    worldToHandleTransform->TransformVector(viewDirection_World, viewDirection_Handle);
-
-    double xAxis[3] = { 1.0, 0.0, 0.0 };
-    double yAxis[3] = { 0.0, 1.0, 0.0 };
-    double zAxis[3] = { 0.0, 0.0, 1.0 };
-    zAxis[0] = viewDirection_Handle[0];
-    zAxis[1] = viewDirection_Handle[1];
-    zAxis[2] = viewDirection_Handle[2];
-    vtkMath::Normalize(zAxis);
-
-    vtkMath::Cross(viewUp_Handle, viewDirection_Handle, xAxis);
-    vtkMath::Normalize(xAxis);
-
-    vtkMath::Cross(viewDirection_Handle, xAxis, yAxis);
-    vtkMath::Normalize(yAxis);
-
-    orientationArray->SetTuple9(i, xAxis[0], xAxis[1], xAxis[2], yAxis[0], yAxis[1], yAxis[2], zAxis[0], zAxis[1], zAxis[2]);
-  }
-}
-
-//----------------------------------------------------------------------
-void vtkMRMLInteractionWidgetRepresentation::UpdateRotationHandleOrientation()
-{
-  vtkPolyData* handlePolyData = this->GetHandlePolydata(InteractionRotationHandle);
-  if (!handlePolyData)
-  {
-    return;
-  }
-
-  vtkDoubleArray* orientationArray = vtkDoubleArray::SafeDownCast(handlePolyData->GetPointData()->GetAbstractArray("orientation"));
-  if (!orientationArray)
-  {
-    return;
-  }
-
-  double viewDirection_World[3] = { 0.0, 0.0, 0.0 };
-  double viewUp_World[3] = { 0.0, 1.0, 0.0 };
-  if (this->GetSliceNode())
-  {
-    this->SlicePlane->GetNormal(viewDirection_World);
-    double viewup[4] = { 0.0, 1.0, 0.0, 0.0 };
-    double viewup2[4] = { 0.0, 1.0, 0.0, 0.0 };
-    this->GetSliceNode()->GetXYToRAS()->MultiplyPoint(viewup, viewup2);
-    viewUp_World[0] = viewup2[0];
-    viewUp_World[1] = viewup2[1];
-    viewUp_World[2] = viewup2[2];
-  }
-  else
-  {
-    double handlePosition_World[3] = { 0.0, 0.0, 0.0 };
-    this->GetInteractionHandlePositionWorld(InteractionRotationHandle, 3, handlePosition_World);
-    this->GetHandleToCameraVectorWorld(handlePosition_World, viewDirection_World);
-
     vtkCamera* camera = this->GetRenderer()->GetActiveCamera();
-    camera->GetViewUp(viewUp_World);
+    if (camera->GetParallelProjection())
+    {
+      this->CachedParallelProjection = true;
+      camera->GetViewPlaneNormal(this->CachedCameraDirection);
+    }
+    else
+    {
+      this->CachedParallelProjection = false;
+      camera->GetPosition(this->CachedCameraPosition);
+    }
+    camera->GetViewUp(this->CachedViewUp_World);
   }
-
-  vtkSmartPointer<vtkTransform> worldToHandleTransform = vtkTransform::SafeDownCast(this->Pipeline->HandleToWorldTransform->GetInverse());
-
-  double viewDirection_Handle[3] = { 0.0, 0.0, 0.0 };
-  worldToHandleTransform->TransformVector(viewDirection_World, viewDirection_Handle);
-
-  double viewUp_Handle[3] = { 0.0, 0.0, 0.0 };
-  worldToHandleTransform->TransformVector(viewUp_World, viewUp_Handle);
-
-  double xAxis[3] = { 1.0, 0.0, 0.0 };
-  double yAxis[3] = { 0.0, 1.0, 0.0 };
-  double zAxis[3] = { 0.0, 0.0, 1.0 };
-  zAxis[0] = viewDirection_Handle[0];
-  zAxis[1] = viewDirection_Handle[1];
-  zAxis[2] = viewDirection_Handle[2];
-  vtkMath::Normalize(zAxis);
-
-  vtkMath::Cross(viewUp_Handle, viewDirection_Handle, xAxis);
-  vtkMath::Normalize(xAxis);
-
-  vtkMath::Cross(viewDirection_Handle, xAxis, yAxis);
-  vtkMath::Normalize(yAxis);
-
-  orientationArray->SetTuple9(3, xAxis[0], xAxis[1], xAxis[2], yAxis[0], yAxis[1], yAxis[2], zAxis[0], zAxis[1], zAxis[2]);
 }
 
 //----------------------------------------------------------------------
@@ -1412,72 +1837,6 @@ vtkPolyData* vtkMRMLInteractionWidgetRepresentation::GetHandlePolydata(int type)
     return this->Pipeline->ScaleHandlePoints;
   }
   return nullptr;
-}
-
-//----------------------------------------------------------------------
-int vtkMRMLInteractionWidgetRepresentation::UpdateHandleColors(int type, int colorIndex)
-{
-  vtkPolyData* handlePolyData = this->GetHandlePolydata(type);
-  if (!handlePolyData)
-  {
-    return colorIndex;
-  }
-
-  vtkPointData* pointData = handlePolyData->GetPointData();
-  if (!pointData)
-  {
-    return colorIndex;
-  }
-
-  vtkSmartPointer<vtkFloatArray> colorArray = vtkFloatArray::SafeDownCast(pointData->GetAbstractArray("colorIndex"));
-  if (!colorArray)
-  {
-    colorArray = vtkSmartPointer<vtkFloatArray>::New();
-    colorArray->SetName("colorIndex");
-    colorArray->SetNumberOfComponents(1);
-    pointData->AddArray(colorArray);
-    pointData->SetActiveScalars("colorIndex");
-  }
-  colorArray->Initialize();
-  colorArray->SetNumberOfTuples(handlePolyData->GetNumberOfPoints() * 2);
-
-  double color[4] = { 0.0, 0.0, 0.0, 0.0 };
-  for (int i = 0; i < handlePolyData->GetNumberOfPoints(); ++i)
-  {
-    this->GetHandleColor(type, i, color);
-    this->Pipeline->ColorTable->SetTableValue(colorIndex, color);
-    colorArray->SetTuple1(i, colorIndex);
-    ++colorIndex;
-
-    double grey = 0.3;
-    bool selected = this->GetActiveComponentType() == type && this->GetActiveComponentIndex() == i;
-    if (selected)
-    {
-      grey = 0.0;
-    }
-    this->Pipeline->ColorTable->SetTableValue(colorIndex, grey, grey, grey, color[3]);
-    ++colorIndex;
-  }
-
-  return colorIndex;
-}
-
-//----------------------------------------------------------------------
-void vtkMRMLInteractionWidgetRepresentation::UpdateHandleColors()
-{
-  int numberOfHandles = this->GetNumberOfHandles();
-  int numberOfColors = numberOfHandles * 2; // alternate fill and outline colors
-  numberOfColors += 2;                      // Additional colors for minimal fill.
-
-  this->Pipeline->ColorTable->SetNumberOfTableValues(numberOfColors);
-  this->Pipeline->ColorTable->SetTableRange(0, double(numberOfColors) - 1);
-
-  int colorIndex = 0;
-  colorIndex = this->UpdateHandleColors(InteractionRotationHandle, colorIndex);
-  colorIndex = this->UpdateHandleColors(InteractionTranslationHandle, colorIndex);
-  colorIndex = this->UpdateHandleColors(InteractionScaleHandle, colorIndex);
-
-  this->Pipeline->ColorTable->Build();
 }
 
 //----------------------------------------------------------------------
@@ -1558,7 +1917,6 @@ bool vtkMRMLInteractionWidgetRepresentation::GetHandleVisibility(int type, int i
 //----------------------------------------------------------------------
 double vtkMRMLInteractionWidgetRepresentation::GetHandleOpacity(int type, int index)
 {
-  // Determine if the handle should be displayed
   bool handleVisible = this->GetHandleVisibility(type, index);
   if (!handleVisible)
   {
@@ -1571,7 +1929,6 @@ double vtkMRMLInteractionWidgetRepresentation::GetHandleOpacity(int type, int in
   this->GetInteractionHandleAxisWorld(type, index, axis_World);
   if (axis_World[0] == 0.0 && axis_World[1] == 0.0 && axis_World[2] == 0.0)
   {
-    // No axis specified. The handle should be viewable from any direction.
     return opacity * this->GetInteractionHandleOpacity();
   }
 
@@ -1589,7 +1946,6 @@ double vtkMRMLInteractionWidgetRepresentation::GetHandleOpacity(int type, int in
   double angle = vtkMath::DegreesFromRadians(vtkMath::AngleBetweenVectors(viewNormal_World, axis_World));
   if (type == InteractionRotationHandle)
   {
-    // Fade happens when the axis approaches 90 degrees from the view normal
     if (angle > 90.0 - this->EndFadeAngleDegrees)
     {
       opacity = 0.0;
@@ -1602,7 +1958,6 @@ double vtkMRMLInteractionWidgetRepresentation::GetHandleOpacity(int type, int in
   }
   else if (type == InteractionTranslationHandle || type == InteractionScaleHandle)
   {
-    // Fade happens when the axis approaches 0 degrees from the view normal
     if (angle < this->EndFadeAngleDegrees)
     {
       opacity = 0.0;
@@ -1625,34 +1980,16 @@ void vtkMRMLInteractionWidgetRepresentation::GetHandleToCameraVectorWorld(double
     return;
   }
 
-  if (this->GetSliceNode())
+  if (this->CachedParallelProjection)
   {
-    double slicePlaneNormalWorld4[4] = { 0.0, 0.0, 1.0, 0.0 };
-    vtkMRMLSliceNode* sliceNode = this->GetSliceNode();
-    if (sliceNode)
-    {
-      sliceNode->GetXYToRAS()->MultiplyPoint(slicePlaneNormalWorld4, slicePlaneNormalWorld4);
-    }
-    normal_World[0] = slicePlaneNormalWorld4[0];
-    normal_World[1] = slicePlaneNormalWorld4[1];
-    normal_World[2] = slicePlaneNormalWorld4[2];
-    vtkMath::Normalize(normal_World);
+    normal_World[0] = this->CachedCameraDirection[0];
+    normal_World[1] = this->CachedCameraDirection[1];
+    normal_World[2] = this->CachedCameraDirection[2];
   }
-  else if (this->GetRenderer() && this->GetRenderer()->GetActiveCamera())
+  else
   {
-    // 3D and VR views
-    vtkCamera* camera = this->GetRenderer()->GetActiveCamera();
-    if (camera->GetParallelProjection())
-    {
-      camera->GetViewPlaneNormal(normal_World);
-    }
-    else
-    {
-      double cameraPosition_World[3] = { 0.0, 0.0, 0.0 };
-      camera->GetPosition(cameraPosition_World);
-      vtkMath::Subtract(cameraPosition_World, handlePosition_World, normal_World);
-      vtkMath::Normalize(normal_World);
-    }
+    vtkMath::Subtract(this->CachedCameraPosition, handlePosition_World, normal_World);
+    vtkMath::Normalize(normal_World);
   }
 }
 
@@ -1807,6 +2144,15 @@ vtkMRMLInteractionWidgetRepresentation::HandleInfoList vtkMRMLInteractionWidgetR
 {
   HandleInfoList handleInfoList;
 
+  // The handle info is used for picking, which can happen between renders (or before the first
+  // render), so the cached camera state and the handle-to-world transform cannot be assumed to be
+  // up-to-date here.
+  this->UpdateCameraState();
+  if (this->Pipeline)
+  {
+    this->UpdateHandleToWorldTransform();
+  }
+
   for (int index = 0; index < this->GetNumberOfHandles(InteractionRotationHandle); ++index)
   {
     handleInfoList.push_back(this->GetHandleInfo(InteractionRotationHandle, index));
@@ -1959,12 +2305,20 @@ void vtkMRMLInteractionWidgetRepresentation::UpdateViewScaleFactor()
     double cameraPos_World[3] = { 0.0, 0.0, 0.0 };
     this->Renderer->GetActiveCamera()->GetPosition(cameraPos_World);
 
-    double distance = sqrt(vtkMath::Distance2BetweenPoints(handlePoint_World, cameraPos_World));
-
     double cameraDirection_World[3] = { 0.0, 0.0, 0.0 };
     this->Renderer->GetActiveCamera()->GetDirectionOfProjection(cameraDirection_World);
     vtkMath::Normalize(cameraDirection_World);
-    vtkMath::MultiplyScalar(cameraDirection_World, distance);
+
+    // Use projected depth (along view direction) instead of Euclidean distance
+    // so that lateral position on screen doesn't affect handle size.
+    double handleToCamera[3];
+    vtkMath::Subtract(handlePoint_World, cameraPos_World, handleToCamera);
+    double depth = vtkMath::Dot(handleToCamera, cameraDirection_World);
+    // The depth is negative if the handle is behind the camera (which can happen in VR when the user
+    // walks past the handles). Keep the point that the scale factor is computed at in front of the
+    // camera, otherwise the computed scale factor is meaningless.
+    depth = std::max(depth, this->Renderer->GetActiveCamera()->GetClippingRange()[0]);
+    vtkMath::MultiplyScalar(cameraDirection_World, depth);
 
     double handleFocalPoint_World[3] = { 0.0, 0.0, 0.0 };
     vtkMath::Add(cameraPos_World, cameraDirection_World, handleFocalPoint_World);

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionWidgetRepresentation.h
@@ -51,29 +51,26 @@
 
 // VTK includes
 #include <vtkActor.h>
-#include <vtkActor2D.h>
-#include <vtkAppendPolyData.h>
-#include <vtkArrayCalculator.h>
-#include <vtkGlyph3D.h>
-#include <vtkLookupTable.h>
+#include <vtkFloatArray.h>
+#include <vtkGlyph3DMapper.h>
+#include <vtkIntArray.h>
 #include <vtkPlane.h>
 #include <vtkPointPlacer.h>
-#include <vtkPointSetToLabelHierarchy.h>
-#include <vtkPolyDataMapper.h>
-#include <vtkPolyDataMapper2D.h>
 #include <vtkProperty.h>
-#include <vtkProperty2D.h>
 #include <vtkSmartPointer.h>
-#include <vtkSphereSource.h>
-#include <vtkTextActor.h>
-#include <vtkTextProperty.h>
-#include <vtkTensorGlyph.h>
 #include <vtkTransform.h>
-#include <vtkTransformPolyDataFilter.h>
+#include <vtkUnsignedCharArray.h>
+#include <vtkWeakPointer.h>
+
+// STD includes
+#include <map>
+#include <memory>
+#include <vector>
 
 class vtkMRMLInteractionEventData;
 class vtkMRMLDisplayNode;
 class vtkMRMLDisplayableNode;
+struct SharedHandleRenderer;
 
 class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLInteractionWidgetRepresentation : public vtkMRMLAbstractWidgetRepresentation
 {
@@ -86,6 +83,11 @@ public:
 
   /// Update the representation from display node
   void UpdateFromMRML(vtkMRMLNode* caller, unsigned long event, void* callData = nullptr) override;
+
+  /// Set the renderer that the representation is displayed in.
+  /// Unregisters the representation from the renderer that it was previously displayed in, so that its
+  /// interaction handles are no longer rendered there.
+  void SetRenderer(vtkRenderer* renderer) override;
 
   /// Methods to make this class behave as a vtkProp.
   void GetActors(vtkPropCollection*) override;
@@ -105,7 +107,11 @@ public:
 
   virtual vtkPointPlacer* GetPointPlacer();
 
-  /// Returns the actor for the interaction widget.
+  /// Returns the per-representation actor for the interaction widget.
+  /// In slice views this is the actor that renders the handles.
+  /// In 3D views the handles are drawn by a shared per-renderer actor and only
+  /// this actor's visibility is honored; property, mapper, or transform changes
+  /// on the returned actor have no effect on the rendered handles.
   vtkProp* GetInteractionActor();
 
   /// Returns true if the representation is displayable in the current view.
@@ -119,8 +125,6 @@ public:
 
   /// Update the interaction pipeline
   virtual void UpdateInteractionPipeline();
-
-  virtual void UpdateHandlePolyData();
 
   /// Get the axis for the handle specified by the index in local coordinates
   virtual void GetInteractionHandleAxisLocal(int type, int index, double axis[3]);
@@ -144,7 +148,11 @@ public:
     GlyphArrow,
     GlyphCircle,
     GlyphRing,
-    GlyphCrosshair
+    GlyphCrosshair,
+    GlyphArrowOutline,
+    GlyphCircleOutline,
+    GlyphRingOutline,
+    GlyphCrosshairOutline
   };
 
   virtual int GetActiveComponentType() = 0;
@@ -212,24 +220,24 @@ protected:
     vtkSmartPointer<vtkPolyData> RingOutlinePolyData;
     vtkSmartPointer<vtkPolyData> CrosshairOutlinePolyData;
 
-    std::map<std::pair<int, int>, vtkSmartPointer<vtkPolyData>> HandleGlyphPolyDataMap;
-    std::map<std::pair<int, int>, vtkSmartPointer<vtkPolyData>> HandleOutlineGlyphPolyDataMap;
-
     vtkSmartPointer<vtkPolyData> RotationHandlePoints;
     vtkSmartPointer<vtkPolyData> TranslationHandlePoints;
     vtkSmartPointer<vtkPolyData> ScaleHandlePoints;
 
-    vtkSmartPointer<vtkAppendPolyData> Append;
-    vtkSmartPointer<vtkTransformPolyDataFilter> HandleToWorldTransformFilter;
     vtkSmartPointer<vtkTransform> HandleToWorldTransform;
-    vtkSmartPointer<vtkLookupTable> ColorTable;
 
-    vtkSmartPointer<vtkPolyDataMapper> Mapper3D;
-    vtkSmartPointer<vtkProperty> Property3D;
-    vtkSmartPointer<vtkActor> Actor3D;
+    vtkSmartPointer<vtkPolyData> InstancePolyData;
+    vtkSmartPointer<vtkFloatArray> GlyphOrientationArray;
+    vtkSmartPointer<vtkFloatArray> GlyphScaleArray;
+    vtkSmartPointer<vtkIntArray> GlyphSourceIndexArray;
+    vtkSmartPointer<vtkUnsignedCharArray> ColorArray;
+
+    vtkSmartPointer<vtkGlyph3DMapper> Mapper;
+    vtkSmartPointer<vtkProperty> Property;
+    vtkSmartPointer<vtkActor> Actor;
 
     vtkSmartPointer<vtkTransform> WorldToSliceTransform;
-    vtkSmartPointer<vtkTransformPolyDataFilter> WorldToSliceTransformFilter;
+    vtkSmartPointer<vtkTransform> ActorTransform;
   };
 
   struct HandleInfo
@@ -278,20 +286,19 @@ protected:
   virtual void CreateRotationHandles();
   virtual void CreateTranslationHandles();
   virtual void CreateScaleHandles();
-  virtual void UpdateHandleColors();
-  virtual int UpdateHandleColors(int type, int startIndex);
+  virtual void UpdateInstanceArrays();
+  virtual void UpdateActorTransform();
   virtual vtkPolyData* GetHandlePolydata(int type);
 
-  virtual void UpdateHandleOrientation();
-  virtual void UpdateTranslationHandleOrientation();
-  virtual void UpdateScaleHandleOrientation();
-  virtual void UpdateRotationHandleOrientation();
+  /// Cache camera state (direction, position, view up) for use by per-handle computations.
+  virtual void UpdateCameraState();
 
   /// Set the scale of the interaction handles in world coordinates
   virtual void SetWidgetScale(double scale);
 
   /// Get the vector from the interaction handle to the camera in world coordinates.
   /// In slice views and in 3D with parallel projection this is the same as the camera view direction.
+  /// Uses cached camera state from UpdateCameraState().
   virtual void GetHandleToCameraVectorWorld(double handlePosition_World[3], double normal_World[3]);
 
   /// Orthogonalize the transform axes. The Z-axis will not be changed.
@@ -339,12 +346,76 @@ protected:
 
   double WidgetScale{ 1.0 };
 
+  bool CachedParallelProjection{ true };
+  double CachedCameraPosition[3]{ 0.0, 0.0, 0.0 };
+  double CachedCameraDirection[3]{ 0.0, 0.0, 1.0 };
+  double CachedViewUp_World[3]{ 0.0, 1.0, 0.0 };
+
+  /// State that the handle instance arrays were last built for. Rebuilding the arrays is relatively
+  /// expensive, so it is only done when this state changes.
+  /// The camera state is compared by value rather than by MTime, because the camera is modified on
+  /// every render by clipping range updates, which do not affect the appearance of the handles.
+  /// Clipping range is intentionally excluded: the clamp in UpdateViewScaleFactor only changes the
+  /// result when the handle is behind/inside the near plane (not visible), and the camera pose change
+  /// that causes that already reopens the gate.
+  struct RenderState
+  {
+    vtkMTimeType RepresentationMTime{ 0 };
+    vtkMTimeType SliceXYToRASMTime{ 0 };
+    double CameraPosition[3]{ 0.0, 0.0, 0.0 };
+    double CameraDirectionOfProjection[3]{ 0.0, 0.0, 0.0 };
+    double CameraViewUp[3]{ 0.0, 0.0, 0.0 };
+    double CameraParallelScale{ 0.0 };
+    double CameraViewAngle{ 0.0 };
+    bool CameraParallelProjection{ false };
+    int RendererSize[2]{ 0, 0 };
+    int ScreenSize[2]{ 0, 0 };
+    int ActiveComponentType{ -1 };
+    int ActiveComponentIndex{ -1 };
+
+    bool operator==(const RenderState& other) const;
+    bool operator!=(const RenderState& other) const { return !(*this == other); }
+  };
+
+  /// Get the state that the handle instance arrays would be built for if they were rebuilt now.
+  RenderState GetCurrentRenderState();
+
+  /// Rebuild the handle instance arrays if the state that they were built for has changed.
+  /// Returns true if the arrays have been rebuilt.
+  bool UpdatePipelineIfNeeded();
+
+  RenderState LastRenderState;
+  bool HasVisibleHandles{ false };
+
   bool Interacting{ false };
 
   vtkSmartPointer<vtkPointPlacer> PointPlacer;
 
   virtual void SetupInteractionPipeline();
   InteractionPipeline* Pipeline;
+
+  ///@{
+  /// Shared handle renderer: in 3D views, all interaction handle instances are rendered by a single
+  /// shared actor per vtkRenderer (one instanced draw per glyph source instead of one actor per
+  /// handle). The map is keyed by renderer pointer; entries are created on first use and removed
+  /// when the last representation unregisters or when the renderer fires DeleteEvent.
+  static std::map<vtkRenderer*, std::unique_ptr<SharedHandleRenderer>> SharedHandleRenderers;
+  static SharedHandleRenderer* GetSharedHandleRenderer(vtkRenderer* renderer, bool create = false);
+  static void OnSharedRendererStartEvent(vtkObject* caller, unsigned long eid, void* clientData, void* callData);
+  static void OnSharedRendererDelete(vtkObject* caller, unsigned long eid, void* clientData, void* callData);
+  void RegisterWithSharedHandleRenderer();
+  void UnregisterFromSharedHandleRenderer();
+  bool IsSharedRenderingRepresentation(SharedHandleRenderer* shared) const;
+  static void ConfigureHandleInstancePipeline(vtkSmartPointer<vtkPolyData>& instancePolyData,
+                                              vtkSmartPointer<vtkFloatArray>& orientationArray,
+                                              vtkSmartPointer<vtkFloatArray>& scaleArray,
+                                              vtkSmartPointer<vtkIntArray>& sourceIndexArray,
+                                              vtkSmartPointer<vtkUnsignedCharArray>& colorArray,
+                                              vtkSmartPointer<vtkGlyph3DMapper>& mapper,
+                                              vtkSmartPointer<vtkProperty>& property,
+                                              vtkSmartPointer<vtkActor>& actor);
+  static unsigned char ColorComponentToUChar(double c);
+  ///@}
 
 private:
   vtkMRMLInteractionWidgetRepresentation(const vtkMRMLInteractionWidgetRepresentation&) = delete;

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager.cxx
@@ -169,6 +169,7 @@ void vtkMRMLLinearTransformsDisplayableManager::vtkInternal::UpdatePipelineFromD
     if (widget->GetNeedToRender())
     {
       this->External->RequestRender();
+      widget->NeedToRenderOff();
     }
   }
 }
@@ -360,6 +361,7 @@ void vtkMRMLLinearTransformsDisplayableManager::ProcessMRMLNodesEvents(vtkObject
       if (interactionWidget.second->GetNeedToRender())
       {
         this->RequestRender();
+        interactionWidget.second->NeedToRenderOff();
       }
     }
   }
@@ -370,6 +372,10 @@ void vtkMRMLLinearTransformsDisplayableManager::ProcessMRMLNodesEvents(vtkObject
     for (auto interactionWidget : this->Internal->InteractionWidgets)
     {
       interactionWidget.second->UpdateFromMRML(this->Internal->GetAbstractViewNode(), event, callData);
+      if (interactionWidget.second->GetNeedToRender())
+      {
+        interactionWidget.second->NeedToRenderOff();
+      }
     }
   }
   else


### PR DESCRIPTION
Replace the per-representation vtkAppendPolyData / vtkTransformPolyDataFilter CPU pipeline with a single shared vtkGlyph3DMapper per representation that batches all handle glyphs (rotation, translation, scale) into one GPU instanced draw call, using per-instance orientation/scale/color arrays instead of composing handle polydata by hand on the CPU every frame.

Previously the full handle polydata pipeline (append + transform filter) was rebuilt on every render call, even when nothing about the handles had actually changed - e.g. camera clipping-range updates alone were enough to trigger MTime propagation and force a full rebuild. Add a RenderState struct that caches the camera pose, slice transform MTime, and active component, and only rebuilds the instance arrays when that state actually changes.

Benchmark: 80 vtkMRMLMarkupsROINode instances with HandlesInteractive enabled simultaneously in the 3D view (~1200 handle actors total), orbiting the camera for 100 Render() calls x 2 runs, identical window size (1384x835), RelWithDebInfo build, before/after this commit:

| | main (before) | branch (after) | speedup |
| --- | ---  | --- | --- |
| avg | 568 ms/frame | 76 ms/frame | ~7.5x |
| median | 557 ms/frame | 71 ms/frame | ~7.8x |
| min | 503 ms/frame | 62 ms/frame | ~8.1x |
| frame rate | ~1.8 fps | ~13 fps | ~7.2x  |