### PR TITLE
BUG: Fix Windows installer file associations and unsafe uninstall

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -486,7 +486,30 @@ if(CPACK_GENERATOR STREQUAL "NSIS")
   # Slicer does *NOT* require setting the windows path
   set(CPACK_NSIS_MODIFY_PATH OFF)
 
+  # An empty application name would make the registry paths generated below
+  # (file associations, GPU preference) refer to their parent key, and the
+  # uninstaller would then recursively delete unrelated registry entries.
+  # See https://github.com/Slicer/Slicer/issues/9383
+  if("${Slicer_MAIN_PROJECT_APPLICATION_NAME}" STREQUAL "")
+    message(FATAL_ERROR "Slicer_MAIN_PROJECT_APPLICATION_NAME must not be empty when generating an NSIS package")
+  endif()
+  set(APPLICATION_NAME "${Slicer_MAIN_PROJECT_APPLICATION_NAME}")
   set(EXECUTABLE_NAME "${Slicer_MAIN_PROJECT_APPLICATION_NAME}")
+
+  # ProgID used to register file associations and the URL protocol.
+  # It is defined as an NSIS constant (instead of being expanded by CMake directly
+  # into the registry commands below) so that the NSIS compiler fails if the name
+  # is empty: an empty name would make the uninstaller delete the whole
+  # SOFTWARE\Classes registry key.
+  string(APPEND CPACK_NSIS_DEFINES "\n  ;ProgID used for file associations (must not be empty)")
+  string(APPEND CPACK_NSIS_DEFINES "\n  !define SLICER_FILE_ASSOCIATION_PROGID \\\"${APPLICATION_NAME}\\\"")
+  string(APPEND CPACK_NSIS_DEFINES "\n  !if \\\"\\\${SLICER_FILE_ASSOCIATION_PROGID}\\\" == \\\"\\\"")
+  string(APPEND CPACK_NSIS_DEFINES "\n    !error \\\"SLICER_FILE_ASSOCIATION_PROGID must not be empty: the uninstaller would delete the whole Classes registry key\\\"")
+  string(APPEND CPACK_NSIS_DEFINES "\n  !endif\n")
+  # Reference to the NSIS constant, escaped so that it is expanded by the NSIS
+  # compiler and not by CPack.
+  set(_file_association_progid "\\\${SLICER_FILE_ASSOCIATION_PROGID}")
+
   # Set application name used to create Start Menu shortcuts
   set(CPACK_NSIS_DISPLAY_NAME "${Slicer_MAIN_PROJECT_APPLICATION_DISPLAY_NAME} ${CPACK_PACKAGE_VERSION}")
   slicer_verbose_set(CPACK_PACKAGE_EXECUTABLES "..\\\\${EXECUTABLE_NAME}" "${CPACK_NSIS_DISPLAY_NAME}")
@@ -541,21 +564,28 @@ if(CPACK_GENERATOR STREQUAL "NSIS")
   # -------------------------------------------------------------------------
   set(FILE_EXTENSIONS .mrml .xcat .mrb)
   if(FILE_EXTENSIONS)
