### PR TITLE
PERF: Avoid re-clipping models when nothing has changed

### DIFF
--- a/Libs/MRML/Core/vtkMRMLClipNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLClipNode.cxx
@@ -82,7 +82,7 @@ void vtkMRMLClipNode::ReadXMLAttributes(const char** atts)
   Superclass::ReadXMLAttributes(atts);
   vtkMRMLReadXMLBeginMacro(atts);
   vtkMRMLReadXMLEnumMacro(clipType, ClipType);
-  vtkMRMLReadXMLEnumMacro(clippingmethod, ClippingMethod);
+  vtkMRMLReadXMLEnumMacro(clippingMethod, ClippingMethod);
   vtkMRMLReadXMLEndMacro();
 }
 

--- a/Libs/MRML/Core/vtkMRMLClipNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLClipNode.cxx
@@ -377,8 +377,12 @@ void vtkMRMLClipNode::OnNodeReferenceModified(vtkMRMLNodeReference* reference)
 //----------------------------------------------------------------------------
 void vtkMRMLClipNode::UpdateImplicitFunction()
 {
-  vtkImplicitFunctionCollection* functions = this->ImplicitFunction->GetFunction();
-  functions->RemoveAllItems();
+  // Build the new list of functions separately, and replace the current list only if it differs.
+  // The clipping nodes update their implicit functions in place, so a change in their position
+  // is already seen through the modified time of the functions. Rebuilding the list here on every
+  // event would mark the implicit function modified even when nothing has changed, which would
+  // make all models that use this clip node re-clipped on the next render (can take seconds on a large mesh).
+  vtkNew<vtkImplicitFunctionCollection> functions;
 
   int numClipNodes = this->GetNumberOfClippingNodes();
   for (int n = 0; n < numClipNodes; n++)
@@ -396,7 +400,7 @@ void vtkMRMLClipNode::UpdateImplicitFunction()
     {
       invertableBoolean->InvertOn();
     }
-    this->ImplicitFunction->AddFunction(invertableBoolean);
+    functions->AddItem(invertableBoolean);
 
     vtkMRMLTransformableNode* transformableNode = vtkMRMLTransformableNode::SafeDownCast(clippingNode);
     if (transformableNode && transformableNode->GetImplicitFunctionWorld())
@@ -428,7 +432,54 @@ void vtkMRMLClipNode::UpdateImplicitFunction()
     }
   }
 
