### PR TITLE
BUG: Skip bundled extension CPack install projects on macOS

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -131,11 +131,16 @@ endif()
 set(CPACK_INSTALL_CMAKE_PROJECTS)
 
 # Ensure external project associated with bundled extensions are packaged
-foreach(extension_name ${Slicer_BUNDLED_EXTENSION_NAMES})
-  if(DEFINED "${extension_name}_CPACK_INSTALL_CMAKE_PROJECTS")
-    set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${${extension_name}_CPACK_INSTALL_CMAKE_PROJECTS}")
-  endif()
-endforeach()
+# On macOS this raw multi-project install is not used: SlicerCPackBundleFixup's
+# dependency-closure script is the sole mechanisum embedding needed dylibgs into
+# the .app, and installing here too just leaves a stray copy beside the bundle.
+if(NOT APPLE)
+  foreach(extension_name ${Slicer_BUNDLED_EXTENSION_NAMES})
+    if(DEFINED "${extension_name}_CPACK_INSTALL_CMAKE_PROJECTS")
+      set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${${extension_name}_CPACK_INSTALL_CMAKE_PROJECTS}")
+    endif()
+  endforeach()
+endif()
 
 # Install CTK Apps and Plugins (PythonQt modules, QtDesigner plugins ...)
 if(NOT "${CTK_DIR}" STREQUAL "" AND EXISTS "${CTK_DIR}/CTK-build/CMakeCache.txt")


### PR DESCRIPTION
On macOS, packaging does not use the raw multi-project CPACK_INSTALL_CMAKE_PROJECTS install mechanism: SlicerCPackBundleFixup's dependency-closure script is the sole mechanism that embeds needed dylibs into the .app bundle. Appending bundled extensions' <extension>_CPACK_INSTALL_CMAKE_PROJECTS entries in this case only installed a stray duplicate copy of extension files beside the bundle instead of into it.

Guard the loop with NOT APPLE, matching the existing behavior already applied to Slicer_ADDITIONAL_PROJECTS/Slicer_ADDITIONAL_DEPENDENCIES entries later in this file.

@lassoan I observed this when bundling SlicerIGSIO into my 3D Slicer custom application and running the macOS .dmg for it. I had observed next to the .app bundle that there was also a "lib" directory beside it containing a "MyCustomAppName-5.13" directory with "libvtkIGSIOCalibration.dylib", "libvtkIGSIOCommon.dylib", "libvtkSequenceIO.dylib", and "libvtkVolumeReconstruction.dylib". 