### PR TITLE
COMP: Keep the app resource compile off the target's include closure

### DIFF
--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -466,13 +466,26 @@ macro(slicerMacroBuildApplication)
     get_filename_component(_slicerapp_icon_dir "${SLICERAPP_WIN_ICON_FILE}" DIRECTORY)
     set(_slicerapp_rc "${CMAKE_CURRENT_BINARY_DIR}/${SLICERAPP_NAME}.rc")
     file(WRITE "${_slicerapp_rc}" "IDI_ICON1 ICON \"${_slicerapp_icon_name}\"\n")
-    # Override AdditionalIncludeDirectories for this source file to contain only
-    # the icon's directory, preventing propagation of all target include directories
-    # to rc.exe which would cause MSB6002 command-line length failures.
-    set_source_files_properties("${_slicerapp_rc}" PROPERTIES
-      VS_SETTINGS "AdditionalIncludeDirectories=${_slicerapp_icon_dir}"
+    # Compile the resource in its own OBJECT library so it does not inherit the
+    # application's include directories. CMake expands <INCLUDES> into the RC
+    # compile from the target's include closure, which for SlicerApp is 764
+    # directories -- a 47 KB command line, past the 32767-character limit
+    # CreateProcess enforces, so a Ninja build aborts with
+    # "CreateProcess: The parameter is incorrect".
+    #
+    # VS_SETTINGS previously guarded this, but only for the Visual Studio
+    # generator (it writes AdditionalIncludeDirectories into the vcxproj), so
+    # single-config generators were left unprotected. A source-level
+    # INCLUDE_DIRECTORIES property does not work either: it ADDS directories for
+    # the source rather than replacing the target's. Setting the property on a
+    # dedicated target does replace it, and the icon directory is all the
+    # resource compile needs.
+    add_library(${slicerapp_target}Resources OBJECT "${_slicerapp_rc}")
+    set_target_properties(${slicerapp_target}Resources PROPERTIES
+      INCLUDE_DIRECTORIES "${_slicerapp_icon_dir}"
+      FOLDER "${SLICERAPP_FOLDER}"
       )
-    list(APPEND SLICERAPP_SRCS "${_slicerapp_rc}")
+    list(APPEND SLICERAPP_SRCS $<TARGET_OBJECTS:${slicerapp_target}Resources>)
   endif()
 
   ctk_add_executable_utf8(${slicerapp_target}


### PR DESCRIPTION
## Problem

Building on Windows with the **Ninja** generator aborts while compiling the generated application resource:

```
[1376/2733] Linking CXX shared library bin\qSlicerApp.dll
CreateProcess failed. Command attempted:
"...\cmcldeps.exe RC C:\...\Slicer-build\Applications\SlicerApp\SlicerApp.rc ..."
ninja: fatal: CreateProcess: The parameter is incorrect.
 (is the command line too long?)
```

The `.rc` holds a single line:

```
IDI_ICON1 ICON "Slicer.ico"
```

but CMake expands `<INCLUDES>` into the RC compile from the **target's** include directories (`CMakeRCInformation.cmake`: `<CMAKE_RC_COMPILER> <DEFINES> <INCLUDES> <FLAGS> /fo <OBJECT> <SOURCE>`). For `SlicerApp` that is 764 directories — **45510 characters of `-I` flags in a 47491-character command line**, against the 32767-character limit `CreateProcess` enforces.

## Why the existing guard doesn't cover it

This is the same failure the current `VS_SETTINGS` line was added to prevent:

```cmake
# ... would cause MSB6002 command-line length failures.
set_source_files_properties("${_slicerapp_rc}" PROPERTIES
  VS_SETTINGS "AdditionalIncludeDirectories=${_slicerapp_icon_dir}"
  )
```

`VS_SETTINGS` is honored **only by the Visual Studio generator**, which reads `AdditionalIncludeDirectories` from the vcxproj. Under a single-config generator it is silently ignored, leaving the guard inert — the build fails with ninja's wording (`CreateProcess: The parameter is incorrect`) instead of MSBuild's (`MSB6002`).

Setting the source property `INCLUDE_DIRECTORIES` does **not** fix it either: that property *adds* directories for the source rather than replacing the target's. Measured, the include list grew from 764 entries to 765.

## Change

Compile the resource in a dedicated `OBJECT` library, whose `INCLUDE_DIRECTORIES` **target** property does replace the inherited list, and add its objects to the application. The icon directory is all the resource compile needs, and this behaves identically under every generator.

## Verification

Windows 11, MSVC 19.38.33130 (VS 2022 17.8), CMake 4.4.2, Ninja, Qt 6.11.2.

| | before | after |
|---|---|---|
| `INCLUDES` for the RC compile | 45510 chars (764 dirs) | **69 chars** (1 dir) |
| RC compile statements | 1 | 1 |
| `SlicerApp.rc.res` linked into `SlicerApp-real.exe` | yes | yes |

```
INCLUDES = -I C:\...\Slicer\Applications\SlicerApp\Resources
```

Companion to #9367, #9368 and #9369 — all Windows + Ninja build issues from the same sweep, all independent of one another.
