### PR TITLE
COMP: Use ninja response files on Windows to stay under the command-line limit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,24 @@ endif()
 project(Slicer VERSION "${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR}.${Slicer_VERSION_PATCH}")
 
 #-----------------------------------------------------------------------------
+# Response files (Windows + Ninja)
+#-----------------------------------------------------------------------------
+# Slicer's include closure (VTK, CTK, ITK, GDCM, Qt, Python) grows the compile
+# command line past the 32767-character limit CreateProcess enforces, and ninja
+# then aborts the build with
+#
+#   ninja: fatal: CreateProcess: The parameter is incorrect.
+#    (is the command line too long?)
+#
+# Multi-config Visual Studio builds never hit this because MSBuild passes
+# compiler flags through response files already. Ask the Ninja generator to do
+# the same. Only set when the user has not chosen a value.
+if(WIN32 AND CMAKE_GENERATOR MATCHES "Ninja" AND NOT DEFINED CMAKE_NINJA_FORCE_RESPONSE_FILE)
+  set(CMAKE_NINJA_FORCE_RESPONSE_FILE ON CACHE BOOL
+    "Force ninja to pass compiler and linker flags via response files" FORCE)
+endif()
+
+#-----------------------------------------------------------------------------
 # Update CMake module path
 #------------------------------------------------------------------------------
 set(CMAKE_MODULE_PATH


### PR DESCRIPTION
## Problem

Building Slicer on Windows with the **Ninja** generator fails partway through the inner Slicer build:

```
[4/4351] Building CXX object E\SurfaceToolbox\DynamicModeler\Logic\FastMarching\...\GW_Face.cpp.obj

CreateProcess failed. Command attempted:
""C:\...\MSVC\14.38.33130\bin\Hostx64\x64\cl.exe"  /nologo /TP -DDIY_HAS_MPI=0 ...
ninja: fatal: CreateProcess: The parameter is incorrect.
 (is the command line too long?)
```

The compile command measured **47744 characters** against the 32767-character limit `CreateProcess` enforces:

| | |
|---|---|
| total command length | 47744 |
| `-I` flags | 238 (~15.6 KB on their own) |
| `-D` defines | 41 |

The include closure is the accumulated VTK + CTK + ITK + GDCM + Qt + Python set, e.g.

```
-IC:\...\CTK-build\CTK-build\Libs\Visualization\VTK\Widgets\CTKVisualizationVTKWidgets_autogen\include   (122 chars)
-IC:\...\ITK\Modules\ThirdParty\GDCM\src\gdcm\Source\DataStructureAndEncodingDefinition               (107 chars)
```

Which translation unit trips first depends only on how much of that closure it happens to pull in, so this is not specific to the module named above.

Multi-config Visual Studio builds are unaffected, because MSBuild already passes compiler flags through response files — which is why CI does not see it.

## Change

Enable `CMAKE_NINJA_FORCE_RESPONSE_FILE` for Windows + Ninja builds, so flags move into a response file and the command line stays short.

Guarded on `NOT DEFINED` so an explicit user setting still wins, and scoped to `WIN32` + Ninja so no other configuration changes behaviour.

## Why it is set in the inner project

The inner Slicer `ExternalProject_Add` receives a fixed `CMAKE_CACHE_ARGS` list plus `mark_as_superbuild()` accumulations (`SuperBuild.cmake`), and arbitrary `CMAKE_*` cache variables are not among them. A `-D` on the superbuild configure therefore never reaches the inner build, which is where the limit is hit.

## Verification

Windows 11, MSVC 19.38.33130 (VS 2022 17.8), CMake 4.4.2, Ninja, Qt 6.11.2, `Release`.

Before: build aborts at the first oversized command.
After: ninja emits `RSP_FILE = ....obj.rsp` for those targets and the inner Slicer build proceeds past 860+ objects with no `CreateProcess` failures.

Found while building Slicer in a downstream ITK testbed that must use Ninja, because it is the only generator honouring `CMAKE_<LANG>_COMPILER_LAUNCHER` (ccache).