+    # Register the ProgID (also used as URL protocol handler) and its open command
+    set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
+      "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}
+WriteRegStr SHCTX \\\"SOFTWARE\\\\Classes\\\\${_file_association_progid}\\\" \\\"\\\" \\\"${Slicer_MAIN_PROJECT_APPLICATION_DISPLAY_NAME} supported file\\\"
+WriteRegStr SHCTX \\\"SOFTWARE\\\\Classes\\\\${_file_association_progid}\\\" \\\"URL Protocol\\\" \\\"\\\"
+WriteRegStr SHCTX \\\"SOFTWARE\\\\Classes\\\\${_file_association_progid}\\\\shell\\\\open\\\\command\\\" \
+\\\"\\\" \\\"$\\\\\\\"$INSTDIR\\\\${EXECUTABLE_NAME}.exe$\\\\\\\" $\\\\\\\"%1$\\\\\\\"\\\"
+")
+    set(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS "${CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS}
+DeleteRegKey SHCTX \\\"SOFTWARE\\\\Classes\\\\${_file_association_progid}\\\"
+")
+    # Associate each file extension with the ProgID
     foreach(ext ${FILE_EXTENSIONS})
       string(LENGTH "${ext}" len)
       math(EXPR len_m1 "${len} - 1")
       string(SUBSTRING "${ext}" 1 ${len_m1} ext_wo_dot)
       set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
         "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}
-WriteRegStr SHCTX \\\"SOFTWARE\\\\Classes\\\\${APPLICATION_NAME}\\\" \\\"\\\" \\\"${APPLICATION_NAME} supported file\\\"
-WriteRegStr SHCTX \\\"SOFTWARE\\\\Classes\\\\${APPLICATION_NAME}\\\" \\\"URL Protocol\\\" \\\"\\\"
-WriteRegStr SHCTX \\\"SOFTWARE\\\\Classes\\\\${APPLICATION_NAME}\\\\shell\\\\open\\\\command\\\" \
-\\\"\\\" \\\"$\\\\\\\"$INSTDIR\\\\${EXECUTABLE_NAME}.exe$\\\\\\\" $\\\\\\\"%1$\\\\\\\"\\\"
-WriteRegStr SHCTX \\\"SOFTWARE\\\\Classes\\\\${ext}\\\" \\\"\\\" \\\"${APPLICATION_NAME}\\\"
+WriteRegStr SHCTX \\\"SOFTWARE\\\\Classes\\\\${ext}\\\" \\\"\\\" \\\"${_file_association_progid}\\\"
 WriteRegStr SHCTX \\\"SOFTWARE\\\\Classes\\\\${ext}\\\" \\\"Content Type\\\" \\\"application/x-${ext_wo_dot}\\\"
 ")
       set(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS "${CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS}
-DeleteRegKey SHCTX \\\"SOFTWARE\\\\Classes\\\\${APPLICATION_NAME}\\\"
 DeleteRegKey SHCTX \\\"SOFTWARE\\\\Classes\\\\${ext}\\\"
 ")
     endforeach()

--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -560,6 +560,27 @@ if(CPACK_GENERATOR STREQUAL "NSIS")
 ")
 
   # -------------------------------------------------------------------------
+  # Uninstall guard
+  # -------------------------------------------------------------------------
+  # The uninstallers of 3D Slicer releases from 5.9.0-2025-09-18 up to 5.13.0-2026-09-04
+  # recursively delete the whole HKCU\Software\Classes registry key (see
+  # https://github.com/Slicer/Slicer/issues/9383). The installer adds a registry key that
+  # sorts before all other keys and cannot be deleted, which makes these uninstallers
+  # stop before they can do any damage. The key is intentionally not removed by the
+  # uninstaller, since it protects against uninstallers of other (older) installations.
+  # The script is extracted to the temporary plugins directory of the installer, which
+  # is deleted when the installer exits.
+  string(REPLACE "/" "\\\\" _uninstall_guard_script "${Slicer_SOURCE_DIR}/CMake/SlicerUninstallGuard.ps1")
+  set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
+    "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}
+DetailPrint \\\"Adding Slicer Uninstall Guard registry key\\\"
+InitPluginsDir
+File \\\"/oname=$PLUGINSDIR\\\\SlicerUninstallGuard.ps1\\\" \\\"${_uninstall_guard_script}\\\"
+nsExec::ExecToLog 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \\\"$PLUGINSDIR\\\\SlicerUninstallGuard.ps1\\\"'
+Pop $0
+")
+
+  # -------------------------------------------------------------------------
   # File extensions
   # -------------------------------------------------------------------------
   set(FILE_EXTENSIONS .mrml .xcat .mrb)

--- a/CMake/SlicerUninstallGuard.ps1
+++ b/CMake/SlicerUninstallGuard.ps1
@@ -1,0 +1,71 @@
+# Slicer Uninstall Guard
+#
+# The uninstallers of 3D Slicer releases from 5.9.0-2025-09-18 up to
+# 5.13.0-2026-09-04 recursively delete the entire HKCU\Software\Classes
+# registry key, destroying the file associations of all applications of the
+# current user (see https://github.com/Slicer/Slicer/issues/9383).
+#
+# Registry key deletion stops at the first error, therefore a key that sorts
+# before all other keys ("!" sorts first) and that cannot be deleted prevents
+# the damage. This script creates such a key and denies its deletion to everyone.
+#
+# The script is run by the Windows installer. It is idempotent and can also be
+# run manually. The key is intentionally left in place when the application is
+# uninstalled, since it protects against the uninstallers of other (older)
+# Slicer installations.
+#
+# Status of the guard can be checked with:
+#   (Get-Acl 'HKCU:\Software\Classes\!SlicerUninstallGuard').Access | Where-Object { $_.AccessControlType -eq 'Deny' }
+#
+# The guard can be removed (not recommended) with:
+#   $k = 'HKCU:\Software\Classes\!SlicerUninstallGuard'; $a = Get-Acl $k
+#   @($a.Access | Where-Object { $_.AccessControlType -eq 'Deny' }) | ForEach-Object { [void]$a.RemoveAccessRule($_) }
+#   Set-Acl $k $a; Remove-Item $k -Recurse -Force
+
+$ErrorActionPreference = 'Stop'
+
+$key = 'HKCU:\Software\Classes\!SlicerUninstallGuard'
+$deleteRight = [int][System.Security.AccessControl.RegistryRights]::Delete
+
+try {
+  $created = $false
+  if (-not (Test-Path $key)) {
+    New-Item $key -Force | Out-Null
+    Set-ItemProperty $key '(default)' 'Guard against Slicer bug github.com/Slicer/Slicer/issues/9383'
+    $created = $true
+  }
+
+  $acl = Get-Acl $key
+  $hasDenyDelete = @($acl.Access | Where-Object {
+      $_.AccessControlType -eq 'Deny' -and (([int]$_.RegistryRights -band $deleteRight) -ne 0)
+    }).Count -gt 0
+  if (-not $hasDenyDelete) {
+    $everyone = New-Object System.Security.Principal.SecurityIdentifier 'S-1-1-0'
+    $rule = New-Object System.Security.AccessControl.RegistryAccessRule($everyone, 'Delete', 'Deny')
+    $acl.AddAccessRule($rule)
+    Set-Acl $key $acl
+  }
+
+  # Verify that the key cannot be deleted
+  $deleted = $false
+  try {
+    Remove-Item $key -Force -ErrorAction Stop
+    $deleted = $true
+  } catch {
+    $deleted = $false
+  }
+  if ($deleted) {
+    Write-Output 'FAILED: Slicer Uninstall Guard is not effective (the registry key could be deleted)'
+    exit 1
+  }
+  if ($created -or -not $hasDenyDelete) {
+    Write-Output 'Slicer Uninstall Guard added and verified'
+  } else {
+    Write-Output 'Slicer Uninstall Guard already present'
+  }
+  exit 0
+}
+catch {
+  Write-Output "FAILED: Slicer Uninstall Guard could not be added: $($_.Exception.Message)"
+  exit 1
+}


### PR DESCRIPTION
Fixes #9383

## Problem

Commit 5b5ae87dd2 ("ENH: Use applicationDisplayName in user facing text") removed the initialization of `APPLICATION_NAME` in `SlicerCPack.cmake` while the NSIS file association commands kept referencing it. Since the variable expanded to an empty string in every package built from 3D Slicer 5.9.0-2025-09-18 up to 5.13.0-2026-09-04 (including stable releases 5.10.0 to 5.12.3):

- the installer wrote the open command to `SOFTWARE\Classes\shell\open\command` instead of `SOFTWARE\Classes\Slicer\shell\open\command` and associated `.mrml`, `.mrb` and `.xcat` with an empty ProgID;
- the uninstaller ran `DeleteRegKey SHCTX "SOFTWARE\Classes\"`, recursively deleting the file associations of all applications of the current user (see https://github.com/Slicer/Slicer/issues/9383#issuecomment-5553280392).

## Changes

**Commit 1: BUG: Fix Windows installer file associations and unsafe uninstall**

- Restores the `APPLICATION_NAME` initialization.
- Adds a CMake configure-time `FATAL_ERROR` if the application name is empty.
- Emits the ProgID as an NSIS constant (`SLICER_FILE_ASSOCIATION_PROGID`) guarded by `!if`/`!error`, so an empty name aborts the NSIS compilation instead of producing an installer that deletes the parent key.
- Writes the ProgID key once instead of once per extension, and uses the application display name for the user-facing file type description ("3D Slicer supported file").

**Commit 2: ENH: Add Slicer Uninstall Guard registry key in Windows installer**

- Adds `CMake/SlicerUninstallGuard.ps1`, which creates `HKCU\Software\Classes\!SlicerUninstallGuard`, denies its deletion to everyone, and verifies that the key cannot be deleted. Registry key deletion stops at the first error, so this key (which sorts before all others) stops the uninstallers of affected releases before they can do damage (see https://github.com/Slicer/Slicer/issues/9383#issuecomment-5553432853).
- The installer extracts the script into its temporary plugins directory and runs it with the bundled `nsExec` plugin, so no console window is shown and nothing is left in the install tree. The key is intentionally not removed by the uninstaller, since it protects against uninstallers of older installations.

## Testing

- Reconfigured and rebuilt the NSIS package on Windows 11. The generated `project.nsi` contains `SOFTWARE\Classes\${SLICER_FILE_ASSOCIATION_PROGID}` for the ProgID key, open command and uninstall, and each extension maps to the ProgID.
- Verified with makensis that an empty `SLICER_FILE_ASSOCIATION_PROGID` aborts compilation with the `!error` message, and that a non-empty one produces `SOFTWARE\Classes\Slicer` paths.
- Ran `SlicerUninstallGuard.ps1` against a temporary key name: the Deny-Delete ACE was added, a plain delete was refused, and a second run reported the guard as already present. On a machine where the guard already exists, the script reports "already present" and leaves the key untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
