### PR TITLE
BUG: Preserve render-pass lists during MIP initialization

### DIFF
--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
@@ -171,17 +171,20 @@ public:
       if (pipeline->VolumeActorInformation->Has(vtkOpenGLRenderPass::RenderPasses()))
       {
         // Iterate on the OpenGL render passes to remove the SSAO pass if attached
+        bool removedSSAOPass = false;
         int numRenderPasses = pipeline->VolumeActorInformation->Length(vtkOpenGLRenderPass::RenderPasses());
         for (int i = 0; i < numRenderPasses; ++i)
         {
           if (vtkSSAOPass::SafeDownCast(pipeline->VolumeActorInformation->Get(vtkOpenGLRenderPass::RenderPasses(), i)))
           {
             pipeline->VolumeActorInformation->Remove(vtkOpenGLRenderPass::RenderPasses(), i);
+            removedSSAOPass = true;
           }
         }
 
-        // Cleanup OpenGL render passes if empty after removal of the SSAO pass to avoid crashes in the GPU mapper
-        if (pipeline->VolumeActorInformation->Length(vtkOpenGLRenderPass::RenderPasses()) == 0)
+        // Remove lists emptied by SSAO filtering to avoid crashes in the GPU mapper.
+        // An initially empty list may still be under construction in vtkInformationObjectBaseVectorKey::Append().
+        if (removedSSAOPass && pipeline->VolumeActorInformation->Length(vtkOpenGLRenderPass::RenderPasses()) == 0)
         {
           pipeline->VolumeActorInformation->Remove(vtkOpenGLRenderPass::RenderPasses());
         }

--- a/Modules/Loadable/VolumeRendering/Testing/Python/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/Testing/Python/CMakeLists.txt
@@ -1,3 +1,5 @@
+slicer_add_python_unittest(SCRIPT VolumeRenderingRenderPassTest.py)
+
 if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
 
   # add tests

--- a/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingRenderPassTest.py
+++ b/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingRenderPassTest.py
@@ -1,0 +1,64 @@
+import unittest
+
+import vtk
+
+import slicer
+
+
+class VolumeRenderingRenderPassTest(unittest.TestCase):
+    def setUp(self):
+        self.enterContext(slicer.util.RenderBlocker())
+        slicer.mrmlScene.Clear()
+        self.addCleanup(slicer.mrmlScene.Clear)
+
+        layoutManager = slicer.app.layoutManager()
+        layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutOneUp3DView)
+        self.view = layoutManager.threeDWidget(0).threeDView()
+
+        source = vtk.vtkRTAnalyticSource()
+        source.SetWholeExtent(-2, 2, -2, 2, -2, 2)
+        source.Update()
+        self.volume = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode")
+        self.volume.SetAndObserveImageData(source.GetOutput())
+        self.volume.CreateDefaultDisplayNodes()
+        displayNode = slicer.modules.volumerendering.logic().CreateDefaultVolumeRenderingNodes(self.volume)
+        displayNode.SetVisibility(True)
+
+    def testRenderPassReferences(self):
+        """MIP and MinIP must preserve non-SSAO passes and release their references."""
+        manager = self.view.displayableManagerByClassName("vtkMRMLVolumeRenderingDisplayableManager")
+        information = manager.GetVolumeActor(self.volume).GetPropertyKeys()
+        key = vtk.vtkOpenGLRenderPass.RenderPasses()
+
+        for technique in (slicer.vtkMRMLViewNode.MaximumIntensityProjection, slicer.vtkMRMLViewNode.MinimumIntensityProjection):
+            with self.subTest(technique=technique):
+                self.view.mrmlViewNode().SetRaycastTechnique(technique)
+                self.assertFalse(information.Has(key))
+                peeling = vtk.vtkDualDepthPeelingPass()
+                peelingReferences = peeling.GetReferenceCount()
+
+                # The first Append emits ModifiedEvent while its new list is still empty.
+                information.Append(key, peeling)
+                self.assertTrue(information.Has(key))
+                self.assertEqual(information.Length(key), 1)
+                self.assertEqual(information.Get(key, 0), peeling)
+
+                ssao = vtk.vtkSSAOPass()
+                ssaoReferences = ssao.GetReferenceCount()
+                information.Append(key, ssao)
+                # SSAO sets this override after appending itself in PreRenderProp.
+                information.Set(vtk.vtkOpenGLActor.GLDepthMaskOverride(), 1)
+                self.assertFalse(information.Has(vtk.vtkOpenGLActor.GLDepthMaskOverride()))
+                self.assertEqual(information.Length(key), 1)
+                self.assertEqual(information.Get(key, 0), peeling)
+                self.assertEqual(ssao.GetReferenceCount(), ssaoReferences)
+
+                information.Remove(key, peeling)
+                self.assertEqual(peeling.GetReferenceCount(), peelingReferences)
+                information.Remove(key)
+
+                # Removing the only SSAO pass must still remove the empty list.
+                information.Append(key, ssao)
+                information.Set(vtk.vtkOpenGLActor.GLDepthMaskOverride(), 1)
+                self.assertFalse(information.Has(key))
+                self.assertEqual(ssao.GetReferenceCount(), ssaoReferences)


### PR DESCRIPTION
MIP and MinIP volume rendering can leak render passes and their graphics resources, causing Slicer to exit with a leak error.

VTK emits `ModifiedEvent` while creating the empty `RenderPasses` list, before `Append` inserts the pass. Slicer’s callback removes that empty list even when it has not removed an SSAO pass, invalidating the append and leaving references unbalanced.

Only remove an empty list when the callback actually removed an SSAO pass.

Adds a regression test that failed before and passed after this fix.

Confirmed that other volume rendering tests pass.

Related to #7560 (which introduced the callback being corrected here)