### PR TITLE
ENH: Use application display name for macOS bundle

### DIFF
--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -510,7 +510,7 @@ macro(slicerMacroBuildApplication)
     set(link_flags "-Wl,-rpath,@loader_path/../")
     set_target_properties(${slicerapp_target}
       PROPERTIES
-        MACOSX_BUNDLE_BUNDLE_NAME "${SLICERAPP_APPLICATION_NAME} ${Slicer_MAIN_PROJECT_VERSION_FULL}"
+        MACOSX_BUNDLE_BUNDLE_NAME "${SLICERAPP_APPLICATION_DISPLAY_NAME} ${Slicer_MAIN_PROJECT_VERSION_FULL}"
         MACOSX_BUNDLE_BUNDLE_VERSION "${Slicer_MAIN_PROJECT_VERSION_FULL}"
         MACOSX_BUNDLE_GUI_IDENTIFIER "${Slicer_MACOSX_BUNDLE_GUI_IDENTIFIER}"
         MACOSX_BUNDLE_INFO_PLIST "${Slicer_CMAKE_DIR}/MacOSXBundleInfo.plist.in"


### PR DESCRIPTION
The application name in the macOS menu bar will now use the application display name such as "3D Slicer" which matches the already used application display name in the window title area.

Current observation with `main` code where the application display name is not in use in the menu bar:
<img width="223" height="79" alt="image" src="https://github.com/user-attachments/assets/93499d5c-c671-4652-88e4-8a5365cb15de" />

With this PR, both places (menubar and window title) appropriately use the application display name.

Note that I originally observed this issue while working on my 3D Slicer custom application where I observed it wasn't using the application display name in the menu bar location.