+  if (vtkMRMLClipNode::AreImplicitFunctionCollectionsEqual(functions, this->ImplicitFunction->GetFunction()))
+  {
+    return;
+  }
+
+  this->ImplicitFunction->GetFunction()->RemoveAllItems();
+  vtkCollectionSimpleIterator it;
+  vtkImplicitFunction* function = nullptr;
+  for (functions->InitTraversal(it); (function = functions->GetNextImplicitFunction(it));)
+  {
+    this->ImplicitFunction->AddFunction(function);
+  }
+
   this->ImplicitFunction->Modified();
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLClipNode::AreImplicitFunctionCollectionsEqual(vtkImplicitFunctionCollection* functions1, vtkImplicitFunctionCollection* functions2)
+{
+  if (functions1 == functions2)
+  {
+    return true;
+  }
+  if (!functions1 || !functions2 || functions1->GetNumberOfItems() != functions2->GetNumberOfItems())
+  {
+    return false;
+  }
+  for (int i = 0; i < functions1->GetNumberOfItems(); ++i)
+  {
+    vtkImplicitFunction* function1 = vtkImplicitFunction::SafeDownCast(functions1->GetItemAsObject(i));
+    vtkImplicitFunction* function2 = vtkImplicitFunction::SafeDownCast(functions2->GetItemAsObject(i));
+    if (function1 == function2)
+    {
+      continue;
+    }
+    // Invertable booleans are created by UpdateImplicitFunction, so they are compared by content
+    vtkImplicitInvertableBoolean* boolean1 = vtkImplicitInvertableBoolean::SafeDownCast(function1);
+    vtkImplicitInvertableBoolean* boolean2 = vtkImplicitInvertableBoolean::SafeDownCast(function2);
+    if (!boolean1 || !boolean2 || boolean1->GetInvert() != boolean2->GetInvert())
+    {
+      return false;
+    }
+    if (!vtkMRMLClipNode::AreImplicitFunctionCollectionsEqual(boolean1->GetFunction(), boolean2->GetFunction()))
+    {
+      return false;
+    }
+  }
+  return true;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLClipNode.h
+++ b/Libs/MRML/Core/vtkMRMLClipNode.h
@@ -236,6 +236,11 @@ protected:
   /// Update the implicit function based on the clipping nodes.
   void UpdateImplicitFunction();
 
+  /// Returns true if the two collections contain the same functions.
+  /// Invertable boolean functions are compared by content (invert flag and contained functions),
+  /// all other functions are compared by pointer.
+  static bool AreImplicitFunctionCollectionsEqual(vtkImplicitFunctionCollection* functions1, vtkImplicitFunctionCollection* functions2);
+
   int GetSliceClipState(const char* nodeID);
   void SetSliceClipState(const char* nodeID, int state);
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -100,6 +100,10 @@ public:
   /// Find first picked node from prop3Ds in cell picker and set PickedNodeID in Internal
   void FindFirstPickedDisplayNodeFromPickerProp3Ds();
 
+  /// Returns true if the model is displayed clipped: clipping is enabled (in the display node or in
+  /// the overriding hierarchy display node), it has a clip node, and at least one clipping node is enabled.
+  bool IsClipped(vtkMRMLDisplayNode* displayNode);
+
 public:
   vtkMRMLModelDisplayableManager* External;
 
@@ -111,6 +115,7 @@ public:
   std::map<std::string, vtkWeakPointer<vtkMRMLDisplayableNode>> DisplayableNodes;
   std::map<std::string, vtkSmartPointer<vtkTransformFilter>>    DisplayNodeTransformFilters;
   std::map<std::string, vtkSmartPointer<vtkAlgorithm>>          Clippers;
+  std::map<std::string, vtkSmartPointer<vtkImplicitBoolean>>    ClipFunctions;
   std::map<std::string, vtkSmartPointer<vtkCapPolyData>>        Cappers;
   std::map<std::string, vtkSmartPointer<vtkProp3D>>             DisplayedCapActors;
   std::map<std::string, vtkSmartPointer<vtkTransformFilter>>    DisplayNodeCapTransformFilters;
@@ -169,6 +174,41 @@ void vtkMRMLModelDisplayableManager::vtkInternal::ResetPick()
   }
   this->PickedCellID = -1;
   this->PickedPointID = -1;
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLModelDisplayableManager::vtkInternal::IsClipped(vtkMRMLDisplayNode* displayNode)
+{
+  vtkMRMLModelDisplayNode* modelDisplayNode = vtkMRMLModelDisplayNode::SafeDownCast(displayNode);
+  if (!modelDisplayNode)
+  {
+    return false;
+  }
+  vtkMRMLClipNode* clipNode = modelDisplayNode->GetClipNode();
+  if (!clipNode)
+  {
+    return false;
+  }
+  int clipping = modelDisplayNode->GetClipping();
+  vtkMRMLDisplayableNode* displayableNode = modelDisplayNode->GetDisplayableNode();
+  vtkMRMLDisplayNode* hdnode = displayableNode ? vtkMRMLFolderDisplayNode::GetOverridingHierarchyDisplayNode(displayableNode) : nullptr;
+  if (hdnode)
+  {
+    clipping = hdnode->GetClipping();
+  }
+  if (!clipping)
+  {
+    return false;
+  }
+  int numberOfClipNodes = clipNode->GetNumberOfClippingNodes();
+  for (int i = 0; i < numberOfClipNodes; ++i)
+  {
+    if (clipNode->GetNthClippingNodeState(i) != vtkMRMLClipNode::ClipOff)
+    {
+      return true;
+    }
+  }
+  return false;
 }
 
 //---------------------------------------------------------------------------
@@ -685,6 +725,7 @@ void vtkMRMLModelDisplayableManager::ClearDisplayMaps()
   }
   this->Internal->DisplayNodeTransformFilters.clear();
   this->Internal->Clippers.clear();
