### PR TITLE
BUG: Update the grid transform before returning its array

### DIFF
--- a/Applications/SlicerApp/Testing/Python/UtilTest.py
+++ b/Applications/SlicerApp/Testing/Python/UtilTest.py
@@ -79,6 +79,7 @@ class UtilTestTest(ScriptedLoadableModuleTest):
         self.test_arrayFromModelPoints()
         self.test_arrayFromVTKMatrix()
         self.test_arrayFromTransformMatrix()
+        self.test_arrayFromGridTransform()
         self.test_arrayFromMarkupsControlPoints()
         self.test_array()
 
@@ -467,6 +468,50 @@ class UtilTestTest(ScriptedLoadableModuleTest):
         for r in range(4):
             for c in range(4):
                 self.assertEqual(narrayUpdated[r, c], transformMatrixUpdated.GetElement(r, c))
+
+    def test_arrayFromGridTransform(self):
+        # Test if the displacement field of a grid transform node can be accessed as a numpy array.
+        # The array is the displacement grid of the transform from the parent. If the node stores
+        # the transform to the parent, the transform from the parent is its inverse, computed on
+        # demand, which uses (and shares) the same displacement grid.
+        import numpy as np
+
+        def gridTransform(displacementZ):
+            gridImage = vtk.vtkImageData()
+            gridImage.SetDimensions(2, 2, 3)
+            gridImage.SetSpacing(10.0, 10.0, 5.0)
+            gridImage.AllocateScalars(vtk.VTK_DOUBLE, 3)
+            gridImage.GetPointData().GetScalars().Fill(0.0)
+            transform = slicer.vtkOrientedGridTransform()
+            transform.SetDisplacementGridData(gridImage)
+            return transform, gridImage
+
+        for storedDirection in ("from parent", "to parent"):
+            self.delayDisplay(f"Testing slicer.util.arrayFromGridTransform with the displacement grid stored {storedDirection}")
+            transform, gridImage = gridTransform(0.0)
+            transformNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLGridTransformNode")
+            if storedDirection == "from parent":
+                transformNode.SetAndObserveTransformFromParent(transform)
+            else:
+                transformNode.SetAndObserveTransformToParent(transform)
+
+            narray = slicer.util.arrayFromGridTransform(transformNode)
+            self.assertEqual(narray.shape, (3, 2, 2, 3))
+            self.assertEqual(narray.max(), 0.0)
+
+            # Writing into the array changes the stored displacement grid, and the node's transform.
+            narray[:, :, :, 2] = 7.0
+            slicer.util.arrayFromGridTransformModified(transformNode)
+            self.assertEqual(gridImage.GetScalarComponentAsDouble(1, 1, 2, 2), 7.0)
+            point = [3.0, 4.0, 5.0]
+            transformed = [0.0, 0.0, 0.0]
+            storedTransform = transformNode.GetTransformFromParent() if storedDirection == "from parent" else transformNode.GetTransformToParent()
+            storedTransform.TransformPoint(point, transformed)
+            self.assertAlmostEqual(transformed[2] - point[2], 7.0)
+            transformNode.GetTransformFromParent().TransformPoint(point, transformed)
+            self.assertAlmostEqual(transformed[2] - point[2], 7.0 if storedDirection == "from parent" else -7.0, places=3)
+
+        self.delayDisplay("Testing slicer.util.arrayFromGridTransform passed")
 
     def test_arrayFromMarkupsControlPoints(self):
         # Test if retrieving markups control coordinates as a numpy array works

--- a/Applications/SlicerApp/Testing/Python/UtilTest.py
+++ b/Applications/SlicerApp/Testing/Python/UtilTest.py
@@ -474,7 +474,6 @@ class UtilTestTest(ScriptedLoadableModuleTest):
         # The array is the displacement grid of the transform from the parent. If the node stores
         # the transform to the parent, the transform from the parent is its inverse, computed on
         # demand, which uses (and shares) the same displacement grid.
-        import numpy as np
 
         def gridTransform(displacementZ):
             gridImage = vtk.vtkImageData()

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2136,6 +2136,11 @@ def arrayFromModelPolyIds(modelNode):
 def arrayFromGridTransform(gridTransformNode):
     """Return voxel array from transform node as numpy array.
 
+    Note that the same coefficients are returned regardless of the transform node stores
+    the transform *from* the parent or *to* the parent.
+    ``gridTransformNode.GetTransformFromParent().GetInverseFlag()`` returns true if the grid
+    transform specifies transform *to* the parent.
+
     Vector values are not copied. Values in the transform node can be modified
     by changing values in the numpy array.
     After all modifications has been completed, call :py:meth:`arrayFromGridTransformModified`.
@@ -2145,6 +2150,9 @@ def arrayFromGridTransform(gridTransformNode):
       See :py:meth:`arrayFromVolume` for details.
     """
     transformGrid = gridTransformNode.GetTransformFromParent()
+    # Need to call Update() on the transform before accessing it,
+    # because it may need to be computed from its inverse
+    transformGrid.Update()
     displacementGrid = transformGrid.GetDisplacementGrid()
     nshape = tuple(reversed(displacementGrid.GetDimensions()))
     import vtk.util.numpy_support
@@ -2278,6 +2286,7 @@ def updateTransformMatrixFromArray(transformNode, narray, toWorld=False):
 def arrayFromGridTransformModified(gridTransformNode):
     """Indicate that modification of a numpy array returned by :py:meth:`arrayFromGridTransform` has been completed."""
     transformGrid = gridTransformNode.GetTransformFromParent()
+    transformGrid.Update()
     displacementGrid = transformGrid.GetDisplacementGrid()
     displacementGrid.GetPointData().GetScalars().Modified()
     displacementGrid.Modified()


### PR DESCRIPTION
slicer.util.arrayFromGridTransform reads the displacement grid of the node's transform from the parent. If the node stores the transform to the parent, the transform from the parent is its inverse, computed on demand, and it has no displacement grid until it is updated, so the function failed with an AttributeError.

The transform is now updated before its grid is read (also in arrayFromGridTransformModified). The updated inverse shares the stored grid, so the array still gives write access to the node's coefficients. The docstring explains that in this case the array holds the to-parent displacements and points to the transform's inverse flag.

A util test covers both storage directions, including writing through the array and the direction of the resulting transforms.