### PR TITLE
COMP: Order lazy vtk module generation after launcher configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1233,6 +1233,17 @@ add_subdirectory(
   ${CMAKE_CURRENT_BINARY_DIR}/Applications
   )
 
+# ${PYTHON_EXECUTABLE} is a launcher that reads its PYTHONPATH and LibraryPaths
+# from ${Slicer_MAIN_PROJECT_APPLICATION_NAME}LauncherSettings.ini, which the
+# launcher configuration target writes only after the application links. State
+# the ordering so generators free to schedule it earlier do not run the vtk
+# module generator against an unwritten settings file.
+if(TARGET SlicerGenerateLazyVtkModule
+    AND TARGET ${Slicer_MAIN_PROJECT_APPLICATION_NAME}ConfigureLauncher)
+  add_dependencies(SlicerGenerateLazyVtkModule
+    ${Slicer_MAIN_PROJECT_APPLICATION_NAME}ConfigureLauncher)
+endif()
+
 #-----------------------------------------------------------------------------
 # Templates
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Generating `bin/Python/vtk.py` fails on Windows with the Ninja generator because `SlicerGenerateLazyVtkModule` declares no ordering against the launcher configuration target that writes the settings file `${PYTHON_EXECUTABLE}` depends on. Adds the missing `add_dependencies` edge.

Supersedes the earlier approach in this PR, which registered the TBB and Qt directories explicitly via a new `--dll-directory` option on `GenerateLazyVtkModule.py`. Per @lassoan's review that mechanism already exists in the launcher; only the build order was wrong.

<details>
<summary>Failure</summary>

```
[2246/4351] Generating lazily-loading vtk module
FAILED: bin/Python/vtk.py
Traceback (most recent call last):
  File ".../Utilities/Scripts/GenerateLazyVtkModule.py", line 36, in module_order
    import vtkmodules.all
  File ".../VTK-build/lib/site-packages/vtkmodules/all.py", line 7, in <module>
    from .vtkCommonCore import *
ImportError: DLL load failed while importing vtkCommonCore: The specified module could not be found.
```

Since Python 3.8 the DLLs an extension module depends on are resolved only from
directories registered with `os.add_dll_directory()`; `PATH` is not searched.
`vtkCommon-9.6.dll` imports `tbb12.dll` (confirmed with `dumpbin /dependents`),
and `vtkRenderingQt` needs the Qt 6 runtime.

</details>

<details>
<summary>Why the launcher already covers this</summary>

The `PythonSlicer` launcher that backs `PYTHON_EXECUTABLE` exports `LibraryPaths`,
and the generated `sitecustomize.py` calls `slicer_dll_directories.add()`, which
turns each entry into an `os.add_dll_directory()` call.

| step | file |
|---|---|
| launcher chains to the app settings file | `SuperBuild/python_configure_python_launcher.cmake` — `ADDITIONAL_SETTINGS_FILEPATH_BUILD`, and `LibraryPaths` in `PYTHONLAUNCHER_ADDITIONAL_PATH_ENVVARS_BUILD` |
| Qt bin and every EP library path land in that file | `CMake/SlicerBlockCTKAppLauncherSettings.cmake` — `SLICER_LIBRARY_PATHS_BUILD` |
| entries become `add_dll_directory` calls | `slicer_dll_directories.py`, invoked from `sitecustomize.py` |

Both directories the previous approach named are already in `SLICER_LIBRARY_PATHS_BUILD`,
so no new dependency has to be spelled out — and a future VTK dependency is covered
without another edit here.

</details>

<details>
<summary>Why Visual Studio was unaffected</summary>

`<AppName>LauncherSettings.ini` is written by the launcher configuration target,
which `ctkAppLauncherConfigureForTarget` makes depend on the application
executable, so it runs late. `SlicerGenerateLazyVtkModule` had no ordering
relation to it.

The Visual Studio generator sorts `ALL_BUILD.vcxproj` references by target name,
so `SlicerConfigureLauncher` precedes `SlicerGenerateLazyVtkModule` and MSBuild
always writes the `.ini` first. Ninja is free to choose the other order, and does.

</details>

<details>
<summary>Placement notes</summary>

Two deviations from the literal `add_dependencies(SlicerGenerateLazyVtkModule SlicerConfigureLauncher)`:

- Placed in the top-level `CMakeLists.txt` after `add_subdirectory(${Slicer_APPLICATIONS_DIR} ...)` rather than in `Base/Python/CMakeLists.txt`. `Base` is added before `Applications`, so the launcher target does not exist yet while `Base/Python` is being processed.
- Uses `${Slicer_MAIN_PROJECT_APPLICATION_NAME}ConfigureLauncher`, since a custom application names that target after itself, and it is that application's settings file the Python launcher chains to.

The pre-existing explicit `PYTHONPATH` on the custom command is left alone. Its
comment describes the same race this change closes, so it may now be redundant —
happy to drop it here or in a follow-up.

</details>

<!--
provenance: claude-code /gh-triage-pr session 2026-08-24
approach_v1: --dll-directory option on GenerateLazyVtkModule.py + hardcoded TBB/Qt in Base/Python/CMakeLists.txt (abandoned)
approach_v2: add_dependencies edge in CMakeLists.txt after Applications add_subdirectory
key_files:
  CMakeLists.txt (after add_subdirectory ${Slicer_APPLICATIONS_DIR})
  CMake/SlicerMacroBuildApplication.cmake:745 ctkAppLauncherConfigureForTarget
  CMake/SlicerBlockCTKAppLauncherSettings.cmake:69-102 SLICER_LIBRARY_PATHS_BUILD
  SuperBuild/python_configure_python_launcher.cmake:277 ctkAppLauncherConfigureForExecutable
verification_status: NOT yet re-verified on Windows after the v1 -> v2 rewrite
related: #9371
-->