+  this->Internal->ClipFunctions.clear();
   this->Internal->Cappers.clear();
   if (this->GetRenderer())
   {
@@ -811,8 +852,27 @@ void vtkMRMLModelDisplayableManager::UpdateModelMesh(vtkMRMLDisplayableNode* dis
       vtkImplicitFunction* implicitFunction = clipNode->GetImplicitFunctionWorld();
       if (implicitFunction)
       {
-        implicitBoolean = vtkSmartPointer<vtkImplicitBoolean>::New();
-        implicitBoolean->AddFunction(implicitFunction);
+        // Reuse the clip function of the display node and only modify it if the clip node's function
+        // or the model's transform has changed. Creating a new clip function on each update would
+        // modify the clipper and the cap filter, therefore the whole mesh would be clipped again on the
+        // next render (can take seconds on a large mesh), and this method is called on every modified
+        // event of the model, its display node, and its clip node, and on every scene update.
+        auto clipFunctionIter = this->Internal->ClipFunctions.find(modelDisplayNode->GetID());
+        if (clipFunctionIter == this->Internal->ClipFunctions.end())
+        {
+          implicitBoolean = vtkSmartPointer<vtkImplicitBoolean>::New();
+          this->Internal->ClipFunctions[modelDisplayNode->GetID()] = implicitBoolean;
+        }
+        else
+        {
+          implicitBoolean = clipFunctionIter->second;
+        }
+        vtkImplicitFunctionCollection* clipFunctions = implicitBoolean->GetFunction();
+        if (clipFunctions->GetNumberOfItems() != 1 || clipFunctions->GetItemAsObject(0) != implicitFunction)
+        {
+          clipFunctions->RemoveAllItems();
+          implicitBoolean->AddFunction(implicitFunction);
+        }
 
         vtkSmartPointer<vtkAlgorithm> oldClipper = nullptr;
         if (this->Internal->Clippers.find(modelDisplayNode->GetID()) != this->Internal->Clippers.end())
@@ -823,12 +883,22 @@ void vtkMRMLModelDisplayableManager::UpdateModelMesh(vtkMRMLDisplayableNode* dis
         filterUpdateNeeded = oldClipper != clipper;
       }
 
-      if (tnode && !hasNonLinearTransform)
+      if (tnode && !hasNonLinearTransform && implicitBoolean)
       {
         // If the transform is non-linear, worldTransform will have already been set.
         // Only need to calculate here for linear transforms.
         tnode->GetTransformToWorld(worldTransform);
-        implicitBoolean->SetTransform(worldTransform);
+        // It is important to only update the transform if the transform chain is actually changed,
+        // because modifying the clip function makes the whole mesh clipped again on the next render.
+        if (!vtkMRMLTransformNode::AreTransformsEqual(worldTransform, implicitBoolean->GetTransform()))
+        {
+          implicitBoolean->SetTransform(worldTransform);
+        }
+      }
+      else if (implicitBoolean && implicitBoolean->GetTransform())
+      {
+        // The model is no longer under a linear transform
+        implicitBoolean->SetTransform(static_cast<vtkAbstractTransform*>(nullptr));
       }
     }
 
@@ -886,7 +956,20 @@ void vtkMRMLModelDisplayableManager::UpdateModelMesh(vtkMRMLDisplayableNode* dis
         if (actor && actor->GetMapper())
         {
           vtkMapper* mapper = actor->GetMapper();
-          if (transformFilter)
+          if (clipper)
+          {
+            // Keep using the existing clipper (and the clipped mesh stored in it), just make sure
+            // its input and output are connected to the current mesh and mapper.
+            vtkAlgorithmOutput* clipperInput = transformFilter ? transformFilter->GetOutputPort() : meshConnection;
+            clipper->SetInputConnection(clipperInput);
+            auto capIter = this->Internal->Cappers.find(displayNode->GetID());
+            if (capIter != this->Internal->Cappers.end())
+            {
+              capIter->second->SetInputConnection(clipperInput);
+            }
+            mapper->SetInputConnection(clipper->GetOutputPort());
+          }
+          else if (transformFilter)
           {
             mapper->SetInputConnection(transformFilter->GetOutputPort());
           }
@@ -901,8 +984,9 @@ void vtkMRMLModelDisplayableManager::UpdateModelMesh(vtkMRMLDisplayableNode* dis
           }
         }
 
-        vtkMRMLTransformNode* tnode = displayableNode->GetParentTransformNode();
-        if ((!clipping || tnode == nullptr) && !mapperUpdateNeeded && !filterUpdateNeeded)
+        // Clipped models under a transform do not need to be rebuilt either, because the transform
+        // is applied to the existing clip function above.
+        if (!mapperUpdateNeeded && !filterUpdateNeeded)
         {
           continue;
         }
@@ -1089,7 +1173,7 @@ void vtkMRMLModelDisplayableManager::RemoveModelProps()
       int clipModel = 0;
       if (modelDisplayNode != nullptr)
       {
-        clipModel = modelDisplayNode->GetClipping();
+        clipModel = this->Internal->IsClipped(modelDisplayNode) ? 1 : 0;
       }
       auto clipIter = this->Internal->DisplayedClipState.find(iter->first);
       if (clipIter == this->Internal->DisplayedClipState.end())
@@ -1098,8 +1182,10 @@ void vtkMRMLModelDisplayableManager::RemoveModelProps()
       }
       else
       {
-
-        if (clipIter->second || (modelDisplayNode->GetClipping() && clipIter->second != clipModel))
+        // Only remove the props if the clipping state has changed since they were created.
+        // Removing props of all clipped models would discard the clipper (and the clipped mesh stored in it)
+        // on every scene update, which would make the whole mesh clipped again on the next render.
+        if (clipIter->second != clipModel)
         {
           removedIDs.push_back(iter->first);
         }
@@ -1170,6 +1256,12 @@ void vtkMRMLModelDisplayableManager::RemoveDisplayedID(const std::string& id)
   if (clipperIter != this->Internal->Clippers.end())
   {
     this->Internal->Clippers.erase(clipperIter);
+  }
+
+  auto clipFunctionIter = this->Internal->ClipFunctions.find(id);
+  if (clipFunctionIter != this->Internal->ClipFunctions.end())
+  {
+    this->Internal->ClipFunctions.erase(clipFunctionIter);
   }
 
   auto capIter = this->Internal->Cappers.find(id);
@@ -1937,10 +2029,7 @@ vtkAlgorithm* vtkMRMLModelDisplayableManager::GetClipper(vtkMRMLDisplayNode* dno
       }
       extractGeometry->SetImplicitFunction(clipFunction);
       extractGeometry->ExtractInsideOff();
-      if (clippingMethod == vtkMRMLClipNode::WholeCellsWithBoundary)
-      {
-        extractGeometry->ExtractBoundaryCellsOn();
-      }
+      extractGeometry->SetExtractBoundaryCells(clippingMethod == vtkMRMLClipNode::WholeCellsWithBoundary);
     }
   }
   else
@@ -1966,10 +2055,7 @@ vtkAlgorithm* vtkMRMLModelDisplayableManager::GetClipper(vtkMRMLDisplayNode* dno
       }
       extractPolyDataGeometry->SetImplicitFunction(clipFunction);
       extractPolyDataGeometry->ExtractInsideOff();
-      if (clippingMethod == vtkMRMLClipNode::WholeCellsWithBoundary)
-      {
-        extractPolyDataGeometry->ExtractBoundaryCellsOn();
-      }
+      extractPolyDataGeometry->SetExtractBoundaryCells(clippingMethod == vtkMRMLClipNode::WholeCellsWithBoundary);
     }
   }
 


### PR DESCRIPTION
Clipping a large mesh takes seconds, and it was redone on almost every render whenever a model was clipped. This PR makes the clip node and the model displayable manager keep their clip functions and clippers between updates, so the mesh is only clipped again when something actually changed.

- `vtkMRMLClipNode::UpdateImplicitFunction` rebuilt its implicit boolean on every modified event of its clipping nodes, marking it modified even when no clipping node had moved. It now builds the new function list separately and only replaces the current list if it differs.
- `vtkMRMLModelDisplayableManager::UpdateModelMesh` created a new `vtkImplicitBoolean` and set a new transform on it on every update. The clip function is now kept per display node and only modified when the clip node's function or the model's transform has actually changed. The mapper of a clipped model stays connected to the existing clipper instead of being rebuilt on every update under a transform.
- `RemoveModelProps` removed the props of every clipped model on every scene update, discarding the clipper and its clipped mesh. It now only removes props when the model's clipping state has changed.
- `GetClipper` now turns boundary cell extraction off again when the clipping method changes, since the extract filter is reused.

A separate commit fixes the `clippingMethod` XML attribute name in `ReadXMLAttributes`, which did not match the name written by `WriteXML`, so the clipping method was lost when a scene was loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
