### PR TITLE
BUG: Keep segment editor effect cursor when hovering over markups

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
@@ -358,7 +358,12 @@ bool vtkMRMLViewInteractorStyle::DelegateInteractionEventDataToDisplayableManage
     double distance2 = VTK_DOUBLE_MAX;
     if (displayableManager->CanProcessInteractionEvent(eventData, distance2))
     {
-      if (!canProcessEvent || (distance2 < closestDistance2))
+      // If multiple displayable managers report the same distance (typically 0.0, meaning that they
+      // claim the event unconditionally) then the one that already has the focus is preferred.
+      // This ensures that an interaction that is in progress (e.g., panning the view by click-and-drag)
+      // is not interrupted by a displayable manager that captures all events (e.g., hover events).
+      if (!canProcessEvent || (distance2 < closestDistance2) //
+          || (distance2 == closestDistance2 && displayableManager == this->FocusedDisplayableManager))
       {
         canProcessEvent = true;
         closestDisplayableManager = displayableManager;

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorDrawEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorDrawEffect.py
@@ -18,6 +18,9 @@ class SegmentEditorDrawEffect(AbstractScriptedSegmentEditorLabelEffect):
     def __init__(self, scriptedEffect):
         scriptedEffect.name = "Draw"  # no tr (don't translate it because modules find effects by name)
         scriptedEffect.title = _("Draw")
+        # Mouse clicks and drags in slice views are used for drawing, so other objects in the views
+        # (e.g., markups control points) must not be highlighted and must not change the mouse cursor on hover.
+        scriptedEffect.captureMouseMoveEventsInSliceView = True
         self.drawPipelines = {}
         AbstractScriptedSegmentEditorLabelEffect.__init__(self, scriptedEffect)
 

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorLevelTracingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorLevelTracingEffect.py
@@ -19,6 +19,9 @@ class SegmentEditorLevelTracingEffect(AbstractScriptedSegmentEditorLabelEffect):
     def __init__(self, scriptedEffect):
         scriptedEffect.name = "Level tracing"  # no tr (don't translate it because modules find effects by name)
         scriptedEffect.title = _("Level tracing")
+        # Mouse clicks in slice views are used for applying the traced outline, so other objects in the views
+        # (e.g., markups control points) must not be highlighted and must not change the mouse cursor on hover.
+        scriptedEffect.captureMouseMoveEventsInSliceView = True
         AbstractScriptedSegmentEditorLabelEffect.__init__(self, scriptedEffect)
 
         # Effect-specific members
@@ -106,7 +109,9 @@ class SegmentEditorLevelTracingEffect(AbstractScriptedSegmentEditorLabelEffect):
                         '<b><font color="red">'
                         + _("Slice view is not aligned with segmentation axis.<br>To use this effect, click the 'Slice views orientation' warning button.")
                         + "</font></b>")
-                abortEvent = True
+                # The event is not aborted (it is only previewed here), so that the view can update the cursor
+                # position (used by the Data Probe) and process click-and-drag interactions. Other objects in the
+                # view do not get focus on hover because captureMouseMoveEventsInSliceView is enabled.
                 self.lastXY = xy
         elif eventId == vtk.vtkCommand.EnterEvent:
             self.sliceRotatedErrorLabel.text = ""

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.cxx
@@ -1264,6 +1264,30 @@ void qSlicerSegmentEditorAbstractEffect::setShowEffectCursorInThreeDView(bool sh
   this->m_ShowEffectCursorInThreeDView = show;
 }
 
+//----------------------------------------------------------------------------
+bool qSlicerSegmentEditorAbstractEffect::captureMouseMoveEventsInSliceView()
+{
+  return m_CaptureMouseMoveEventsInSliceView;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSegmentEditorAbstractEffect::setCaptureMouseMoveEventsInSliceView(bool capture)
+{
+  this->m_CaptureMouseMoveEventsInSliceView = capture;
+}
+
+//----------------------------------------------------------------------------
+bool qSlicerSegmentEditorAbstractEffect::captureMouseMoveEventsInThreeDView()
+{
+  return m_CaptureMouseMoveEventsInThreeDView;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSegmentEditorAbstractEffect::setCaptureMouseMoveEventsInThreeDView(bool capture)
+{
+  this->m_CaptureMouseMoveEventsInThreeDView = capture;
+}
+
 //-----------------------------------------------------------------------------
 void qSlicerSegmentEditorAbstractEffect::interactionNodeModified(vtkMRMLInteractionNode* interactionNode)
 {

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.h
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.h
@@ -97,6 +97,21 @@ public:
   /// False by default.
   Q_PROPERTY(bool showEffectCursorInThreeDView READ showEffectCursorInThreeDView WRITE setShowEffectCursorInThreeDView)
 
+  /// If this property is set to true then, while the effect is active, mouse move events (without modifier keys)
+  /// in slice views are captured by the segment editor: objects displayed in the view (such as markups control points
+  /// or slice intersection handles) are not notified when the mouse hovers over them, therefore they are not highlighted
+  /// and they do not change the mouse cursor. Interactions that are already in progress (e.g., panning the view by
+  /// click-and-drag) are not affected.
+  /// It is recommended to enable it in effects that handle mouse interactions in slice views themselves, so that
+  /// hovering over other objects does not suggest that they can be interacted with.
+  /// The value is applied when the effect is activated.
+  /// False by default.
+  Q_PROPERTY(bool captureMouseMoveEventsInSliceView READ captureMouseMoveEventsInSliceView WRITE setCaptureMouseMoveEventsInSliceView)
+
+  /// Same as captureMouseMoveEventsInSliceView, but for 3D views.
+  /// False by default.
+  Q_PROPERTY(bool captureMouseMoveEventsInThreeDView READ captureMouseMoveEventsInThreeDView WRITE setCaptureMouseMoveEventsInThreeDView)
+
 public:
   typedef QObject Superclass;
   qSlicerSegmentEditorAbstractEffect(QObject* parent = nullptr);
@@ -416,6 +431,12 @@ public:
   bool showEffectCursorInSliceView();
   bool showEffectCursorInThreeDView();
 
+  void setCaptureMouseMoveEventsInSliceView(bool capture);
+  void setCaptureMouseMoveEventsInThreeDView(bool capture);
+
+  bool captureMouseMoveEventsInSliceView();
+  bool captureMouseMoveEventsInThreeDView();
+
   /// Get image data of source volume aligned with the modifier labelmap.
   /// \return Pointer to the image data
   Q_INVOKABLE vtkOrientedImageData* sourceVolumeImageData();
@@ -488,6 +509,8 @@ protected:
 
   bool m_ShowEffectCursorInSliceView{ true };
   bool m_ShowEffectCursorInThreeDView{ false };
+  bool m_CaptureMouseMoveEventsInSliceView{ false };
+  bool m_CaptureMouseMoveEventsInThreeDView{ false };
 
   double m_FillValue{ 1.0 };
   double m_EraseValue{ 0.0 };

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
@@ -938,6 +938,10 @@ qSlicerSegmentEditorPaintEffect::qSlicerSegmentEditorPaintEffect(QObject* parent
   this->m_AlwaysErase = false;
   this->m_Erase = false;
   this->m_ShowEffectCursorInThreeDView = true;
+  // Mouse clicks and drags in views are used for painting, so other objects in the views
+  // (e.g., markups control points) must not be highlighted and must not change the mouse cursor on hover.
+  this->m_CaptureMouseMoveEventsInSliceView = true;
+  this->m_CaptureMouseMoveEventsInThreeDView = true;
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScissorsEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScissorsEffect.cxx
@@ -1157,6 +1157,10 @@ qSlicerSegmentEditorScissorsEffect::qSlicerSegmentEditorScissorsEffect(QObject* 
   this->m_Name = QString(/*no tr*/ "Scissors");
   this->m_Title = tr("Scissors");
   this->m_ShowEffectCursorInThreeDView = true;
+  // Mouse clicks and drags in views are used for cutting, so other objects in the views
+  // (e.g., markups control points) must not be highlighted and must not change the mouse cursor on hover.
+  this->m_CaptureMouseMoveEventsInSliceView = true;
+  this->m_CaptureMouseMoveEventsInThreeDView = true;
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
@@ -23,6 +23,7 @@
 
 // MRML includes
 #include <vtkMRMLFolderDisplayNode.h>
+#include <vtkMRMLInteractionEventData.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLSliceNode.h>
 #include <vtkMRMLSegmentationDisplayNode.h>
@@ -41,6 +42,7 @@
 #include <vtkVersion.h> // must precede reference to VTK_MAJOR_VERSION
 #include <vtkActor2D.h>
 #include <vtkCallbackCommand.h>
+#include <vtkCommand.h>
 #include <vtkCellArray.h>
 #include <vtkGeometryFilter.h>
 #include <vtkPlaneCutter.h>
@@ -48,6 +50,7 @@
 #include <vtkContourTriangulator.h>
 #include <vtkDataSetAttributes.h>
 #include <vtkDoubleArray.h>
+#include <vtkEvent.h>
 #include <vtkEventBroker.h>
 #include <vtkGeneralTransform.h>
 #include <vtkImageMapper.h>
@@ -1307,6 +1310,40 @@ void vtkMRMLSegmentationsDisplayableManager2D::PrintSelf(ostream& os, vtkIndent 
 {
   this->Superclass::PrintSelf(os, indent);
   os << indent << "vtkMRMLSegmentationsDisplayableManager2D: " << this->GetClassName() << "\n";
+  os << indent << "CaptureMouseMoveEvents: " << (this->CaptureMouseMoveEvents ? "true" : "false") << "\n";
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLSegmentationsDisplayableManager2D::IsCapturedMouseMoveEvent(vtkMRMLInteractionEventData* eventData)
+{
+  if (!this->CaptureMouseMoveEvents || !eventData || eventData->GetType() != vtkCommand::MouseMoveEvent)
+  {
+    return false;
+  }
+  // Mouse move events with modifier keys are not captured, so that modifier-key interactions
+  // with the view and with other objects (e.g., shift + mouse move to move the crosshair) remain available.
+  int modifiers = eventData->GetModifiers();
+  return (modifiers & (vtkEvent::ShiftModifier | vtkEvent::ControlModifier | vtkEvent::AltModifier)) == 0;
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLSegmentationsDisplayableManager2D::CanProcessInteractionEvent(vtkMRMLInteractionEventData* eventData, double& closestDistance2)
+{
+  if (!this->IsCapturedMouseMoveEvent(eventData))
+  {
+    return false;
+  }
+  // Claim the event with zero distance so that no other displayable manager gets the focus on hover.
+  // A displayable manager that already has the focus keeps it, so interactions in progress are not interrupted.
+  closestDistance2 = 0.0;
+  return true;
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLSegmentationsDisplayableManager2D::ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData)
+{
+  // There is nothing to do with the event, it is just consumed so that other displayable managers do not receive it.
+  return this->IsCapturedMouseMoveEvent(eventData);
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.h
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.h
@@ -26,6 +26,7 @@
 
 #include "vtkSlicerSegmentationsModuleMRMLDisplayableManagerExport.h"
 
+class vtkMRMLInteractionEventData;
 class vtkMRMLSegmentationDisplayNode;
 class vtkStringArray;
 class vtkDoubleArray;
@@ -77,6 +78,22 @@ public:
   std::string GetCustomSegmentRendererSegmentID(int index);
   // @}
 
+  // @{
+  /// If enabled then this displayable manager claims all mouse move events that are received without
+  /// modifier keys (Shift, Ctrl, Alt) with zero distance. Therefore, other displayable managers do not get
+  /// the focus when the mouse hovers over objects in the view (such as markups control points or slice
+  /// intersection handles), so these objects are not highlighted and they do not change the mouse cursor.
+  /// Interactions that are already in progress (e.g., panning the view by click-and-drag) are not affected.
+  /// Segment editor effects enable it to indicate that they handle mouse interactions in the view.
+  /// Disabled by default.
+  vtkSetMacro(CaptureMouseMoveEvents, bool);
+  vtkGetMacro(CaptureMouseMoveEvents, bool);
+  vtkBooleanMacro(CaptureMouseMoveEvents, bool);
+  // @}
+
+  bool CanProcessInteractionEvent(vtkMRMLInteractionEventData* eventData, double& closestDistance2) override;
+  bool ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData) override;
+
 protected:
   void UnobserveMRMLScene() override;
   void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
@@ -97,6 +114,12 @@ protected:
 protected:
   vtkMRMLSegmentationsDisplayableManager2D();
   ~vtkMRMLSegmentationsDisplayableManager2D() override;
+
+  /// Returns true if the event is a mouse move event that this displayable manager captures.
+  /// \sa CaptureMouseMoveEvents
+  bool IsCapturedMouseMoveEvent(vtkMRMLInteractionEventData* eventData);
+
+  bool CaptureMouseMoveEvents{ false };
 
 private:
   vtkMRMLSegmentationsDisplayableManager2D(const vtkMRMLSegmentationsDisplayableManager2D&) = delete;

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager3D.cxx
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager3D.cxx
@@ -29,6 +29,7 @@
 #include <vtkEventBroker.h>
 #include <vtkMRMLClipNode.h>
 #include <vtkMRMLFolderDisplayNode.h>
+#include <vtkMRMLInteractionEventData.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLTransformNode.h>
 #include <vtkMRMLViewNode.h>
@@ -41,8 +42,10 @@
 #include <vtkCallbackCommand.h>
 #include <vtkCellPicker.h>
 #include <vtkClipPolyData.h>
+#include <vtkCommand.h>
 #include <vtkDataSetAttributes.h>
 #include <vtkDoubleArray.h>
+#include <vtkEvent.h>
 #include <vtkExtractPolyDataGeometry.h>
 #include <vtkGeneralTransform.h>
 #include <vtkImplicitBoolean.h>
@@ -949,6 +952,40 @@ void vtkMRMLSegmentationsDisplayableManager3D::PrintSelf(ostream& os, vtkIndent 
 {
   this->Superclass::PrintSelf(os, indent);
   os << indent << "vtkMRMLSegmentationsDisplayableManager3D: " << this->GetClassName() << "\n";
+  os << indent << "CaptureMouseMoveEvents: " << (this->CaptureMouseMoveEvents ? "true" : "false") << "\n";
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLSegmentationsDisplayableManager3D::IsCapturedMouseMoveEvent(vtkMRMLInteractionEventData* eventData)
+{
+  if (!this->CaptureMouseMoveEvents || !eventData || eventData->GetType() != vtkCommand::MouseMoveEvent)
+  {
+    return false;
+  }
+  // Mouse move events with modifier keys are not captured, so that modifier-key interactions
+  // with the view and with other objects remain available.
+  int modifiers = eventData->GetModifiers();
+  return (modifiers & (vtkEvent::ShiftModifier | vtkEvent::ControlModifier | vtkEvent::AltModifier)) == 0;
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLSegmentationsDisplayableManager3D::CanProcessInteractionEvent(vtkMRMLInteractionEventData* eventData, double& closestDistance2)
+{
+  if (!this->IsCapturedMouseMoveEvent(eventData))
+  {
+    return false;
+  }
+  // Claim the event with zero distance so that no other displayable manager gets the focus on hover.
+  // A displayable manager that already has the focus keeps it, so interactions in progress are not interrupted.
+  closestDistance2 = 0.0;
+  return true;
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLSegmentationsDisplayableManager3D::ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData)
+{
+  // There is nothing to do with the event, it is just consumed so that other displayable managers do not receive it.
+  return this->IsCapturedMouseMoveEvent(eventData);
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager3D.h
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager3D.h
@@ -26,6 +26,8 @@
 
 #include "vtkSlicerSegmentationsModuleMRMLDisplayableManagerExport.h"
 
+class vtkMRMLInteractionEventData;
+
 /// \brief Display segmentations in 3D views
 ///
 /// Displays poly data representations of segmentations in 3D viewers
@@ -47,12 +49,34 @@ public:
   /// Get the MRML ID of the picked node, returns empty string if no pick
   const char* GetPickedNodeID() override;
 
+  // @{
+  /// If enabled then this displayable manager claims all mouse move events that are received without
+  /// modifier keys (Shift, Ctrl, Alt) with zero distance. Therefore, other displayable managers do not get
+  /// the focus when the mouse hovers over objects in the view (such as markups control points), so these
+  /// objects are not highlighted and they do not change the mouse cursor.
+  /// Interactions that are already in progress (e.g., rotating the view by click-and-drag) are not affected.
+  /// Segment editor effects enable it to indicate that they handle mouse interactions in the view.
+  /// Disabled by default.
+  vtkSetMacro(CaptureMouseMoveEvents, bool);
+  vtkGetMacro(CaptureMouseMoveEvents, bool);
+  vtkBooleanMacro(CaptureMouseMoveEvents, bool);
+  // @}
+
+  bool CanProcessInteractionEvent(vtkMRMLInteractionEventData* eventData, double& closestDistance2) override;
+  bool ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData) override;
+
   /// Get the ID of the picked segment, returns empty string if no pick
   virtual const char* GetPickedSegmentID();
 
 protected:
   vtkMRMLSegmentationsDisplayableManager3D();
   ~vtkMRMLSegmentationsDisplayableManager3D() override;
+
+  /// Returns true if the event is a mouse move event that this displayable manager captures.
+  /// \sa CaptureMouseMoveEvents
+  bool IsCapturedMouseMoveEvent(vtkMRMLInteractionEventData* eventData);
+
+  bool CaptureMouseMoveEvents{ false };
 
   void UnobserveMRMLScene() override;
   void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;

--- a/Modules/Loadable/Segmentations/Testing/Python/CMakeLists.txt
+++ b/Modules/Loadable/Segmentations/Testing/Python/CMakeLists.txt
@@ -30,3 +30,19 @@ foreach(scriptName ${EXTENSION_TEST_PYTHON_SCRIPTS})
     TESTNAME_PREFIX nomainwindow_
     )
 endforeach()
+
+#-----------------------------------------------------------------------------
+# Tests that require the main window (interaction with slice views)
+set(EXTENSION_TEST_PYTHON_SCRIPTS_MAIN_WINDOW
+  SegmentEditorEffectViewInteractionTest.py
+  )
+
+foreach(scriptName ${EXTENSION_TEST_PYTHON_SCRIPTS_MAIN_WINDOW})
+  slicer_add_python_unittest(
+    SCRIPT ${scriptName}
+    SLICER_ARGS --disable-cli-modules
+                --additional-module-paths
+                  ${MODULE_BUILD_DIR}
+                  ${CMAKE_BINARY_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}
+    )
+endforeach()

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentEditorEffectViewInteractionTest.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentEditorEffectViewInteractionTest.py
@@ -1,0 +1,217 @@
+import logging
+
+import numpy as np
+import vtk
+
+import slicer
+from slicer.ScriptedLoadableModule import *
+
+
+class SegmentEditorEffectViewInteractionTest(ScriptedLoadableModuleTest):
+    """Test how segment editor effects interact with other objects displayed in slice and 3D views."""
+
+    def setUp(self):
+        slicer.mrmlScene.Clear(0)
+
+    def runTest(self):
+        self.setUp()
+        self.test_MouseMoveEventsCapturedInSliceView()
+        self.setUp()
+        self.test_MouseMoveEventsCapturedInThreeDView()
+
+    # ------------------------------------------------------------------------------
+    def setupScene(self):
+        """Create a volume, a markups control point, and a segment editor widget with an empty segment."""
+        layoutManager = slicer.app.layoutManager()
+        self.assertIsNotNone(layoutManager)
+        layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutFourUpView)
+
+        # Volume displayed in the slice views
+        voxels = np.zeros((32, 64, 64), dtype=np.uint8)
+        voxels[:, 16:48, 16:48] = 100
+        self.volumeNode = slicer.util.addVolumeFromArray(voxels, name="Volume")
+        slicer.util.setSliceViewerLayers(background=self.volumeNode, fit=True)
+        slicer.app.processEvents()
+
+        # Markups control point in the middle of the Red slice view (on the current slice plane)
+        sliceWidget = layoutManager.sliceWidget("Red")
+        sliceView = sliceWidget.sliceView()
+        sliceNode = sliceWidget.mrmlSliceNode()
+        sliceView.forceRender()
+        dimensions = sliceNode.GetDimensions()
+        centerRAS = sliceView.convertXYZToRAS([float(dimensions[0] // 2), float(dimensions[1] // 2), 0.0])
+        self.markupsNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+        self.markupsNode.CreateDefaultDisplayNodes()
+        self.markupsNode.AddControlPoint(centerRAS)
+        self.markupsDisplayNode = self.markupsNode.GetDisplayNode()
+
+        # Segment editor
+        segmentationNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
+        segmentationNode.CreateDefaultDisplayNodes()
+        segmentationNode.SetReferenceImageGeometryParameterFromVolumeNode(self.volumeNode)
+        segmentationNode.GetSegmentation().AddEmptySegment("Segment")
+        segmentEditorNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentEditorNode")
+        self.segmentEditorWidget = slicer.qMRMLSegmentEditorWidget()
+        self.segmentEditorWidget.setMRMLScene(slicer.mrmlScene)
+        self.segmentEditorWidget.setMRMLSegmentEditorNode(segmentEditorNode)
+        self.segmentEditorWidget.setSegmentationNode(segmentationNode)
+        self.segmentEditorWidget.setSourceVolumeNode(self.volumeNode)
+        self.segmentEditorWidget.show()
+        slicer.app.processEvents()
+
+    def activateEffect(self, effectName):
+        self.segmentEditorWidget.setActiveEffectByName(effectName)
+        slicer.app.processEvents()
+        effect = self.segmentEditorWidget.activeEffect()
+        self.assertIsNotNone(effect)
+        self.assertEqual(effect.name, effectName)
+        return effect
+
+    def deactivateEffect(self):
+        self.segmentEditorWidget.setActiveEffect(None)
+        slicer.app.processEvents()
+        self.assertIsNone(self.segmentEditorWidget.activeEffect())
+
+    def moveMouse(self, view, xy):
+        """Send a synthetic mouse move event to a slice or 3D view."""
+        view.forceRender()
+        interactor = view.interactorStyle().GetInteractor()
+        interactor.SetEventPosition(int(xy[0]), int(xy[1]))
+        interactor.MouseMoveEvent()
+        slicer.app.processEvents()
+
+    def activeComponentType(self):
+        return self.markupsDisplayNode.GetActiveComponentType()
+
+    # ------------------------------------------------------------------------------
+    def test_MouseMoveEventsCapturedInSliceView(self):
+        """Check that while an effect that captures mouse move events in slice views (Draw) is active,
+        hovering over a markups control point does not activate it, while the cursor position
+        (used by the Data Probe) is still updated and the view can still be panned by click-and-drag.
+        """
+        logging.info("Test: mouse move events are captured by segment editor effect in slice view")
+        self.setupScene()
+
+        sliceWidget = slicer.app.layoutManager().sliceWidget("Red")
+        sliceView = sliceWidget.sliceView()
+        sliceNode = sliceWidget.mrmlSliceNode()
+        interactor = sliceView.interactorStyle().GetInteractor()
+
+        def controlPointXY():
+            xyz = sliceView.convertRASToXYZ(self.markupsNode.GetNthControlPointPositionWorld(0))
+            return [round(xyz[0]), round(xyz[1])]
+
+        sliceView.forceRender()
+        pointXY = controlPointXY()
+        farFromPointXY = [pointXY[0] // 2, pointXY[1] // 2]
+
+        # Without active effect, hovering over the control point activates it
+        self.moveMouse(sliceView, pointXY)
+        self.assertEqual(self.activeComponentType(), slicer.vtkMRMLMarkupsDisplayNode.ComponentControlPoint)
+        self.moveMouse(sliceView, farFromPointXY)
+        self.assertEqual(self.activeComponentType(), slicer.vtkMRMLMarkupsDisplayNode.ComponentNone)
+
+        drawEffect = self.activateEffect("Draw")
+        self.assertTrue(drawEffect.captureMouseMoveEventsInSliceView)
+        self.assertFalse(drawEffect.captureMouseMoveEventsInThreeDView)
+
+        # Hovering over the control point must not activate it while the effect is active
+        self.moveMouse(sliceView, farFromPointXY)
+        self.moveMouse(sliceView, pointXY)
+        self.assertEqual(self.activeComponentType(), slicer.vtkMRMLMarkupsDisplayNode.ComponentNone)
+
+        # The cursor position (used by the Data Probe) must still be updated
+        crosshairNode = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLCrosshairNode")
+        self.assertIsNotNone(crosshairNode)
+        cursorXYZ = [0.0, 0.0, 0.0]
+        self.assertEqual(crosshairNode.GetCursorPositionXYZ(cursorXYZ), sliceNode)
+        self.assertEqual(round(cursorXYZ[0]), pointXY[0])
+        self.assertEqual(round(cursorXYZ[1]), pointXY[1])
+
+        # Panning the view by middle-click-and-drag must still work
+        xyToRASBefore = vtk.vtkMatrix4x4()
+        xyToRASBefore.DeepCopy(sliceNode.GetXYToRAS())
+        interactor.SetEventPosition(pointXY[0], pointXY[1])
+        interactor.MiddleButtonPressEvent()
+        self.moveMouse(sliceView, [pointXY[0] + 30, pointXY[1] + 20])
+        interactor.MiddleButtonReleaseEvent()
+        slicer.app.processEvents()
+        matrixChanged = any(xyToRASBefore.GetElement(row, col) != sliceNode.GetXYToRAS().GetElement(row, col)
+                            for row in range(4) for col in range(4))
+        self.assertTrue(matrixChanged, "Slice view was not panned while Draw effect was active")
+
+        # Hovering over the control point (at its new position after panning) is still not activating it
+        pointXY = controlPointXY()
+        self.moveMouse(sliceView, pointXY)
+        self.assertEqual(self.activeComponentType(), slicer.vtkMRMLMarkupsDisplayNode.ComponentNone)
+
+        # Deactivating the effect restores activation of the control point on hover
+        self.deactivateEffect()
+        self.moveMouse(sliceView, farFromPointXY)
+        self.moveMouse(sliceView, pointXY)
+        self.assertEqual(self.activeComponentType(), slicer.vtkMRMLMarkupsDisplayNode.ComponentControlPoint)
+
+        self.segmentEditorWidget.close()
+        logging.info("Test finished")
+
+    # ------------------------------------------------------------------------------
+    def test_MouseMoveEventsCapturedInThreeDView(self):
+        """Check that while an effect that captures mouse move events in 3D views (Paint) is active,
+        hovering over a markups control point does not activate it, while the view can still be
+        rotated by click-and-drag.
+        """
+        logging.info("Test: mouse move events are captured by segment editor effect in 3D view")
+        self.setupScene()
+
+        threeDWidget = slicer.app.layoutManager().threeDWidget(0)
+        threeDView = threeDWidget.threeDView()
+        interactor = threeDView.interactorStyle().GetInteractor()
+        threeDView.resetFocalPoint()
+        threeDView.forceRender()
+        renderer = threeDView.renderWindow().GetRenderers().GetFirstRenderer()
+
+        def controlPointXY():
+            position = self.markupsNode.GetNthControlPointPositionWorld(0)
+            renderer.SetWorldPoint(position[0], position[1], position[2], 1.0)
+            renderer.WorldToDisplay()
+            displayPosition = renderer.GetDisplayPoint()
+            return [round(displayPosition[0]), round(displayPosition[1])]
+
+        pointXY = controlPointXY()
+        farFromPointXY = [pointXY[0] // 2, pointXY[1] // 2]
+
+        # Without active effect, hovering over the control point activates it
+        self.moveMouse(threeDView, pointXY)
+        self.assertEqual(self.activeComponentType(), slicer.vtkMRMLMarkupsDisplayNode.ComponentControlPoint)
+        self.moveMouse(threeDView, farFromPointXY)
+        self.assertEqual(self.activeComponentType(), slicer.vtkMRMLMarkupsDisplayNode.ComponentNone)
+
+        paintEffect = self.activateEffect("Paint")
+        self.assertTrue(paintEffect.captureMouseMoveEventsInSliceView)
+        self.assertTrue(paintEffect.captureMouseMoveEventsInThreeDView)
+
+        # Hovering over the control point must not activate it while the effect is active
+        self.moveMouse(threeDView, farFromPointXY)
+        self.moveMouse(threeDView, pointXY)
+        self.assertEqual(self.activeComponentType(), slicer.vtkMRMLMarkupsDisplayNode.ComponentNone)
+
+        # Rotating the view by left-click-and-drag (in an empty area, where nothing can be painted) must still work
+        cameraNode = threeDView.cameraNode()
+        positionBefore = list(cameraNode.GetPosition())
+        interactor.SetEventPosition(farFromPointXY[0], farFromPointXY[1])
+        interactor.LeftButtonPressEvent()
+        self.moveMouse(threeDView, [farFromPointXY[0] + 30, farFromPointXY[1] + 20])
+        interactor.LeftButtonReleaseEvent()
+        slicer.app.processEvents()
+        self.assertNotEqual(positionBefore, list(cameraNode.GetPosition()), "3D view was not rotated while Paint effect was active")
+
+        # Deactivating the effect restores activation of the control point on hover
+        self.deactivateEffect()
+        threeDView.forceRender()
+        pointXY = controlPointXY()
+        self.moveMouse(threeDView, farFromPointXY)
+        self.moveMouse(threeDView, pointXY)
+        self.assertEqual(self.activeComponentType(), slicer.vtkMRMLMarkupsDisplayNode.ComponentControlPoint)
+
+        self.segmentEditorWidget.close()
+        logging.info("Test finished")

--- a/Modules/Loadable/Segmentations/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/Segmentations/Widgets/CMakeLists.txt
@@ -7,6 +7,7 @@ set(${KIT}_EXPORT_DIRECTIVE "Q_SLICER_MODULE_${MODULE_NAME_UPPER}_WIDGETS_EXPORT
 set(${KIT}_INCLUDE_DIRECTORIES
   ${vtkSlicerSegmentationsModuleMRML_INCLUDE_DIRS}
   ${vtkSlicerSegmentationsModuleLogic_INCLUDE_DIRS}
+  ${vtkSlicerSegmentationsModuleMRMLDisplayableManager_INCLUDE_DIRS}
   ${qSlicerSegmentationsEditorEffects_INCLUDE_DIRS}
   ${qSlicerTerminologiesModuleWidgets_INCLUDE_DIRS}
   )
@@ -58,6 +59,7 @@ set(${KIT}_TARGET_LIBRARIES
   qSlicerTerminologiesModuleWidgets
   vtkSlicerSegmentationsModuleMRML
   vtkSlicerSegmentationsModuleLogic
+  vtkSlicerSegmentationsModuleMRMLDisplayableManager
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -30,6 +30,8 @@
 #include "vtkMRMLSegmentEditorNode.h"
 #include "qMRMLSegmentationGeometryDialog.h"
 #include "vtkSlicerSegmentEditorLogic.h"
+#include "vtkMRMLSegmentationsDisplayableManager2D.h"
+#include "vtkMRMLSegmentationsDisplayableManager3D.h"
 
 // vtkSegmentationCore Includes
 #include "vtkSegmentation.h"
@@ -155,6 +157,11 @@ public:
 
   bool segmentationDisplayableInView(vtkMRMLAbstractViewNode* viewNode) const;
 
+  /// Enable capturing of mouse move events in slice and 3D views if the active effect requests it, disable it otherwise.
+  /// \sa qSlicerSegmentEditorAbstractEffect::captureMouseMoveEventsInSliceView
+  /// \sa qSlicerSegmentEditorAbstractEffect::captureMouseMoveEventsInThreeDView
+  void updateMouseMoveEventsCaptureInViews();
+
   QToolButton* toolButton(qSlicerSegmentEditorAbstractEffect* effect);
 
   QString sourceVolumeNodeID() const { return QString::fromStdString(SourceVolumeNode ? SourceVolumeNode->GetID() : ""); }
@@ -195,6 +202,10 @@ public:
 
   /// List of view node IDs where custom cursor is set
   QSet<QString> CustomCursorInViewNodeIDs;
+
+  /// IDs of view nodes in which this widget enabled capturing of mouse move events.
+  /// \sa updateMouseMoveEventsCaptureInViews
+  QSet<QString> MouseMoveEventsCapturedInViewNodeIDs;
 
   /// Indicates if views and layouts are observed
   /// (essentially, the widget is active).
@@ -459,6 +470,83 @@ void qMRMLSegmentEditorWidgetPrivate::selectFirstSegment() const
 bool qMRMLSegmentEditorWidgetPrivate::segmentationDisplayableInView(vtkMRMLAbstractViewNode* viewNode) const
 {
   return this->Logic->IsSegmentationDisplayableInView(viewNode);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentEditorWidgetPrivate::updateMouseMoveEventsCaptureInViews()
+{
+  qSlicerApplication* app = qSlicerApplication::application();
+  qSlicerLayoutManager* layoutManager = app ? app->layoutManager() : nullptr;
+  if (!layoutManager)
+  {
+    // application is closing
+    return;
+  }
+
+  // Capture mouse move events only while the active effect requests it and the mouse mode is view/transform.
+  // In other mouse modes (e.g., markups placement), objects in the views must receive all mouse move events.
+  bool captureAllowed = this->ViewsObserved && this->ActiveEffect //
+                        && (!this->InteractionNode || this->InteractionNode->GetCurrentInteractionMode() == vtkMRMLInteractionNode::ViewTransform);
+  bool captureInSliceViews = captureAllowed && this->ActiveEffect->captureMouseMoveEventsInSliceView();
+  bool captureInThreeDViews = captureAllowed && this->ActiveEffect->captureMouseMoveEventsInThreeDView();
+
+  // Returns false if this widget did not enable capturing in the view, so it must not disable it either
+  // (capturing may have been enabled by another segment editor widget).
+  auto updateCapturedViewNodeIDs = [this](vtkMRMLAbstractViewNode* viewNode, bool capture) -> bool
+  {
+    QString viewNodeID = QString::fromStdString(viewNode->GetID());
+    if (capture)
+    {
+      this->MouseMoveEventsCapturedInViewNodeIDs.insert(viewNodeID);
+      return true;
+    }
+    if (!this->MouseMoveEventsCapturedInViewNodeIDs.contains(viewNodeID))
+    {
+      return false;
+    }
+    this->MouseMoveEventsCapturedInViewNodeIDs.remove(viewNodeID);
+    return true;
+  };
+
+  for (const QString& sliceViewName : layoutManager->sliceViewNames())
+  {
+    qMRMLSliceWidget* sliceWidget = layoutManager->sliceWidget(sliceViewName);
+    if (!sliceWidget || !sliceWidget->sliceView() || !sliceWidget->mrmlSliceNode())
+    {
+      continue;
+    }
+    bool capture = captureInSliceViews && this->segmentationDisplayableInView(sliceWidget->mrmlSliceNode());
+    if (!updateCapturedViewNodeIDs(sliceWidget->mrmlSliceNode(), capture))
+    {
+      continue;
+    }
+    vtkMRMLSegmentationsDisplayableManager2D* displayableManager =
+      vtkMRMLSegmentationsDisplayableManager2D::SafeDownCast(sliceWidget->sliceView()->displayableManagerByClassName("vtkMRMLSegmentationsDisplayableManager2D"));
+    if (displayableManager)
+    {
+      displayableManager->SetCaptureMouseMoveEvents(capture);
+    }
+  }
+
+  for (int threeDViewId = 0; threeDViewId < layoutManager->threeDViewCount(); ++threeDViewId)
+  {
+    qMRMLThreeDWidget* threeDWidget = layoutManager->threeDWidget(threeDViewId);
+    if (!threeDWidget || !threeDWidget->threeDView() || !threeDWidget->mrmlViewNode())
+    {
+      continue;
+    }
+    bool capture = captureInThreeDViews && this->segmentationDisplayableInView(threeDWidget->mrmlViewNode());
+    if (!updateCapturedViewNodeIDs(threeDWidget->mrmlViewNode(), capture))
+    {
+      continue;
+    }
+    vtkMRMLSegmentationsDisplayableManager3D* displayableManager =
+      vtkMRMLSegmentationsDisplayableManager3D::SafeDownCast(threeDWidget->threeDView()->displayableManagerByClassName("vtkMRMLSegmentationsDisplayableManager3D"));
+    if (displayableManager)
+    {
+      displayableManager->SetCaptureMouseMoveEvents(capture);
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1140,6 +1228,8 @@ void qMRMLSegmentEditorWidget::updateEffectsSectionFromMRML()
   // Set active effect
   d->LastActiveEffect = d->ActiveEffect;
   d->ActiveEffect = activeEffect;
+
+  d->updateMouseMoveEventsCaptureInViews();
 }
 
 //-----------------------------------------------------------------------------
@@ -1227,7 +1317,7 @@ void qMRMLSegmentEditorWidget::onMRMLSceneEndBatchProcessEvent()
 //-----------------------------------------------------------------------------
 void qMRMLSegmentEditorWidget::onInteractionNodeModified()
 {
-  Q_D(const qMRMLSegmentEditorWidget);
+  Q_D(qMRMLSegmentEditorWidget);
   if (!d->InteractionNode || !d->ActiveEffect)
   {
     return;
@@ -1235,6 +1325,9 @@ void qMRMLSegmentEditorWidget::onInteractionNodeModified()
   // Only notify the active effect about interaction node changes
   // (inactive effects should not interact with the user)
   d->ActiveEffect->interactionNodeModified(d->InteractionNode);
+
+  // Mouse move events are captured only in view/transform mouse mode
+  d->updateMouseMoveEventsCaptureInViews();
 }
 
 //------------------------------------------------------------------------------
@@ -1696,6 +1789,7 @@ void qMRMLSegmentEditorWidget::onLayoutChanged(int layoutIndex)
   {
     // Refresh view observations with the new layout
     this->setupViewObservations();
+    d->updateMouseMoveEventsCaptureInViews();
 
     if (d->AutoShowSourceVolumeNode)
     {
@@ -1980,6 +2074,9 @@ void qMRMLSegmentEditorWidget::removeViewObservations()
   }
   d->EventObservations.clear();
   d->ViewsObserved = false;
+
+  // Views are not observed anymore, so mouse move events must not be captured
+  d->updateMouseMoveEventsCaptureInViews();
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Alternative fix for #9358.

While a segment editor effect such as Draw was active, hovering over a markups control point (or a slice intersection handle) gave focus to that widget: it was highlighted and the mouse cursor changed to a hand, even though clicking was handled by the effect. After a draw stroke the hand cursor could remain until the effect was changed.

Instead of forcing the cursor in the effect or hijacking low-level events, changes in this PR make the segment editor participate in the displayable manager focus mechanism:
Draw, Level tracing, Paint, Erase, and Scissors effects request capturing of mouse move events in slice and/or 3D views via the new `captureMouseMoveEventsInSliceView` / `captureMouseMoveEventsInThreeDView` properties. `qMRMLSegmentEditorWidget` propagates them to the segmentations displayable managers of the views while the effect is active. `vtkMRMLSegmentationsDisplayableManager2D/3D` claim these events with zero distance, so no other displayable manager gets focus on hover.

Unlike aborting interactor events (that a few effects did before), the Data Probe cursor position is still updated and other interactor observers keep receiving the events.

`vtkMRMLViewInteractorStyle` prefers the displayable manager that already has the focus when distances are equal, so interactions in progress (pan, zoom, camera rotation) are not interrupted by the capturing manager, regardless of displayable manager registration order.