### PR TITLE
BUG: Keep Draw cursor while the effect is active

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorDrawEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorDrawEffect.py
@@ -52,6 +52,16 @@ class SegmentEditorDrawEffect(AbstractScriptedSegmentEditorLabelEffect):
     def setupOptionsFrame(self):
         pass
 
+    def reassertCursor(self, viewWidget):
+        # Markup widgets set the view's cursor directly on hover, independently of this effect.
+        # Since this tool remains the active one throughout (hovering or clicking on an object
+        # does not switch tools), the cursor should not show their icon instead. Doing so
+        # misleadingly suggests that interacting with that object is possible, so we force here
+        # this effect's own cursor.
+        cursor = self.scriptedEffect.createCursor(viewWidget)
+        viewWidget.sliceView().setViewCursor(cursor)
+        viewWidget.sliceView().setDefaultViewCursor(cursor)
+
     def processInteractionEvents(self, callerInteractor, eventId, viewWidget):
         abortEvent = False
 
@@ -62,6 +72,9 @@ class SegmentEditorDrawEffect(AbstractScriptedSegmentEditorLabelEffect):
         pipeline = self.pipelineForWidget(viewWidget)
         if pipeline is None:
             return abortEvent
+
+        if pipeline.actionState != "drawing":
+            self.reassertCursor(viewWidget)
 
         anyModifierKeyPressed = callerInteractor.GetShiftKey() or callerInteractor.GetControlKey() or callerInteractor.GetAltKey()
 


### PR DESCRIPTION
There is a bug with the mouse cursor when mixing segmentation Draw effect with other object types. In the segmentation widget, when using the “Draw” tool, the cursor icon changes when hovering over a markup object (or reorientation controls), but the Draw tool is still active. 

Steps to reproduce: 
- Load a volume.
- In Markups module, create for example a Line.
- In Segment Editor module, add a segment.
- Click on Draw effect => the cursor changes to drawing.
- Move the mouse on the line handle => the cursor changes to "hand" shape indicating we can move it.
- Left-click with mouse and drag => the drawing is active but the cursor does not change, and then never goes back to Draw icon.

The cursor should stay in Draw mode until we deselect the effect.