### PR TITLE
ENH: Scale OBJ mesh coordinates based on unit specified in file header

### DIFF
--- a/Docs/user_guide/data_loading_and_saving.md
+++ b/Docs/user_guide/data_loading_and_saving.md
@@ -150,13 +150,22 @@ Readers may support 2D, 3D, and 4D images of various types, such as scalar, vect
 
 ### Models
 
-Surface or volumetric meshes.
+Surface or volumetric meshes. Where a format description below states that the coordinate system can be specified in the file header, the convention described in [Specifying the coordinate system in model files](#specifying-the-coordinate-system-in-model-files) is used.
 
-- [**VTK Polygonal Data**](https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf) (.vtk, .vtp): Default coordinate system: LPS. Coordinate system (LPS/RAS) can be specified in header. Full color (RGB or RGBA) meshes can be read and written (color must be assigned as point scalar data of `unsigned char` type and 3 or 4 components). Texture image can be applied using "Texture model" module (in SlicerIGT extension).
+- [**VTK Polygonal Data**](https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf) (.vtk, .vtp):
+  - Default coordinate system: LPS. Coordinate system (LPS/RAS) can be specified in header.
+  - Full color (RGB or RGBA) meshes can be read and written (color must be assigned as point scalar data of `unsigned char` type and 3 or 4 components).
+  - Texture image can be applied using "Texture model" module (in SlicerIGT extension).
 - [**VTK Unstructured Grid Data**](https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf) (.vtk, .vtu): Volumetric mesh. Default coordinate system: LPS. Coordinate system (LPS/RAS) can be specified in header.
 - **STereoLithography** (.stl): Format most commonly used for 3D printing. Default coordinate system: LPS. Coordinate system (LPS/RAS) can be specified in header.
-- **Wavefront OBJ** (.obj): Default coordinate system: LPS. Coordinate system (LPS/RAS) can be specified in header. Texture image can be applied using "Texture model" module (in SlicerIGT extension). The non-standard [technique of saving vertex color as additional values after coordinates](https://web.archive.org/web/20220508010504/www.paulbourke.net/dataformats/obj/colour.html) is not supported - if vertex coloring is needed then convert to PLY, VTK, or VTP format using another software.
-- **Stanford Triangle Format** (.ply): Default coordinate system: LPS. Coordinate system (LPS/RAS) can be specified in header. Full color (RGB or RGBA) meshes can be read and written (color must be assigned to vertex data in `uchar` type properties named `red`, `green`, `blue`, and optional `alpha`). Texture image can be applied using "Texture model" module (in SlicerIGT extension).
+- **Wavefront OBJ** (.obj):
+  - Default coordinate system: LPS. Coordinate system (LPS/RAS) can be specified in header.
+  - Some applications (for example, Materialise Mimics and 3-matic) write the length unit of the vertex coordinates into the file header as a comment, such as `vertex coordinates are measured in units, where 1 unit = 1000.000000 mm`; if this comment is found then the vertex coordinates are automatically scaled to millimeters when the file is loaded (only `mm` unit is supported).
+  - Texture image can be applied using "Texture model" module (in SlicerIGT extension). The non-standard [technique of saving vertex color as additional values after coordinates](https://web.archive.org/web/20220508010504/www.paulbourke.net/dataformats/obj/colour.html) is not supported - if vertex coloring is needed then convert to PLY, VTK, or VTP format using another software.
+- **Stanford Triangle Format** (.ply):
+  - Default coordinate system: LPS. Coordinate system (LPS/RAS) can be specified in header.
+  - Full color (RGB or RGBA) meshes can be read and written (color must be assigned to vertex data in `uchar` type properties named `red`, `green`, `blue`, and optional `alpha`).
+  - Texture image can be applied using "Texture model" module (in SlicerIGT extension).
 - **BYU** (.byu, .g; reading only): Coordinate system: LPS.
 - **UCD** (.ucd; reading only): Coordinate system: LPS.
 - **ITK meta** (.meta; reading only): Coordinate system: LPS.
@@ -164,6 +173,18 @@ Surface or volumetric meshes.
   - **Freesurfer surfaces** (.orig, .inflated, .sphere, .white, .smoothwm, .pial; reading only)
 - [SlicerHeart extension](https://github.com/SlicerHeart/SlicerHeart):
   - **CARTO surface model** (.vtk; writing only): special .vtk polydata file format variant, which contains patient name and ID to allow import into CARTO cardiac electrophysiology mapping systems
+
+#### Specifying the coordinate system in model files
+
+Most mesh file formats have no standard way of storing the anatomical coordinate system, therefore Slicer uses the following convention: the coordinate system is specified by a `SPACE=RAS` or `SPACE=LPS` string (following the NRRD `space` field naming convention) stored in the file header:
+
+- **VTK legacy files** (.vtk): in the header comment (second line of the file), for example: `3D Slicer output. SPACE=RAS`
+- **VTK XML files** (.vtp, .vtu): in a string array named `SPACE` in the field data of the mesh, containing a single value: `RAS` or `LPS`
+- **STL** (.stl): in the file header (the 80-byte header of binary STL files, or the text after `solid` in ASCII STL files), for example: `3D Slicer output. SPACE=RAS`.
+- **Wavefront OBJ** (.obj): in a comment line, for example: `# 3D Slicer output. SPACE=RAS`
+- **Stanford PLY** (.ply): in a comment line in the file header, for example: `comment SPACE=RAS`
+
+When reading a file, Slicer searches the header text for the `SPACE=RAS` or `SPACE=LPS` string (it may appear anywhere within the header comment, surrounding text is ignored); if neither is found then the coordinates are assumed to be in the LPS coordinate system. When writing a file, Slicer always adds the coordinate system specification to the file header. By default, models are written using the LPS coordinate system; this can be changed in the "Coordinate system" option in the Save dialog.
 
 ### Segmentations
 

--- a/Libs/MRML/Core/Testing/vtkMRMLModelStorageNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLModelStorageNodeTest1.cxx
@@ -25,10 +25,12 @@ Program:   3D Slicer
 #include <array>
 
 // STD includes
+#include <fstream>
 #include <iostream>
 
 //---------------------------------------------------------------------------
 int TestReadWriteData(vtkMRMLScene* scene, const char* extension, vtkPointSet* mesh, int coordinateSystem, bool cellsMayBeSubdivided = false);
+int TestReadOBJWithCoordinateUnitComment(vtkMRMLScene* scene, const char* comment, double expectedScale);
 void CreateVoxelMeshes(vtkUnstructuredGrid* ug, vtkPolyData* poly);
 
 //---------------------------------------------------------------------------
@@ -60,6 +62,11 @@ int vtkMRMLModelStorageNodeTest1(int argc, char* argv[])
     CHECK_EXIT_SUCCESS(TestReadWriteData(scene.GetPointer(), ".vtk", ug.GetPointer(), coordinateSystem));
     CHECK_EXIT_SUCCESS(TestReadWriteData(scene.GetPointer(), ".vtu", ug.GetPointer(), coordinateSystem));
   }
+
+  // Test that vertex coordinate unit specified in OBJ file header comment
+  // (written by Materialise Mimics and 3-matic) is used for scaling the coordinates to millimeters.
+  CHECK_EXIT_SUCCESS(TestReadOBJWithCoordinateUnitComment(scene, "# vertex coordinates are measured in units, where 1 unit = 1.000000 mm", 1.0));
+  CHECK_EXIT_SUCCESS(TestReadOBJWithCoordinateUnitComment(scene, "# vertex coordinates are measured in units, where 1 unit = 1000.000000 mm", 1000.0));
 
   std::cout << "Test passed." << std::endl;
   return EXIT_SUCCESS;
@@ -137,5 +144,53 @@ int TestReadWriteData(vtkMRMLScene* scene, const char* extension, vtkPointSet* m
   CHECK_BOOL(storageNode->ReadData(modelNode.GetPointer()), true);
   CHECK_INT(storageNode->GetCoordinateSystem(), coordinateSystem);
 
+  return EXIT_SUCCESS;
+}
+
+//---------------------------------------------------------------------------
+int TestReadOBJWithCoordinateUnitComment(vtkMRMLScene* scene, const char* comment, double expectedScale)
+{
+  std::cout << "Testing .obj with header comment: " << comment << std::endl;
+
+  const double originalPoints[3][3] = { { 0.001, 0.002, 0.003 }, { 0.004, 0.005, 0.006 }, { 0.007, 0.008, 0.009 } };
+
+  std::string fileName = std::string(scene->GetRootDirectory()) + std::string("/vtkMRMLModelNodeTest1UnitComment.obj");
+  std::ofstream outputFile(fileName.c_str());
+  CHECK_BOOL(outputFile.is_open(), true);
+  outputFile << comment << "\n";
+  // Specify RAS coordinate system in the file header so that the loaded point coordinates
+  // are not flipped by RAS/LPS conversion.
+  outputFile << "# SPACE=RAS\n";
+  for (int pointIndex = 0; pointIndex < 3; pointIndex++)
+  {
+    outputFile << "v " << originalPoints[pointIndex][0] << " " << originalPoints[pointIndex][1] << " " << originalPoints[pointIndex][2] << "\n";
+  }
+  outputFile << "f 1 2 3\n";
+  outputFile.close();
+
+  // Add model node with storage node
+  vtkNew<vtkMRMLModelNode> modelNode;
+  CHECK_NOT_NULL(scene->AddNode(modelNode));
+  modelNode->AddDefaultStorageNode();
+  vtkMRMLModelStorageNode* storageNode = vtkMRMLModelStorageNode::SafeDownCast(modelNode->GetStorageNode());
+  CHECK_NOT_NULL(storageNode);
+  storageNode->SetFileName(fileName.c_str());
+
+  // Test reading
+  CHECK_BOOL(storageNode->ReadData(modelNode), true);
+  vtkPointSet* mesh = modelNode->GetMesh();
+  CHECK_NOT_NULL(mesh);
+  CHECK_INT(mesh->GetNumberOfPoints(), 3);
+  for (int pointIndex = 0; pointIndex < 3; pointIndex++)
+  {
+    double coordinate[3] = { 0.0, 0.0, 0.0 };
+    mesh->GetPoint(pointIndex, coordinate);
+    for (int componentIndex = 0; componentIndex < 3; componentIndex++)
+    {
+      CHECK_DOUBLE_TOLERANCE(coordinate[componentIndex], originalPoints[pointIndex][componentIndex] * expectedScale, 1e-4);
+    }
+  }
+
+  scene->RemoveNode(modelNode);
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/vtkMRMLModelStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelStorageNode.cxx
@@ -62,6 +62,9 @@
 #include <itkSpatialObjectReader.h>
 #include <itkSpatialObjectWriter.h>
 
+// STD includes
+#include <sstream>
+
 typedef itk::DefaultDynamicMeshTraits<double, 3, 3, double> MeshTrait;
 typedef itk::Mesh<double, 3, MeshTrait> floatMesh;
 
@@ -324,6 +327,31 @@ int vtkMRMLModelStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
       meshFromFile = reader->GetOutput();
       this->GetUserMessages()->SetObservedObject(nullptr);
       coordinateSystemInFileHeader = vtkMRMLModelStorageNode::GetCoordinateSystemFromFileHeader(reader->GetComment());
+      // The file header comment may specify the length unit of the vertex coordinates.
+      // Apply scaling to convert the coordinates to millimeters.
+      double coordinateUnitScale = 1.0;
+      std::string coordinateUnit;
+      if (vtkMRMLModelStorageNode::GetCoordinateUnitScaleFromFileHeader(reader->GetComment(), coordinateUnitScale, coordinateUnit))
+      {
+        if (vtksys::SystemTools::LowerCase(coordinateUnit) != "mm")
+        {
+          vtkWarningToMessageCollectionMacro(this->GetUserMessages(),
+                                             "vtkMRMLModelStorageNode::ReadDataInternal",
+                                             "Model file '" << fullName << "' specifies vertex coordinate unit as '" << coordinateUnit
+                                                            << "'. Only 'mm' is supported, therefore coordinate values are loaded without unit conversion.");
+        }
+        else if (coordinateUnitScale <= 0.0)
+        {
+          vtkWarningToMessageCollectionMacro(this->GetUserMessages(),
+                                             "vtkMRMLModelStorageNode::ReadDataInternal",
+                                             "Model file '" << fullName << "' specifies invalid vertex coordinate unit scale '" << coordinateUnitScale
+                                                            << "'. Coordinate values are loaded without unit conversion.");
+        }
+        else if (coordinateUnitScale != 1.0 && meshFromFile)
+        {
+          vtkMRMLModelStorageNode::ScalePointSet(meshFromFile, meshFromFile, coordinateUnitScale, coordinateUnitScale, coordinateUnitScale);
+        }
+      }
     }
     else if (extension == std::string(".meta")) // model in meta format
     {
@@ -861,19 +889,25 @@ vtkMRMLModelNode* vtkMRMLModelStorageNode::GetAssociatedDataNode()
 //----------------------------------------------------------------------------
 void vtkMRMLModelStorageNode::ConvertBetweenRASAndLPS(vtkPointSet* inputMesh, vtkPointSet* outputMesh)
 {
+  vtkMRMLModelStorageNode::ScalePointSet(inputMesh, outputMesh, -1.0, -1.0, 1.0);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLModelStorageNode::ScalePointSet(vtkPointSet* inputMesh, vtkPointSet* outputMesh, double scaleX, double scaleY, double scaleZ)
+{
   if (!inputMesh || !outputMesh)
   {
-    vtkGenericWarningMacro("vtkMRMLModelStorageNode::ConvertBetweenRASAndLPS: invalid input or output mesh");
+    vtkGenericWarningMacro("vtkMRMLModelStorageNode::ScalePointSet: invalid input or output mesh");
     return;
   }
-  vtkNew<vtkTransform> transformRasLps;
-  transformRasLps->Scale(-1, -1, 1);
+  vtkNew<vtkTransform> scaleTransform;
+  scaleTransform->Scale(scaleX, scaleY, scaleZ);
   // vtkTransformPolyDataFilter preserves texture coordinates, while vtkTransformFilter removes them,
   // therefore we must use vtkTransformPolyDataFilter for surface meshes.
   if (inputMesh->IsA("vtkPolyData"))
   {
     vtkNew<vtkTransformPolyDataFilter> transformFilter;
-    transformFilter->SetTransform(transformRasLps);
+    transformFilter->SetTransform(scaleTransform);
     transformFilter->SetInputData(inputMesh);
     transformFilter->Update();
     outputMesh->ShallowCopy(transformFilter->GetOutput());
@@ -881,12 +915,36 @@ void vtkMRMLModelStorageNode::ConvertBetweenRASAndLPS(vtkPointSet* inputMesh, vt
   else
   {
     vtkNew<vtkTransformFilter> transformFilter;
-    transformFilter->SetTransform(transformRasLps);
+    transformFilter->SetTransform(scaleTransform);
     transformFilter->SetInputData(inputMesh);
     transformFilter->TransformAllInputVectorsOn();
     transformFilter->Update();
     outputMesh->ShallowCopy(transformFilter->GetOutput());
   }
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLModelStorageNode::GetCoordinateUnitScaleFromFileHeader(const char* header, double& scale, std::string& unit)
+{
+  if (!header)
+  {
+    return false;
+  }
+  std::string headerStr = header;
+  // Materialise Mimics and 3-matic write the length unit of the vertex coordinates into the OBJ file header as a comment,
+  // such as "vertex coordinates are measured in units, where 1 unit = 1000.000000 mm". Use this information to read the file
+  // with correct scale.
+  const std::string key = "vertex coordinates are measured in units, where 1 unit =";
+  size_t keyPosition = vtksys::SystemTools::LowerCase(headerStr).find(key);
+  if (keyPosition == std::string::npos)
+  {
+    return false;
+  }
+  std::istringstream valueStream(headerStr.substr(keyPosition + key.size()));
+  scale = 0.0;
+  unit.clear();
+  valueStream >> scale >> unit;
+  return true;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLModelStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelStorageNode.h
@@ -23,6 +23,26 @@ class vtkPointSet;
 /// \brief MRML node for model storage on disk.
 ///
 /// Storage nodes has methods to read/write vtkPolyData to/from disk.
+///
+/// Coordinate system conversion (RAS/LPS): Slicer stores mesh point coordinates internally in the
+/// RAS coordinate system, while most model files use LPS. A model file may specify its coordinate
+/// system by a "SPACE=RAS" or "SPACE=LPS" specification, stored in the file header comment
+/// (STL, OBJ, PLY, legacy VTK) or in a "SPACE" field data array (VTP, VTU). When a file is read,
+/// this specification (if found) overrides the CoordinateSystem property of the node, and if the
+/// file is in LPS then the mesh is converted to RAS by flipping the sign of the first two
+/// coordinate axes. If no coordinate system specification is found in the file then the current
+/// value of the CoordinateSystem property is used (LPS by default; RAS when importing legacy scenes,
+/// which were saved before the coordinate system was written into model files). When a file is
+/// written, the mesh is converted from RAS to the coordinate system chosen in the CoordinateSystem
+/// property and the "SPACE=..." specification is written into the file header.
+///
+/// Automatic unit scaling: some applications (for example, Materialise Mimics and 3-matic) write
+/// the length unit of the vertex coordinates into the OBJ file header as a comment, such as
+/// "vertex coordinates are measured in units, where 1 unit = 1000.000000 mm". When an OBJ file
+/// containing this specification is read, the point coordinates are automatically multiplied by the
+/// specified scale to convert them to millimeters (the length unit used internally in Slicer).
+/// Only "mm" unit is supported; if any other unit or a non-positive scale is specified then a
+/// warning is logged and the coordinates are loaded without unit conversion.
 class VTK_MRML_EXPORT vtkMRMLModelStorageNode : public vtkMRMLStorageNode
 {
 public:
@@ -55,6 +75,10 @@ public:
   /// between RAS and LPS coordinate system.
   static void ConvertBetweenRASAndLPS(vtkPointSet* inputMesh, vtkPointSet* outputMesh);
 
+  /// Helper function that scales point coordinates of a mesh (polydata, unstructured grid, or even just a point cloud)
+  /// by the given scale factors along the x, y, z axes.
+  static void ScalePointSet(vtkPointSet* inputMesh, vtkPointSet* outputMesh, double scaleX, double scaleY, double scaleZ);
+
 protected:
   vtkMRMLModelStorageNode();
   ~vtkMRMLModelStorageNode() override;
@@ -79,6 +103,8 @@ protected:
   static int GetCoordinateSystemFromFileHeader(const char* header);
 
   static int GetCoordinateSystemFromFieldData(vtkPointSet* mesh);
+
+  static bool GetCoordinateUnitScaleFromFileHeader(const char* header, double& scale, std::string& unit);
 
   int CoordinateSystem;
 };


### PR DESCRIPTION
Some applications (for example, Materialise Mimics and 3-matic) write the length unit of the vertex coordinates into the OBJ file header as a comment, such as "vertex coordinates are measured in units, where 1 unit = 1000.000000 mm". Vertex coordinates are now automatically scaled to millimeters when such a file is loaded. Only "mm" unit is supported; for any other unit or invalid scale value a warning is logged and the coordinates are loaded without unit conversion.

Added test and documentation. For completeness, also amended the documentation with description of how coordinate system is also read from mesh file header.